### PR TITLE
Add naive facility matching function

### DIFF
--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -7,3 +7,4 @@ class CsvHeaderField:
 class ProcessingResultSection:
     PARSING = 'parsing'
     GEOCODING = 'geocoding'
+    MATCHING = 'matching'


### PR DESCRIPTION
## Overview

The `match_facility_list_item` function will eventually be run in a background task to process geocoded `FacilityListItem` objects. This naive string matching approach is a placeholder so we can build out the entire CSV processing pipeline.

Connects #79

## Testing Instructions

* Verify that `./scripts/test --django` completes without error

