### PR TITLE
Enable downloading facility list item matches CSV

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -14,6 +14,7 @@
         "immutability-helper": "2.9.0",
         "lodash": "4.17.11",
         "mapbox-gl": "0.52.0",
+        "papaparse": "4.6.3",
         "prop-types": "15.6.2",
         "react": "16.7.0",
         "react-copy-to-clipboard": "5.0.1",

--- a/src/app/src/__tests__/utils.listItemCSV.tests.js
+++ b/src/app/src/__tests__/utils.listItemCSV.tests.js
@@ -1,0 +1,419 @@
+/* eslint-env jest */
+const {
+    createMatchRowFromListItem,
+    formatPotentialMatchData,
+    formatDataForCSV,
+    csvHeaders,
+} = require('../util/util.listItemCSV');
+
+const { facilityMatchStatusChoicesEnum } = require('../util/constants');
+
+it('creates the first few fields for a match row from a list item', () => {
+    const listItemWithoutMatchedFacility = {
+        row_index: 1,
+        status: 'status',
+        country_code: 'country_code',
+        country_name: 'country_name',
+        name: 'name',
+        address: 'address',
+        matchedFacility: null,
+    };
+
+    const expectedListItemWithoutMatchedFacilityMatch = [
+        1,
+        'status',
+        'country_code',
+        'country_name',
+        'name',
+        'address',
+        '',
+        '',
+        '',
+        '',
+        '',
+    ];
+
+    const rowForListItemWithoutMatchedFacility =
+        createMatchRowFromListItem(listItemWithoutMatchedFacility);
+
+    expectedListItemWithoutMatchedFacilityMatch.forEach((field, index) => {
+        expect(rowForListItemWithoutMatchedFacility[index]).toBe(field);
+    });
+
+    const listItemWithMatchedFacility = {
+        row_index: 1,
+        status: 'status',
+        country_code: 'country_code',
+        country_name: 'country_name',
+        name: 'name',
+        address: 'address',
+        matched_facility: {
+            oar_id: 'oar_id',
+            name: 'oar_name',
+            address: 'oar_address',
+            location: {
+                lng: 'oar_lng',
+                lat: 'oar_lat',
+            },
+        },
+    };
+
+    const expectedListItemWithMatchedFacilityMatch = [
+        1,
+        'status',
+        'country_code',
+        'country_name',
+        'name',
+        'address',
+        'oar_id',
+        'oar_name',
+        'oar_address',
+        'oar_lng',
+        'oar_lat',
+    ];
+
+    const rowForListItemWithMatchedFacility =
+          createMatchRowFromListItem(listItemWithMatchedFacility);
+
+    expectedListItemWithMatchedFacilityMatch.forEach((field, index) => {
+        expect(rowForListItemWithMatchedFacility[index]).toBe(field);
+    });
+});
+
+it('formats a potential match into a list of fields for a CSV row', () => {
+    const potentialMatchData = {
+        oar_id: 'oar_id',
+        name: 'name',
+        address: 'address',
+        confidence: 'confidence',
+        status: 'status',
+        location: {
+            lat: 'lat',
+            lng: 'lng',
+        },
+    };
+
+    const expectedFormattedPotentialMatchData = [
+        'oar_id',
+        'name',
+        'address',
+        'lng',
+        'lat',
+        'confidence',
+        'status',
+    ];
+
+    formatPotentialMatchData(potentialMatchData).forEach((field, index) => {
+        expect(expectedFormattedPotentialMatchData[index]).toBe(field);
+    });
+});
+
+it('creates a single CSV row for a list item with no matches', () => {
+    const mockListItemData = [
+        {
+            row_index: 'row_index',
+            status: 'status',
+            country_code: 'country_code',
+            country_name: 'country_name',
+            name: 'name',
+            address: 'address',
+            matched_facility: null,
+            matches: [],
+        },
+    ];
+
+    const expectedCSVData = [
+        csvHeaders,
+        [
+            'row_index',
+            'status',
+            'country_code',
+            'country_name',
+            'name',
+            'address',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+        ],
+    ];
+
+    const formattedCSVData = formatDataForCSV(mockListItemData);
+
+    expect(formattedCSVData.length).toBe(formattedCSVData.length);
+    expect(formattedCSVData.length).toBe(2);
+
+    const [headerRow, rest] = formattedCSVData;
+    const [expectedHeaderRow, expectedRest] = expectedCSVData;
+
+    expectedHeaderRow.forEach((field, index) => {
+        expect(headerRow[index]).toBe(field);
+    });
+
+    expectedRest.forEach((field, index) => {
+        expect(rest[index]).toBe(field);
+    });
+});
+
+it('creates a single CSV row for a list item with one PENDING and one REJECTED match', () => {
+    const mockListItemData = [
+        {
+            row_index: 'row_index',
+            status: 'status',
+            country_code: 'country_code',
+            country_name: 'country_name',
+            name: 'name',
+            address: 'address',
+            matched_facility: null,
+            matches: [
+                {
+                    oar_id: 'oar_id',
+                    name: 'oar_name',
+                    address: 'oar_address',
+                    confidence: 'confidence',
+                    status: facilityMatchStatusChoicesEnum.REJECTED,
+                    location: {
+                        lng: 'rejected_lng',
+                        lat: 'rejected_lat',
+                    },
+                },
+                {
+                    oar_id: 'oar_id',
+                    name: 'oar_name',
+                    address: 'oar_address',
+                    confidence: 'confidence',
+                    status: facilityMatchStatusChoicesEnum.PENDING,
+                    location: {
+                        lng: 'pending_lng',
+                        lat: 'pending_lat',
+                    },
+                },
+            ],
+        },
+    ];
+
+    const expectedCSVData = [
+        csvHeaders,
+        [
+            'row_index',
+            'status',
+            'country_code',
+            'country_name',
+            'name',
+            'address',
+            '',
+            '',
+            '',
+            '',
+            '',
+            'oar_id',
+            'oar_name',
+            'oar_address',
+            'pending_lng',
+            'pending_lat',
+            'confidence',
+            facilityMatchStatusChoicesEnum.PENDING,
+        ],
+    ];
+
+    const formattedCSVData = formatDataForCSV(mockListItemData);
+
+    expect(formattedCSVData.length).toBe(formattedCSVData.length);
+    expect(formattedCSVData.length).toBe(2);
+
+    const [headerRow, rest] = formattedCSVData;
+    const [expectedHeaderRow, expectedRest] = expectedCSVData;
+
+    expectedHeaderRow.forEach((field, index) => {
+        expect(headerRow[index]).toBe(field);
+    });
+
+    expectedRest.forEach((field, index) => {
+        expect(rest[index]).toBe(field);
+    });
+});
+
+it('creates two CSV rows for a list item with two PENDING matches', () => {
+    const mockListItemData = [
+        {
+            row_index: 'row_index',
+            status: 'status',
+            country_code: 'country_code',
+            country_name: 'country_name',
+            name: 'name',
+            address: 'address',
+            matched_facility: null,
+            matches: [
+                {
+                    oar_id: 'oar_id_one',
+                    name: 'oar_name_one',
+                    address: 'oar_address_one',
+                    confidence: 'confidence_one',
+                    status: facilityMatchStatusChoicesEnum.PENDING,
+                    location: {
+                        lat: 'lat_one',
+                        lng: 'lng_one',
+                    },
+                },
+                {
+                    oar_id: 'oar_id_two',
+                    name: 'oar_name_two',
+                    address: 'oar_address_two',
+                    confidence: 'confidence_two',
+                    status: facilityMatchStatusChoicesEnum.PENDING,
+                    location: {
+                        lat: 'lat_two',
+                        lng: 'lng_two',
+                    },
+                },
+            ],
+        },
+    ];
+
+    const expectedCSVData = [
+        csvHeaders,
+        [
+            'row_index',
+            'status',
+            'country_code',
+            'country_name',
+            'name',
+            'address',
+            '',
+            '',
+            '',
+            '',
+            '',
+            'oar_id_one',
+            'oar_name_one',
+            'oar_address_one',
+            'lng_one',
+            'lat_one',
+            'confidence_one',
+            facilityMatchStatusChoicesEnum.PENDING,
+        ],
+        [
+            'row_index',
+            'status',
+            'country_code',
+            'country_name',
+            'name',
+            'address',
+            '',
+            '',
+            '',
+            '',
+            '',
+            'oar_id_two',
+            'oar_name_two',
+            'oar_address_two',
+            'lng_two',
+            'lat_two',
+            'confidence_two',
+            facilityMatchStatusChoicesEnum.PENDING,
+        ],
+    ];
+
+    const formattedCSVData = formatDataForCSV(mockListItemData);
+
+    expect(formattedCSVData.length).toBe(formattedCSVData.length);
+    expect(formattedCSVData.length).toBe(3);
+
+    const [headerRow, first, second] = formattedCSVData;
+    const [expectedHeaderRow, expectedFirst, expectedSecond] = expectedCSVData;
+
+    expectedHeaderRow.forEach((field, index) => {
+        expect(headerRow[index]).toBe(field);
+    });
+
+    expectedFirst.forEach((field, index) => {
+        expect(first[index]).toBe(field);
+    });
+
+    expectedSecond.forEach((field, index) => {
+        expect(second[index]).toBe(field);
+    });
+});
+
+it('creates a CSV row for a list item with a matched facility', () => {
+    const mockListItemData = [
+        {
+            row_index: 'row_index',
+            status: 'status',
+            country_code: 'country_code',
+            country_name: 'country_name',
+            name: 'name',
+            address: 'address',
+            matched_facility: {
+                oar_id: 'oar_id',
+                name: 'oar_name',
+                address: 'oar_address',
+                location: {
+                    lat: 'lat',
+                    lng: 'lng',
+                },
+            },
+            matches: [
+                {
+                    oar_id: 'oar_id',
+                    name: 'oar_name',
+                    address: 'oar_address',
+                    confidence: 'confidence',
+                    status: facilityMatchStatusChoicesEnum.AUTOMATIC,
+                    location: {
+                        lat: 'lat',
+                        lng: 'lng',
+                    },
+                },
+            ],
+        },
+    ];
+
+    const expectedCSVData = [
+        csvHeaders,
+        [
+            'row_index',
+            'status',
+            'country_code',
+            'country_name',
+            'name',
+            'address',
+            'oar_id',
+            'oar_name',
+            'oar_address',
+            'lng',
+            'lat',
+            'oar_id',
+            'oar_name',
+            'oar_address',
+            'lng',
+            'lat',
+            'confidence',
+            facilityMatchStatusChoicesEnum.AUTOMATIC,
+        ],
+    ];
+
+    const formattedCSVData = formatDataForCSV(mockListItemData);
+
+    expect(formattedCSVData.length).toBe(formattedCSVData.length);
+    expect(formattedCSVData.length).toBe(2);
+
+    const [headerRow, rest] = formattedCSVData;
+    const [expectedHeaderRow, expectedRest] = expectedCSVData;
+
+    expectedHeaderRow.forEach((field, index) => {
+        expect(headerRow[index]).toBe(field);
+    });
+
+    expectedRest.forEach((field, index) => {
+        expect(rest[index]).toBe(field);
+    });
+});

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -5,6 +5,7 @@ import { Link, Switch, Route } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
 
 import AppGrid from './AppGrid';
 import FacilityListItemsEmpty from './FacilityListItemsEmpty';
