### PR TITLE
Implement List Details page

### DIFF
--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -15,6 +15,7 @@ import UserProfile from './components/UserProfile';
 import Contribute from './components/Contribute';
 import MapAndSidebar from './components/MapAndSidebar';
 import FacilityLists from './components/FacilityLists';
+import FacilityListItems from './components/FacilityListItems';
 import ErrorBoundary from './components/ErrorBoundary';
 
 import './App.css';
@@ -27,6 +28,7 @@ import {
     authRegisterFormRoute,
     contributeRoute,
     listsRoute,
+    facilityListItemsRoute,
     facilitiesRoute,
     profileRoute,
 } from './util/constants';
@@ -74,6 +76,10 @@ class App extends Component {
                                 <Route
                                     path={contributeRoute}
                                     component={Contribute}
+                                />
+                                <Route
+                                    path={facilityListItemsRoute}
+                                    component={FacilityListItems}
                                 />
                                 <Route
                                     path={listsRoute}

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -1,0 +1,36 @@
+import { createAction } from 'redux-act';
+
+import csrfRequest from '../util/csrfRequest';
+
+import {
+    logErrorAndDispatchFailure,
+    makeSingleFacilityListURL,
+} from '../util/util';
+
+export const startFetchFacilityListItems = createAction('START_FETCH_FACILITY_LIST_ITEMS');
+export const failFetchFacilityListItems = createAction('FAIL_FETCH_FACILITY_LIST_ITEMS');
+export const completeFetchFacilityListItems = createAction('COMPLETE_FETCH_FACILITY_LIST_ITEMS');
+export const resetFacilityListItems = createAction('RESET_FACILITY_LIST_ITEMS');
+
+export function fetchFacilityListItems(listID = null) {
+    return (dispatch) => {
+        dispatch(startFetchFacilityListItems());
+
+        if (!listID) {
+            return dispatch(logErrorAndDispatchFailure(
+                null,
+                'Missing required parameter list ID',
+                failFetchFacilityListItems,
+            ));
+        }
+
+        return csrfRequest
+            .get(makeSingleFacilityListURL(listID))
+            .then(({ data }) => dispatch(completeFetchFacilityListItems(data)))
+            .catch(err => dispatch(logErrorAndDispatchFailure(
+                err,
+                `An error prevented fetching facility list items for ${listID}`,
+                failFetchFacilityListItems,
+            )));
+    };
+}

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -1,0 +1,159 @@
+import React, { Component } from 'react';
+import { arrayOf, bool, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import { Link, Switch, Route } from 'react-router-dom';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+
+import AppGrid from './AppGrid';
+import FacilityListItemsEmpty from './FacilityListItemsEmpty';
+import FacilityListItemsTable from './FacilityListItemsTable';
+
+import {
+    fetchFacilityListItems,
+    resetFacilityListItems,
+} from '../actions/facilityListDetails';
+
+import {
+    listsRoute,
+    facilityListItemsRoute,
+} from '../util/constants';
+
+import { facilityListPropType } from '../util/propTypes';
+
+const facilityListItemsStyles = Object.freeze({
+    subheaderStyles: Object.freeze({
+        display: 'flex',
+        justifyContent: 'space-between',
+        width: '100%',
+        padding: '0.5rem',
+        marginBottom: '0.5rem',
+        alignContent: 'center',
+        alignItems: 'center',
+    }),
+    descriptionStyles: Object.freeze({
+        marginBottm: '30px',
+    }),
+});
+
+class FacilityListItems extends Component {
+    componentDidMount() {
+        return this.props.fetchListItems();
+    }
+
+    componentWillUnmount() {
+        return this.props.clearListItems();
+    }
+
+    render() {
+        const {
+            data,
+            fetching,
+            error,
+        } = this.props;
+
+        if (fetching) {
+            return (
+                <AppGrid title="">
+                    <CircularProgress />
+                </AppGrid>
+            );
+        }
+
+        if (error && error.length) {
+            return (
+                <AppGrid title="Unable to retrieve that list">
+                    <ul>
+                        {
+                            error
+                                .map(err => (
+                                    <li key={err}>
+                                        {err}
+                                    </li>))
+                        }
+                    </ul>
+                </AppGrid>
+            );
+        }
+
+        if (!data) {
+            return (
+                <AppGrid title="No list was found for that ID">
+                    <div />
+                </AppGrid>
+            );
+        }
+
+        return (
+            <AppGrid title={data.name || data.id}>
+                <div style={facilityListItemsStyles.subheaderStyles}>
+                    <Typography
+                        variant="subheading"
+                        style={facilityListItemsStyles.descriptionStyles}
+                    >
+                        {data.description || ''}
+                    </Typography>
+                    <Link
+                        to={listsRoute}
+                        href={listsRoute}
+                    >
+                        Back to lists
+                    </Link>
+                </div>
+                {
+                    data.items.length
+                        ? (
+                            <Switch>
+                                <Route
+                                    path={facilityListItemsRoute}
+                                    component={FacilityListItemsTable}
+                                />
+                            </Switch>)
+                        : <FacilityListItemsEmpty />
+                }
+            </AppGrid>
+        );
+    }
+}
+
+FacilityListItems.defaultProps = {
+    data: null,
+    error: null,
+};
+
+FacilityListItems.propTypes = {
+    data: facilityListPropType,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+    fetchListItems: func.isRequired,
+    clearListItems: func.isRequired,
+};
+
+function mapStateToProps({
+    facilityListDetails: {
+        data,
+        fetching,
+        error,
+    },
+}) {
+    return {
+        data,
+        fetching,
+        error,
+    };
+}
+
+function mapDispatchToProps(dispatch, {
+    match: {
+        params: {
+            listID,
+        },
+    },
+}) {
+    return {
+        fetchListItems: () => dispatch(fetchFacilityListItems(listID)),
+        clearListItems: () => dispatch(resetFacilityListItems()),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FacilityListItems);

--- a/src/app/src/components/FacilityListItemsEmpty.jsx
+++ b/src/app/src/components/FacilityListItemsEmpty.jsx
@@ -1,0 +1,25 @@
+import React, { memo } from 'react';
+
+const facilityListItemsEmptyStyles = Object.freeze({
+    containerStyle: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+    }),
+    linkStyle: Object.freeze({
+        marginTop: '30px',
+        width: '90px',
+    }),
+});
+
+const FacilityListItemsEmpty = memo(() => (
+    <div
+        className="margin-top-16"
+        style={facilityListItemsEmptyStyles.containerStyle}
+    >
+        <p>
+            No items were found for this list.
+        </p>
+    </div>
+));
+
+export default FacilityListItemsEmpty;

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { arrayOf, func, shape, string } from 'prop-types';
+import { connect } from 'react-redux';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableHead from '@material-ui/core/TableHead';
+import TableBody from '@material-ui/core/TableBody';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import TableFooter from '@material-ui/core/TableFooter';
+import TablePagination from '@material-ui/core/TablePagination';
+
+import { facilityListItemPropType } from '../util/propTypes';
+
+import {
+    makePaginatedFacilityListItemsDetailLinkWithRowCount,
+    getValueFromEvent,
+    makeSliceArgumentsForTablePagination,
+    createPaginationOptionsFromQueryString,
+} from '../util/util';
+
+import { rowsPerPageOptions } from '../util/constants';
+
+const facilityListItemsTableStyles = Object.freeze({
+    containerStyles: Object.freeze({
+        width: '100%',
+        marginBottom: '80px',
+    }),
+    tableWrapperStyles: Object.freeze({
+        overflowX: 'auto',
+    }),
+});
+
+function FacilityListItemsTable({
+    items,
+    match: {
+        params: {
+            listID,
+        },
+    },
+    history: {
+        push,
+        location: {
+            search,
+        },
+    },
+}) {
+    const {
+        page,
+        rowsPerPage,
+    } = createPaginationOptionsFromQueryString(search);
+
+    const handleChangePage = (_, newPage) =>
+        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            (newPage + 1),
+            rowsPerPage,
+        ));
+
+    const handleChangeRowsPerPage = e =>
+        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            page,
+            getValueFromEvent(e),
+        ));
+
+    const paginatedItems = items
+        .slice(...makeSliceArgumentsForTablePagination(page - 1, rowsPerPage));
+
+    const paginationControlsRow = (
+        <TableRow>
+            <TablePagination
+                count={items.length}
+                rowsPerPage={Number(rowsPerPage)}
+                rowsPerPageOptions={rowsPerPageOptions}
+                onChangeRowsPerPage={handleChangeRowsPerPage}
+                page={page - 1}
+                onChangePage={handleChangePage}
+            />
+        </TableRow>
+    );
+
+    return (
+        <Paper style={facilityListItemsTableStyles.containerStyles}>
+            <div style={facilityListItemsTableStyles.tableWrapperStyles}>
+                <Table>
+                    <TableHead>
+                        {paginationControlsRow}
+                        <TableRow>
+                            <TableCell>
+                                CSV Row Index
+                            </TableCell>
+                            <TableCell>
+                                Country
+                            </TableCell>
+                            <TableCell>
+                                Name
+                            </TableCell>
+                            <TableCell>
+                                Address
+                            </TableCell>
+                            <TableCell>
+                                Status
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {
+                            paginatedItems
+                                .map(item => (
+                                    <TableRow
+                                        key={item.row_index}
+                                        hover
+                                    >
+                                        <TableCell>
+                                            {item.row_index}
+                                        </TableCell>
+                                        <TableCell>
+                                            {item.country_code}
+                                        </TableCell>
+                                        <TableCell>
+                                            {item.name}
+                                        </TableCell>
+                                        <TableCell>
+                                            {item.address}
+                                        </TableCell>
+                                        <TableCell>
+                                            {item.status}
+                                        </TableCell>
+                                    </TableRow>))
+                        }
+                    </TableBody>
+                    <TableFooter>
+                        {paginationControlsRow}
+                    </TableFooter>
+                </Table>
+            </div>
+        </Paper>
+    );
+}
+
+FacilityListItemsTable.propTypes = {
+    items: arrayOf(facilityListItemPropType).isRequired,
+    match: shape({
+        params: shape({
+            listID: string.isRequired,
+        }),
+    }).isRequired,
+    history: shape({
+        push: func.isRequired,
+    }).isRequired,
+};
+
+function mapStateToProps({
+    facilityListDetails: {
+        data: {
+            items,
+        },
+    },
+}) {
+    return {
+        items,
+    };
+}
+
+export default connect(mapStateToProps)(FacilityListItemsTable);

