### PR TITLE
Pass GIT_COMMIT to test and lint scripts

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -42,6 +42,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Make sure the database is up for Django tests
         docker-compose up -d database
 
-        ./scripts/test --ci
+        # Test using tagged container images
+        GIT_COMMIT="${GIT_COMMIT}" \
+            ./scripts/test --ci
     fi
 fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -26,9 +26,18 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             run --rm --no-deps app \
             yarn lint
 
-        # Lint Django app
-        docker-compose \
-            run --rm --no-deps --entrypoint flake8 django \
-            --exclude settings.py,manage.py,*.pyc,api/migrations/*
+        if [ "${1:-}" = "--ci" ]; then
+            # Lint Django app
+            GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+                -f docker-compose.yml \
+                -f docker-compose.ci.yml \
+                run --rm --no-deps --entrypoint flake8 django \
+                --exclude settings.py,manage.py,*.pyc,api/migrations/*
+        else
+            # Lint Django app
+            docker-compose \
+                run --rm --no-deps --entrypoint flake8 django \
+                --exclude settings.py,manage.py,*.pyc,api/migrations/*
+        fi
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -17,6 +17,16 @@ function lint() {
     ./scripts/lint
 }
 
+function lint_ci() {
+    if [[ -n "${GIT_COMMIT}" ]]; then
+        GIT_COMMIT="${GIT_COMMIT}" \
+            ./scripts/lint --ci
+    else
+        echo "ERROR: No GIT_COMMIT variable defined."
+        exit 1
+    fi
+}
+
 function test_django() {
     docker-compose \
         run --rm --entrypoint python django \
@@ -52,7 +62,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     elif [ "${1:-}" = "--django" ]; then
         test_django
     elif [ "${1:-}" = "--ci" ]; then
-        lint
+        lint_ci
         test_app
         test_django_ci
     else

--- a/scripts/test
+++ b/scripts/test
@@ -24,11 +24,16 @@ function test_django() {
 }
 
 function test_django_ci() {
-    GIT_COMMIT="${GIT_COMMIT}" docker-compose \
-        -f docker-compose.yml \
-        -f docker-compose.ci.yml \
-        run --rm --entrypoint python django \
-        manage.py test --noinput
+    if [[ -n "${GIT_COMMIT}" ]]; then
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            run --rm --entrypoint python django \
+            manage.py test --noinput
+    else
+        echo "ERROR: No GIT_COMMIT variable defined."
+        exit 1
+    fi
 }
 
 function test_app() {


### PR DESCRIPTION
## Overview

As part of #191, we wanted to resolve the disconnect between image references across `test` and `cibuild`. 

Looking at the [build logs](http://civicci01.internal.azavea.com/job/Open%20Apparel%20Registry/job/open-apparel-registry/job/develop/lastSuccessfulBuild/console), it doesn't look like I was thorough enough. When flake8 was invoked in `./scripts/lint`, it built another container tagged `:latest`.

## Testing Instructions

See Jenkins checks below.