### PR TITLE
Add support for Rollbar on Django

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,9 +53,17 @@ node {
 		        // set it as the value of the `GIT_COMMIT` environment variable.
 		        env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
 
+		        // Environment used in Rollbar deploy notifications.
+		        // https://docs.rollbar.com/reference#post-deploy
+		        env.OAR_DEPLOYMENT_ENVIRONMENT = 'staging'
+
 				wrap([$class: 'AnsiColorBuildWrapper']) {
 					sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
-					sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+					withCredentials([[$class: 'StringBinding',
+									credentialsId: 'OAR_ROLLBAR_ACCESS_TOKEN',
+									variable: 'OAR_ROLLBAR_ACCESS_TOKEN']]) {
+						sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+					}
 				}
 			}
 		}

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -112,6 +112,8 @@ data "template_file" "app" {
 
     google_geocoding_api_key = "${var.google_geocoding_api_key}"
 
+    rollbar_server_side_access_token = "${var.rollbar_server_side_access_token}"
+
     django_secret_key = "${var.django_secret_key}"
 
     default_from_email = "${var.default_from_email}"
@@ -153,6 +155,8 @@ data "template_file" "app_cli" {
     postgres_db       = "${var.rds_database_name}"
 
     google_geocoding_api_key = "${var.google_geocoding_api_key}"
+
+    rollbar_server_side_access_token = "${var.rollbar_server_side_access_token}"
 
     django_secret_key = "${var.django_secret_key}"
 

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -13,7 +13,8 @@
         { "name": "DJANGO_ENV", "value": "${environment}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
-        { "name": "GOOGLE_GEOCODING_API_KEY", "value": "${google_geocoding_api_key}" }
+        { "name": "GOOGLE_GEOCODING_API_KEY", "value": "${google_geocoding_api_key}" },
+        { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" }
     ],
     "portMappings": [
       {

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -15,7 +15,8 @@
         { "name": "DJANGO_ENV", "value": "${environment}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
-        { "name": "GOOGLE_GEOCODING_API_KEY", "value": "${google_geocoding_api_key}" }
+        { "name": "GOOGLE_GEOCODING_API_KEY", "value": "${google_geocoding_api_key}" },
+        { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" }
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -56,6 +56,8 @@ variable "app_port" {
 
 variable "google_geocoding_api_key" {}
 
+variable "rollbar_server_side_access_token" {}
+
 variable "django_secret_key" {}
 
 variable "default_from_email" {}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,5 +13,7 @@ services:
       - GIT_COMMIT=${GIT_COMMIT:-latest}
       - OAR_DEBUG=1
       - OAR_SETTINGS_BUCKET=openapparelregistry-staging-config-us-east-1
+      - OAR_ROLLBAR_ACCESS_TOKEN
+      - OAR_DEPLOYMENT_ENVIRONMENT=${OAR_DEPLOYMENT_ENVIRONMENT:-staging}
     working_dir: /usr/local/src
     entrypoint: bash

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,6 +23,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        # Ensure container images are current
+        docker-compose build
+
         # Install frontend NPM modules
         docker-compose \
             run --rm --no-deps app \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -42,6 +42,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Make sure the database is up for Django tests
         docker-compose up -d database
 
-        ./scripts/test
+        ./scripts/test --ci
     fi
 fi

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,18 +23,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        # Ensure container images are current
-        docker-compose build
-
         # Install frontend NPM modules
         docker-compose \
             run --rm --no-deps app \
             yarn install
-
-        # Make sure the database is up for Django tests
-        docker-compose up -d database
-
-        ./scripts/test
 
         # Build static asset bundle for React frontend
         docker-compose \
@@ -46,5 +38,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             -f docker-compose.yml \
             -f docker-compose.ci.yml \
             build django
+
+        # Make sure the database is up for Django tests
+        docker-compose up -d database
+
+        ./scripts/test
     fi
 fi

--- a/scripts/infra
+++ b/scripts/infra
@@ -50,6 +50,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 ;;
             apply)
                 terraform apply "${OAR_SETTINGS_BUCKET}.tfplan"
+
+                # Notify Rollbar of the deploy when running on Jenkins
+                if [[ -n "${OAR_ROLLBAR_ACCESS_TOKEN}" && -n "${OAR_DEPLOYMENT_ENVIRONMENT}" ]]; then
+                    curl -s https://api.rollbar.com/api/1/deploy/ \
+                        -F "access_token=${OAR_ROLLBAR_ACCESS_TOKEN}" \
+                        -F "environment=${OAR_DEPLOYMENT_ENVIRONMENT}" \
+                        -F "revision=${GIT_COMMIT}" \
+                        -F "local_username=jenkins"
+                fi
                 ;;
             *)
                 echo "ERROR: I don't have support for that Terraform subcommand!"

--- a/scripts/test
+++ b/scripts/test
@@ -23,6 +23,14 @@ function test_django() {
         manage.py test --noinput
 }
 
+function test_django_ci() {
+    GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+        -f docker-compose.yml \
+        -f docker-compose.ci.yml \
+        run --rm --entrypoint python django \
+        manage.py test --noinput
+}
+
 function test_app() {
     docker-compose \
         run --rm --no-deps app \
@@ -38,6 +46,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         test_app
     elif [ "${1:-}" = "--django" ]; then
         test_django
+    elif [ "${1:-}" = "--ci" ]; then
+        lint
+        test_app
+        test_django_ci
     else
         lint
         test_app

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -119,7 +119,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'spa.middleware.SPAMiddleware',
-    'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
+    'rollbar.contrib.django.middleware.RollbarNotifierMiddlewareExcluding404',
 ]
 
 ROOT_URLCONF = 'oar.urls'

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -102,6 +102,7 @@ REST_AUTH_SERIALIZERS = {
 }
 
 REST_FRAMEWORK = {
+    'EXCEPTION_HANDLER': 'rollbar.contrib.django_rest_framework.post_exception_handler',
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
@@ -118,6 +119,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'spa.middleware.SPAMiddleware',
+    'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
 ]
 
 ROOT_URLCONF = 'oar.urls'
@@ -223,3 +225,12 @@ GOOGLE_GEOCODING_API_KEY = os.getenv('GOOGLE_GEOCODING_API_KEY')
 if GOOGLE_GEOCODING_API_KEY is None:
     raise ImproperlyConfigured(
         'Invalid GOOGLE_GEOCODING_API_KEY provided, must be set')
+
+if not DEBUG:
+    ROLLBAR = {
+        'access_token': os.getenv('ROLLBAR_SERVER_SIDE_ACCESS_TOKEN'),
+        'environment': ENVIRONMENT.lower(),
+        'root': BASE_DIR,
+    }
+    import rollbar
+    rollbar.init(**ROLLBAR)

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -13,3 +13,4 @@ pyflakes==2.0.0
 pytz==2018.7
 requests==2.21.0
 django-amazon-ses==2.0.0
+rollbar==0.14.6


### PR DESCRIPTION
## Overview

* Wire up Rollbar for Django (https://docs.rollbar.com/docs/python/#section-django)
* Add Rollbar [deploy notifications](https://docs.rollbar.com/reference#post-deploy)
* Build container images before `cibuild`

I included what I did out-of-band in the parent issue.


Closes #62 

## Testing Instructions

First, I had Jenkins cycle my changes onto staging:

```bash
$ git push -u origin feature/jrb/django-rollbar:test/jrb/django-rollbar
```

See deploy notification in #oar Slack channel:

<img width="569" alt="image" src="https://user-images.githubusercontent.com/1774125/52440825-20f42e00-2aed-11e9-98aa-772f3d41aba7.png">

Next, I triggered #188 by logging into https://staging.openapparel.org/admin:

<img width="595" alt="image" src="https://user-images.githubusercontent.com/1774125/52440949-6284d900-2aed-11e9-9801-ebfa55a954c9.png">

https://rollbar.com/OpenApparelRegistry/OpenApparelRegistry/items/3/




