### PR TITLE
Switch Django to use port 8081

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In development, the [Django](https://www.djangoproject.com) app sits behind a [G
 | Service                          | Port                            |
 | -------------------------------- | ------------------------------- |
 | React development server         | [`3000`](http://localhost:3000) |
-| Gunicorn for Django app          | [`8080`](http://localhost:8080) |
+| Gunicorn for Django app          | [`8081`](http://localhost:8081) |
 | Restify development server       | [`8000`](http://localhost:8000) |
 
 # Scripts

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 3000, host: 3000
 
   # Gunicorn for Django app
-  config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :forwarded_port, guest: 8081, host: 8081
  
   # Restify development server
   config.vm.network :forwarded_port, guest: 8000, host: 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,14 +34,14 @@ services:
       database:
         condition: service_healthy
     command:
-        - '-b :8080'
+        - '-b :8081'
         - '--reload'
         - '--access-logfile=-'
         - '--error-logfile=-'
         - '--log-level=debug'
         - 'oar.wsgi'
     ports:
-        - '8080:8080'
+        - '8081:8081'
 
   app:
     image: node:8-slim
@@ -51,7 +51,7 @@ services:
       - $HOME/.aws:/root/.aws:ro
     env_file: .env.frontend
     environment:
-      - REACT_APP_API_URL=http://localhost:8080
+      - REACT_APP_API_URL=http://localhost:8081
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=2000
       - PORT=3000

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/local/src
 
-CMD ["-b :8080", \
+CMD ["-b :8081", \
 "--workers=2", \
 "--timeout=60", \
 "--access-logfile=-", \


### PR DESCRIPTION
Fixes port collision to make `develop` pass.

See failed build: http://civicci01.internal.azavea.com/job/azavea/job/open-apparel-registry/job/develop/9/