--- a/src/app/src/components/FacilityLists.jsx
+++ b/src/app/src/components/FacilityLists.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import Grid from '@material-ui/core/Grid';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
 import AppGrid from './AppGrid';
@@ -75,14 +74,7 @@ class FacilityLists extends Component {
 
             return (
                 <AppGrid title="My Lists">
-                    <Grid
-                        container
-                        className="margin-bottom-16"
-                    >
-                        <Grid item xs={12}>
-                            {insetComponent}
-                        </Grid>
-                    </Grid>
+                    {insetComponent}
                 </AppGrid>
             );
         }
@@ -93,12 +85,7 @@ class FacilityLists extends Component {
 
         return (
             <AppGrid title="My Lists">
-                <Grid
-                    container
-                    className="margin-bottom-16"
-                >
-                    {tableComponent}
-                </Grid>
+                {tableComponent}
             </AppGrid>
         );
     }

--- a/src/app/src/components/FacilityListsTable.jsx
+++ b/src/app/src/components/FacilityListsTable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { arrayOf } from 'prop-types';
+import { arrayOf, func, shape } from 'prop-types';
+import { withRouter } from 'react-router-dom';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
@@ -8,9 +9,13 @@ import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 
 import { facilityListPropType } from '../util/propTypes';
+import { makeFacilityListItemsDetailLink } from '../util/util';
 
