### PR TITLE
Make Google API key available to Django via .env.backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,34 @@
 
 The Open Apparel Registry (OAR) is a tool to identify every apparel facility worldwide.
 
-* [Requirements](#requirements)
-* [Setup](#setup)
-  * [AWS](#aws)
-* [Development](#development)
-  * [Legacy API](#legacy-api)
-  * [Hot Reloading 🔥](#hot-reloading-)
-* [Ports](#ports)
-* [Scripts](#scripts)
+- [Requirements](#requirements)
+- [Setup](#setup)
+- [Development](#development)
+  - [Legacy API](#legacy-api)
+  - [Hot Reloading 🔥](#hot-reloading-)
+  - [Ports](#ports)
+- [Scripts](#scripts)
 
-# Requirements
+## Requirements
+
 - Vagrant 2.1+
 - VirtualBox 5.0+
 - AWS CLI 1.1+
 - IAM credentials (for artifacts, secrets, etc)
 
-# Setup
+## Setup
 
-Setup the project's development environment:
+First, configure a local AWS profile with access to an S3 bucket with files containing project specific environment variables:
+
+```bash
+$ aws configure --profile open-apparel-registry
+AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+Default region name [None]: us-east-1
+Default output format [None]:
+```
+
+Next, use `setup` to bring up the development environment:
 
 ```bash
 $ ./scripts/setup
@@ -34,19 +44,7 @@ $ vagrant ssh
 vagrant@vagrant:/vagrant$
 ```
 
-#### AWS
-
-Before running `setup`, you need to configure an AWS profile with IAM credentials from the Open Apparel Registry account.
-
-```bash
-$ aws configure --profile open-apparel-registry
-AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
-AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-Default region name [None]: us-east-1
-Default output format [None]:
-```
-
-# Development
+## Development
 
 To start the application, run:
 
@@ -58,7 +56,7 @@ $ vagrant ssh
 vagrant@vagrant:/vagrant$ ./scripts/server
 ```
 
-#### Legacy API
+### Legacy API
 
 The legacy API is included in this repository. It uses [Restify](http://restify.com), a NodeJS framework, and MongoDB with ElasticSearch.
 
@@ -84,30 +82,30 @@ There is a separate `docker-compose.restify.yml` file that contains the legacy D
 
 The NodeJS backend uses [Nodemon](https://nodemon.io) to monitor for any source code changes and will automatically restart.
 
-#### Hot Reloading 🔥
+### Hot Reloading 🔥
 
 Because the frontend uses [Create React App](https://github.com/facebook/create-react-app/), which integrates with webpack, the page will automatically reload if you make changes to the code.
 
 In development, the [Django](https://www.djangoproject.com) app sits behind a [Gunicorn](https://www.gunicorn.org) worker that is passed the [`--reload` flag](https://docs.gunicorn.org/en/stable/settings.html#reload).
 
-# Ports
+### Ports
 
-| Service                          | Port                            |
-| -------------------------------- | ------------------------------- |
-| React development server         | [`6543`](http://localhost:6543) |
-| Gunicorn for Django app          | [`8081`](http://localhost:8081) |
-| Restify development server       | [`8000`](http://localhost:8000) |
+| Service                    | Port                            |
+| -------------------------- | ------------------------------- |
+| React development server   | [`6543`](http://localhost:6543) |
+| Gunicorn for Django app    | [`8081`](http://localhost:8081) |
+| Restify development server | [`8000`](http://localhost:8000) |
 
-# Scripts
+## Scripts
 
-| Name                   | Description                                                                  |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| `bootstrap`            | Pull `.env` files from S3 		                    |
-| `generate_fixed_dumps` | Import database dumps from Sourcemap, run `create_master_account_api_key.js`, and export new database dumps |
-| `infra`      	         | Plan and apply remote infrastructure changes 			                    |
-| `server`               | Run `docker-compose.yml` services                                            |
-| `setup`                | Provision Vagrant VM and run `update`                                        |
-| `test`                 | Run tests                                                                   |
-| `update`               | Builds and pulls container images using docker-compose                      |
-| `src/restify/scripts/create_master_account_api_key.js` | Generate a new API key associated with the UID defined by `MASTER_ACCOUNT` (in `.env.backend`) and print it in the console |
-| `src/restify/scripts/synchronize.js` | Index existing `Factory`, `Address`, and `Geo` MongoDB collections for ElasticSearch ([with `.synchronize()`](https://github.com/mongoosastic/mongoosastic#indexing-an-existing-collection)) |
+| Name                                                   | Description                                                                                                                                                                                  |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bootstrap`                                            | Pull `.env` files from S3                                                                                                                                                                    |
+| `generate_fixed_dumps`                                 | Import database dumps from Sourcemap, run `create_master_account_api_key.js`, and export new database dumps                                                                                  |
+| `infra`                                                | Plan and apply remote infrastructure changes                                                                                                                                                 |
+| `server`                                               | Run `docker-compose.yml` services                                                                                                                                                            |
+| `setup`                                                | Provision Vagrant VM and run `update`                                                                                                                                                        |
+| `test`                                                 | Run tests                                                                                                                                                                                    |
+| `update`                                               | Builds and pulls container images using docker-compose                                                                                                                                       |
+| `src/restify/scripts/create_master_account_api_key.js` | Generate a new API key associated with the UID defined by `MASTER_ACCOUNT` (in `.env.backend`) and print it in the console                                                                   |
+| `src/restify/scripts/synchronize.js`                   | Index existing `Factory`, `Address`, and `Geo` MongoDB collections for ElasticSearch ([with `.synchronize()`](https://github.com/mongoosastic/mongoosastic#indexing-an-existing-collection)) |

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -2,6 +2,8 @@
 aws_cli_version: "1.16.*"
 aws_profile: "open-apparel-registry"
 
+oar_settings_bucket: "openapparelregistry-development-config-us-east-1"
+
 docker_version: "18.*"
 docker_compose_version: "1.21.*"
 docker_users:

--- a/deployment/ansible/roles/open-apparel-registry.environment/tasks/main.yml
+++ b/deployment/ansible/roles/open-apparel-registry.environment/tasks/main.yml
@@ -5,6 +5,12 @@
     regexp: "^AWS_PROFILE="
     line: "AWS_PROFILE={{ aws_profile }}"
 
+- name: Set OAR_SETTINGS_BUCKET
+  lineinfile:
+    path: "/etc/environment" 
+    regexp: "^OAR_SETTINGS_BUCKET="
+    line: "OAR_SETTINGS_BUCKET={{ oar_settings_bucket }}"
+
 - name: Set vm.max_map_count for ElasticSearch
   sysctl:
     name: vm.max_map_count

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   django:
     image: open-apparel-registry-api
+    env_file: .env.backend
     environment:
         - POSTGRES_HOST=database
         - POSTGRES_PORT=5432

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 
 import os
 
+from django.core.exceptions import ImproperlyConfigured
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -177,3 +179,8 @@ WATCHMAN_CHECKS = (
 
 # Application settings
 MAX_UPLOADED_FILE_SIZE_IN_BYTES = 5242880
+
+GOOGLE_GEOCODING_API_KEY = os.getenv('GOOGLE_GEOCODING_API_KEY')
+if GOOGLE_GEOCODING_API_KEY is None:
+    raise ImproperlyConfigured(
+        'Invalid GOOGLE_GEOCODING_API_KEY provided, must be set')


### PR DESCRIPTION
## Overview

Take advantage of the existing S3 file syncing mechanism to pull down environment variable files from a secure location. Make the file's contents available to Django, and ensure that the variable is converted to a top-level Django setting inside of `settings.py`.

Fixes #109 

## Testing Instructions

* Use `setup` to provision the virtual machine (needed for `bootstrap` step below to work)
* Run `bootstrap` within the virtual machine to get the remote environment variable files
* Comment out the reference to `GOOGLE_GEOCODING_API_KEY` in `.env.backend`
* Run `server` within the virtual machine; ensure that Django raises a `ImproperlyConfigured` exception