### PR TITLE
Set Google API key for collectstatic

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -17,7 +17,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Lint Bash scripts
-        if which shellcheck > /dev/null; then
+        if command -v shellcheck > /dev/null; then
             shellcheck scripts/*
         fi
 

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -8,7 +8,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/local/src
 
-RUN python manage.py collectstatic --no-input
+RUN GOOGLE_GEOCODING_API_KEY="" \
+    python manage.py collectstatic --no-input
 
 CMD ["-b :8081", \
 "--workers=2", \


### PR DESCRIPTION
## Overview

Within the Django container image `Dockerfile`, ensure that the `collectstatic` command sets the `GOOGLE_GEOCODING_API_KEY` environment variable to avoid runtime exceptions.

Also fixes a small `shellcheck` linting issue with (wait for it), `lint`.

## Testing Instructions

Ensure that the following STRTA execute cleanly within the context of the virtual machine:

- `update`
- `cibuild`