### PR TITLE
Enable users to request passwords & reset passwords

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -31,6 +31,7 @@
         "redux-persist": "5.10.0",
         "redux-thunk": "2.3.0",
         "supercluster": "2.3.0",
+        "validator": "10.11.0",
         "viewport-mercator-project": "5.1.0"
     },
     "scripts": {

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -10,6 +10,7 @@ import history from './util/history';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import RegisterForm from './components/RegisterForm';
+import ResetPasswordForm from './components/ResetPasswordForm';
 import LoginForm from './components/LoginForm';
 import UserProfile from './components/UserProfile';
 import Contribute from './components/Contribute';
@@ -26,6 +27,7 @@ import {
     mainRoute,
     authLoginFormRoute,
     authRegisterFormRoute,
+    authResetPasswordFormRoute,
     contributeRoute,
     listsRoute,
     facilityListItemsRoute,
@@ -68,6 +70,10 @@ class App extends Component {
                                 <Route
                                     path={authLoginFormRoute}
                                     component={LoginForm}
+                                />
+                                <Route
+                                    path={authResetPasswordFormRoute}
+                                    component={ResetPasswordForm}
                                 />
                                 <Route
                                     path={profileRoute}

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -41,6 +41,9 @@ const {
     createConfirmFacilityListItemMatchURL,
     createRejectFacilityListItemMatchURL,
     makeMyFacilitiesRoute,
+    makeResetPasswordEmailURL,
+    getTokenFromQueryString,
+    makeResetPasswordConfirmURL,
 } = require('../util/util');
 
 const {
@@ -680,4 +683,36 @@ it('creates a link to see facilities for a contributor ID', () => {
     const expectedFacilitiesRoute = '/facilities/?contributors=contributor';
 
     expect(makeMyFacilitiesRoute(contributor)).toBe(expectedFacilitiesRoute);
+});
+
+it('creates a URL for requesting a password reset', () => {
+    const expectedURL = '/rest-auth/password/reset/';
+    expect(makeResetPasswordEmailURL()).toBe(expectedURL);
+});
+
+it('creates a URL for confirming a password reset', () => {
+    const expectedURL = '/rest-auth/password/reset/confirm/';
+    expect(makeResetPasswordConfirmURL()).toBe(expectedURL);
+});
+
+it('gets a `token` from a querystring', () => {
+    const simpleToken = '?token=helloworld';
+    const expectedSimpleTokenMatch = 'helloworld';
+
+    expect(getTokenFromQueryString(simpleToken)).toBe(expectedSimpleTokenMatch);
+
+    const missingToken = '?hello=world';
+    const expectedMissingTokenMatch = '';
+
+    expect(getTokenFromQueryString(missingToken)).toBe(expectedMissingTokenMatch);
+
+    const listOfTokens = '?token=foo&token=bar&token=baz';
+    const expectedListOfTokensMatch = 'foo';
+
+    expect(getTokenFromQueryString(listOfTokens)).toBe(expectedListOfTokensMatch);
+
+    const missingQueryString = '';
+    const expectedMissingQueryStringMatch = '';
+
+    expect(getTokenFromQueryString(missingQueryString)).toBe(expectedMissingQueryStringMatch);
 });

--- a/src/app/src/actions/auth.js
+++ b/src/app/src/actions/auth.js
@@ -1,4 +1,6 @@
 import { createAction } from 'redux-act';
+import isEmail from 'validator/lib/isEmail';
+import { toast } from 'react-toastify';
 
 import csrfRequest from '../util/csrfRequest';
 
@@ -7,6 +9,8 @@ import {
     makeUserLoginURL,
     makeUserLogoutURL,
     makeUserSignupURL,
+    makeResetPasswordEmailURL,
+    makeResetPasswordConfirmURL,
     createSignupErrorMessages,
     createSignupRequestData,
 } from '../util/util';
@@ -34,9 +38,9 @@ export const startSubmitLogOut = createAction('START_SUBMIT_LOG_OUT');
 export const failSubmitLogOut = createAction('FAIL_SUBMIT_LOG_OUT');
 export const completeSubmitLogOut = createAction('COMPLETE_SUBMIT_LOG_OUT');
 
-export const startSubmitForgotPassword = createAction('START_SUBMIT_FORGOT_PASSWORD');
-export const failSubmitForgotPassword = createAction('FAIL_SUBMIT_FORGOT_PASSWORD');
-export const completeSubmitForgotPassword = createAction('COMPLETE_SUBMIT_FORGOT_PASSWORD');
+export const startRequestForgotPasswordEmail = createAction('START_REQUEST_FORGOT_PASSWORD_EMAIL');
+export const failRequestForgotPasswordEmail = createAction('FAIL_REQUEST_FORGOT_PASSWORD_EMAIL');
+export const completeRequestForgotPasswordEmail = createAction('COMPLETE_REQUEST_FORGOT_PASSWORD_EMAIL');
 
 export const openForgotPasswordDialog = createAction('OPEN_FORGOT_PASSWORD_DIALOG');
 export const closeForgotPasswordDialog = createAction('CLOSE_FORGOT_PASSWORD_DIALOG');
@@ -45,6 +49,17 @@ export const updateForgotPasswordEmailAddress =
 
 export const resetAuthFormState = createAction('RESET_AUTH_FORM_STATE');
 export const resetAuthState = createAction('RESET_AUTH_STATE');
+
+export const updateResetPasswordFormUID = createAction('UPDATE_RESET_PASSWORD_FORM_UID');
+export const updateResetPasswordFormToken = createAction('UPDATE_RESET_PASSWORD_FORM_TOKEN');
+export const updateResetPasswordFormPassword = createAction('UPDATE_RESET_PASSWORD_FORM_PASSWORD');
+export const updateResetPasswordFormPasswordConfirmation =
+    createAction('UPDATE_RESET_PASSWORD_FORM_PASSWORD_CONFIRMATION');
+
+export const startSubmitResetPasswordForm = createAction('START_SUBMIT_RESET_PASSWORD_FORM');
+export const failSubmitResetPasswordForm = createAction('FAIL_SUBMIT_RESET_PASSWORD_FORM');
+export const completeSubmitResetPasswordForm = createAction('COMPLETE_SUBMIT_RESET_PASSWORD_FORM');
+export const resetResetPasswordFormState = createAction('RESET_RESET_PASSWORD_FORM_STATE');
 
 export function submitSignUpForm() {
     return (dispatch, getState) => {
@@ -135,17 +150,46 @@ export function sessionLogin() {
     };
 }
 
-export function submitForgotPassword() {
-    return (dispatch) => {
-        dispatch(startSubmitForgotPassword());
+export function requestForgotPasswordEmail() {
+    return (dispatch, getState) => {
+        dispatch(startRequestForgotPasswordEmail());
 
-        return Promise
-            .resolve(true)
-            .then(() => dispatch(completeSubmitForgotPassword()))
-            .catch(e => dispatch(logErrorAndDispatchFailure(
-                e,
+        const {
+            auth: {
+                forgotPassword: {
+                    form: {
+                        email,
+                    },
+                },
+            },
+        } = getState();
+
+        if (!email) {
+            return dispatch(logErrorAndDispatchFailure(
+                null,
+                'Email address was not provided',
+                failRequestForgotPasswordEmail,
+            ));
+        }
+
+        if (!isEmail(email)) {
+            return dispatch(logErrorAndDispatchFailure(
+                null,
+                'Email address is invalid',
+                failRequestForgotPasswordEmail,
+            ));
+        }
+
+        return csrfRequest
+            .post(makeResetPasswordEmailURL(), { email })
+            .then(() => {
+                toast('Check your email for password reset instructions');
+                return dispatch(completeRequestForgotPasswordEmail());
+            })
+            .catch(() => dispatch(logErrorAndDispatchFailure(
+                null,
                 'An error prevented sending the forgot password email',
-                failSubmitForgotPassword,
+                failRequestForgotPasswordEmail,
             )));
     };
 }
@@ -161,6 +205,64 @@ export function submitLogOut() {
                 e,
                 'An error prevented logging out',
                 failSubmitLogOut,
+            )));
+    };
+}
+
+export function submitResetPassword() {
+    return (dispatch, getState) => {
+        dispatch(startSubmitResetPasswordForm());
+
+        const {
+            auth: {
+                resetPassword: {
+                    uid,
+                    token,
+                    newPassword,
+                    newPasswordConfirmation,
+                },
+            },
+        } = getState();
+
+        if (!uid || !token) {
+            return dispatch(logErrorAndDispatchFailure(
+                null,
+                'An error prevented resetting your password',
+                failSubmitResetPasswordForm,
+            ));
+        }
+
+        if (!newPassword || !newPasswordConfirmation) {
+            return dispatch(logErrorAndDispatchFailure(
+                null,
+                'Password and password confirmation fields are required',
+                failSubmitResetPasswordForm,
+            ));
+        }
+
+        if (newPassword !== newPasswordConfirmation) {
+            return dispatch(logErrorAndDispatchFailure(
+                null,
+                'Password and confirmation don\'t match',
+                failSubmitResetPasswordForm,
+            ));
+        }
+
+        return csrfRequest
+            .post(
+                makeResetPasswordConfirmURL(),
+                {
+                    uid,
+                    token,
+                    new_password1: newPassword,
+                    new_password2: newPasswordConfirmation,
+                },
+            )
+            .then(() => dispatch(completeSubmitResetPasswordForm()))
+            .catch(e => dispatch(logErrorAndDispatchFailure(
+                e,
+                'An error prevented resetting your password',
+                failSubmitResetPasswordForm,
             )));
     };
 }

--- a/src/app/src/components/ResetPasswordForm.jsx
+++ b/src/app/src/components/ResetPasswordForm.jsx
@@ -1,0 +1,192 @@
+import React, { Component } from 'react';
+import { arrayOf, bool, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import Grid from '@material-ui/core/Grid';
+
+import ControlledTextInput from './ControlledTextInput';
+import AppGrid from './AppGrid';
+import Button from './Button';
+import ShowOnly from './ShowOnly';
+
+import {
+    updateResetPasswordFormUID,
+    updateResetPasswordFormToken,
+    updateResetPasswordFormPassword,
+    updateResetPasswordFormPasswordConfirmation,
+    submitResetPassword,
+    resetResetPasswordFormState,
+} from '../actions/auth';
+
+import { formValidationErrorMessageStyle } from '../util/styles';
+
+import {
+    getValueFromEvent,
+    getTokenFromQueryString,
+} from '../util/util';
+
+import { authLoginFormRoute } from '../util/constants';
+
+const NEW_PASSWORD = 'NEW_PASSWORD';
+const CONFIRM_NEW_PASSWORD = 'CONFIRM_NEW_PASSWORD';
+
+class ResetPasswordForm extends Component {
+    componentDidMount() {
+        this.props.setUID();
+        return this.props.setToken();
+    }
+
+    componentWillUnmount() {
+        return this.props.resetForm();
+    }
+
+    render() {
+        const {
+            newPassword,
+            newPasswordConfirmation,
+            fetching,
+            error,
+            confirmationResponse,
+            updatePassword,
+            updateConfirmPassword,
+            submitForm,
+        } = this.props;
+
+        if (confirmationResponse) {
+            return (
+                <AppGrid title="Reset Password">
+                    <Grid item xs={12} sm={7}>
+                        <p>
+                            Your password was reset successfully.
+                        </p>
+                        <br />
+                        <Link
+                            to={authLoginFormRoute}
+                            href={authLoginFormRoute}
+                            className="link-underline"
+                        >
+                            Login
+                        </Link>
+                    </Grid>
+                </AppGrid>
+            );
+        }
+
+        return (
+            <AppGrid title="Reset Password">
+                <Grid item xs={12} sm={7}>
+                    <div className="form__field">
+                        <label
+                            className="form__label"
+                            htmlFor={NEW_PASSWORD}
+                        >
+                            New password
+                        </label>
+                        <ControlledTextInput
+                            id={NEW_PASSWORD}
+                            type="password"
+                            value={newPassword}
+                            onChange={updatePassword}
+                        />
+                    </div>
+                    <div className="form__field">
+                        <label
+                            className="form__label"
+                            htmlFor={CONFIRM_NEW_PASSWORD}
+                        >
+                            Confirm new password
+                        </label>
+                        <ControlledTextInput
+                            id={CONFIRM_NEW_PASSWORD}
+                            type="password"
+                            value={newPasswordConfirmation}
+                            onChange={updateConfirmPassword}
+                        />
+                    </div>
+                    <ShowOnly when={!!(error && error.length)}>
+                        <ul style={formValidationErrorMessageStyle}>
+                            {
+                                error && error.length
+                                    ? error.map(err => (
+                                        <li key={err}>
+                                            {err}
+                                        </li>))
+                                    : null
+                            }
+                        </ul>
+                    </ShowOnly>
+                    <Button
+                        text="Reset Password"
+                        onClick={submitForm}
+                        disabled={fetching}
+                    />
+                </Grid>
+            </AppGrid>
+        );
+    }
+}
+
+ResetPasswordForm.defaultProps = {
+    error: null,
+};
+
+ResetPasswordForm.propTypes = {
+    newPassword: string.isRequired,
+    newPasswordConfirmation: string.isRequired,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+    confirmationResponse: bool.isRequired,
+    setUID: func.isRequired,
+    setToken: func.isRequired,
+    resetForm: func.isRequired,
+    updatePassword: func.isRequired,
+    updateConfirmPassword: func.isRequired,
+    submitForm: func.isRequired,
+};
+
+function mapStateToProps({
+    auth: {
+        resetPassword: {
+            newPassword,
+            newPasswordConfirmation,
+            fetching,
+            error,
+            confirmationResponse,
+        },
+    },
+}) {
+    return {
+        newPassword,
+        newPasswordConfirmation,
+        fetching,
+        error,
+        confirmationResponse,
+    };
+}
+
+function mapDispatchToProps(dispatch, {
+    match: {
+        params: {
+            uid,
+        },
+    },
+    history: {
+        location: {
+            search,
+        },
+    },
+}) {
+    return {
+        setUID: () => dispatch(updateResetPasswordFormUID(uid)),
+        setToken: () =>
+            dispatch(updateResetPasswordFormToken(getTokenFromQueryString(search))),
+        updatePassword: e =>
+            dispatch(updateResetPasswordFormPassword(getValueFromEvent(e))),
+        updateConfirmPassword: e =>
+            dispatch(updateResetPasswordFormPasswordConfirmation(getValueFromEvent(e))),
+        submitForm: () => dispatch(submitResetPassword()),
+        resetForm: () => dispatch(resetResetPasswordFormState()),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ResetPasswordForm);

--- a/src/app/src/components/SendResetPasswordEmailForm.jsx
+++ b/src/app/src/components/SendResetPasswordEmailForm.jsx
@@ -12,7 +12,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 
 import {
     updateForgotPasswordEmailAddress,
-    submitForgotPassword,
+    requestForgotPasswordEmail,
     openForgotPasswordDialog,
     closeForgotPasswordDialog,
 } from '../actions/auth';
@@ -113,13 +113,13 @@ SendResetPasswordEmailForm.propTypes = {
 
 function mapStateToProps({
     auth: {
-        fetching,
-        error,
         forgotPassword: {
             form: {
                 email,
             },
             dialogIsOpen,
+            fetching,
+            error,
         },
     },
 }) {
@@ -134,7 +134,7 @@ function mapStateToProps({
 function mapDispatchToProps(dispatch) {
     return {
         updateEmail: e => dispatch(updateForgotPasswordEmailAddress(getValueFromEvent(e))),
-        submitForm: () => dispatch(submitForgotPassword()),
+        submitForm: () => dispatch(requestForgotPasswordEmail()),
         handleOpen: () => dispatch(openForgotPasswordDialog()),
         handleClose: () => dispatch(closeForgotPasswordDialog()),
     };

--- a/src/app/src/reducers/AuthReducer.js
+++ b/src/app/src/reducers/AuthReducer.js
@@ -11,9 +11,9 @@ import {
     startSessionLogin,
     failSessionLogin,
     completeSessionLogin,
-    startSubmitForgotPassword,
-    failSubmitForgotPassword,
-    completeSubmitForgotPassword,
+    startRequestForgotPasswordEmail,
+    failRequestForgotPasswordEmail,
+    completeRequestForgotPasswordEmail,
     startSubmitLogOut,
     failSubmitLogOut,
     completeSubmitLogOut,
@@ -25,6 +25,14 @@ import {
     updateForgotPasswordEmailAddress,
     resetAuthFormState,
     resetAuthState,
+    updateResetPasswordFormUID,
+    updateResetPasswordFormToken,
+    updateResetPasswordFormPassword,
+    updateResetPasswordFormPasswordConfirmation,
+    startSubmitResetPasswordForm,
+    failSubmitResetPasswordForm,
+    completeSubmitResetPasswordForm,
+    resetResetPasswordFormState,
 } from '../actions/auth';
 
 import { registrationFieldsEnum } from '../util/constants';
@@ -55,6 +63,17 @@ const initialState = Object.freeze({
             email: '',
         }),
         dialogIsOpen: false,
+        error: null,
+        fetching: false,
+    }),
+    resetPassword: Object.freeze({
+        uid: null,
+        token: null,
+        newPassword: '',
+        newPasswordConfirmation: '',
+        fetching: false,
+        error: null,
+        confirmationResponse: false,
     }),
     user: Object.freeze({
         user: null,
@@ -104,21 +123,31 @@ export default createReducer({
         },
     }),
     [updateForgotPasswordEmailAddress]: (state, payload) => update(state, {
-        error: { $set: null },
         forgotPassword: {
             form: {
                 email: { $set: payload },
             },
+            error: { $set: null },
         },
     }),
     [startSubmitSignUpForm]: startFetching,
     [startSubmitLoginForm]: startFetching,
     [startSubmitLogOut]: startFetching,
-    [startSubmitForgotPassword]: startFetching,
+    [startRequestForgotPasswordEmail]: state => update(state, {
+        forgotPassword: {
+            fetching: { $set: true },
+            error: { $set: null },
+        },
+    }),
     [failSubmitSignUpForm]: failFetching,
     [failSubmitLoginForm]: failFetching,
     [failSubmitLogOut]: failFetching,
-    [failSubmitForgotPassword]: failFetching,
+    [failRequestForgotPasswordEmail]: (state, payload) => update(state, {
+        forgotPassword: {
+            fetching: { $set: false },
+            error: { $set: payload },
+        },
+    }),
     [completeSubmitSignUpForm]: state => update(state, {
         fetching: { $set: false },
         error: { $set: null },
@@ -154,9 +183,7 @@ export default createReducer({
             fetching: { $set: false },
         },
     }),
-    [completeSubmitForgotPassword]: state => update(state, {
-        fetching: { $set: false },
-        error: { $set: null },
+    [completeRequestForgotPasswordEmail]: state => update(state, {
         forgotPassword: { $set: initialState.forgotPassword },
     }),
     [completeSubmitLogOut]: () => initialState,
@@ -174,6 +201,52 @@ export default createReducer({
         forgotPassword: { $set: initialState.forgotPassword },
         fetching: { $set: false },
         error: { $set: null },
+    }),
+    [updateResetPasswordFormUID]: (state, payload) => update(state, {
+        resetPassword: {
+            uid: { $set: payload },
+        },
+    }),
+    [updateResetPasswordFormToken]: (state, payload) => update(state, {
+        resetPassword: {
+            token: { $set: payload },
+        },
+    }),
+    [updateResetPasswordFormPassword]: (state, payload) => update(state, {
+        resetPassword: {
+            newPassword: { $set: payload },
+        },
+    }),
+    [updateResetPasswordFormPasswordConfirmation]: (state, payload) => update(state, {
+        resetPassword: {
+            newPasswordConfirmation: { $set: payload },
+        },
+    }),
+    [startSubmitResetPasswordForm]: state => update(state, {
+        resetPassword: {
+            fetching: { $set: true },
+            error: { $set: null },
+        },
+    }),
+    [failSubmitResetPasswordForm]: (state, payload) => update(state, {
+        resetPassword: {
+            fetching: { $set: false },
+            error: { $set: payload },
+        },
+    }),
+    [completeSubmitResetPasswordForm]: state => update(state, {
+        resetPassword: {
+            fetching: { $set: false },
+            error: { $set: null },
+            newPassword: { $set: '' },
+            newPasswordConfirmation: { $set: '' },
+            confirmationResponse: { $set: true },
+        },
+    }),
+    [resetResetPasswordFormState]: state => update(state, {
+        resetPassword: {
+            $set: initialState.resetPassword,
+        },
     }),
     [resetAuthState]: () => initialState,
 }, initialState);

--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -15,6 +15,8 @@ import {
     setSelectedFacilityListItemsRowIndex,
 } from '../actions/facilityListDetails';
 
+import { completeSubmitLogOut } from '../actions/auth';
+
 import { facilityListItemStatusChoicesEnum } from '../util/constants';
 
 const initialState = Object.freeze({
@@ -109,4 +111,5 @@ export default createReducer({
     [completeConfirmFacilityListItemPotentialMatch]: completeConfirmMatch,
     [completeRejectFacilityListItemPotentialMatch]: completeConfirmMatch,
     [setSelectedFacilityListItemsRowIndex]: toggleSelectedRowIndex,
+    [completeSubmitLogOut]: () => initialState,
 }, initialState);

--- a/src/app/src/reducers/FacilityListsReducer.js
+++ b/src/app/src/reducers/FacilityListsReducer.js
@@ -8,6 +8,8 @@ import {
     resetUserFacilityLists,
 } from '../actions/facilityLists';
 
+import { completeSubmitLogOut } from '../actions/auth';
+
 const initialState = Object.freeze({
     facilityLists: Object.freeze([]),
     fetching: false,
@@ -29,4 +31,5 @@ export default createReducer({
         facilityLists: { $set: payload },
     }),
     [resetUserFacilityLists]: () => initialState,
+    [completeSubmitLogOut]: () => initialState,
 }, initialState);

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -163,6 +163,7 @@ export const profileFormFields = Object.freeze([
 export const mainRoute = '/';
 export const authLoginFormRoute = '/auth/login';
 export const authRegisterFormRoute = '/auth/register';
+export const authResetPasswordFormRoute = '/auth/resetpassword/:uid';
 export const contributeRoute = '/contribute';
 export const listsRoute = '/lists';
 export const facilityListItemsRoute = '/lists/:listID';

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -155,6 +155,20 @@ export const createPaginationOptionsFromQueryString = (qs) => {
     });
 };
 
+export const getTokenFromQueryString = (qs) => {
+    const qsToParse = startsWith(qs, '?')
+        ? qs.slice(1)
+        : qs;
+
+    const {
+        token = '',
+    } = querystring.parse(qsToParse);
+
+    return isArray(token)
+        ? head(token)
+        : token;
+};
+
 export const allFiltersAreEmpty = filters => values(filters)
     .reduce((acc, next) => {
         if (!isEmpty(next)) {
@@ -311,3 +325,9 @@ export const createRejectFacilityListItemMatchURL = listID =>
 
 export const makeMyFacilitiesRoute = organizationID =>
     `/facilities/?contributors=${organizationID}`;
+
+export const makeResetPasswordEmailURL = () =>
+    '/rest-auth/password/reset/';
+
+export const makeResetPasswordConfirmURL = () =>
+    '/rest-auth/password/reset/confirm/';

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -11482,6 +11482,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@10.11.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
+  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
+
 value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"

--- a/src/django/api/templates/mail/reset_user_password_body.html
+++ b/src/django/api/templates/mail/reset_user_password_body.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Reset your Open Apparel Registry password
+        </title>
+    </head>
+    <body>
+        <p>
+            Hi,
+        </p>
+        <p>
+            We're sending you this email because someone requested to reset the password
+            for the Open Apparel Registry account associated with this email address.
+        </p>
+        <p>
+            You can reset your password by visiting the following link:
+            <a href="{{ protocol }}://{{ domain }}/auth/resetpassword/{{ uid }}?token={{ token }}">
+                {{ protocol }}://{{ domain }}/auth/resetpassword/{{ uid }}?token={{ token }}
+            </a>
+        </p>
+        <p>
+            Sincerely,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/reset_user_password_body.txt
+++ b/src/django/api/templates/mail/reset_user_password_body.txt
@@ -1,0 +1,12 @@
+{% block content %}
+Hi,
+
+We're sending you this email because someone requested to reset the password
+for the Open Apparel Registry account associated with this email address.
+
+You can reset your password by visiting the following link: {{ protocol }}://{{ domain }}/auth/resetpassword/{{uid}}?token={{ token }}
+
+Sincerely,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/reset_user_password_subject.txt
+++ b/src/django/api/templates/mail/reset_user_password_subject.txt
@@ -1,0 +1,1 @@
+Reset your Open Apparel Registry password

--- a/src/django/api/templates/mail/signature_block.html
+++ b/src/django/api/templates/mail/signature_block.html
@@ -1,0 +1,3 @@
+<p>
+    Open Apparel Registry
+</p>

--- a/src/django/api/templates/mail/signature_block.txt
+++ b/src/django/api/templates/mail/signature_block.txt
@@ -1,0 +1,3 @@
+{% block content %}
+Open Apparel Registry
+{% endblock content %}

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -258,33 +258,6 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
             raise NotFound()
 
 
-# TODO: Remove the following URLS once Django versions have been
-# implemented. These are here as imitations of the URLS available via
-# the legacy Restify API.
-@api_view(['GET'])
-@permission_classes((AllowAny,))
-def get_lists(request):
-    return Response({"lists": []})
-
-
-@api_view(['GET'])
-@permission_classes((AllowAny,))
-def get_list(request):
-    return Response({"temps": []})
-
-
-@api_view(['GET'])
-@permission_classes((AllowAny,))
-def confirm_temp(request):
-    return Response({"temp": None})
-
-
-@api_view(['POST'])
-@permission_classes((AllowAny,))
-def update_source_name(request):
-    return Response({"source": None})
-
-
 class FacilityListViewSet(viewsets.ModelViewSet):
     queryset = FacilityList.objects.all()
     serializer_class = FacilityListSerializer

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -104,6 +104,8 @@ AUTH_USER_MODEL = 'api.User'
 
 REST_AUTH_SERIALIZERS = {
     'USER_DETAILS_SERIALIZER': 'api.serializers.UserSerializer',
+    'PASSWORD_RESET_SERIALIZER': 'api.serializers.UserPasswordResetSerializer',
+    'PASSWORD_RESET_CONFIRM_SERIALIZER': 'api.serializers.UserPasswordResetConfirmSerializer',
 }
 
 REST_FRAMEWORK = {

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -32,6 +32,7 @@ router.register('facilities', views.FacilitiesViewSet, 'facility')
 
 
 urlpatterns = [
+    url(r'^', include('django.contrib.auth.urls')),
     url(r'^web/environment\.js', environment, name='environment'),
     url(r'^api/', include(router.urls)),
     path('admin/', admin.site.urls),
@@ -54,11 +55,4 @@ urlpatterns = [
     url(r'^api/contributor-types/', views.all_contributor_types,
         name='all_contributor_types'),
     url(r'^api/countries/', views.all_countries, name='all_countries'),
-    # TODO: Remove the following URLs once the Django versions have been
-    # implemented. These are here as imitations of the URLs available via
-    # the legacy Restify API:
-    url(r'getList/', views.get_list, name='get_list'),
-    url(r'confirmTemp/', views.confirm_temp, name='confirm_temp'),
-    url(r'updateSourceName/', views.update_source_name,
-        name='update_source_name'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Overview

This PR adds a reset password workflow which is:

- submitting an email in the Forgot popup on the `/auth/login` page now sends an email including a link
- visiting the link in the app shows a reset password form
- submitting the form resets the user's password, using a UID and token encoded in the password form link like `/auth/resetpassword/<UID>?token=<TOKEN>`

Second commit here fixes a bug whereby the list and list details pages weren't being cleared correctly on logout.

Connects #97

## Demo

![screen shot 2019-02-22 at 5 13 56 pm](https://user-images.githubusercontent.com/4165523/53274485-6015a800-36c5-11e9-875a-79f6adf1e4fe.png)

![screen shot 2019-02-22 at 5 14 16 pm](https://user-images.githubusercontent.com/4165523/53274488-60ae3e80-36c5-11e9-991a-489a445e34da.png)

![screen shot 2019-02-22 at 5 14 38 pm](https://user-images.githubusercontent.com/4165523/53274487-60ae3e80-36c5-11e9-96e8-bb388820b3d1.png)

![screen shot 2019-02-22 at 5 14 49 pm](https://user-images.githubusercontent.com/4165523/53274486-60ae3e80-36c5-11e9-8a89-d67c165010a5.png)

## Notes

Borrowed the implementation for this from GARP, which has a similar functionality for developer password resets.

## Testing Instructions

- get this branch then `./scripts/update`
- with an existing user, visit `/auth/login` then open the reset password dialog and enter the user email address
- visit the link in the email logged to the terminal and verify you see the password reset form
- complete the form and verify that you can successfully reset the password and that you're able to login with your new password
- while logged in, visit your lists page
- log out and verify that the lists page and list details page are cleared