### PR TITLE
Rename remaining `showChildren` prop to `when`

### DIFF
--- a/src/app/src/containers/ControlPanel.jsx
+++ b/src/app/src/containers/ControlPanel.jsx
@@ -716,7 +716,7 @@ class ControlPanel extends PureComponent {
                                                 disableRipple
                                             >
                                                 <ShowOnly
-                                                    showChildren={!showFacroiesList}
+                                                    when={!showFacroiesList}
                                                 >
                                                     VIEW{' '}
                                                 </ShowOnly>

--- a/src/app/src/containers/Lists.jsx
+++ b/src/app/src/containers/Lists.jsx
@@ -294,7 +294,7 @@ class Lists extends Component {
                     <Grid container className="margin-bottom-64">
                         <ShowOnly when={data.length > 0}>
                             <ShowOnly
-                                showChildren={
+                                when={
                                     processdate &&
                                     processdateStr &&
                                     processdateStr !== ''
@@ -596,13 +596,13 @@ class Lists extends Component {
                                                                         </TableCell>
                                                                         <TableCell padding="dense">
                                                                             <ShowOnly
-                                                                                showChildren={
+                                                                                when={
                                                                                     n.processed !==
                                                                                         undefined
                                                                                 }
                                                                             >
                                                                                 <ShowOnly
-                                                                                    showChildren={
+                                                                                    when={
                                                                                         exactMatch
                                                                                     }
                                                                                     className="display-flex"
@@ -611,7 +611,7 @@ class Lists extends Component {
                                                                                         Match
                                                                                 </ShowOnly>
                                                                                 <ShowOnly
-                                                                                    showChildren={
+                                                                                    when={
                                                                                         m.confirm ===
                                                                                                 undefined &&
                                                                                             !exactMatch
@@ -650,7 +650,7 @@ class Lists extends Component {
                                                                                     </div>
                                                                                 </ShowOnly>
                                                                                 <ShowOnly
-                                                                                    showChildren={
+                                                                                    when={
                                                                                         !exactMatch &&
                                                                                             (m.confirm ||
                                                                                                 m.confirm ===


### PR DESCRIPTION
## Overview

In #87 I renamed the `ShowOnly` component's `if` prop to `when`, but tried out renaming it to `showChildren` first. However, when finally renaming everything to use `when` I missed three uses. This PR renames those three.

Connects #31 

## Testing

- `./script/server` and verify that the app works
- search the project for `showChildren` and verify that you don't see anymore uses of that name