-export default function FacilityListsTable({
+function FacilityListsTable({
     facilityLists,
+    history: {
+        push,
+    },
 }) {
     return (
         <Paper style={{ width: '100%' }}>
@@ -38,7 +43,11 @@ export default function FacilityListsTable({
                     {
                         facilityLists
                             .map(list => (
-                                <TableRow key={list.id}>
+                                <TableRow
+                                    key={list.id}
+                                    hover
+                                    onClick={() => push(makeFacilityListItemsDetailLink(list.id))}
+                                >
                                     <TableCell>
                                         {list.name}
                                     </TableCell>
@@ -64,4 +73,9 @@ export default function FacilityListsTable({
 
 FacilityListsTable.propTypes = {
     facilityLists: arrayOf(facilityListPropType).isRequired,
+    history: shape({
+        push: func.isRequired,
+    }).isRequired,
 };
+
+export default withRouter(FacilityListsTable);

--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -1,0 +1,32 @@
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    startFetchFacilityListItems,
+    failFetchFacilityListItems,
+    completeFetchFacilityListItems,
+    resetFacilityListItems,
+} from '../actions/facilityListDetails';
+
+const initialState = Object.freeze({
+    data: null,
+    fetching: false,
+    error: null,
+});
+
+export default createReducer({
+    [startFetchFacilityListItems]: state => update(state, {
+        fetching: { $set: true },
+        error: { $set: null },
+    }),
+    [failFetchFacilityListItems]: (state, payload) => update(state, {
+        fetching: { $set: false },
+        error: { $set: payload },
+    }),
+    [completeFetchFacilityListItems]: (state, payload) => update(state, {
+        data: { $set: payload },
+        fetching: { $set: false },
+        error: { $set: null },
+    }),
+    [resetFacilityListItems]: () => initialState,
+}, initialState);

--- a/src/app/src/reducers/index.js
+++ b/src/app/src/reducers/index.js
@@ -10,6 +10,7 @@ import AuthReducer from './AuthReducer';
 import ProfileReducer from './ProfileReducer';
 import UploadReducer from './UploadReducer';
 import FacilityListsReducer from './FacilityListsReducer';
+import FacilityListDetailsReducer from './FacilityListDetailsReducer';
 import FilterOptionsReducer from './FilterOptionsReducer';
 import FiltersReducer from './FiltersReducer';
 import UIReducer from './UIReducer';
@@ -21,6 +22,7 @@ export default combineReducers({
     profile: ProfileReducer,
     upload: UploadReducer,
     facilityLists: FacilityListsReducer,
+    facilityListDetails: FacilityListDetailsReducer,
     filterOptions: FilterOptionsReducer,
     filters: FiltersReducer,
     ui: UIReducer,

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -165,6 +165,7 @@ export const authLoginFormRoute = '/auth/login';
 export const authRegisterFormRoute = '/auth/register';
 export const contributeRoute = '/contribute';
 export const listsRoute = '/lists';
+export const facilityListItemsRoute = '/lists/:listID';
 export const facilitiesRoute = '/facilities';
 export const facilityDetailsRoute = '/facilities/:oarID';
 export const profileRoute = '/profile/:id';
@@ -216,4 +217,26 @@ export const filterSidebarTabs = Object.freeze([
         tab: filterSidebarTabsEnum.search,
         label: 'Search',
     }),
+]);
+
+// These values must be kept in sync with the tuple of STATUS_CHOICES
+// declared on the API's FacilityListItem model. See:
+// https://github.com/open-apparel-registry/open-apparel-registry/blob/a6e68960d3e1c547c7c2c1935fd28fde6108e3c6/src/django/api/models.py#L224
+
+export const facilityListItemStatusChoicesEnum = Object.freeze({
+    UPLOADED: 'UPLOADED',
+    PARSED: 'PARSED',
+    GEOCODED: 'GEOCODED',
+    MATCHED: 'MATCHED',
+    POTENTIAL_MATCH: 'POTENTIAL_MATCH',
+    CONFIRMED_MATCH: 'CONFIRMED_MATCH',
+    ERROR: 'ERROR',
+});
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_ROWS_PER_PAGE = 20;
+export const rowsPerPageOptions = Object.freeze([
+    DEFAULT_ROWS_PER_PAGE,
+    50,
+    100,
 ]);

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -3,6 +3,7 @@ import { arrayOf, bool, func, number, oneOf, oneOfType, shape, string } from 'pr
 import {
     registrationFieldsEnum,
     profileFieldsEnum,
+    facilityListItemStatusChoicesEnum,
 } from './constants';
 
 export const registrationFormValuesPropType = shape({
@@ -43,6 +44,23 @@ export const tokenPropType = shape({
     created: string.isRequired,
 });
 
+export const facilityListItemPropType = shape({
+    id: number.isRequired,
+    row_index: number.isRequired,
+    raw_data: string.isRequired,
+    status: oneOf(Object.values(facilityListItemStatusChoicesEnum)).isRequired,
+    processing_started_at: string,
+    processing_completed_at: string,
+    processing_results: arrayOf(shape({})),
+    name: string.isRequired,
+    address: string.isRequired,
+    country_code: string.isRequired,
+    geocoded_point: string,
+    geocoded_address: string,
+    facility_list: number.isRequired,
+    facility: string,
+});
+
 export const facilityListPropType = shape({
     id: number.isRequired,
     name: string,
@@ -50,6 +68,7 @@ export const facilityListPropType = shape({
     file_name: string.isRequired,
     is_active: bool.isRequired,
     is_public: bool.isRequired,
+    items: arrayOf(facilityListItemPropType),
 });
 
 export const contributorOptionsPropType = arrayOf(shape({

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -14,6 +14,7 @@ import flow from 'lodash/flow';
 import noop from 'lodash/noop';
 import compact from 'lodash/compact';
 import startsWith from 'lodash/startsWith';
+import head from 'lodash/head';
 import { featureCollection, bbox } from '@turf/turf';
 import { saveAs } from 'file-saver';
 
@@ -24,6 +25,8 @@ import {
     registrationFormFields,
     contributeCSVTemplate,
     facilitiesRoute,
+    DEFAULT_PAGE,
+    DEFAULT_ROWS_PER_PAGE,
 } from './constants';
 
 export function DownloadCSV(data, fileName) {
@@ -117,6 +120,37 @@ export const createFiltersFromQueryString = (qs) => {
         contributors: createSelectOptionsFromParams(contributors),
         contributorTypes: createSelectOptionsFromParams(contributorTypes),
         countries: createSelectOptionsFromParams(countries),
+    });
+};
+
+export const getNumberFromParsedQueryStringParamOrUseDefault = (inputValue, defaultValue) => {
+    if (!inputValue) {
+        return defaultValue;
+    }
+
+    const nonArrayValue = isArray(inputValue)
+        ? head(inputValue)
+        : inputValue;
+
+    return Number(nonArrayValue) || defaultValue;
+};
+
+export const createPaginationOptionsFromQueryString = (qs) => {
+    const qsToParse = startsWith(qs, '?')
+        ? qs.slice(1)
+        : qs;
+
+    const {
+        page,
+        rowsPerPage,
+    } = querystring.parse(qsToParse);
+
+    return Object.freeze({
+        page: getNumberFromParsedQueryStringParamOrUseDefault(page, DEFAULT_PAGE),
+        rowsPerPage: getNumberFromParsedQueryStringParamOrUseDefault(
+            rowsPerPage,
+            DEFAULT_ROWS_PER_PAGE,
+        ),
     });
 };
 
@@ -243,3 +277,12 @@ export const getBBoxForArrayOfGeoJSONPoints = flow(
     featureCollection,
     bbox,
 );
+
+export const makeFacilityListItemsDetailLink = id => `/lists/${id}`;
+export const makePaginatedFacilityListItemsDetailLinkWithRowCount = (id, page, rowsPerPage) =>
+    `/lists/${id}?page=${page}&rowsPerPage=${rowsPerPage}`;
+
+export const makeSliceArgumentsForTablePagination = (page, rowsPerPage) => Object.freeze([
+    page * rowsPerPage,
+    (page + 1) * rowsPerPage,
+]);

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -221,6 +221,8 @@ class FacilityListItem(models.Model):
     CONFIRMED_MATCH = 'CONFIRMED_MATCH'
     ERROR = 'ERROR'
 
+    # These status choices must be kept in sync with the client's
+    # `facilityListItmeStatusChoicesEnum`.
     STATUS_CHOICES = (
         (UPLOADED, UPLOADED),
         (PARSED, PARSED),

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -2,7 +2,11 @@ from rest_framework.serializers import (CharField,
                                         ModelSerializer,
                                         SerializerMethodField)
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
-from api.models import FacilityList, Facility, User, Organization
+from api.models import (FacilityList,
+                        FacilityListItem,
+                        Facility,
+                        User,
+                        Organization)
 
 
 class UserSerializer(ModelSerializer):
@@ -78,3 +82,10 @@ class FacilitySerializer(GeoFeatureModelSerializer):
     # Added to ensure including the OAR ID in the geojson properties map
     def get_oar_id(self, facility):
         return facility.id
+
+
+class FacilityListItemSerializer(ModelSerializer):
+    class Meta:
+        model = FacilityListItem
+        exclude = ('created_at', 'updated_at', 'geocoded_point',
+                   'geocoded_address')


### PR DESCRIPTION
## Overview

This PR creates a paginated table which it uses to display a set of facility lists items for a specific list as depicted below.

Connects #190

## Demo

![list-details](https://user-images.githubusercontent.com/4165523/52666426-43ff5300-2edc-11e9-8ed7-db090121bcbe.gif)

![list-details-2](https://user-images.githubusercontent.com/4165523/52666429-46fa4380-2edc-11e9-903f-9775f7fe7423.gif)

![list-details-3](https://user-images.githubusercontent.com/4165523/52666463-5ed1c780-2edc-11e9-8829-fade26aac3df.gif)

## Testing

- get this branch, then `./scripts/server` and visit http://localhost:6543
- login to your account and upload a list from one of the existing fixtures in the repository
- in the VM, run `./scripts/manage batch_process parse --list-id <YOUR-LIST-ID>` where `<YOUR-LIST-ID>` is the ID for the list you just uploaded
- visit http://localhost:6543/lists and click on your list to select it
- verify that you visit the details page and that your list items are displayed with proper values in each cell for ones that have been parsed
- try the pagination and row count changes and verify that they work and that they update the URL state correctly -- you should be able to visit a paginated link directly and get the proper set of results
