### PR TITLE
Move React app `node_modules` to `/var/cache/`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     image: node:10-slim
     volumes:
       - ./src/app:/usr/local/src
+      - /var/cache/open-apparel-registry-node-modules:/usr/local/src/node_modules
       - ./dist:/usr/local/src/build
       - $HOME/.aws:/root/.aws:ro
     env_file: .env.frontend


### PR DESCRIPTION
## Overview

This PR updates the docker-compose setup to mount the React app's node modules dir as a volume from `/var/cache/open-apparel-registry-node-modules` in VM instead of keeping it in the src directory.

This speeds up installation by quite a bit. Previously it took 8-10 minutes to install them; now it takes just over two minutes:

![screen shot 2019-01-11 at 4 14 24 pm](https://user-images.githubusercontent.com/4165523/51059972-fe3d2b00-15bb-11e9-8dbf-efcd87a8bc24.png)

I believe that having it in `app/src/node_modules` created some overhead with the file system watching, since that dir is mounted from the container to the VM back to the host.

This also seems to have massively sped up the linting and unit tests, I think because they no longer have to parse the node_modules dir at all?

![screen shot 2019-01-11 at 4 15 27 pm](https://user-images.githubusercontent.com/4165523/51060029-262c8e80-15bc-11e9-99ee-32a3d792fe0f.png)

Connects #71

## Testing

- get this branch, then remove your React container image and `./scripts/update`
- verify that the node_modules installation takes < 200 seconds
- run `./scripts/test` and verify that it also completes much more rapidly