### PR TITLE
Display country name on list items table

### DIFF
--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -82,10 +82,10 @@ function FacilityListItemsConfirmationTableRow({
             <TableCell
                 align="center"
                 padding="dense"
-                style={listTableCellStyles.countryCodeStyles}
+                style={listTableCellStyles.countryNameStyles}
             >
                 <FacilityListItemsDetailedTableRowCell
-                    title={item.country_code || ' '}
+                    title={item.country_name || ' '}
                     subtitle=" "
                     hrIsHidden
                     stringIsHidden

--- a/src/app/src/components/FacilityListItemsErrorTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsErrorTableRow.jsx
@@ -16,7 +16,7 @@ const propsAreEqual = (prevProps, nextProps) =>
 
 const FacilityListItemsErrorTableRow = memo(({
     rowIndex,
-    countryCode,
+    countryName,
     name,
     address,
     status,
@@ -44,10 +44,10 @@ const FacilityListItemsErrorTableRow = memo(({
         <TableCell
             align="center"
             padding="dense"
-            style={listTableCellStyles.countryCodeStyles}
+            style={listTableCellStyles.countryNameStyles}
         >
             <FacilityListItemsDetailedTableRowCell
-                title={countryCode}
+                title={countryName}
                 hrIsHidden
                 stringIsHidden
                 data={errors}
@@ -101,7 +101,7 @@ FacilityListItemsErrorTableRow.defaultProps = {
 
 FacilityListItemsErrorTableRow.propTypes = {
     rowIndex: oneOfType([number, string]).isRequired,
-    countryCode: string.isRequired,
+    countryName: string.isRequired,
     name: string.isRequired,
     status: facilityListItemStatusPropType.isRequired,
     hover: bool,

--- a/src/app/src/components/FacilityListItemsMatchTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsMatchTableRow.jsx
@@ -18,7 +18,7 @@ const propsAreEqual = (prevProps, nextProps) =>
 
 const FacilityListItemsMatchTableRow = memo(({
     rowIndex,
-    countryCode,
+    countryName,
     name,
     address,
     status,
@@ -47,10 +47,10 @@ const FacilityListItemsMatchTableRow = memo(({
         <TableCell
             align="center"
             padding="dense"
-            style={listTableCellStyles.countryCodeStyles}
+            style={listTableCellStyles.countryNameStyles}
         >
             <FacilityListItemsDetailedTableRowCell
-                title={countryCode || ' '}
+                title={countryName || ' '}
                 subtitle=" "
                 hrIsHidden
                 stringIsHidden
@@ -106,7 +106,7 @@ FacilityListItemsMatchTableRow.defaultProps = {
 
 FacilityListItemsMatchTableRow.propTypes = {
     rowIndex: oneOfType([number, string]).isRequired,
-    countryCode: string.isRequired,
+    countryName: string.isRequired,
     name: string.isRequired,
     status: facilityListItemStatusPropType.isRequired,
     hover: bool,

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -110,7 +110,7 @@ function FacilityListItemsTable({
                     <FacilityListItemsTableRow
                         key={item.row_index}
                         rowIndex={item.row_index}
-                        countryCode={item.country_code}
+                        countryName={item.country_name}
                         name={item.name}
                         address={item.address}
                         status={item.status}
@@ -125,7 +125,7 @@ function FacilityListItemsTable({
                     <FacilityListItemsErrorTableRow
                         key={item.row_index}
                         rowIndex={item.row_index}
-                        countryCode={item.country_code}
+                        countryName={item.country_name}
                         name={item.name}
                         address={item.address}
                         status={item.status}
@@ -141,7 +141,7 @@ function FacilityListItemsTable({
                     <FacilityListItemsMatchTableRow
                         key={item.row_index}
                         rowIndex={item.row_index}
-                        countryCode={item.country_code}
+                        countryName={item.country_name}
                         name={item.name}
                         address={item.address}
                         status={item.status}
@@ -155,7 +155,7 @@ function FacilityListItemsTable({
                 <FacilityListItemsTableRow
                     key={item.row_index}
                     rowIndex={item.row_index}
-                    countryCode={item.country_code}
+                    countryName={item.country_name}
                     name={item.name}
                     address={item.address}
                     status={item.status}
@@ -173,7 +173,7 @@ function FacilityListItemsTable({
                         {paginationControlsRow}
                         <FacilityListItemsTableRow
                             rowIndex="CSV Row Index"
-                            countryCode="Country Code"
+                            countryName="Country Name"
                             name="Name"
                             address="Address"
                             status="Status"

--- a/src/app/src/components/FacilityListItemsTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsTableRow.jsx
@@ -18,7 +18,7 @@ const propsAreEqual = (prevProps, nextProps) =>
 
 const FacilityListItemsTableRow = memo(({
     rowIndex,
-    countryCode,
+    countryName,
     name,
     address,
     status,
@@ -44,9 +44,9 @@ const FacilityListItemsTableRow = memo(({
         <TableCell
             align="center"
             padding="dense"
-            style={listTableCellStyles.countryCodeStyles}
+            style={listTableCellStyles.countryNameStyles}
         >
-            {countryCode}
+            {countryName}
         </TableCell>
         <TableCell
             padding="none"
@@ -76,7 +76,7 @@ FacilityListItemsTableRow.defaultProps = {
 
 FacilityListItemsTableRow.propTypes = {
     rowIndex: oneOfType([number, string]).isRequired,
-    countryCode: string.isRequired,
+    countryName: string.isRequired,
     name: string.isRequired,
     status: facilityListItemStatusPropType.isRequired,
     hover: bool,

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -72,6 +72,7 @@ export const facilityListItemPropType = shape({
     name: string.isRequired,
     address: string.isRequired,
     country_code: string.isRequired,
+    country_name: string.isRequired,
     geocoded_point: string,
     geocoded_address: string,
     facility_list: number.isRequired,

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -11,7 +11,7 @@ export const listTableCellStyles = Object.freeze({
         flex: '1',
         fontSize: '16px',
     }),
-    countryCodeStyles: Object.freeze({
+    countryNameStyles: Object.freeze({
         flex: '1',
         fontSize: '16px',
     }),

--- a/src/django/api/countries.py
+++ b/src/django/api/countries.py
@@ -251,7 +251,7 @@ COUNTRY_CHOICES = [
     ('ZW', 'Zimbabwe'),
 ]
 
-COUNTRY_NAMES = {code: name for (code, name) in COUNTRY_CHOICES}
+COUNTRY_NAMES = dict(COUNTRY_CHOICES)
 
 COUNTRY_CODES = {
     'afghanistan': 'AF',

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -8,6 +8,7 @@ from api.models import (FacilityList,
                         FacilityMatch,
                         User,
                         Organization)
+from api.countries import COUNTRY_NAMES
 
 
 class UserSerializer(ModelSerializer):
@@ -128,6 +129,7 @@ class FacilityMatchSerializer(ModelSerializer):
 
 class FacilityListItemSerializer(ModelSerializer):
     matches = SerializerMethodField()
+    country_name = SerializerMethodField()
     processing_errors = SerializerMethodField()
     matched_facility = SerializerMethodField()
 
@@ -141,6 +143,9 @@ class FacilityListItemSerializer(ModelSerializer):
             facility_list_item.facilitymatch_set.order_by('id'),
             many=True,
         ).data
+
+    def get_country_name(self, facility_list_item):
+        return COUNTRY_NAMES.get(facility_list_item.country_code, '')
 
     def get_processing_errors(self, facility_list_item):
         if facility_list_item.status != FacilityListItem.ERROR:


### PR DESCRIPTION
## Overview

- add serializer to return `country_name` from the API, defaulting to
empty string for unparsed or unparseable list items
- update list items table to display country name instead of country
code for parsed list items

Connects #214

## Demo

![screen shot 2019-02-22 at 1 56 34 pm](https://user-images.githubusercontent.com/4165523/53264477-aeb54900-36a9-11e9-9b09-4a7f39de1384.png)

## Notes

First two commits here are from #222 

## Testing Instructions

- serve this branch, then upload and parse a list if you don't already have one set up
- visit the list items table for your parsed list and verify that country names are displayed instead of country codes

