### PR TITLE
Add corejs library for use in IE11 polyfills

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -8,6 +8,7 @@
         "@material-ui/icons": "3.0.1",
         "@turf/turf": "5.1.6",
         "axios": "0.18.0",
+        "core-js": "2.6.4",
         "file-saver": "2.0.0",
         "json2csv": "4.1.6",
         "immutability-helper": "2.9.0",

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -1,3 +1,11 @@
+// polyfills for IE11
+// catalog of other is available at https://github.com/zloirock/core-js/tree/v2
+import 'core-js/fn/string/starts-with';
+import 'core-js/fn/object/values';
+import 'core-js/fn/array/find';
+import 'core-js/fn/array/find-index';
+import 'core-js/fn/object/assign';
+
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -4062,6 +4062,11 @@ copy-to-clipboard@^3:
   dependencies:
     toggle-selection "^1.0.3"
 
+core-js@2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
+  integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"


### PR DESCRIPTION
## Overview

Add corejs library which enables importing polyfills for IE11 on a
method-by-method basis, and to adjust which polyfills are imported while
the development server is running.

I chose this solution as an alternative to using `@babel/polyfill` which
unfortunately caused a 10x increase in the time it took for the client
dev server to start, seemingly because it was parsing all the code in
node_modules for every polyfill.

corejs also lets you import additional polyfills on the fly, so it seemed like a lightweight way to
help the set of necessary polyfills keep up with whatever syntax we were using.

See https://github.com/zloirock/core-js/tree/v2

Connects #180 

## Demo

![screen shot 2019-02-08 at 5 16 57 pm](https://user-images.githubusercontent.com/4165523/52509469-4143eb80-2bc6-11e9-95a5-3d35c90073a0.png)

## Testing Instructions

- get this branch and `./scripts/update`
- visit localhost:6543 in FF, Chrome, Safari and verify the app works as before in each
- visit the app in IE11 and verify that it also works
