### PR TITLE
Use a street address for geocoder testing

### DIFF
--- a/src/django/api/test_data.py
+++ b/src/django/api/test_data.py
@@ -1,3 +1,119 @@
+azavea_office_data = {
+    'full_response': {
+        'results': [
+            {
+                'address_components': [
+                    {
+                        'long_name': '990',
+                        'short_name': '990',
+                        'types': [
+                            'street_number'
+                        ]
+                    },
+                    {
+                        'long_name': 'Spring '
+                        'Garden '
+                        'Street',
+                        'short_name': 'Spring '
+                        'Garden '
+                        'St',
+                        'types': [
+                            'route'
+                        ]
+                    },
+                    {
+                        'long_name': 'North '
+                        'Philadelphia',
+                        'short_name': 'North '
+                        'Philadelphia',
+                        'types': [
+                            'neighborhood',
+                            'political'
+                        ]
+                    },
+                    {
+                        'long_name': 'Philadelphia',
+                        'short_name': 'Philadelphia',
+                        'types': [
+                            'locality',
+                            'political'
+                        ]
+                    },
+                    {
+                        'long_name': 'Philadelphia '
+                        'County',
+                        'short_name': 'Philadelphia '
+                        'County',
+                        'types': [
+                            'administrative_area_level_2',
+                            'political'
+                        ]
+                    },
+                    {
+                        'long_name': 'Pennsylvania',
+                        'short_name': 'PA',
+                        'types': [
+                            'administrative_area_level_1',
+                            'political'
+                        ]
+                    },
+                    {
+                        'long_name': 'United '
+                        'States',
+                        'short_name': 'US',
+                        'types': [
+                            'country',
+                            'political'
+                        ]
+                    },
+                    {
+                        'long_name': '19123',
+                        'short_name': '19123',
+                        'types': ['postal_code']
+                    }
+                ],
+                'formatted_address': '990 Spring Garden St, '
+                'Philadelphia, PA 19123, '
+                'USA',
+                'geometry': {
+                    'location': {
+                        'lat': 39.9614572,
+                        'lng': -75.1541475
+                    },
+                    'location_type': 'ROOFTOP',
+                    'viewport': {
+                        'northeast': {
+                            'lat': 39.9628061802915,
+                            'lng': -75.15279851970848
+                        },
+                        'southwest': {
+                            'lat': 39.9601082197085,
+                            'lng': -75.1554964802915
+                        }
+                    }
+                },
+                'place_id': 'ChIJMzsCZH_IxokRJfDHFHZZDTw',
+                'plus_code': {
+                    'compound_code': 'XR6W+H8 '
+                    'Philadelphia, '
+                    'Pennsylvania, '
+                    'United States',
+                    'global_code': '87F6XR6W+H8'
+                },
+                'types': [
+                    'street_address'
+                ]
+            }
+        ],
+        'status': 'OK'
+    },
+    'geocoded_address': '990 Spring Garden St, Philadelphia, PA 19123, USA',
+    'geocoded_point': {
+        'lat': 39.9614572,
+        'lng': -75.1541475
+    }
+}
+
 parsed_city_hall_data = {
     'geocoded_point': {
         'lat': 39.9525839,

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -20,7 +20,7 @@ from api.processing import (parse_facility_list_item,
 from api.geocoding import (create_geocoding_api_url,
                            format_geocoded_address_data,
                            geocode_address)
-from api.test_data import parsed_city_hall_data
+from api.test_data import azavea_office_data, parsed_city_hall_data
 
 
 class FacilityListCreateTest(APITestCase):
@@ -291,8 +291,8 @@ class GeocodingUtilsTest(TestCase):
 
 class GeocodingTest(TestCase):
     def test_correct_address_is_geocoded_properly(self):
-        geocoded_data = geocode_address('City Hall, Philly', 'US')
-        self.assertDictEqual(geocoded_data, parsed_city_hall_data)
+        geocoded_data = geocode_address('990 Spring Garden St, Philly', 'US')
+        self.assertDictEqual(geocoded_data, azavea_office_data)
 
     def test_ungeocodable_address_returns_value_error(self):
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
## Overview

Google was not reliably returning the name result for "City Hall," which lead to a brittle test.

Connects #153

## Testing Instructions

* Verify that `./scripts/test --django` passes multiple times.

