### PR TITLE
Set `use_https` correctly for password reset email

### DIFF
--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -205,7 +205,7 @@ class UserPasswordResetSerializer(PasswordResetSerializer):
             domain_override = request.get_host()
 
         opts = {
-            'use_https': request.is_secure(),
+            'use_https': settings.ENVIRONMENT != 'Development',
             'domain_override': domain_override,
             'from_email': getattr(settings, 'DEFAULT_FROM_EMAIL'),
             'request': request,


### PR DESCRIPTION
## Overview

Adjust the `use_https` setting for the password reset email to False
in development and True in production. This effectively changes the
`protocol` setting used in the base PasswordResetForm's `save` method:

https://github.com/django/django/blob/master/django/contrib/auth/forms.py#L290

Connects #231
Connects #97 

## Demo

Using `'use_https': settings.ENVIRONMENT != 'Development',`:

![screen shot 2019-02-26 at 10 49 47 am](https://user-images.githubusercontent.com/4165523/53426061-466dac80-39b4-11e9-9cb1-3112959db16d.png)

Using `'use_https': settings.ENVIRONMENT == 'Development',`:

![screen shot 2019-02-26 at 10 48 54 am](https://user-images.githubusercontent.com/4165523/53426027-3524a000-39b4-11e9-8469-468a7782d84c.png)

## Testing Instructions

- serve this branch then use the password reset form to send a reset email and verify that it uses http
- adjust the `use_https` line updated in this changeset to be

```
'use_https': settings.ENVIRONMENT == 'Development',
```

... then reload the server and send another password reset email to verify that the email now uses https