### PR TITLE
Get mapbox token at compile time

### DIFF
--- a/src/app/src/util/constants.oarmap.js
+++ b/src/app/src/util/constants.oarmap.js
@@ -1,6 +1,4 @@
-import env from './env';
-
-export const MAPBOX_TOKEN = env('REACT_APP_MAPBOX_TOKEN');
+export const MAPBOX_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 
 export const CIRCLE_COLOR = '#1A237E';
 export const CIRCLE_TEXT_COLOR = '#fff';

--- a/src/app/src/util/env.js
+++ b/src/app/src/util/env.js
@@ -1,7 +1,0 @@
-export default function (v) {
-    if (window.ENVIRONMENT && v in window.ENVIRONMENT) {
-        return window.ENVIRONMENT[v];
-    }
-
-    return process.env[v];
-}


### PR DESCRIPTION
## Overview

The mapbox token was unset when trying to get it at runtime, so return
to getting it at compile time.

Note: this essentially just reverts the mapbox key part of the Rollbar changes.

Connects #223 

## Testing Instructions

- get this branch, then test that the mapbox map works on both server and cibuild versions

