### PR TITLE
Add Management Command for Batch Processing Items

### DIFF
--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -4,10 +4,10 @@ class CsvHeaderField:
     ADDRESS = 'address'
 
 
-class ProcessingResultSection:
-    PARSING = 'parsing'
-    GEOCODING = 'geocoding'
-    MATCHING = 'matching'
+class ProcessingAction:
+    PARSE = 'parse'
+    GEOCODE = 'geocode'
+    MATCH = 'match'
 
 
 class FacilitiesQueryParams:

--- a/src/django/api/management/commands/batch_process.py
+++ b/src/django/api/management/commands/batch_process.py
@@ -1,0 +1,110 @@
+import os
+import sys
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from api.constants import ProcessingAction
+from api.models import FacilityList, FacilityListItem
+from api.processing import (parse_facility_list_item,
+                            geocode_facility_list_item,
+                            match_facility_list_item)
+
+ACTIONS = {
+    ProcessingAction.PARSE: parse_facility_list_item,
+    ProcessingAction.GEOCODE: geocode_facility_list_item,
+    ProcessingAction.MATCH: match_facility_list_item,
+}
+
+
+class Command(BaseCommand):
+    help = 'Run an action on all items in a facility list. If ' \
+           'AWS_BATCH_JOB_ARRAY_INDEX environment variable is set, will ' \
+           'process those items whose row_index matches it. Otherwise, will ' \
+           'process all items for the given facility list.'
+
+    def add_arguments(self, parser):
+        # Create a group of arguments explicitly labeled as required,
+        # because by default named arguments are considered optional.
+        group = parser.add_argument_group('required arguments')
+        group.add_argument('-a', '--action',
+                           required=True,
+                           help='The processing action to perform. '
+                                'One of "parse", "geocode", "match"')
+        group.add_argument('-l', '--list-id',
+                           required=True,
+                           help='The id of the facility list to process.')
+
+    def handle(self, *args, **options):
+        action = options['action']
+        list_id = options['list_id']
+
+        # Crash if invalid action specified
+        if action not in ACTIONS.keys():
+            self.stderr.write('Validation Error: Invalid action "{}". '
+                              'Must be one of "parse", "geocode", "match".'
+                              .format(action))
+            sys.exit(1)
+
+        process = ACTIONS[action]
+
+        # Crash if invalid list_id specified
+        try:
+            facility_list = FacilityList.objects.get(pk=list_id)
+        except FacilityList.DoesNotExist:
+            self.stderr.write('Validation Error: '
+                              'No facility list with id {}.'.format(list_id))
+            sys.exit(1)
+
+        row_index = os.environ.get('AWS_BATCH_JOB_ARRAY_INDEX')
+        if row_index:
+            items = FacilityListItem.objects.filter(
+                facility_list=facility_list,
+                row_index=row_index)
+        else:
+            items = FacilityListItem.objects.filter(
+                facility_list=facility_list)
+
+        result = {
+            'success': 0,
+            'failure': 0,
+        }
+
+        # Process all items, save affected items, facilities, matches,
+        # and tally successes and failures
+        for item in items:
+            try:
+                with transaction.atomic():
+                    if action == ProcessingAction.MATCH:
+                        facility, match = process(item)
+                        item.save()
+                        facility.save()
+                        # Assign facility to match after it has been
+                        # saved and assigned an ID
+                        match.facility = facility
+                        match.save()
+                    else:
+                        process(item)
+                        item.save()
+
+                if item.status == FacilityListItem.ERROR:
+                    result['failure'] += 1
+                else:
+                    result['success'] += 1
+            except ValueError as e:
+                self.stderr.write('Value Error: {}'.format(e))
+                result['failure'] += 1
+
+        # Print successes
+        if result['success'] > 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    '{}: {} successes'.format(
+                        action, result['success'])))
+
+        # Print failures
+        if result['failure'] > 0:
+            self.stdout.write(
+                self.style.ERROR(
+                    '{}: {} failures'.format(
+                        action, result['failure'])))

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from django.contrib.auth.models import (AbstractBaseUser,
                                         BaseUserManager,
                                         PermissionsMixin)
@@ -369,8 +371,23 @@ class Facility(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    @classmethod
+    def make_oar_id(cls):
+        # TODO implement a better OAR ID.
+        new_id = None
+        while new_id is None:
+            new_id = uuid4().hex[:8]
+            if Facility.objects.filter(id=new_id).exists():
+                new_id = None
+        return new_id
+
     def __str__(self):
         return '{name} ({id})'.format(**self.__dict__)
+
+    def save(self, *args, **kwargs):
+        if self.id == '':
+            self.id = Facility.make_oar_id()
+        super(Facility, self).save(*args, **kwargs)
 
 
 class FacilityMatch(models.Model):

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -133,3 +133,4 @@ def match_facility_list_item(item):
             'trace': traceback.format_exc(),
             'finished_at': str(datetime.utcnow()),
         }
+        return None, None

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from django.contrib.gis.geos import Point
 
-from api.constants import CsvHeaderField, ProcessingResultSection
+from api.constants import CsvHeaderField, ProcessingAction
 from api.models import Facility, FacilityMatch, FacilityListItem
 from api.countries import COUNTRY_CODES, COUNTRY_NAMES
 from api.geocoding import geocode_address
@@ -44,14 +44,14 @@ def parse_facility_list_item(item):
         if CsvHeaderField.ADDRESS in fields:
             item.address = values[fields.index(CsvHeaderField.ADDRESS)]
         item.status = FacilityListItem.PARSED