@@ -21,6 +22,8 @@ import {
 } from '../util/constants';
 
 import { facilityListPropType } from '../util/propTypes';
+
+import { downloadListItemCSV } from '../util/util';
 
 const facilityListItemsStyles = Object.freeze({
     headerStyles: Object.freeze({
@@ -43,6 +46,9 @@ const facilityListItemsStyles = Object.freeze({
     }),
     descriptionStyles: Object.freeze({
         marginBottm: '30px',
+    }),
+    buttonStyles: Object.freeze({
+        marginLeft: '20px',
     }),
 });
 
@@ -104,21 +110,36 @@ class FacilityListItems extends Component {
                     style={facilityListItemsStyles.tableStyles}
                 >
                     <div style={facilityListItemsStyles.headerStyles}>
-                        <h2 style={facilityListItemsStyles.titleStyles}>
-                            {data.name || data.id}
-                        </h2>
-                        <Typography
-                            variant="subheading"
-                            style={facilityListItemsStyles.descriptionStyles}
-                        >
-                            {data.description || ''}
-                        </Typography>
-                        <Link
-                            to={listsRoute}
-                            href={listsRoute}
-                        >
-                            Back to lists
-                        </Link>
+                        <div>
+                            <h2 style={facilityListItemsStyles.titleStyles}>
+                                {data.name || data.id}
+                            </h2>
+                            <Typography
+                                variant="subheading"
+                                style={facilityListItemsStyles.descriptionStyles}
+                            >
+                                {data.description || ''}
+                            </Typography>
+                        </div>
+                        <div>
+                            <Button
+                                variant="outlined"
+                                color="primary"
+                                style={facilityListItemsStyles.buttonStyles}
+                                onClick={() => downloadListItemCSV(data)}
+                            >
+                                Download CSV
+                            </Button>
+                            <Button
+                                variant="outlined"
+                                component={Link}
+                                to={listsRoute}
+                                href={listsRoute}
+                                style={facilityListItemsStyles.buttonStyles}
+                            >
+                                Back to lists
+                            </Button>
+                        </div>
                     </div>
                     {
                         data.items.length

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -82,12 +82,20 @@ export const facilityListItemPropType = shape({
         address: string.isRequired,
         name: string.isRequired,
         created_from_id: number.isRequired,
+        location: shape({
+            lng: number.isRequired,
+            lat: number.isRequired,
+        }).isRequired,
     }),
     matches: arrayOf(shape({
         id: number.isRequired,
         oar_id: string.isRequired,
         address: string.isRequired,
         name: string.isRequired,
+        location: shape({
+            lng: number.isRequired,
+            lat: number.isRequired,
+        }).isRequired,
     }).isRequired),
 });
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -30,6 +30,8 @@ import {
     DEFAULT_ROWS_PER_PAGE,
 } from './constants';
 
+import { createListItemCSV } from './util.listItemCSV';
+
 export function DownloadCSV(data, fileName) {
     saveAs(
         new Blob([data], { type: 'text/csv;charset=utf-8;' }),
@@ -41,6 +43,12 @@ export function DownloadCSV(data, fileName) {
 
 export const downloadContributorTemplate = () =>
     DownloadCSV(contributeCSVTemplate, 'OAR_Contributor_Template.csv');
+
+export const downloadListItemCSV = list =>
+    DownloadCSV(
+        createListItemCSV(list.items),
+        `${list.id}_${list.name}_${(new Date()).toLocaleDateString()}.csv`,
+    );
 
 export const makeUserLoginURL = () => '/user-login/';
 export const makeUserLogoutURL = () => '/user-logout/';

--- a/src/app/src/util/util.listItemCSV.js
+++ b/src/app/src/util/util.listItemCSV.js
@@ -1,0 +1,99 @@
+/* eslint-disable camelcase */
+import get from 'lodash/get';
+import fill from 'lodash/fill';
+import isEmpty from 'lodash/isEmpty';
+import flow from 'lodash/flow';
+import { unparse } from 'papaparse';
+
+import { facilityMatchStatusChoicesEnum } from './constants';
+
+export const csvHeaders = Object.freeze([
+    'row_index',
+    'status',
+    'country_code',
+    'country_name',
+    'name',
+    'address',
+    'matched_facility_oar_id',
+    'matched_facility_name',
+    'matched_facility_address',
+    'matched_facility_lng',
+    'matched_facility_lat',
+    'potential_match_oar_id',
+    'potential_match_name',
+    'potential_match_address',
+    'potential_match_lng',
+    'potential_match_lat',
+    'potential_match_confidence',
+    'potential_match_status',
+]);
+
+const emptyPotentialMatchData = Object.freeze(fill(Array(7), ''));
+
+export const createMatchRowFromListItem = ({
+    row_index,
+    status,
+    country_code,
+    country_name,
+    name,
+    address,
+    matched_facility,
+}) => Object.freeze([
+    row_index,
+    status,
+    country_code,
+    country_name,
+    name,
+    address,
+    get(matched_facility, 'oar_id', ''),
+    get(matched_facility, 'name', ''),
+    get(matched_facility, 'address', ''),
+    get(matched_facility, 'location.lng', ''),
+    get(matched_facility, 'location.lat', ''),
+]);
+
+export const formatPotentialMatchData = ({
+    oar_id,
+    name,
+    address,
+    confidence,
+    status,
+    location: {
+        lng,
+        lat,
+    },
+}) => Object.freeze([
+    oar_id,
+    name,
+    address,
+    lng,
+    lat,
+    confidence,
+    status,
+]);
+
+export const listItemReducer = (acc, next) => {
+    if (isEmpty(next.matches)) {
+        return acc.concat([
+            createMatchRowFromListItem(next).concat(emptyPotentialMatchData),
+        ]);
+    }
+
+    const matchRows = next
+        .matches
+        .filter(({ status }) => status !== facilityMatchStatusChoicesEnum.REJECTED)
+        .reduce(
+            (rows, nextRow) => rows
+                .concat([
+                    createMatchRowFromListItem(next)
+                        .concat(formatPotentialMatchData(nextRow)),
+                ]),
+            [],
+        );
+
+    return acc.concat(matchRows);
+};
+
+export const formatDataForCSV = listItems => listItems.reduce(listItemReducer, [csvHeaders]);
+
+export const createListItemCSV = flow(formatDataForCSV, unparse);

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -8613,6 +8613,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
   integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
 
+papaparse@4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.3.tgz#742e5eaaa97fa6c7e1358d2934d8f18f44aee781"
+  integrity sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ==
+
 param-case@2.1.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -118,11 +118,12 @@ class FacilityMatchSerializer(ModelSerializer):
     oar_id = SerializerMethodField()
     name = SerializerMethodField()
     address = SerializerMethodField()
+    location = SerializerMethodField()
 
     class Meta:
         model = FacilityMatch
         fields = ('id', 'status', 'confidence', 'results',
-                  'oar_id', 'name', 'address')
+                  'oar_id', 'name', 'address', 'location')
 
     def get_oar_id(self, match):
         return match.facility.id
@@ -132,6 +133,14 @@ class FacilityMatchSerializer(ModelSerializer):
 
     def get_address(self, match):
         return match.facility.address
+
+    def get_location(self, match):
+        [lng, lat] = match.facility.location
+
+        return {
+            "lat": lat,
+            "lng": lng,
+        }
 
 
 class FacilityListItemSerializer(ModelSerializer):
@@ -173,11 +182,17 @@ class FacilityListItemSerializer(ModelSerializer):
         if facility_list_item.facility is None:
             return None
 
+        [lng, lat] = facility_list_item.facility.location
+
         return {
             "oar_id": facility_list_item.facility.id,
             "address": facility_list_item.facility.address,
             "name": facility_list_item.facility.name,
             "created_from_id": facility_list_item.facility.created_from.id,
+            "location": {
+                "lat": lat,
+                "lng": lng,
+            },
         }
 
 


### PR DESCRIPTION
## Overview

This PR enables users to download CSVs of facility match data from the list details page. I created a suite of utility functions and tests for formatting the data into a 2-d array, then used Papaparse along with the existing FileSaver library to handle downloading it.

Connects #204 

## Demo

![screen shot 2019-02-27 at 3 06 21 pm](https://user-images.githubusercontent.com/4165523/53519823-29afa280-3aa2-11e9-8619-5a12f1ea6a53.png)

Sample CSV:

[15_list eight_2_27_2019.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/2912151/15_list.eight_2_27_2019.csv.txt)

## Notes

Only the second commit is work for this issue, but feel free to test the first commit too (which is properly up as a PR in #235)

## Testing

- get this branch then `./scripts/update`
- serve this branch, then upload and process a facility list
- click the download button to verify that the download works and the data is formatted correctly into columns
- verify that the set of columns is the correct set for this phrase of work
- run `./scripts/test` to verify that the tests pass