### PR TITLE
Allow Postgres to be accessible from host machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,9 @@ Vagrant.configure("2") do |config|
     vb.memory = 4096 # React ran out of memory at 1024
   end
 
+  # Postgres Database
+    config.vm.network :forwarded_port, guest: 5432, host: 5432
+
   # React development server
   config.vm.network :forwarded_port, guest: 6543, host: 6543
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,17 @@
 version: '2.3'
 services:
+  database:
+    image: quay.io/azavea/postgis:2.4-postgres10.3-slim
+    environment:
+      - POSTGRES_USER=openapparelregistry
+      - POSTGRES_PASSWORD=openapparelregistry
+      - POSTGRES_DB=openapparelregistry
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "openapparelregistry"]
+      interval: 3s
+      timeout: 3s
+      retries: 3
+
   django:
     image: "openapparelregistry:${GIT_COMMIT:-latest}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - POSTGRES_USER=openapparelregistry
       - POSTGRES_PASSWORD=openapparelregistry
       - POSTGRES_DB=openapparelregistry
+    ports:
+      - '5432:5432'
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "openapparelregistry"]
       interval: 3s


### PR DESCRIPTION
## Overview

This allows the use of custom Postgres GUI clients, such as [Postico](https://eggerapps.at/postico/), to be used to inspect the database.

## Demo

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/1430060/52370677-867ae880-2a21-11e9-99c7-84001b23d5d1.png">