### PR TITLE
Indicate when facility list item is facility source

### DIFF
--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -105,6 +105,24 @@ function FacilityListItemsTable({
                 );
             }
 
+            if (item.status === facilityListItemStatusChoicesEnum.MATCHED
+                && item.id === item.matched_facility.created_from_id) {
+                return (
+                    <FacilityListItemsTableRow
+                        key={item.row_index}
+                        rowIndex={item.row_index}
+                        countryName={item.country_name}
+                        name={item.name}
+                        address={item.address}
+                        status={item.status}
+                        handleSelectRow={handleSelectRow}
+                        hover={false}
+                        newFacility
+                        oarID={item.matched_facility.oar_id}
+                    />
+                );
+            }
+
             if (item.row_index !== selectedFacilityListItemsRowIndex) {
                 return (
                     <FacilityListItemsTableRow

--- a/src/app/src/components/FacilityListItemsTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsTableRow.jsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import { bool, func, number, oneOfType, string } from 'prop-types';
+import { Link } from 'react-router-dom';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 import isEqual from 'lodash/isEqual';
@@ -8,13 +9,17 @@ import { facilityListItemStatusPropType } from '../util/propTypes';
 
 import { listTableCellStyles } from '../util/styles';
 
+import { makeFacilityDetailLink } from '../util/util';
+
 const propsAreEqual = (prevProps, nextProps) =>
     isEqual(prevProps.rowIndex, nextProps.rowIndex)
     && isEqual(prevProps.countryCode, nextProps.countryCode)
     && isEqual(prevProps.name, nextProps.name)
     && isEqual(prevProps.address, nextProps.address)
     && isEqual(prevProps.status, nextProps.status)
-    && isEqual(prevProps.hover, nextProps.hover);
+    && isEqual(prevProps.hover, nextProps.hover)
+    && isEqual(prevProps.newFacility, nextProps.newFacility)
+    && isEqual(prevProps.oarID, nextProps.oarID);
 
 const FacilityListItemsTableRow = memo(({
     rowIndex,
@@ -24,6 +29,8 @@ const FacilityListItemsTableRow = memo(({
     status,
     hover,
     handleSelectRow,
+    newFacility,
+    oarID,
 }) => (
     <TableRow
         hover={hover}
@@ -52,7 +59,17 @@ const FacilityListItemsTableRow = memo(({
             padding="none"
             style={listTableCellStyles.nameCellStyles}
         >
-            {name}
+            {
+                (newFacility && oarID)
+                    ? (
+                        <Link
+                            to={makeFacilityDetailLink(oarID)}
+                            href={makeFacilityDetailLink(oarID)}
+                        >
+                            {name}
+                        </Link>)
+                    : name
+            }
         </TableCell>
         <TableCell
             padding="none"
@@ -64,7 +81,11 @@ const FacilityListItemsTableRow = memo(({
             padding="none"
             style={listTableCellStyles.statusCellStyles}
         >
-            {status}
+            {
+                newFacility
+                    ? 'NEW_FACILITY'
+                    : status
+            }
         </TableCell>
     </TableRow>
 ), propsAreEqual);
@@ -72,6 +93,8 @@ const FacilityListItemsTableRow = memo(({
 FacilityListItemsTableRow.defaultProps = {
     hover: false,
     handleSelectRow: null,
+    newFacility: false,
+    oarID: null,
 };
 
 FacilityListItemsTableRow.propTypes = {
@@ -81,6 +104,8 @@ FacilityListItemsTableRow.propTypes = {
     status: facilityListItemStatusPropType.isRequired,
     hover: bool,
     handleSelectRow: func,
+    newFacility: bool,
+    oarID: string,
 };
 
 export default FacilityListItemsTableRow;

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -81,6 +81,7 @@ export const facilityListItemPropType = shape({
         oar_id: string.isRequired,
         address: string.isRequired,
         name: string.isRequired,
+        created_from_id: number.isRequired,
     }),
     matches: arrayOf(shape({
         id: number.isRequired,

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -177,6 +177,7 @@ class FacilityListItemSerializer(ModelSerializer):
             "oar_id": facility_list_item.facility.id,
             "address": facility_list_item.facility.address,
             "name": facility_list_item.facility.name,
+            "created_from_id": facility_list_item.facility.created_from.id,
         }
 
 


### PR DESCRIPTION
## Overview

- update the list item table to indicate whether a facility list item is
a facility source, displaying a `NEW_FACILITY` status if so

Connects #215 

## Demo

![screen shot 2019-02-27 at 10 14 53 am](https://user-images.githubusercontent.com/4165523/53500678-d1b07600-3a78-11e9-8ee3-6b6b20b2a22f.png)

## Testing Instructions

- serve this branch, then upload and process a facility list using the instructions in https://github.com/open-apparel-registry/open-apparel-registry/pull/206
- refresh the list items page for the now-processed list and verify that facility list items which have led to newly created facilities have static rows with `NEW_FACILITY` displayed as their status and that they are linked to the facilities detail page for the facility
