### PR TITLE
Remove `containers/` dir

### DIFF
--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -12,10 +12,10 @@ import Footer from './components/Footer';
 import RegisterForm from './components/RegisterForm';
 import LoginForm from './components/LoginForm';
 import UserProfile from './components/UserProfile';
-import Contribute from './containers/Contribute';
-import Map from './containers/Map';
+import Contribute from './components/Contribute';
+import Map from './components/Map';
 import requireAuth from './requireAuth';
-import Lists from './containers/Lists';
+import Lists from './components/Lists';
 import ErrorBoundary from './components/ErrorBoundary';
 
 import './App.css';

--- a/src/app/src/components/Contribute.jsx
+++ b/src/app/src/components/Contribute.jsx
@@ -7,10 +7,10 @@ import MaterialButton from '@material-ui/core/Button';
 import { toast } from 'react-toastify';
 import PropTypes from 'prop-types';
 import { DownloadCSV } from '../util/util';
-import AppGrid from '../components/AppGrid';
-import ControlledTextInput from '../components/ControlledTextInput';
-import Button from '../components/Button';
-import ShowOnly from '../components/ShowOnly';
+import AppGrid from './AppGrid';
+import ControlledTextInput from './ControlledTextInput';
+import Button from './Button';
+import ShowOnly from './ShowOnly';
 import COLOURS from '../util/COLOURS';
 
 const styles = {

--- a/src/app/src/components/ControlPanel.jsx
+++ b/src/app/src/components/ControlPanel.jsx
@@ -21,8 +21,8 @@ import Checkbox from '@material-ui/core/Checkbox';
 import ListItemText from '@material-ui/core/ListItemText';
 import { parse } from 'json2csv';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import FactoryInfo from '../components/FactoryInfo';
-import ShowOnly from '../components/ShowOnly';
+import FactoryInfo from './FactoryInfo';
+import ShowOnly from './ShowOnly';
 import countries from '../data/countries.json';
 import * as sourceActions from '../actions/source';
 

--- a/src/app/src/components/Lists.jsx
+++ b/src/app/src/components/Lists.jsx
@@ -23,10 +23,10 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import PropTypes from 'prop-types';
 import { parse } from 'json2csv';
-import ShowOnly from '../components/ShowOnly';
-import TablePaginationWrapper from '../components/TablePaginationWrapper';
+import ShowOnly from './ShowOnly';
+import TablePaginationWrapper from './TablePaginationWrapper';
 import * as listsActions from '../actions/lists';
-import AppGrid from '../components/AppGrid';
+import AppGrid from './AppGrid';
 import { DownloadCSV } from '../util/util';
 
 const styles = {

--- a/src/app/src/components/Map.jsx
+++ b/src/app/src/components/Map.jsx
@@ -11,9 +11,9 @@ import { toast } from 'react-toastify';
 import PropTypes from 'prop-types';
 import ControlPanel from './ControlPanel';
 import * as mapActions from '../actions/map';
-import Button from '../components/Button';
-import MapLayers from '../components/MapLayers';
-import LandingAlert from '../components/LandingAlert';
+import Button from './Button';
+import MapLayers from './MapLayers';
+import LandingAlert from './LandingAlert';
 import '../styles/css/Map.css';
 
 mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_TOKEN;

--- a/src/app/src/components/Profile.jsx
+++ b/src/app/src/components/Profile.jsx
@@ -9,13 +9,13 @@ import { bindActionCreators } from 'redux';
 import { Link } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
-import Button from '../components/Button';
-import TextInput from '../components/inputs/TextInput';
-import SelectInput from '../components/inputs/SelectInput';
+import Button from './Button';
+import TextInput from './inputs/TextInput';
+import SelectInput from './inputs/SelectInput';
 import * as userActions from '../actions/user';
 import COLOURS from '../util/COLOURS';
-import AppGrid from '../components/AppGrid';
-import ShowOnly from '../components/ShowOnly';
+import AppGrid from './AppGrid';
+import ShowOnly from './ShowOnly';
 import '../styles/css/specialStates.css';
 
 const contributorTypeOptions = [


### PR DESCRIPTION
## Overview

The original React source had a `components` dir and a `containers` dir,
which is an idiomatic distinction meant to map on to a distinction
between React components which are connected to Redux and React
components which are not.

However, the original source files often didn't adhere to that
distinction, and our typical team design pattern is to use Redux state
pretty freely.

To reduce the dev environment's complexity, this commit

- moves the last five remaining files from `containers/` into
`components/`
- updates the import paths to work with the new file locations
- deletes the `containers/` dir

Connects #91

## Testing Instructions

- get this branch
- `./scripts/server` to verify that the application still works
- `./scripts/test` to verify that the tests still work

