### PR TITLE
Remove Django from requirements.txt

### DIFF
--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,4 +1,3 @@
-Django==2.0.9
 django-jsonview==1.2.0
 django-watchman==0.15.0
 django-extensions==2.1.4


### PR DESCRIPTION
## Overview

Since Django is provided by the base Docker image, remove it from
requirements.txt.

## Testing Instructions

- `vagrant destroy`
- `./scripts/setup`
- `./scripts/server`
- `./scripts/test`

to verify that each step above works

