### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+
+[{package.json,Vagrantfile}]
+indent_size = 2
+


### PR DESCRIPTION
## Overview

This PR adds an .editorconfig file to match our recent projects.

Closes #19

## Notes

I assume some of the existing files won't go through the editorconfig unchanged, but it seems like they should gradually be changed to match conventions regardless.

## Testing Instructions

- verify that the .editorconfig file here matches the one in the Civic Apps app template
