### PR TITLE
Avoid a crash in Django admin by specifying a custom OarUserAdmin

### DIFF
--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -3,7 +3,17 @@ from django.contrib.auth.admin import UserAdmin
 
 from api import models
 
-admin.site.register(models.User, UserAdmin)
+
+class OarUserAdmin(UserAdmin):
+    exclude = ('last_name', 'date_joined', 'first_name')
+    fieldsets = (
+        (None, {'fields': ('email', 'username', 'is_staff', 'is_active',
+                           'should_receive_newsletter',
+                           'has_agreed_to_terms_of_service')}),
+    )
+
+
+admin.site.register(models.User, OarUserAdmin)
 admin.site.register(models.Organization)
 admin.site.register(models.FacilityList)
 admin.site.register(models.FacilityListItem)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -139,13 +139,13 @@ class User(AbstractBaseUser, PermissionsMixin):
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return self.name
+        return self.email
 
     def get_full_name(self):
-        return self.name
+        return self.email
 
     def get_short_name(self):
-        return self.name
+        return self.email
 
     def first_name(self):
         pass


### PR DESCRIPTION
## Overview

The built-in admin forms were looking for fields and values that do not exist on our custom User model. Adding a customer admin class allows us to specify the fields that should be excluded and the fields that should appear on the form.

Connects #188

## Demo

<img width="958" alt="screen shot 2019-02-07 at 3 14 07 pm" src="https://user-images.githubusercontent.com/17363/52446384-1f296b00-2aeb-11e9-9cae-be58bbc56a66.png">

<img width="1362" alt="screen shot 2019-02-07 at 3 14 23 pm" src="https://user-images.githubusercontent.com/17363/52446395-23558880-2aeb-11e9-9aaa-a5af333c61dc.png">

<img width="716" alt="screen shot 2019-02-07 at 3 14 32 pm" src="https://user-images.githubusercontent.com/17363/52446401-26e90f80-2aeb-11e9-9079-15657e8a263b.png">

## Testing Instructions

* Load fixtures if they have not been loaded already.
* Browse `/admin` and log in as `admin@openapparel.org`.
* Verify that the user-related pages are browsable.