-        item.processing_results[ProcessingResultSection.PARSING] = {
+        item.processing_results[ProcessingAction.PARSE] = {
             'started_at': started,
             'error': False,
             'finished_at': str(datetime.utcnow()),
         }
     except Exception as e:
         item.status = FacilityListItem.ERROR
-        item.processing_results[ProcessingResultSection.PARSING] = {
+        item.processing_results[ProcessingAction.PARSE] = {
             'started_at': started,
             'error': True,
             'message': str(e),
@@ -74,7 +74,7 @@ def geocode_facility_list_item(item):
             data["geocoded_point"]["lat"]
         )
         item.geocoded_address = data["geocoded_address"]
-        item.processing_results[ProcessingResultSection.GEOCODING] = {
+        item.processing_results[ProcessingAction.GEOCODE] = {
             'started_at': started,
             'error': False,
             'data': data["full_response"],
@@ -83,7 +83,7 @@ def geocode_facility_list_item(item):
         }
     except Exception as e:
         item.status = FacilityListItem.ERROR
-        item.processing_results[ProcessingResultSection.GEOCODING] = {
+        item.processing_results[ProcessingAction.GEOCODE] = {
             'started_at': started,
             'error': True,
             'message': str(e),
@@ -118,7 +118,7 @@ def match_facility_list_item(item):
                               status=FacilityMatch.AUTOMATIC)
 
         item.status = FacilityListItem.MATCHED
-        item.processing_results[ProcessingResultSection.MATCHING] = {
+        item.processing_results[ProcessingAction.MATCH] = {
             'started_at': started,
             'error': False,
             'finished_at': str(datetime.utcnow()),
@@ -126,7 +126,7 @@ def match_facility_list_item(item):
         return facility, match
     except Exception as e:
         item.status = FacilityListItem.ERROR
-        item.processing_results[ProcessingResultSection.MATCHING] = {
+        item.processing_results[ProcessingAction.MATCH] = {
             'started_at': started,
             'error': True,
             'message': str(e),

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -11,7 +11,7 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
-from api.constants import ProcessingResultSection
+from api.constants import ProcessingAction
 from api.models import (Facility, FacilityList, FacilityListItem,
                         FacilityMatch, Organization, User)
 from api.processing import (parse_facility_list_item,
@@ -255,9 +255,9 @@ class FacilityListCreateTest(APITestCase):
 class FacilityListItemParseTest(TestCase):
     def assert_successful_parse_results(self, item):
         self.assertEqual(FacilityListItem.PARSED, item.status)
-        self.assertTrue(ProcessingResultSection.PARSING
+        self.assertTrue(ProcessingAction.PARSE
                         in item.processing_results)
-        results = item.processing_results[ProcessingResultSection.PARSING]
+        results = item.processing_results[ProcessingAction.PARSE]
         self.assertTrue('error' in results)
         self.assertFalse(results['error'])
         self.assertTrue('started_at' in results)
@@ -266,9 +266,9 @@ class FacilityListItemParseTest(TestCase):
 
     def assert_failed_parse_results(self, item, message=None):
         self.assertEqual(FacilityListItem.ERROR, item.status)
-        self.assertTrue(ProcessingResultSection.PARSING
+        self.assertTrue(ProcessingAction.PARSE
                         in item.processing_results)
-        results = item.processing_results[ProcessingResultSection.PARSING]
+        results = item.processing_results[ProcessingAction.PARSE]
         self.assertTrue('error' in results)
         self.assertTrue(results['error'])
         self.assertTrue('message' in results)
@@ -417,7 +417,7 @@ class FacilityListItemGeocodingTest(TestCase):
         self.assertEqual(item.status, FacilityListItem.GEOCODED)
         self.assertIn(
             'results',
-            item.processing_results[ProcessingResultSection.GEOCODING]['data'],
+            item.processing_results[ProcessingAction.GEOCODE]['data'],
         )
 
     def test_failed_geocoded_item_has_error_results(self):
@@ -435,7 +435,7 @@ class FacilityListItemGeocodingTest(TestCase):
         self.assertIsNone(item.geocoded_point)
         self.assertIn(
             'error',
-            item.processing_results[ProcessingResultSection.GEOCODING],
+            item.processing_results[ProcessingAction.GEOCODE],
         )
 
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -498,6 +498,7 @@ class FacilityListItemMatchingTest(TestCase):
         item_1.save()
         facility_1, match_1 = match_facility_list_item(item_1)
         facility_1.save()
+        match_1.facility = facility_1
         match_1.save()
         item_2 = FacilityListItem(row_index=1,
                                   address='1234 Main St', country_code='US',


### PR DESCRIPTION
## Overview

Adds a management command for batch processing of facility list items.

Connects #161 

## Demo

![image](https://user-images.githubusercontent.com/1430060/52298450-f8cfc800-2950-11e9-96e0-b840d0dba9f2.png)

## Notes

What should be done in the case of partial failures? For example, if geocoding fails for a few results, matching cannot be run at all. But neither can geocoding be re-run, leaving the user in a trapped state:

![image](https://user-images.githubusercontent.com/1430060/52298857-fd48b080-2951-11e9-9cdf-d7aaf158994a.png)

Should there be a flag to ignore error cases? Or to abort if there is a single error?

## Testing Instructions

* Check out this branch
* Run `manage batch_process --help`
* Run `manage batch_process --action [parse|geocode|match] --list-id [id]`
* Ensure it works correctly and handles failure cases