### PR TITLE
Process line items with AWS Batch

### DIFF
--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -51,7 +51,7 @@ data "template_file" "default_job_definition" {
   template = "${file("job-definitions/default.json")}"
 
   vars {
-    image_url = "${module.ecr_repository.repository_url}:${var.image_tag}"
+    image_url = "${module.ecr_repository_batch.repository_url}:${var.image_tag}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database.port}"

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -1,5 +1,5 @@
 locals {
-  app_image = "${module.ecr_repository.repository_url}:${var.image_tag}"
+  app_image = "${module.ecr_repository_app.repository_url}:${var.image_tag}"
 }
 
 #

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -46,6 +46,28 @@ resource "aws_iam_role_policy" "ses_send_email" {
   policy = "${data.aws_iam_policy_document.ses_send_email.json}"
 }
 
+data "aws_iam_policy_document" "batch_describe_and_submit" {
+  statement {
+    effect = "Allow"
+
+    resources = ["*"]
+    actions = [
+      "batch:DescribeJobQueues",
+      "batch:DescribeJobs",
+      "batch:DescribeJobDefinitions",
+      "batch:DescribeComputeEnvironments",
+      "batch:SubmitJob"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "batch_describe_and_submit" {
+  name   = "BatchDescribeAndSubmit"
+  role   = "${aws_iam_role.app_task_role.name}"
+  policy = "${data.aws_iam_policy_document.batch_describe_and_submit.json}"
+}
+
+
 #
 # EC2 IAM resources
 #

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -2,7 +2,7 @@
   "image": "${image_url}",
   "vcpus": 2,
   "memory": 4096,
-  "command": ["--version"],
+  "command": ["./manage.py", "batch_process", "--list-id" , "Ref::listid", "--action", "Ref::action"],
   "environment": [
       { "name": "POSTGRES_HOST", "value": "${postgres_host}" },
       { "name": "POSTGRES_PORT", "value": "${postgres_port}" },

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -12,7 +12,6 @@
       { "name": "DJANGO_ENV", "value": "${environment}" },
       { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
       { "name": "GOOGLE_GEOCODING_API_KEY", "value": "${google_geocoding_api_key}" },
-      { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" },
       { "name": "BATCH_MODE", "value": "True" }
   ]
 }

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -12,6 +12,7 @@
       { "name": "DJANGO_ENV", "value": "${environment}" },
       { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
       { "name": "GOOGLE_GEOCODING_API_KEY", "value": "${google_geocoding_api_key}" },
-      { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" }
+      { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" },
+      { "name": "BATCH_MODE", "value": "True" }
   ]
 }

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -9,10 +9,18 @@ resource "aws_s3_bucket" "logs" {
   }
 }
 
-module "ecr_repository" {
+module "ecr_repository_app" {
   source = "github.com/azavea/terraform-aws-ecr-repository?ref=0.1.0"
 
   repository_name = "${lower(replace(var.project, " ", ""))}"
+
+  attach_lifecycle_policy = true
+}
+
+module "ecr_repository_batch" {
+  source = "github.com/azavea/terraform-aws-ecr-repository?ref=0.1.0"
+
+  repository_name = "${lower(replace(var.project, " ", ""))}-batch"
 
   attach_lifecycle_policy = true
 }

--- a/docker-compose.batch.yml
+++ b/docker-compose.batch.yml
@@ -1,0 +1,9 @@
+version: '2.3'
+services:
+  batch:
+    image: "openapparelregistry-batch:${GIT_COMMIT:-latest}"
+    environment:
+      - GIT_COMMIT=${GIT_COMMIT:-latest}
+    build:
+      context: ./src/batch
+      dockerfile: Dockerfile

--- a/docker-compose.batch.yml
+++ b/docker-compose.batch.yml
@@ -7,3 +7,5 @@ services:
     build:
       context: ./src/batch
       dockerfile: Dockerfile
+      args:
+        GIT_COMMIT: "${GIT_COMMIT:-latest}"

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -39,6 +39,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             -f docker-compose.ci.yml \
             build django
 
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+            -f docker-compose.batch.yml \
+            build batch
+
         # Make sure the database is up for Django tests
         docker-compose up -d database
 

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -31,6 +31,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker tag "openapparelregistry:${GIT_COMMIT}" \
                    "${OAR_AWS_ECR_ENDPOINT}/openapparelregistry:${GIT_COMMIT}"
             docker push "${OAR_AWS_ECR_ENDPOINT}/openapparelregistry:${GIT_COMMIT}"
+
+            docker tag "openapparelregistry-batch:${GIT_COMMIT}" \
+                   "${OAR_AWS_ECR_ENDPOINT}/openapparelregistry-batch:${GIT_COMMIT}"
+            docker push "${OAR_AWS_ECR_ENDPOINT}/openapparelregistry-batch:${GIT_COMMIT}"
         else
             echo "ERROR: No OAR_AWS_ECR_ENDPOINT variable defined."
             exit 1

--- a/src/batch/Dockerfile
+++ b/src/batch/Dockerfile
@@ -1,0 +1,4 @@
+ARG GIT_COMMIT=latest
+FROM openapparelregistry:${GIT_COMMIT}
+
+ENTRYPOINT []

--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -1,0 +1,141 @@
+import boto3
+
+from datetime import datetime
+from django.db import transaction
+
+from api.constants import ProcessingAction
+
+
+def fetch_batch_queue_arn(client, environment):
+    queue_name = 'queue{0}Default'.format(environment)
+    response = client.describe_job_queues(jobQueues=[queue_name])
+    if 'jobQueues' in response:
+        for queue in response['jobQueues']:
+            if 'state' in queue and queue['state'] == 'ENABLED':
+                return queue['jobQueueArn']
+        raise RuntimeError(
+            'No ENABLED queue named {0}. Response: {1}'.format(
+                queue_name, response))
+    else:
+        raise RuntimeError(
+            'Failed to fetch queue. Response {0}'.format(response))
+
+
+def fetch_latest_active_batch_job_definition_arn(client, environment):
+    job_def_name = 'job{0}Default'.format(environment)
+    response = client.describe_job_definitions(
+        jobDefinitionName=job_def_name,
+        status='ACTIVE')
+    if 'jobDefinitions' in response:
+        latest_job_def = None
+        for job_def in response['jobDefinitions']:
+            if latest_job_def is None \
+              or job_def['revision'] > latest_job_def['revision']:
+                latest_job_def = job_def
+        if latest_job_def is None:
+            raise RuntimeError(
+                'No ACTIVE job definition named {0}. Response {1}'.format(
+                    job_def_name, response))
+        return latest_job_def['jobDefinitionArn']
+    else:
+        raise RuntimeError(
+            'No job queues available. Response {0}'.format(response))
+
+
+def submit_jobs(environment, facility_list):
+    """
+    Submit AWS Batch jobs to process each FacilityListItem in a FacilityList
+    through all processing steps.
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job
+    """
+    client = boto3.client('batch')
+    queue_arn = fetch_batch_queue_arn(client, environment)
+    job_def_arn = fetch_latest_active_batch_job_definition_arn(client,
+                                                               environment)
+    job_time = (datetime.utcnow().isoformat()
+                .replace(':', '-').replace('.', '-').replace('T', '-'))
+
+    def submit_job(action, is_array=False, depends_on=None):
+        if depends_on is None:
+            depends_on = []
+        array_properties = {}
+        if is_array:
+            array_properties = {
+                'size': facility_list.facilitylistitem_set.count()
+            }
+        job_name = 'list-{0}-{1}-{2}'.format(
+            facility_list.id, action, job_time)
+        job = client.submit_job(
+            jobName=job_name,
+            jobQueue=queue_arn,
+            jobDefinition=job_def_arn,
+            dependsOn=depends_on,
+            arrayProperties=array_properties,
+            parameters={
+                'listid': str(facility_list.id),
+                'action': action,
+            }
+        )
+        if 'jobId' in job:
+            return job['jobId']
+        else:
+            raise RuntimeError(
+                'Failed to submit job {0}. Response {1}'.format(job_name, job))
+
+    # PARSE
+    started = str(datetime.utcnow())
+    # The parse task is just quick string manipulation. We submit it as a
+    # normal job rather than as an array job to avoid extra overhead that just
+    # slows things down.
+    parse_job_id = submit_job('parse')
+    finished = str(datetime.utcnow())
+    with transaction.atomic():
+        for item in facility_list.facilitylistitem_set.all():
+            item.processing_results.append({
+                'action': ProcessingAction.SUBMIT_JOB,
+                'type': 'parse',
+                'job_id': parse_job_id,
+                'error': False,
+                'started_at': started,
+                'finished_at': finished,
+            })
+            item.save()
+
+    # GEOCODE
+    started = str(datetime.utcnow())
+    geocode_job_id = submit_job('geocode',
+                                depends_on=[{'jobId': parse_job_id}],
+                                is_array=True)
+    finished = str(datetime.utcnow())
+    facility_list.refresh_from_db()
+    with transaction.atomic():
+        for item in facility_list.facilitylistitem_set.all():
+            item.processing_results.append({
+                'action': ProcessingAction.SUBMIT_JOB,
+                'type': 'geocode',
+                'job_id': '{0}:{1}'.format(geocode_job_id, item.row_index),
+                'error': False,
+                'started_at': started,
+                'finished_at': finished,
+            })
+            item.save()
+
+    # MATCH
+    started = str(datetime.utcnow())
+    match_job_id = submit_job('match',
+                              depends_on=[{'jobId': geocode_job_id,
+                                           'type': 'N_TO_N'}],
+                              is_array=True)
+    finished = str(datetime.utcnow())
+    facility_list.refresh_from_db()
+    with transaction.atomic():
+        for item in facility_list.facilitylistitem_set.all():
+            item.processing_results.append({
+                'action': ProcessingAction.SUBMIT_JOB,
+                'type': 'match',
+                'job_id': '{0}:{1}'.format(match_job_id, item.row_index),
+                'error': False,
+                'started_at': started,
+                'finished_at': finished,
+            })
+            item.save()

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -8,6 +8,7 @@ class ProcessingAction:
     PARSE = 'parse'
     GEOCODE = 'geocode'
     MATCH = 'match'
+    SUBMIT_JOB = 'submitjob'
 
 
 class FacilitiesQueryParams:

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_auth.views import LoginView, LogoutView
 
-from oar.settings import MAX_UPLOADED_FILE_SIZE_IN_BYTES
+from oar.settings import MAX_UPLOADED_FILE_SIZE_IN_BYTES, ENVIRONMENT
 
 from api.constants import CsvHeaderField, FacilitiesQueryParams
 from api.models import (FacilityList,
@@ -32,6 +32,7 @@ from api.serializers import (FacilityListSerializer,
                              FacilitySerializer,
                              UserSerializer)
 from api.countries import COUNTRY_CHOICES
+from api.aws_batch import submit_jobs
 
 
 @permission_classes((AllowAny,))
@@ -366,6 +367,9 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 raw_data=line.decode().rstrip()
             )
             new_item.save()
+
+        if ENVIRONMENT in ('Staging', 'Production'):
+            submit_jobs(ENVIRONMENT, new_list)
 
         serializer = self.get_serializer(new_list)
         return Response(serializer.data)

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -35,6 +35,10 @@ if ENVIRONMENT not in VALID_ENVIRONMENTS:
         'Invalid ENVIRONMENT provided, must be one of {}'
         .format(VALID_ENVIRONMENTS))
 
+# A non-empty value of BATCH_MODE signals that we will only be running batch
+# processing management commands
+BATCH_MODE = os.getenv('BATCH_MODE', '')
+
 LOGLEVEL = os.getenv('DJANGO_LOG_LEVEL', 'INFO')
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -46,7 +50,7 @@ ALLOWED_HOSTS = [
     '.openapparel.org'
 ]
 
-if ENVIRONMENT in ['Production', 'Staging']:
+if ENVIRONMENT in ['Production', 'Staging'] and BATCH_MODE == '':
     # Within EC2, the Elastic Load Balancer HTTP health check will use the
     # target instance's private IP address for the Host header.
     #


### PR DESCRIPTION
## Overview

Add a second container for running AWS Batch jobs and add related provisioning and application code to submit jobs that process uploaded CSVs using our existing `batch_process` management command.

Connects #149 

## Demo

<img width="1161" alt="screen shot 2019-02-20 at 6 59 59 pm" src="https://user-images.githubusercontent.com/17363/53138168-9a0a7100-3542-11e9-8eb5-88c0b9c739de.png">

<img width="1170" alt="screen shot 2019-02-20 at 7 00 11 pm" src="https://user-images.githubusercontent.com/17363/53138170-9e368e80-3542-11e9-959b-f6770be7396f.png">

<img width="1109" alt="screen shot 2019-02-20 at 6 59 44 pm" src="https://user-images.githubusercontent.com/17363/53138174-a262ac00-3542-11e9-8328-9c9a20bf6d57.png">


## Notes

Batch does not allow us to override the `ENTRYPOINT` of a container, so we have created a thin wrapper that strips off the gunicorn `ENTRYPOINT` inherited from our Django base container. It is a little wasteful storage-wise to push 2 copies of the same container but we decided it was preferable to do that rather than not use our Azavea base Django container.

We are opting to not rename the `openapparelregistry` repo/image to `openapparelregistry-app` to avoid having terraform destroy the existing repository while this is change is being tested in a shared staging environment.

When the container is run as a normal Django web app process in Staging or Production we check the instance metadata to properly set the `ALLOWED_HOSTS` Django setting. This instance metadata check fails when the container is run in AWS Batch so we have added a the `BATCH_MODE` environment variable which acts as a switch to disable the instance metadata check.

Jobs are only submitted in staging an production because AWS Batch cannot run in development.

This code assumes that we have a single job queue and we will always want to run the latest version of the job definition. This may change in the future if we expand our processing but for now those assumptions make for simpler code.

We record the job IDs in the `FacilityListItem.processing_results`. It is a bit redundant to log the same ID on all the line items but it is consistent with the fact that all processing is done at the item level and allows us to display the entire processing history of an item without needing to collate detail from the item and its parent list.

There is no way to resubmit jobs if the process fails. In this initial version the user can work around that type failure by reuploading the same CSV and using the "replaces" feature.

We needed to add an additional security policy to the app IAM role to allow listing Batch resources and submitting jobs.

## Testing Instructions

This is only testable on staging. I pushed a copy of this branch as `test/process-with-batch`. Jenkins will deploy a branch prefixed with `test/` (At the time this PR was opened, Jenkins jobs are failing)

* Log in as a user other than the admin included in the fixture data.
* Browse https://staging.openapparel.org/contribute and upload a CSV
* Wait (it can sometimes take a while for compute resources to start processing)
  * You can browse the processing status in the AWS console https://console.aws.amazon.com/batch/home?region=us-east-1#/jobs
* Browse the uploaded list at https://staging.openapparel.org/lists/{list-id}. Verify that as items are processed, their status changes.