### PR TITLE
Bump database service container image to use PostgreSQL 10.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   database:
-    image: quay.io/azavea/postgis:2.4-postgres10.3-slim
+    image: quay.io/azavea/postgis:2.4-postgres10.6-slim
     environment:
       - POSTGRES_USER=openapparelregistry
       - POSTGRES_PASSWORD=openapparelregistry


### PR DESCRIPTION
## Overview

We weren't using a 10.6 container image before, because we hadn't yet added one to the docker-postgis build matrix.

Closes #137 

## Testing Instructions

```bash
vagrant@vagrant:/vagrant$ ./scripts/test; echo $?
...
Pulling database (quay.io/azavea/postgis:2.4-postgres10.6-slim)...
2.4-postgres10.6-slim: Pulling from azavea/postgis
5e6ec7f28fb7: Already exists
5e2aec55a5ab: Pull complete
966624e73f54: Pull complete
3c5197efa683: Pull complete
bb4834c5b0ba: Pull complete
32e88c2d07b1: Pull complete
6a7e663589c9: Pull complete
16acf43c5b2b: Pull complete
f0b4a8223658: Pull complete
c900d65a932b: Pull complete
c2bcdb7b93c0: Pull complete
864ece1e6b41: Pull complete
f3a2aa127cdb: Pull complete
b99c92b6c1b2: Pull complete
c3d8f97d778a: Pull complete
Digest: sha256:38854e0815bea895ddaa8a8e900ed05ca1c322b810f9114a4d14986ff40fef91
Status: Downloaded newer image for quay.io/azavea/postgis:2.4-postgres10.6-slim
Starting vagrant_database_1 ... done
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.....................................
----------------------------------------------------------------------
Ran 37 tests in 62.826s

OK
Destroying test database for alias 'default'...
0
vagrant@vagrant:/vagrant$
```
