### PR TITLE
Add resetdb command

### DIFF
--- a/src/django/api/management/commands/resetdb.py
+++ b/src/django/api/management/commands/resetdb.py
@@ -1,0 +1,11 @@
+from django.core.management import call_command
+from django.core.management.base import (BaseCommand)
+
+
+class Command(BaseCommand):
+    help = 'Reset the DB schema, run migrations, and load fixtures.'
+
+    def handle(self, *args, **options):
+        call_command('reset_schema', '--noinput')
+        call_command('migrate')
+        call_command('loadfixtures')


### PR DESCRIPTION
## Overview

We often run these commands in development to rebuild the database in a known state.

## Demo

```
vagrant@vagrant:/vagrant$ ./scripts/manage resetdb
Starting vagrant_database_1 ... done
Operations to perform:
  Apply all migrations: account, admin, api, auth, authtoken, contenttypes, sessions, sites
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0001_initial... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying api.0001_initial... OK
  Applying account.0001_initial... OK
  Applying account.0002_email_max_length... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying authtoken.0001_initial... OK
  Applying authtoken.0002_auto_20160226_1747... OK
  Applying sessions.0001_initial... OK
  Applying sites.0001_initial... OK
  Applying sites.0002_alter_domain_unique... OK
Installed 1435 object(s) from 6 fixture(s)
```

## Testing Instructions

* Verify that `./scripts/manage resetdb` runs without error and resets the database.
