### PR TITLE
Sync filter state with querystring parameters

### DIFF
--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -1,7 +1,20 @@
 import { createAction } from 'redux-act';
 
+import { createFiltersFromQueryString } from '../util/util';
+
 export const updateFacilityNameFilter = createAction('UPDATE_FACILITY_NAME_FILTER');
 export const updateContributorFilter = createAction('UPDATE_CONTRIBUTOR_FILTER');
 export const updateContributorTypeFilter = createAction('UPDATE_CONTRIBUTOR_TYPE_FILTER');
 export const updateCountryFilter = createAction('UPDATE_COUNTRY_FILTER');
 export const resetAllFilters = createAction('RESET_ALL_FILTERS');
+export const updateAllFilters = createAction('UPDATE_ALL_FILTERS');
+
+export function setFiltersFromQueryString(qs = '') {
+    return (dispatch) => {
+        if (!qs) {
+            return null;
+        }
+
+        return dispatch(updateAllFilters(createFiltersFromQueryString(qs)));
+    };
+}

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -61,7 +61,16 @@ function FilterSidebarSearchTab({
     fetchingFacilities,
     searchForFacilities,
     facilities,
+    fetchingOptions,
 }) {
+    if (fetchingOptions) {
+        return (
+            <div className="control-panel__content">
+                <CircularProgress />
+            </div>
+        );
+    }
+
     const noFacilitiesFoundMessage = (() => {
         if (fetchingFacilities) {
             return null;
@@ -119,6 +128,7 @@ function FilterSidebarSearchTab({
                         options={contributorOptions}
                         value={contributors}
                         onChange={updateContributor}
+                        disabled={fetchingOptions || fetchingFacilities}
                     />
                 </div>
                 <div className="form__field">
@@ -138,6 +148,7 @@ function FilterSidebarSearchTab({
                         options={contributorTypeOptions}
                         value={contributorTypes}
                         onChange={updateContributorType}
+                        disabled={fetchingOptions || fetchingFacilities}
                     />
                 </div>
                 <div className="form__field">
@@ -157,6 +168,7 @@ function FilterSidebarSearchTab({
                         options={countryOptions}
                         value={countries}
                         onChange={updateCountry}
+                        disabled={fetchingOptions || fetchingFacilities}
                     />
                 </div>
                 <div className="form__action">
@@ -174,6 +186,7 @@ function FilterSidebarSearchTab({
                             disableRipple
                             color="primary"
                             className="outlined-button"
+                            disabled={fetchingOptions}
                         >
                             Reset
                         </Button>
@@ -193,6 +206,7 @@ function FilterSidebarSearchTab({
                                         className="margin-left-16 blue-background"
                                         style={{ boxShadow: 'none' }}
                                         onClick={searchForFacilities}
+                                        disabled={fetchingOptions}
                                     >
                                         Search
                                     </Button>)
@@ -225,18 +239,22 @@ FilterSidebarSearchTab.propTypes = {
     fetchingFacilities: bool.isRequired,
     searchForFacilities: func.isRequired,
     facilities: facilityCollectionPropType,
+    fetchingOptions: bool.isRequired,
 };
 
 function mapStateToProps({
     filterOptions: {
         contributors: {
             data: contributorOptions,
+            fetching: fetchingContributors,
         },
         contributorTypes: {
             data: contributorTypeOptions,
+            fetching: fetchingContributorTypes,
         },
         countries: {
             data: countryOptions,
+            fetching: fetchingCountries,
         },
     },
     filters: {
@@ -262,6 +280,9 @@ function mapStateToProps({
         countries,
         fetchingFacilities,
         facilities,
+        fetchingOptions: fetchingContributors
+            || fetchingContributorTypes
+            || fetchingCountries,
     };
 }
 

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -9,9 +9,11 @@ import OARMap from './OARMap';
 
 import '../styles/css/Map.css';
 
+import withQueryStringSync from '../util/withQueryStringSync';
+
 import { facilityDetailsRoute } from '../util/constants';
 
-export default function MapAndSidebar() {
+function MapAndSidebar() {
     return (
         <div>
             <LandingAlert />
@@ -42,3 +44,5 @@ export default function MapAndSidebar() {
         </div>
     );
 }
+
+export default withQueryStringSync(MapAndSidebar);

--- a/src/app/src/components/OARMap.jsx
+++ b/src/app/src/components/OARMap.jsx
@@ -37,6 +37,7 @@ const OARMapStyles = Object.freeze({
     }),
 });
 
+const loadEvent = 'load';
 const moveEvent = 'move';
 const clickEvent = 'click';
 const mouseEnterEvent = 'mouseenter';
@@ -66,6 +67,7 @@ class OARMap extends Component {
                 lng,
                 zoom,
             },
+            data,
         } = this.props;
 
         this.oarMap = new mapboxgl.Map({
@@ -91,6 +93,19 @@ class OARMap extends Component {
 
         this.oarMap.on(moveEvent, this.handleMapMove);
         this.oarMap.on(clickEvent, this.handleMapClick);
+
+        this.oarMap.on(loadEvent, () => {
+            if (data) {
+                this.oarMap.addSource(
+                    FACILITIES_SOURCE,
+                    createSourceFromData(data),
+                );
+
+                oarMapLayers.forEach((layer) => { this.oarMap.addLayer(layer); });
+                this.oarMap.on(mouseEnterEvent, oarMapLayerIDEnum.points, this.makePointerCursor);
+                this.oarMap.on(mouseLeaveEvent, oarMapLayerIDEnum.points, this.makePanCursor);
+            }
+        });
     }
 
     componentDidUpdate({ fetching: wasFetching }) {

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -7,7 +7,14 @@ import {
     updateContributorTypeFilter,
     updateCountryFilter,
     resetAllFilters,
+    updateAllFilters,
 } from '../actions/filters';
+
+import {
+    completeFetchContributorOptions,
+    completeFetchContributorTypeOptions,
+    completeFetchCountryOptions,
+} from '../actions/filterOptions';
 
 const initialState = Object.freeze({
     facilityName: '',
@@ -15,6 +22,93 @@ const initialState = Object.freeze({
     contributorTypes: Object.freeze([]),
     countries: Object.freeze([]),
 });
+
+const maybeSetContributorOptionsFromQueryString = (state, payload) => {
+    if (!state.contributors.length) {
+        return state;
+    }
+
+    // filter out any options set from the querystring which turn out
+    // not to be valid according to the API's response
+    const updatedContributors = state
+        .contributors
+        .reduce((accumulator, { value }) => {
+            const validOption = payload
+                .find(({ value: otherValue }) => value === otherValue);
+
+            if (!validOption) {
+                return accumulator;
+            }
+
+            return accumulator
+                .concat(Object.freeze({
+                    value,
+                    label: validOption.label,
+                }));
+        }, []);
+
+    return update(state, {
+        contributors: { $set: updatedContributors },
+    });
+};
+
+const maybeSetContributorTypeOptionsFromQueryString = (state, payload) => {
+    if (!state.contributorTypes.length) {
+        return state;
+    }
+
+    // filter out any options set from the querystring which turn out
+    // not to be valid according to the API's response
+    const updatedContributorTypes = state
+        .contributorTypes
+        .reduce((accumulator, { value }) => {
+            const validOption = payload
+                .find(({ value: otherValue }) => value === otherValue);
+
+            if (!validOption) {
+                return accumulator;
+            }
+
+            return accumulator
+                .concat(Object.freeze({
+                    value,
+                    label: validOption.label,
+                }));
+        }, []);
+
+    return update(state, {
+        contributorTypes: { $set: updatedContributorTypes },
+    });
+};
+
+const maybeSetCountryOptionsFromQueryString = (state, payload) => {
+    if (!state.countries.length) {
+        return state;
+    }
+
+    // filter out any options set from the querystring which turn out
+    // not to be valid according to the API's response
+    const updatedCountries = state
+        .countries
+        .reduce((accumulator, { value }) => {
+            const validOption = payload
+                .find(({ value: otherValue }) => value === otherValue);
+
+            if (!validOption) {
+                return accumulator;
+            }
+
+            return accumulator
+                .concat(Object.freeze({
+                    value,
+                    label: validOption.label,
+                }));
+        }, []);
+
+    return update(state, {
+        countries: { $set: updatedCountries },
+    });
+};
 
 export default createReducer({
     [updateFacilityNameFilter]: (state, payload) => update(state, {
@@ -30,4 +124,8 @@ export default createReducer({
         countries: { $set: payload },
     }),
     [resetAllFilters]: () => initialState,
+    [updateAllFilters]: (_state, payload) => payload,
+    [completeFetchContributorOptions]: maybeSetContributorOptionsFromQueryString,
+    [completeFetchContributorTypeOptions]: maybeSetContributorTypeOptionsFromQueryString,
+    [completeFetchCountryOptions]: maybeSetCountryOptionsFromQueryString,
 }, initialState);

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -1,4 +1,4 @@
-import { arrayOf, bool, func, number, oneOf, shape, string } from 'prop-types';
+import { arrayOf, bool, func, number, oneOf, oneOfType, shape, string } from 'prop-types';
 
 import {
     registrationFieldsEnum,
@@ -53,7 +53,7 @@ export const facilityListPropType = shape({
 });
 
 export const contributorOptionsPropType = arrayOf(shape({
-    value: number.isRequired,
+    value: oneOfType([number, string]).isRequired,
     label: string.isRequired,
 }));
 
@@ -88,4 +88,16 @@ export const facilityPropType = shape({
 export const facilityCollectionPropType = shape({
     type: oneOf([FEATURE_COLLECTION]).isRequired,
     features: arrayOf(facilityPropType).isRequired,
+});
+
+export const reactSelectOptionPropType = shape({
+    value: oneOfType([number, string]).isRequired,
+    label: string.isRequired,
+});
+
+export const filtersPropType = shape({
+    facilityName: string.isRequired,
+    contributors: arrayOf(reactSelectOptionPropType).isRequired,
+    contributorTypes: arrayOf(reactSelectOptionPropType).isRequired,
+    countries: arrayOf(reactSelectOptionPropType).isRequired,
 });

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -1,0 +1,102 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { func, shape, string } from 'prop-types';
+
+import { setFiltersFromQueryString } from '../actions/filters';
+
+import {
+    fetchFacilities,
+    resetFacilities,
+} from '../actions/facilities';
+
+import { filtersPropType } from '../util/propTypes';
+
+import {
+    createQueryStringFromSearchFilters,
+    allFiltersAreEmpty,
+} from '../util/util';
+
+export default function withQueryStringSync(WrappedComponent) {
+    const componentWithWrapper = class extends Component {
+        componentDidMount() {
+            const {
+                history: {
+                    replace,
+                    location: {
+                        search,
+                    },
+                },
+                filters,
+                hydrateFiltersFromQueryString,
+            } = this.props;
+
+            return (search && allFiltersAreEmpty(filters))
+                ? hydrateFiltersFromQueryString(search)
+                : replace(`?${createQueryStringFromSearchFilters(filters)}`);
+        }
+
+        componentDidUpdate() {
+            const {
+                filters,
+                history: {
+                    replace,
+                    location: {
+                        search,
+                    },
+                },
+            } = this.props;
+
+            const newQueryString = `?${createQueryStringFromSearchFilters(filters)}`;
+
+            if (search === newQueryString) {
+                return null;
+            }
+
+            if (!search && newQueryString.length === 1) {
+                return null;
+            }
+
+            return replace(newQueryString);
+        }
+
+        componentWillUnmount() {
+            return this.props.clearFacilities();
+        }
+
+        render() {
+            return <WrappedComponent {...this.props} />;
+        }
+    };
+
+    componentWithWrapper.propTypes = {
+        filters: filtersPropType.isRequired,
+        hydrateFiltersFromQueryString: func.isRequired,
+        clearFacilities: func.isRequired,
+        history: shape({
+            replace: func.isRequired,
+            location: shape({
+                search: string.isRequired,
+            }),
+        }).isRequired,
+    };
+
+    function mapStateToProps({
+        filters,
+    }) {
+        return {
+            filters,
+        };
+    }
+
+    function mapDispatchToProps(dispatch) {
+        return {
+            hydrateFiltersFromQueryString: (qs) => {
+                dispatch(setFiltersFromQueryString(qs));
+                return dispatch(fetchFacilities());
+            },
+            clearFacilities: () => dispatch(resetFacilities()),
+        };
+    }
+
+    return connect(mapStateToProps, mapDispatchToProps)(componentWithWrapper);
+}


### PR DESCRIPTION
## Overview

This PR enables syncing the selected search filter options with querystring parameters via:

- setting the querystring parameters to reflect the filter selection state when filters have been selected
- setting the filter selection state from the querystring parameters when the user visits the app via a shareable link like:

http://localhost:6543/?name=shoe&contributors=2&contributors=4&contributor_types=Auditor&contributor_types=Union&countries=AO&countries=BY

To accomplish this I created a `withQueryStringSync` higher order component which can wrap whatever other component that will manage keeping the querystring and Redux state in sync. I have it applied to the `MapAndSidebar` component now, but it theoretically could wrap only the actual filter component OR wrap the entire application.

I also made corresponding changes to Redux actions, utility functions, and utility function tests. 

Connects #162 

## Demo

![qs-persistence](https://user-images.githubusercontent.com/4165523/52448540-450e3a00-2b02-11e9-9441-d9c1cb065ca2.gif)


## Notes

See https://reactjs.org/docs/higher-order-components.html for explanation of higher order components generally. We use them with libraries but haven't commonly written them; in this case it made sense to use that pattern.

Note that there's a brief moment in which the labels for the query parameters are incorrect; this happens because the list of `contributors` and `countries` options comes back from the API, so we do not know what the label is until checking in the returned response. There's also a check to ensure these parameters are valid according to the API's set of valid options.

I set the select, search, and reset inputs to be disabled while fetching valid options from the API btw.

## Testing Instructions

- serve this branch and visit

http://localhost:6543/?name=shoe&contributors=2&contributors=4&contributor_types=Auditor&contributor_types=Union&countries=AO&countries=BY

to verify that the query parameters are set from the string

- click "Reset" to reset the parameters and verify that they stay in sync
- select some options and verify that they are persisted in the querystring
- visit the Register/Login/Contribute page and verify that the querystring params disappear
- click back to return to the main map page and verify that the querystring params reappear
- click "Share this search" to copy the url to the clipboard, then paste it back in the browser and hit return to verify that your selected params are re-hydrated

- visit http://localhost:6543/?name=shoe&countries=Hello World and verify that the invalid country is dropped from the select option -- and removed from the querystring params -- when the valid set of filters returns from the API