### PR TITLE
Remove Raven and Sentry

### DIFF
--- a/src/api/package.json
+++ b/src/api/package.json
@@ -20,7 +20,6 @@
 		"mongoosastic": "^4.4.1",
 		"mongoose": "^5.3.15",
 		"mongoose-history": "^0.6.0",
-		"raven": "^2.6.3",
 		"restify": "7.3.0",
 		"restify-cors-middleware": "^1.1.1",
 		"restify-errors": "^6.1.1",

--- a/src/api/src/app.js
+++ b/src/api/src/app.js
@@ -1,11 +1,8 @@
 const restify = require('restify');
 const dotenv = require('dotenv');
-const Raven = require('raven')
 console.log('process.env.NODE_ENV: ', process.env.NODE_ENV);
 if (process.env.NODE_ENV === 'development') {
 	dotenv.config();
-} else if (process.env.NODE_ENV === 'production') {
-	Raven.config(process.env.SENTRY_KEY).install()
 }
 
 let app = restify.createServer({ name:'REST-api' });

--- a/src/api/yarn.lock
+++ b/src/api/yarn.lock
@@ -992,11 +992,6 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
-
 chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
@@ -1134,11 +1129,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
-
 cookiejar@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
@@ -1174,11 +1164,6 @@ cross-spawn@^5.0.1:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -2219,7 +2204,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -3191,15 +3176,6 @@ math-random@^1.0.1:
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
-md5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
-
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -4015,17 +3991,6 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-raven@^2.6.3:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/raven/-/raven-2.6.4.tgz#458d4a380c8fbb59e0150c655625aaf60c167ea3"
-  integrity sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==
-  dependencies:
-    cookie "0.3.1"
-    md5 "^2.2.1"
-    stack-trace "0.0.10"
-    timed-out "4.0.1"
-    uuid "3.3.2"
-
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -4657,11 +4622,6 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
-
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
@@ -4852,7 +4812,7 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-timed-out@4.0.1, timed-out@^4.0.0, timed-out@^4.0.1:
+timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
@@ -5061,7 +5021,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@3.3.2, uuid@^3.1.0, uuid@^3.3.2:
+uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==

--- a/src/react/package.json
+++ b/src/react/package.json
@@ -14,7 +14,6 @@
     "lodash": "4.17.10",
     "mapbox-gl": "0.46.0-beta.1",
     "prop-types": "15.6.2",
-    "raven-js": "3.26.3",
     "react": "16.4.0",
     "react-copy-to-clipboard": "5.0.1",
     "react-dom": "16.4.0",

--- a/src/react/src/actions/user.js
+++ b/src/react/src/actions/user.js
@@ -1,6 +1,5 @@
 import firebase from 'firebase';
 import axios from 'axios';
-import Raven from 'raven-js';
 import { toast } from 'react-toastify';
 
 firebase.initializeApp({
@@ -63,7 +62,6 @@ export const loadUser = () => (dispatch) => {
                             contributorType: snapshot.val().contributorType,
                         };
 
-                        Raven.setUserContext(userInfo);
                         dispatch({ type: 'ADD_USER', ...userInfo });
                     } else {
                         dispatch({ type: 'NO_USER' });

--- a/src/react/yarn.lock
+++ b/src/react/yarn.lock
@@ -9388,11 +9388,6 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
   integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
 
-raven-js@3.26.3:
-  version "3.26.3"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.3.tgz#0efb49969b5b11ab965f7b0d6da4ca102b763cb0"
-  integrity sha512-VPAsPfK73A9VPcJx5X/kt0GxOqUGpGDM8vdzsYNQXMhYemyZGiW1JX1AI+f4jxm37Apijj6VVtCyJcYFz3ocSQ==
-
 raw-body@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"


### PR DESCRIPTION
## Overview

Remove Raven from the NPM dependencies for both the API and the frontend. In doing so, purge all references to Sentry from the application.

Closes #5 

## Notes

* While #5 suggests we might replace Sentry with Rollbar, this PR defers that decision to a later date. Sentry wasn't doing any interesting logging, so the existing code didn't give us much to build on immediately.

## Testing Instructions

* Run `vagrant ssh` to shell into the VM
* Run `./scripts/update` to update NPM dependencies
* Run `./scripts/server` and confirm that the API and frontend start up properly
* Visit http://localhost:8000 and confirm that the API returns a welcome message
* Visit http://localhost:3000 and confirm that you can log in
    * Note that #34 is preventing the latest version of Chrome from loading the app -- if you need to get around this, edit `src/react/src/App.jsx` and remove [lines 93-95](https://github.com/azavea/open-apparel-registry/blob/052c59c72e1e6f3b6eaf40a9715d1fb332562eed/src/react/src/App.jsx#L93-L95) and [line 148](https://github.com/azavea/open-apparel-registry/blob/052c59c72e1e6f3b6eaf40a9715d1fb332562eed/src/react/src/App.jsx#L148)