### PR TITLE
Add support for django-spa and WhiteNoise

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     volumes:
       - ./src/app:/usr/local/src
       - /var/cache/open-apparel-registry-node-modules:/usr/local/src/node_modules
-      - ./dist:/usr/local/src/build
+      - ./src/django/static:/usr/local/src/build
       - $HOME/.aws:/root/.aws:ro
     env_file: .env.frontend
     environment:

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -25,15 +25,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         ./scripts/test
 
+        # Build static asset bundle for React frontend
+        docker-compose \
+            run --rm --no-deps app \
+            yarn run build
+
         # Build tagged container images
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f docker-compose.yml \
             -f docker-compose.ci.yml \
             build django
-
-        # Build static asset bundle for React frontend
-        docker-compose \
-            run --rm --no-deps app \
-            yarn run build
     fi
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -17,13 +17,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Ensure container images are current
-        docker-compose build --pull
-
         # Install frontend NPM modules
         docker-compose \
             run --rm --no-deps app \
             yarn install
+
+        # Build static asset bundle for React frontend
+        docker-compose \
+            run --rm --no-deps app \
+            yarn run build
 
         # Bring up PostgreSQL and Django in a way that respects
         # configured service health checks.

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -8,6 +8,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/local/src
 
+RUN python manage.py collectstatic --no-input
+
 CMD ["-b :8081", \
 "--workers=2", \
 "--timeout=60", \

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -82,12 +82,14 @@ REST_FRAMEWORK = {
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'spa.middleware.SPAMiddleware',
 ]
 
 ROOT_URLCONF = 'oar.urls'
@@ -168,6 +170,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+STATICFILES_STORAGE = 'spa.storage.SPAStaticFilesStorage'
 
 # Watchman
 WATCHMAN_ERROR_CODE = 503

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -5,6 +5,7 @@ djangorestframework==3.9.0
 djangorestframework-gis==0.14
 django-rest-auth==0.9.3
 django-allauth==0.37.0
+django-spa==0.2.0
 flake8==3.6.0
 mccabe==0.6.1
 pycodestyle==2.4.0


### PR DESCRIPTION
## Overview

* Build static asset bundle before building container images in `cibuild`
* Build static bundle after installing NPM deps in `update`
* Run `collectstatic` mgmt. command in `django/Dockerfile`
* Add [`django-spa`](https://github.com/metakermit/django-spa) and [`whitenoise`](http://whitenoise.evans.io/en/stable/django.html) to `django/requirements.txt`
* Configure `django-spa` and `whitenoise` in `django/oar/settings.py`

Resolves #57 

## Notes

The fact that building the Django container image relies on a preexisting static asset bundle makes me feel uncomfortable. I don't like that there are actions required for the container image that aren't encapsulated in the `Dockerfile`. 

I'm interesting to hear your thoughts on this. 

It's also worth mentioning we've used `django-spa` on https://github.com/azavea/american-water-tank-management.

## Testing Instructions

Run `scripts/cibuild` within the VM, and see that the static asset bundle has made it's way into the container:

```bash
# After running `cibuild`
vagrant@vagrant:/vagrant$ docker run --rm -ti --entrypoint /bin/bash open-apparel-registry-api:874fc53
root@eeb940a622bf:/usr/local/src# ls -l static/
total 76
drwxr-xr-x 6 root root  4096 Jan 23 17:34 admin
-rw-r--r-- 1 root root   912 Jan 23 17:34 asset-manifest.json
drwxr-xr-x 5 root root  4096 Jan 23 17:34 django_extensions
-rw-r--r-- 1 root root 23762 Jan 23 17:33 favicon.ico
drwxr-xr-x 5 root root  4096 Jan 23 17:34 gis
-rw-r--r-- 1 root root  1396 Jan 23 17:34 index.html
-rw-r--r-- 1 root root   317 Jan 23 17:33 manifest.json
drwxr-xr-x 7 root root  4096 Jan 23 17:34 rest_framework
-rw-r--r-- 1 root root  3846 Jan 23 17:34 service-worker.js
drwxr-xr-x 5 root root  4096 Jan 23 17:34 static
-rw-r--r-- 1 root root 13937 Jan 23 17:34 staticfiles.json
root@eeb940a622bf:/usr/local/src# exit
vagrant@vagrant:/vagrant$ ls -l src/django/static/
total 40
-rw-r--r-- 1 vagrant vagrant   912 Jan 23 17:34 asset-manifest.json
-rw-r--r-- 1 vagrant vagrant 23762 Jan 23 17:33 favicon.ico
-rw-r--r-- 1 vagrant vagrant  1396 Jan 23 17:34 index.html
-rw-r--r-- 1 vagrant vagrant   317 Jan 23 17:33 manifest.json
-rw-r--r-- 1 vagrant vagrant  3846 Jan 23 17:34 service-worker.js
drwxr-xr-x 1 vagrant vagrant   160 Jan 23 17:34 static
vagrant@vagrant:/vagrant$
```

Start the application:

```bash
vagrant@vagrant:/vagrant$ ./scripts/server
```

See the React frontend is served by Django at http://localhost:8081.
