### PR TITLE
Configure redux-devtools

### DIFF
--- a/src/app/src/configureStore.js
+++ b/src/app/src/configureStore.js
@@ -2,13 +2,24 @@ import { compose, createStore, applyMiddleware } from 'redux';
 import { createLogger } from 'redux-logger';
 import { persistStore } from 'redux-persist';
 import thunkMiddleware from 'redux-thunk';
+import isObject from 'lodash/isObject';
+
 import rootReducer from './reducers';
 
-const middleware = process.env.NODE_ENV === 'development'
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+/* eslint-disable no-underscore-dangle */
+const devtoolsExtensionCompose = isDevelopment
+    && isObject(window)
+    && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+/* eslint-enable no-underscore-dangle */
+
+const middleware = isDevelopment
     ? [thunkMiddleware, createLogger({ diff: true, collapsed: true })]
     : [thunkMiddleware];
 
-const createStoreWithMiddleware = applyMiddleware(...middleware)(createStore);
+const composeEnhancers = devtoolsExtensionCompose || compose;
+const enhancer = composeEnhancers(applyMiddleware(...middleware));
 
-export const store = compose(createStoreWithMiddleware(rootReducer, {}));
+export const store = createStore(rootReducer, enhancer);
 export const persistor = persistStore(store);


### PR DESCRIPTION
## Overview

This PR adjusts the Redux store to make use of the Redux devtools browser extension if the environment is development and if the browser has Redux devtools installed; otherwise it's just the usual setup.

One of the main benefits of this is the ability to do time travel debugging via manipulating the store. Demo gif below:

## Demo

![timetravel](https://user-images.githubusercontent.com/4165523/51486577-10168f00-1d6f-11e9-8707-359016c8a3fc.gif)

## Notes

Extension is available for Chrome and Firefox: https://github.com/zalmoxisus/redux-devtools-extension

## Testing Instructions

- get this branch and start the server in a browser which does not have the Redux devtools extension installed and verify that everything works as it did before
- install Redux devtools then reload the app and verify that you can use the tools to inspect the store