### PR TITLE
Replace email with user name and enable downloading CSVs across browsers

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -8,6 +8,7 @@
         "@material-ui/icons": "3.0.1",
         "@turf/turf": "5.1.6",
         "axios": "0.18.0",
+        "file-saver": "2.0.0",
         "json2csv": "4.1.6",
         "immutability-helper": "2.9.0",
         "lodash": "4.17.11",

--- a/src/app/src/components/NavbarLoginButtonGroup.jsx
+++ b/src/app/src/components/NavbarLoginButtonGroup.jsx
@@ -105,7 +105,7 @@ function NavbarLoginButtonGroup({
             >
                 <Translate />
                 <NavbarDropdown
-                    title={user.email.toUpperCase()}
+                    title={user.name}
                     links={createUserDropdownLinks(user, logout)}
                 />
             </span>

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -10,7 +10,9 @@ import negate from 'lodash/negate';
 import omitBy from 'lodash/omitBy';
 import isEmpty from 'lodash/isEmpty';
 import flow from 'lodash/flow';
+import noop from 'lodash/noop';
 import { featureCollection, bbox } from '@turf/turf';
+import { saveAs } from 'file-saver';
 
 import {
     OTHER,
@@ -22,21 +24,16 @@ import {
 } from './constants';
 
 export function DownloadCSV(data, fileName) {
-    const csvData = new Blob([data], { type: 'text/csv;charset=utf-8;' });
-    if (window.navigator.msSaveOrOpenBlob) {
-        // IE hack; see http://msdn.microsoft.com/en-us/library/ie/hh779016.aspx
-        window.navigator.msSaveBlob(csvData, fileName);
-    } else {
-        const csvURL = window.URL.createObjectURL(csvData);
-        const tempLink = document.createElement('a');
-        tempLink.href = csvURL;
-        tempLink.setAttribute('download', fileName);
-        tempLink.click();
-    }
+    saveAs(
+        new Blob([data], { type: 'text/csv;charset=utf-8;' }),
+        fileName,
+    );
+
+    return noop();
 }
 
 export const downloadContributorTemplate = () =>
-    DownloadCSV(contributeCSVTemplate, 'OAR_Contributor_Template');
+    DownloadCSV(contributeCSVTemplate, 'OAR_Contributor_Template.csv');
 
 export const makeUserLoginURL = () => '/user-login/';
 export const makeUserLogoutURL = () => '/user-logout/';

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -5524,6 +5524,11 @@ file-loader@1.1.5:
     loader-utils "^1.0.2"
     schema-utils "^0.3.0"
 
+file-saver@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.0.tgz#74eef7748159503b60008a15af2f1930fb5df7ab"
+  integrity sha512-cYM1ic5DAkg25pHKgi5f10ziAM7RJU37gaH1XQlyNDrtUnzhC/dfoV9zf2OmF0RMKi42jG5B0JWBnPQqyj/G6g==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
## Overview

This PR:

- updates the navbar's indication of who is the logged in user to show the name rather than the email addres
- replaces the existing DownloadCSV function implementation with the https://www.npmjs.com/package/file-saver library, which works across browsers and is better tested.

Connects #176 
Connects #177 

## Notes

The app currently isn't working in IE11 due to some missing polyfills, including one for the string `startsWith` method used by redux-act. I briefly looked into fixing this but then made a dedicated card for it: #180 

## Testing Instructions

- get this branch, then `./scripts/update`
- `./scripts/server` then visit the app on 6543 and login
- verify that you see the name rather than the email address displayed in the top right corner
- click on the `contribute` link then click on "Download OAR Contributor Template" and verify that the file downloads correctly

(repeat the last step in Firefox, Chrome, and Safari. IE11 currently won't work, as noted above, but `file-saver` supports IE10+ https://www.npmjs.com/package/file-saver#supported-browsers)

