### PR TITLE
Create facilities tab & display text search results

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "redpanda",
+    "name": "open-apparel-registry",
     "version": "0.1.0",
     "license": "MIT",
     "private": true,
@@ -10,11 +10,9 @@
         "axios": "0.18.0",
         "core-js": "2.6.4",
         "file-saver": "2.0.0",
-        "json2csv": "4.1.6",
         "immutability-helper": "2.9.0",
         "lodash": "4.17.11",
         "mapbox-gl": "0.52.0",
-        "papaparse": "4.6.3",
         "prop-types": "15.6.2",
         "react": "16.7.0",
         "react-copy-to-clipboard": "5.0.1",
@@ -40,8 +38,7 @@
         "build": "react-scripts build",
         "test": "CI=1 react-scripts test",
         "lint": "eslint src/ --ext .js --ext .jsx",
-        "eject": "react-scripts eject",
-        "deploy": "npm run build && firebase deploy"
+        "eject": "react-scripts eject"
     },
     "devDependencies": {
         "@babel/cli": "7.0.0-beta.49",

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -35,11 +35,18 @@ import {
     profileRoute,
 } from './util/constants';
 
-const styles = {
-    root: {
+const appStyles = Object.freeze({
+    root: Object.freeze({
         flexGrow: 1,
-    },
-};
+    }),
+    mainPanelStyle: Object.freeze({
+        top: '64px',
+        right: '0',
+        left: '0',
+        position: 'fixed',
+        bottom: '47px',
+    }),
+});
 
 class App extends Component {
     componentDidMount() {
@@ -52,7 +59,7 @@ class App extends Component {
                 <Router history={history}>
                     <div className="App">
                         <Navbar />
-                        <div>
+                        <main style={appStyles.mainPanelStyle}>
                             <Switch>
                                 <Route
                                     exact
@@ -92,7 +99,7 @@ class App extends Component {
                                     component={FacilityLists}
                                 />
                             </Switch>
-                        </div>
+                        </main>
                         <Footer />
                         <ToastContainer
                             position="bottom-center"
@@ -115,4 +122,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(() => ({}), mapDispatchToProps)(withStyles(styles)(App));
+export default connect(() => ({}), mapDispatchToProps)(withStyles(appStyles)(App));

--- a/src/app/src/__tests__/utils.facilitiesCSV.tests.js
+++ b/src/app/src/__tests__/utils.facilitiesCSV.tests.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+import isEqual from 'lodash/isEqual';
+
+import {
+    csvHeaders,
+    createFacilityRowFromFeature,
+    formatDataForCSV,
+} from '../util/util.facilitiesCSV';
+
+it('creates a new facility row array from a feature', () => {
+    const feature = {
+        properties: {
+            name: 'name',
+            address: 'address',
+            country_code: 'country_code',
+            country_name: 'country_name',
+            oar_id: 'oar_id',
+        },
+        geometry: {
+            coordinates: [
+                'lng',
+                'lat',
+            ],
+        },
+    };
+
+    const expectedRowArray = [
+        'oar_id',
+        'name',
+        'address',
+        'country_code',
+        'country_name',
+        'lat',
+        'lng',
+    ];
+
+    expect(isEqual(
+        createFacilityRowFromFeature(feature),
+        expectedRowArray,
+    )).toBe(true);
+});
+
+it('creates a 2-d array including headers for exporting as a CSV', () => {
+    const facilities = [
+        {
+            properties: {
+                name: 'name',
+                address: 'address',
+                country_code: 'country_code',
+                country_name: 'country_name',
+                oar_id: 'oar_id',
+            },
+            geometry: {
+                coordinates: [
+                    'lng',
+                    'lat',
+                ],
+            },
+        },
+    ];
+
+    const expected2DArray = [
+        csvHeaders,
+        [
+            'oar_id',
+            'name',
+            'address',
+            'country_code',
+            'country_name',
+            'lat',
+            'lng',
+        ],
+    ];
+
+    expect(isEqual(
+        formatDataForCSV(facilities),
+        expected2DArray,
+    )).toBe(true);
+});

--- a/src/app/src/actions/ui.js
+++ b/src/app/src/actions/ui.js
@@ -2,3 +2,9 @@ import { createAction } from 'redux-act';
 
 export const makeSidebarGuideTabActive = createAction('MAKE_SIDEBAR_GUIDE_TAB_ACTIVE');
 export const makeSidebarSearchTabActive = createAction('MAKE_SIDEBAR_SEARCH_TAB_ACTIVE');
+export const makeSidebarFacilitiesTabActive = createAction('MAKE_SIDEBAR_FACILITIES_TAB_ACTIVE');
+
+export const updateSidebarFacilitiesTabTextFilter =
+    createAction('UPDATE_SIDEBAR_FACILITIES_TAB_TEXT_FILTER');
+export const resetSidebarFacilitiesTabTextFilter =
+    createAction('RESET_SIDEBAR_FACILITIES_TAB_TEXT_FILTER');

--- a/src/app/src/components/AppGrid.jsx
+++ b/src/app/src/components/AppGrid.jsx
@@ -16,7 +16,6 @@ export default function AppGrid({
                 style={{
                     marginLeft: 'auto',
                     marginRight: 'auto',
-                    marginTop: '64px',
                 }}
             >
                 <Grid container style={style}>

--- a/src/app/src/components/AppOverflow.jsx
+++ b/src/app/src/components/AppOverflow.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { node } from 'prop-types';
+
+export default function AppOverflow({
+    children,
+}) {
+    return (
+        <div style={{ height: '100%', overflow: 'auto' }}>
+            {children}
+        </div>
+    );
+}
+
+AppOverflow.propTypes = {
+    children: node.isRequired,
+};

--- a/src/app/src/components/Contribute.jsx
+++ b/src/app/src/components/Contribute.jsx
@@ -6,6 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
 import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
 import ContributeHeader from './ContributeHeader';
 import ContributeForm from './ContributeForm';
 import ContributeTroubleshooting from './ContributeTroubleshooting';
@@ -49,31 +50,33 @@ function ContributeList({
     }
 
     return (
-        <AppGrid title="Contribute">
-            <Grid container className="margin-bottom-64">
-                <Grid item xs={12}>
-                    <ContributeHeader />
-                    <ContributeForm />
-                    <div className="form__field">
-                        <p className="form__label">
-                            Once the list has been successfully
-                            uploaded, view your list and confirm or deny
-                            matches.
-                        </p>
-                    </div>
-                    <div className="form__field">
-                        <Link
-                            to={listsRoute}
-                            href={listsRoute}
-                            className="outlined-button outlined-button--link margin-top-16"
-                        >
-                            View My Lists
-                        </Link>
-                    </div>
+        <AppOverflow>
+            <AppGrid title="Contribute">
+                <Grid container className="margin-bottom-64">
+                    <Grid item xs={12}>
+                        <ContributeHeader />
+                        <ContributeForm />
+                        <div className="form__field">
+                            <p className="form__label">
+                                Once the list has been successfully
+                                uploaded, view your list and confirm or deny
+                                matches.
+                            </p>
+                        </div>
+                        <div className="form__field">
+                            <Link
+                                to={listsRoute}
+                                href={listsRoute}
+                                className="outlined-button outlined-button--link margin-top-16"
+                            >
+                                View My Lists
+                            </Link>
+                        </div>
+                    </Grid>
+                    <ContributeTroubleshooting />
                 </Grid>
-                <ContributeTroubleshooting />
-            </Grid>
-        </AppGrid>
+            </AppGrid>
+        </AppOverflow>
     );
 }
 

--- a/src/app/src/components/ControlledTextInput.jsx
+++ b/src/app/src/components/ControlledTextInput.jsx
@@ -9,6 +9,7 @@ export default function ControlledTextInput({
     hint,
     value,
     onChange,
+    placeholder,
 }) {
     return (
         <Fragment>
@@ -21,6 +22,7 @@ export default function ControlledTextInput({
                 className="noFocus form__text-input"
                 value={value}
                 onChange={onChange}
+                placeholder={placeholder}
             />
         </Fragment>
     );
@@ -29,6 +31,7 @@ export default function ControlledTextInput({
 ControlledTextInput.defaultProps = {
     type: 'text',
     hint: '',
+    placeholder: '',
 };
 
 ControlledTextInput.propTypes = {
@@ -37,4 +40,5 @@ ControlledTextInput.propTypes = {
     type: string,
     hint: string,
     onChange: func.isRequired,
+    placeholder: string,
 };

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -8,6 +8,7 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 
 import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
 import FacilityListItemsEmpty from './FacilityListItemsEmpty';
 import FacilityListItemsTable from './FacilityListItemsTable';
 
@@ -101,59 +102,61 @@ class FacilityListItems extends Component {
         }
 
         return (
-            <Grid
-                container
-                justify="center"
-            >
+            <AppOverflow>
                 <Grid
-                    item
-                    style={facilityListItemsStyles.tableStyles}
+                    container
+                    justify="center"
                 >
-                    <div style={facilityListItemsStyles.headerStyles}>
-                        <div>
-                            <h2 style={facilityListItemsStyles.titleStyles}>
-                                {data.name || data.id}
-                            </h2>
-                            <Typography
-                                variant="subheading"
-                                style={facilityListItemsStyles.descriptionStyles}
-                            >
-                                {data.description || ''}
-                            </Typography>
+                    <Grid
+                        item
+                        style={facilityListItemsStyles.tableStyles}
+                    >
+                        <div style={facilityListItemsStyles.headerStyles}>
+                            <div>
+                                <h2 style={facilityListItemsStyles.titleStyles}>
+                                    {data.name || data.id}
+                                </h2>
+                                <Typography
+                                    variant="subheading"
+                                    style={facilityListItemsStyles.descriptionStyles}
+                                >
+                                    {data.description || ''}
+                                </Typography>
+                            </div>
+                            <div>
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    style={facilityListItemsStyles.buttonStyles}
+                                    onClick={() => downloadListItemCSV(data)}
+                                >
+                                    Download CSV
+                                </Button>
+                                <Button
+                                    variant="outlined"
+                                    component={Link}
+                                    to={listsRoute}
+                                    href={listsRoute}
+                                    style={facilityListItemsStyles.buttonStyles}
+                                >
+                                    Back to lists
+                                </Button>
+                            </div>
                         </div>
-                        <div>
-                            <Button
-                                variant="outlined"
-                                color="primary"
-                                style={facilityListItemsStyles.buttonStyles}
-                                onClick={() => downloadListItemCSV(data)}
-                            >
-                                Download CSV
-                            </Button>
-                            <Button
-                                variant="outlined"
-                                component={Link}
-                                to={listsRoute}
-                                href={listsRoute}
-                                style={facilityListItemsStyles.buttonStyles}
-                            >
-                                Back to lists
-                            </Button>
-                        </div>
-                    </div>
-                    {
-                        data.items.length
-                            ? (
-                                <Switch>
-                                    <Route
-                                        path={facilityListItemsRoute}
-                                        component={FacilityListItemsTable}
-                                    />
-                                </Switch>)
-                            : <FacilityListItemsEmpty />
-                    }
+                        {
+                            data.items.length
+                                ? (
+                                    <Switch>
+                                        <Route
+                                            path={facilityListItemsRoute}
+                                            component={FacilityListItemsTable}
+                                        />
+                                    </Switch>)
+                                : <FacilityListItemsEmpty />
+                        }
+                    </Grid>
                 </Grid>
-            </Grid>
+            </AppOverflow>
         );
     }
 }

--- a/src/app/src/components/FacilityLists.jsx
+++ b/src/app/src/components/FacilityLists.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
 import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
 import FacilityListsEmpty from './FacilityListsEmpty';
 import FacilityListsTable from './FacilityListsTable';
 import ShowOnly from './ShowOnly';
@@ -86,18 +87,20 @@ class FacilityLists extends Component {
             : <FacilityListsEmpty />;
 
         return (
-            <AppGrid title="My Lists">
-                <ShowOnly when={!!myFacilitiesRoute}>
-                    <Link
-                        to={myFacilitiesRoute}
-                        href={myFacilitiesRoute}
-                        style={{ paddingBottom: '20px' }}
-                    >
-                        View my facilities
-                    </Link>
-                </ShowOnly>
-                {tableComponent}
-            </AppGrid>
+            <AppOverflow>
+                <AppGrid title="My Lists">
+                    <ShowOnly when={!!myFacilitiesRoute}>
+                        <Link
+                            to={myFacilitiesRoute}
+                            href={myFacilitiesRoute}
+                            style={{ paddingBottom: '20px' }}
+                        >
+                            View my facilities
+                        </Link>
+                    </ShowOnly>
+                    {tableComponent}
+                </AppGrid>
+            </AppOverflow>
         );
     }
 }

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
-import Typography from '@material-ui/core/Typography';
 
 import FilterSidebarGuideTab from './FilterSidebarGuideTab';
 import FilterSidebarSearchTab from './FilterSidebarSearchTab';
+import FilterSidebarFacilitiesTab from './FilterSidebarFacilitiesTab';
 
 import {
     filterSidebarTabsEnum,
@@ -17,6 +17,7 @@ import {
 import {
     makeSidebarGuideTabActive,
     makeSidebarSearchTabActive,
+    makeSidebarFacilitiesTabActive,
 } from '../actions/ui';
 
 import {
@@ -33,6 +34,13 @@ import {
 } from '../util/propTypes';
 
 import { allListsAreEmpty } from '../util/util';
+
+const filterSidebarStyles = Object.freeze({
+    controlPanelStyles: Object.freeze({
+        height: 'inherit',
+        width: 'inherit',
+    }),
+});
 
 class FilterSidebar extends Component {
     componentDidMount() {
@@ -70,6 +78,7 @@ class FilterSidebar extends Component {
             activeFilterSidebarTab,
             makeGuideTabActive,
             makeSearchTabActive,
+            makeFacilitiesTabActive,
         } = this.props;
 
         const header = (
@@ -85,9 +94,15 @@ class FilterSidebar extends Component {
         const activeTabIndex = filterSidebarTabs
             .findIndex(({ tab }) => tab === activeFilterSidebarTab);
 
-        const handleTabChange = activeFilterSidebarTab === filterSidebarTabsEnum.guide
-            ? makeSearchTabActive
-            : makeGuideTabActive;
+        const handleTabChange = (_, value) => {
+            const changeTab = [
+                makeGuideTabActive,
+                makeSearchTabActive,
+                makeFacilitiesTabActive,
+            ][value];
+
+            return changeTab();
+        };
 
         const tabBar = (
             <AppBar position="static">
@@ -111,17 +126,28 @@ class FilterSidebar extends Component {
                 </Tabs>
             </AppBar>);
 
-        const insetComponent = activeFilterSidebarTab === filterSidebarTabsEnum.guide
-            ? <FilterSidebarGuideTab />
-            : <FilterSidebarSearchTab />;
+        const insetComponent = (() => {
+            switch (activeFilterSidebarTab) {
+                case filterSidebarTabsEnum.guide:
+                    return <FilterSidebarGuideTab />;
+                case filterSidebarTabsEnum.search:
+                    return <FilterSidebarSearchTab />;
+                case filterSidebarTabsEnum.facilities:
+                    return <FilterSidebarFacilitiesTab />;
+                default:
+                    window.console.warn('invalid tab selection', activeFilterSidebarTab);
+                    return null;
+            }
+        })();
 
         return (
-            <div className="control-panel">
+            <div
+                className="control-panel"
+                style={filterSidebarStyles.controlPanelStyles}
+            >
                 {header}
                 {tabBar}
-                <Typography component="div">
-                    {insetComponent}
-                </Typography>
+                {insetComponent}
             </div>
         );
     }
@@ -131,6 +157,7 @@ FilterSidebar.propTypes = {
     activeFilterSidebarTab: oneOf(Object.values(filterSidebarTabsEnum)).isRequired,
     makeGuideTabActive: func.isRequired,
     makeSearchTabActive: func.isRequired,
+    makeFacilitiesTabActive: func.isRequired,
     fetchFilterOptions: func.isRequired,
     fetchContributors: func.isRequired,
     fetchContributorTypes: func.isRequired,
@@ -168,6 +195,7 @@ function mapDispatchToProps(dispatch) {
     return {
         makeGuideTabActive: () => dispatch(makeSidebarGuideTabActive()),
         makeSearchTabActive: () => dispatch(makeSidebarSearchTabActive()),
+        makeFacilitiesTabActive: () => dispatch(makeSidebarFacilitiesTabActive()),
         fetchFilterOptions: () => dispatch(fetchAllFilterOptions()),
         fetchContributors: () => dispatch(fetchContributorOptions()),
         fetchContributorTypes: () => dispatch(fetchContributorTypeOptions()),

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -1,0 +1,302 @@
+import React, { Fragment } from 'react';
+import { arrayOf, bool, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Divider from '@material-ui/core/Divider';
+import get from 'lodash/get';
+
+import ControlledTextInput from './ControlledTextInput';
+
+import {
+    makeSidebarSearchTabActive,
+    updateSidebarFacilitiesTabTextFilter,
+} from '../actions/ui';
+
+import { facilityCollectionPropType } from '../util/propTypes';
+
+import {
+    makeFacilityDetailLink,
+    downloadFacilitiesCSV,
+    getValueFromEvent,
+    caseInsensitiveIncludes,
+    sortFacilitiesAlphabeticallyByName,
+} from '../util/util';
+
+import COLOURS from '../util/COLOURS';
+
+import { filterSidebarStyles } from '../util/styles';
+
+const SEARCH_TERM_INPUT = 'SEARCH_TERM_INPUT';
+
+const facilitiesTabStyles = Object.freeze({
+    noResultsTextStyles: Object.freeze({
+        margin: '30px',
+    }),
+    linkStyles: Object.freeze({
+        display: 'flex',
+        textDecoration: 'none',
+    }),
+    listItemStyles: Object.freeze({
+        wordWrap: 'anywhere',
+    }),
+    listHeaderStyles: Object.freeze({
+        backgroundColor: COLOURS.WHITE,
+        padding: '0.25rem',
+        maxHeight: '130px',
+    }),
+    listStyles: Object.freeze({
+        overflowY: 'scroll',
+        position: 'fixed',
+        // sum heights of navbar, tab bar, panel header, and free text search control
+        top: 'calc(64px + 48px + 130px + 110px)',
+        bottom: '47px',
+        width: '33%',
+    }),
+    listBottomPaddingStyles: Object.freeze({
+        height: '200px',
+    }),
+    titleRowStyles: Object.freeze({
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '1rem',
+    }),
+    listHeaderTextSearchStyles: Object.freeze({
+        padding: '1rem',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+    }),
+});
+
+function FilterSidebarFacilitiesTab({
+    fetching,
+    data,
+    error,
+    returnToSearchTab,
+    filterText,
+    updateFilterText,
+}) {
+    if (fetching) {
+        return (
+            <div
+                className="control-panel__content"
+                style={filterSidebarStyles.controlPanelContentStyles}
+            >
+                <div className="control-panel__body">
+                    <CircularProgress />
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div
+                className="control-panel__content"
+                style={filterSidebarStyles.controlPanelContentStyles}
+            >
+                <div className="control-panel__body">
+                    <Typography
+                        variant="body1"
+                        style={facilitiesTabStyles.noResultsTextStyles}
+                        align="center"
+                    >
+                        An error prevented fetching facilities
+                    </Typography>
+                    <Typography
+                        variant="body1"
+                        style={facilitiesTabStyles.noResultsTextStyles}
+                        align="center"
+                    >
+                        <Button
+                            onClick={returnToSearchTab}
+                            variant="outlined"
+                            color="secondary"
+                        >
+                            Try another search
+                        </Button>
+                    </Typography>
+                </div>
+            </div>
+        );
+    }
+
+    const facilities = get(data, 'features', []);
+
+    if (!facilities.length) {
+        return (
+            <div
+                className="control-panel__content"
+                style={filterSidebarStyles.controlPanelContentStyles}
+            >
+                <div className="control-panel__body">
+                    <Typography
+                        variant="body1"
+                        style={facilitiesTabStyles.noResultsTextStyles}
+                        align="center"
+                    >
+                        No facilities to display
+                    </Typography>
+                    <Typography
+                        variant="body1"
+                        style={facilitiesTabStyles.noResultsTextStyles}
+                        align="center"
+                    >
+                        <Button
+                            onClick={returnToSearchTab}
+                            variant="outlined"
+                            color="secondary"
+                        >
+                            Search for facilities
+                        </Button>
+                    </Typography>
+                </div>
+            </div>
+        );
+    }
+
+    const filteredFacilities = filterText
+        ? facilities
+            .filter(({
+                properties: {
+                    address,
+                    name,
+                    country_name: countryName,
+                },
+            }) => caseInsensitiveIncludes(address, filterText)
+                || caseInsensitiveIncludes(name, filterText)
+                || caseInsensitiveIncludes(countryName, filterText))
+        : facilities;
+
+    const orderedFacilities =
+        sortFacilitiesAlphabeticallyByName(filteredFacilities);
+
+    const listHeaderInsetComponent = (
+        <div style={facilitiesTabStyles.listHeaderStyles}>
+            <Typography
+                variant="title"
+                align="center"
+            >
+                <div
+                    style={facilitiesTabStyles.titleRowStyles}
+                >
+                    {`Displaying ${filteredFacilities.length} facilities`}
+                    <Button
+                        variant="outlined"
+                        color="primary"
+                        styles={facilitiesTabStyles.listHeaderButtonStyles}
+                        onClick={() => downloadFacilitiesCSV(orderedFacilities)}
+                    >
+                        Download CSV
+                    </Button>
+                </div>
+            </Typography>
+            <div style={facilitiesTabStyles.listHeaderTextSearchStyles}>
+                <label
+                    htmlFor={SEARCH_TERM_INPUT}
+                >
+                    Filter results
+                </label>
+                <ControlledTextInput
+                    id={SEARCH_TERM_INPUT}
+                    value={filterText}
+                    onChange={updateFilterText}
+                    placeholder="Filter by name, address, or country"
+                />
+            </div>
+        </div>
+    );
+
+    return (
+        <Fragment>
+            {listHeaderInsetComponent}
+            <div style={filterSidebarStyles.controlPanelContentStyles}>
+                <List style={facilitiesTabStyles.listStyles}>
+                    {
+                        orderedFacilities
+                            .map(({
+                                properties: {
+                                    address,
+                                    name,
+                                    country_name: countryName,
+                                    oar_id: oarID,
+                                },
+                            }) => (
+                                <Fragment key={oarID}>
+                                    <Divider />
+                                    <ListItem
+                                        key={oarID}
+                                        style={facilitiesTabStyles.listItemStyles}
+                                    >
+                                        <Link
+                                            to={makeFacilityDetailLink(oarID)}
+                                            href={makeFacilityDetailLink(oarID)}
+                                            style={facilitiesTabStyles.linkStyles}
+                                        >
+                                            <ListItemText
+                                                primary={`${name} - ${countryName}`}
+                                                secondary={address}
+                                            />
+                                        </Link>
+                                    </ListItem>
+                                </Fragment>))
+                    }
+                    <ListItem style={facilitiesTabStyles.listBottomPaddingStyles} />
+                </List>
+            </div>
+        </Fragment>
+    );
+}
+
+FilterSidebarFacilitiesTab.defaultProps = {
+    data: null,
+    error: null,
+};
+
+FilterSidebarFacilitiesTab.propTypes = {
+    data: facilityCollectionPropType,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+    returnToSearchTab: func.isRequired,
+    filterText: string.isRequired,
+    updateFilterText: func.isRequired,
+};
+
+function mapStateToProps({
+    facilities: {
+        facilities: {
+            data,
+            error,
+            fetching,
+        },
+    },
+    ui: {
+        facilitiesSidebarTabSearch: {
+            filterText,
+        },
+    },
+}) {
+    return {
+        data,
+        error,
+        fetching,
+        filterText,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        returnToSearchTab: () => dispatch(makeSidebarSearchTabActive()),
+        updateFilterText: e =>
+            dispatch((updateSidebarFacilitiesTabTextFilter(getValueFromEvent(e)))),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(FilterSidebarFacilitiesTab);

--- a/src/app/src/components/FilterSidebarGuideTab.jsx
+++ b/src/app/src/components/FilterSidebarGuideTab.jsx
@@ -1,7 +1,12 @@
 import React, { memo } from 'react';
 
+import { filterSidebarStyles } from '../util/styles';
+
 const FilterSidebarGuideTab = memo(() => (
-    <div className="control-panel__content">
+    <div
+        className="control-panel__content"
+        style={filterSidebarStyles.controlPanelContentStyles}
+    >
         <p className="control-panel__body">
             The Open Apparel Registry (OAR) is a tool to
             identify every apparel facility worldwide.

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -24,6 +24,8 @@ import {
     facilityCollectionPropType,
 } from '../util/propTypes';
 
+import { filterSidebarStyles } from '../util/styles';
+
 import { getValueFromEvent } from '../util/util';
 
 const filterSidebarSearchTabStyles = Object.freeze({
@@ -94,7 +96,10 @@ function FilterSidebarSearchTab({
     })();
 
     return (
-        <div className="control-panel__content">
+        <div
+            className="control-panel__content"
+            style={filterSidebarStyles.controlPanelContentStyles}
+        >
             <div>
                 <div className="form__field">
                     <InputLabel

--- a/src/app/src/components/Footer.jsx
+++ b/src/app/src/components/Footer.jsx
@@ -25,7 +25,7 @@ const links = [
 ];
 
 export default () => (
-    <div className="footerContainer" xs={12}>
+    <footer className="footerContainer" xs={12}>
         <div className="links">
             {links.map((l) => {
                 if (l.external && 'prefix' in l) {
@@ -73,5 +73,5 @@ export default () => (
                 alt="Creative Commons Attribution"
             />
         </a>
-    </div>
+    </footer>
 );

--- a/src/app/src/components/LoginForm.jsx
+++ b/src/app/src/components/LoginForm.jsx
@@ -6,6 +6,7 @@ import Grid from '@material-ui/core/Grid';
 
 import ControlledTextInput from './ControlledTextInput';
 import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
 import Button from './Button';
 import ShowOnly from './ShowOnly';
 import SendResetPasswordEmailForm from './SendResetPasswordEmailForm';
@@ -61,70 +62,72 @@ class LoginForm extends Component {
         }
 
         return (
-            <AppGrid title="Log In">
-                <Grid item xs={12} sm={7}>
-                    <p>
-                        You must be a registered user to contribute to the Open
-                        Apparel Registry.
-                        <br />
-                        Don&apos;t have an account?{' '}
-                        <Link
-                            to={authRegisterFormRoute}
-                            href={authRegisterFormRoute}
-                            className="link-underline"
-                        >
-                            Register
-                        </Link>
-                        .
-                    </p>
-                    <div className="form__field">
-                        <label
-                            className="form__label"
-                            htmlFor={LOGIN_EMAIL}
-                        >
-                            Email Address
-                        </label>
-                        <ControlledTextInput
-                            id={LOGIN_EMAIL}
-                            type="email"
-                            value={email}
-                            onChange={updateEmail}
+            <AppOverflow>
+                <AppGrid title="Log In">
+                    <Grid item xs={12} sm={7}>
+                        <p>
+                            You must be a registered user to contribute to the Open
+                            Apparel Registry.
+                            <br />
+                            Don&apos;t have an account?{' '}
+                            <Link
+                                to={authRegisterFormRoute}
+                                href={authRegisterFormRoute}
+                                className="link-underline"
+                            >
+                                Register
+                            </Link>
+                            .
+                        </p>
+                        <div className="form__field">
+                            <label
+                                className="form__label"
+                                htmlFor={LOGIN_EMAIL}
+                            >
+                                Email Address
+                            </label>
+                            <ControlledTextInput
+                                id={LOGIN_EMAIL}
+                                type="email"
+                                value={email}
+                                onChange={updateEmail}
+                            />
+                        </div>
+                        <div className="form__field">
+                            <label
+                                className="form__label"
+                                htmlFor={LOGIN_PASSWORD}
+                            >
+                                Password
+                            </label>
+                            <ControlledTextInput
+                                id={LOGIN_PASSWORD}
+                                type="password"
+                                value={password}
+                                onChange={updatePassword}
+                            />
+                        </div>
+                        <SendResetPasswordEmailForm />
+                        <ShowOnly when={!!(error && error.length)}>
+                            <ul style={formValidationErrorMessageStyle}>
+                                {
+                                    error && error.length
+                                        ? error.map(err => (
+                                            <li key={err}>
+                                                {err}
+                                            </li>))
+                                        : null
+                                }
+                            </ul>
+                        </ShowOnly>
+                        <Button
+                            text="Log In"
+                            onClick={submitForm}
+                            disabled={fetching}
                         />
-                    </div>
-                    <div className="form__field">
-                        <label
-                            className="form__label"
-                            htmlFor={LOGIN_PASSWORD}
-                        >
-                            Password
-                        </label>
-                        <ControlledTextInput
-                            id={LOGIN_PASSWORD}
-                            type="password"
-                            value={password}
-                            onChange={updatePassword}
-                        />
-                    </div>
-                    <SendResetPasswordEmailForm />
-                    <ShowOnly when={!!(error && error.length)}>
-                        <ul style={formValidationErrorMessageStyle}>
-                            {
-                                error && error.length
-                                    ? error.map(err => (
-                                        <li key={err}>
-                                            {err}
-                                        </li>))
-                                    : null
-                            }
-                        </ul>
-                    </ShowOnly>
-                    <Button
-                        text="Log In"
-                        onClick={submitForm}
-                        disabled={fetching}
-                    />
-                </Grid>
-            </AppGrid>
+                    </Grid>
+                </AppGrid>
+            </AppOverflow>
         );
     }
 }

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 
@@ -15,7 +15,7 @@ import { facilityDetailsRoute } from '../util/constants';
 
 function MapAndSidebar() {
     return (
-        <div>
+        <Fragment>
             <LandingAlert />
             <Grid container>
                 <Grid
@@ -47,7 +47,7 @@ function MapAndSidebar() {
                     </Switch>
                 </Grid>
             </Grid>
-        </div>
+        </Fragment>
     );
 }
 

--- a/src/app/src/components/OARMap.jsx
+++ b/src/app/src/components/OARMap.jsx
@@ -31,13 +31,15 @@ import {
     oarMapLayerIDEnum,
 } from '../util/constants.oarmap';
 
+import { emptyFeatureCollection } from '../util/constants';
+
 mapboxgl.accessToken = MAPBOX_TOKEN;
 
 const OARMapStyles = Object.freeze({
     copySearchButtonStyle: Object.freeze({
         position: 'absolute',
         right: '84px',
-        top: '84px',
+        top: '20px',
         fontSize: '12px',
     }),
 });
@@ -134,7 +136,10 @@ class OARMap extends Component {
         );
     }
 
-    componentDidUpdate({ fetching: wasFetching }) {
+    componentDidUpdate({
+        fetching: wasFetching,
+        data: hadData,
+    }) {
         const {
             fetching,
             error,
@@ -148,6 +153,13 @@ class OARMap extends Component {
 
         if (error) {
             return null;
+        }
+
+        if (!data && hadData) {
+            // Clear markers from layer if data has been cleared
+            return this.oarMap.getSource(FACILITIES_SOURCE)
+                ? this.oarMap.getSource(FACILITIES_SOURCE).setData(emptyFeatureCollection)
+                : null;
         }
 
         if (!wasFetching && !singleFacilityData) {

--- a/src/app/src/components/RegisterForm.jsx
+++ b/src/app/src/components/RegisterForm.jsx
@@ -6,6 +6,7 @@ import Grid from '@material-ui/core/Grid';
 import memoize from 'lodash/memoize';
 
 import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
 import ShowOnly from './ShowOnly';
 import Button from './Button';
 import RegisterFormField from './RegisterFormField';
@@ -93,47 +94,49 @@ class RegisterForm extends Component {
                 />));
 
         return (
-            <AppGrid title="Register">
-                <p>
-                    Already have an account?{' '}
-                    <Link
-                        to={authLoginFormRoute}
-                        href={authLoginFormRoute}
-                        className="link-underline"
-                    >
-                        Log In
-                    </Link>
-                    .
-                </p>
-                <Grid container className="margin-bottom-100">
-                    <Grid item xs={12} sm={8}>
-                        <p>
-                            Thank you for contributing to the OAR. Every
-                            contribution further improves the accuracy of the
-                            database. Create an account to begin:
-                        </p>
-                        {formInputs}
-                        <ShowOnly when={!!(error && error.length)}>
-                            <ul style={formValidationErrorMessageStyle}>
-                                {
-                                    error && error.length
-                                        ? error.map(err => (
-                                            <li key={err}>
-                                                {err}
-                                            </li>
-                                        ))
-                                        : null
-                                }
-                            </ul>
-                        </ShowOnly>
-                        <Button
-                            text="Register"
-                            onClick={submitForm}
-                            disabled={fetching}
-                        />
+            <AppOverflow>
+                <AppGrid title="Register">
+                    <p>
+                        Already have an account?{' '}
+                        <Link
+                            to={authLoginFormRoute}
+                            href={authLoginFormRoute}
+                            className="link-underline"
+                        >
+                            Log In
+                        </Link>
+                        .
+                    </p>
+                    <Grid container className="margin-bottom-100">
+                        <Grid item xs={12} sm={8}>
+                            <p>
+                                Thank you for contributing to the OAR. Every
+                                contribution further improves the accuracy of the
+                                database. Create an account to begin:
+                            </p>
+                            {formInputs}
+                            <ShowOnly when={!!(error && error.length)}>
+                                <ul style={formValidationErrorMessageStyle}>
+                                    {
+                                        error && error.length
+                                            ? error.map(err => (
+                                                <li key={err}>
+                                                    {err}
+                                                </li>
+                                            ))
+                                            : null
+                                    }
+                                </ul>
+                            </ShowOnly>
+                            <Button
+                                text="Register"
+                                onClick={submitForm}
+                                disabled={fetching}
+                            />
+                        </Grid>
                     </Grid>
-                </Grid>
-            </AppGrid>
+                </AppGrid>
+            </AppOverflow>
         );
     }
 }

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -6,6 +6,7 @@ import memoize from 'lodash/memoize';
 import noop from 'lodash/noop';
 
 import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
 import Button from './Button';
 import UserProfileField from './UserProfileField';
 import UserAPITokens from './UserAPITokens';
@@ -112,27 +113,29 @@ function UserProfile({
             />));
 
     return (
-        <AppGrid
-            title="My Profile"
-            style={profileStyles.appGridContainer}
-        >
-            <Grid item xs={12} sm={7}>
-                {profileInputs}
-                <div style={profileStyles.submitButton}>
-                    <Button
-                        text="Save Changes"
-                        onClick={submitForm}
-                        disabled={!isEditable && fetching}
-                        color="primary"
-                        variant="contained"
-                        disableRipple
-                    >
-                        Save Changes
-                    </Button>
-                </div>
-                <UserAPITokens />
-            </Grid>
-        </AppGrid>
+        <AppOverflow>
+            <AppGrid
+                title="My Profile"
+                style={profileStyles.appGridContainer}
+            >
+                <Grid item xs={12} sm={7}>
+                    {profileInputs}
+                    <div style={profileStyles.submitButton}>
+                        <Button
+                            text="Save Changes"
+                            onClick={submitForm}
+                            disabled={!isEditable && fetching}
+                            color="primary"
+                            variant="contained"
+                            disableRipple
+                        >
+                            Save Changes
+                        </Button>
+                    </div>
+                    <UserAPITokens />
+                </Grid>
+            </AppGrid>
+        </AppOverflow>
     );
 }
 

--- a/src/app/src/reducers/FacilitiesReducer.js
+++ b/src/app/src/reducers/FacilitiesReducer.js
@@ -15,6 +15,15 @@ import {
     resetSingleFacility,
 } from '../actions/facilities';
 
+import {
+    updateFacilityNameFilter,
+    updateContributorFilter,
+    updateContributorTypeFilter,
+    updateCountryFilter,
+    resetAllFilters,
+    updateAllFilters,
+} from '../actions/filters';
+
 import { makeFeatureCollectionFromSingleFeature } from '../util/util';
 
 const initialState = Object.freeze({
@@ -64,11 +73,18 @@ const handleFetchSingleFacility = (state, payload) => {
     });
 };
 
+const clearFacilitiesDataOnFilterChange = state => update(state, {
+    facilities: {
+        data: { $set: null },
+    },
+});
+
 export default createReducer({
     [startFetchFacilities]: state => update(state, {
         facilities: {
             fetching: { $set: true },
             error: { $set: null },
+            data: { $set: null },
         },
     }),
     [failFetchFacilities]: (state, payload) => update(state, {
@@ -104,4 +120,10 @@ export default createReducer({
     [resetSingleFacility]: state => update(state, {
         singleFacility: { $set: initialState.singleFacility },
     }),
+    [updateFacilityNameFilter]: clearFacilitiesDataOnFilterChange,
+    [updateContributorFilter]: clearFacilitiesDataOnFilterChange,
+    [updateContributorTypeFilter]: clearFacilitiesDataOnFilterChange,
+    [updateCountryFilter]: clearFacilitiesDataOnFilterChange,
+    [resetAllFilters]: clearFacilitiesDataOnFilterChange,
+    [updateAllFilters]: clearFacilitiesDataOnFilterChange,
 }, initialState);

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -4,12 +4,20 @@ import update from 'immutability-helper';
 import {
     makeSidebarGuideTabActive,
     makeSidebarSearchTabActive,
+    makeSidebarFacilitiesTabActive,
+    updateSidebarFacilitiesTabTextFilter,
+    resetSidebarFacilitiesTabTextFilter,
 } from '../actions/ui';
+
+import { completeFetchFacilities } from '../actions/facilities';
 
 import { filterSidebarTabsEnum } from '../util/constants';
 
 const initialState = Object.freeze({
     activeFilterSidebarTab: filterSidebarTabsEnum.search,
+    facilitiesSidebarTabSearch: Object.freeze({
+        filterText: '',
+    }),
 });
 
 export default createReducer({
@@ -21,6 +29,40 @@ export default createReducer({
     [makeSidebarSearchTabActive]: state => update(state, {
         activeFilterSidebarTab: {
             $set: filterSidebarTabsEnum.search,
+        },
+        facilitiesSidebarTabSearch: {
+            searchTerm: {
+                $set: initialState.facilitiesSidebarTabSearch.searchTerm,
+            },
+        },
+    }),
+    [makeSidebarFacilitiesTabActive]: state => update(state, {
+        activeFilterSidebarTab: {
+            $set: filterSidebarTabsEnum.facilities,
+        },
+    }),
+    [completeFetchFacilities]: state => update(state, {
+        activeFilterSidebarTab: {
+            $set: filterSidebarTabsEnum.facilities,
+        },
+        facilitiesSidebarTabSearch: {
+            searchTerm: {
+                $set: initialState.facilitiesSidebarTabSearch.searchTerm,
+            },
+        },
+    }),
+    [updateSidebarFacilitiesTabTextFilter]: (state, payload) => update(state, {
+        facilitiesSidebarTabSearch: {
+            filterText: {
+                $set: payload,
+            },
+        },
+    }),
+    [resetSidebarFacilitiesTabTextFilter]: state => update(state, {
+        facilitiesSidebarTabSearch: {
+            filterText: {
+                $set: initialState.facilitiesSidebarTabSearch.filterText,
+            },
         },
     }),
 }, initialState);

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -2,15 +2,14 @@
   background: #fff;
   box-shadow: 2px 0 4px rgba(0,0,0,.15);
   z-index: 1;
-  overflow: auto;
-  height: calc(100vh - 64px);
-  margin-top: 64px;
+  height: calc(100vh - 64px - 47px);
 }
 
 .panel-header {
   color: white;
   background: #444545;
   padding: 24px 32px;
+  max-height: 110px;
 }
 
 .panel-header__title {
@@ -31,7 +30,7 @@
 
 #map {
   position: absolute;
-  top: 64px;
+  top: 0;
   bottom: 0;
   width: 100%;
 }
@@ -60,6 +59,10 @@
   padding-left: 0px;
   padding-right: 0px;
   padding-top: 14px;
+}
+
+.mapboxgl-ctrl-bottom-right {
+    margin: 30px 0 !important;
 }
 
 .circle {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -207,6 +207,7 @@ export const contributeReplacesNoneSelectionID = -1;
 export const filterSidebarTabsEnum = Object.freeze({
     guide: 'guide',
     search: 'search',
+    facilities: 'facilities',
 });
 
 export const filterSidebarTabs = Object.freeze([
@@ -217,6 +218,10 @@ export const filterSidebarTabs = Object.freeze([
     Object.freeze({
         tab: filterSidebarTabsEnum.search,
         label: 'Search',
+    }),
+    Object.freeze({
+        tab: filterSidebarTabsEnum.facilities,
+        label: 'Facilities',
     }),
 ]);
 
@@ -253,4 +258,9 @@ export const facilityMatchStatusChoicesEnum = Object.freeze({
     AUTOMATIC: 'AUTOMATIC',
     CONFIRMED: 'CONFIRMED',
     REJECTED: 'REJECTED',
+});
+
+export const emptyFeatureCollection = Object.freeze({
+    type: FEATURE_COLLECTION,
+    features: Object.freeze([]),
 });

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -135,6 +135,7 @@ export const facilityPropType = shape({
         name: string.isRequired,
         address: string.isRequired,
         country_code: string.isRequired,
+        country_name: string.isRequired,
         other_names: arrayOf(string).isRequired,
         other_addresses: arrayOf(string).isRequired,
         contributors: arrayOf(string).isRequired,

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -63,3 +63,10 @@ export const confirmRejectMatchRowStyles = Object.freeze({
         justifyContent: 'space-between',
     }),
 });
+
+export const filterSidebarStyles = Object.freeze({
+    controlPanelContentStyles: Object.freeze({
+        height: 'inherit',
+        overflow: 'auto',
+    }),
+});

--- a/src/app/src/util/util.facilitiesCSV.js
+++ b/src/app/src/util/util.facilitiesCSV.js
@@ -1,0 +1,45 @@
+/* eslint-disable camelcase */
+import flow from 'lodash/flow';
+
+import { joinDataIntoCSVString } from './util';
+
+export const csvHeaders = Object.freeze([
+    'oar_id',
+    'name',
+    'address',
+    'country_code',
+    'country_name',
+    'lat',
+    'lng',
+]);
+
+export const createFacilityRowFromFeature = ({
+    properties: {
+        name,
+        address,
+        country_code,
+        country_name,
+        oar_id,
+    },
+    geometry: {
+        coordinates: [
+            lng,
+            lat,
+        ],
+    },
+}) => Object.freeze([
+    oar_id,
+    name,
+    address,
+    country_code,
+    country_name,
+    lat,
+    lng,
+]);
+
+export const facilityReducer = (acc, next) =>
+    acc.concat([createFacilityRowFromFeature(next)]);
+
+export const formatDataForCSV = facilities => facilities.reduce(facilityReducer, [csvHeaders]);
+
+export const createFacilitiesCSV = flow(formatDataForCSV, data => joinDataIntoCSVString(data));

--- a/src/app/src/util/util.listItemCSV.js
+++ b/src/app/src/util/util.listItemCSV.js
@@ -3,7 +3,8 @@ import get from 'lodash/get';
 import fill from 'lodash/fill';
 import isEmpty from 'lodash/isEmpty';
 import flow from 'lodash/flow';
-import { unparse } from 'papaparse';
+
+import { joinDataIntoCSVString } from './util';
 
 import { facilityMatchStatusChoicesEnum } from './constants';
 
@@ -96,4 +97,4 @@ export const listItemReducer = (acc, next) => {
 
 export const formatDataForCSV = listItems => listItems.reduce(listItemReducer, [csvHeaders]);
 
-export const createListItemCSV = flow(formatDataForCSV, unparse);
+export const createListItemCSV = flow(formatDataForCSV, data => joinDataIntoCSVString(data));

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -3913,7 +3913,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.11.0, commander@^2.15.1, commander@^2.8.1:
+commander@2, commander@^2.11.0, commander@^2.8.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -7299,17 +7299,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2csv@4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-4.1.6.tgz#d56b15d72a050b6902ee960232ffd66c18f3051a"
-  integrity sha512-pmitnvvuX9OC6lL6T6F0sl6NsoXG94xLHKnKwdRSEpASFd3xdKHvsksPpNFZtDULP0AwOA0MGKrm1I0c7Enaxg==
-  dependencies:
-    commander "^2.15.1"
-    jsonparse "^1.3.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -7346,11 +7335,6 @@ jsonlint-lines-primitives@~1.6.0:
   dependencies:
     JSV ">= 4.0.x"
     nomnom ">= 1.5.x"
-
-jsonparse@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
-  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -7620,11 +7604,6 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -7640,20 +7619,10 @@ lodash.defaults@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
   integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.template@^4.4.0:
   version "4.4.0"
@@ -8612,11 +8581,6 @@ pako@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
   integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
-
-papaparse@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.3.tgz#742e5eaaa97fa6c7e1358d2934d8f18f44aee781"
-  integrity sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ==
 
 param-case@2.1.x:
   version "2.1.1"

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -92,12 +92,13 @@ class FacilitySerializer(GeoFeatureModelSerializer):
     other_names = SerializerMethodField()
     other_addresses = SerializerMethodField()
     contributors = SerializerMethodField()
+    country_name = SerializerMethodField()
 
     class Meta:
         model = Facility
         fields = ('id', 'name', 'address', 'country_code', 'location',
                   'created_at', 'updated_at', 'oar_id', 'other_names',
-                  'other_addresses', 'contributors')
+                  'other_addresses', 'contributors', 'country_name')
         geo_field = 'location'
 
     # Added to ensure including the OAR ID in the geojson properties map
@@ -112,6 +113,9 @@ class FacilitySerializer(GeoFeatureModelSerializer):
 
     def get_contributors(self, facility):
         return facility.contributors()
+
+    def get_country_name(self, facility):
+        return COUNTRY_NAMES.get(facility.country_code, '')
 
 
 class FacilityMatchSerializer(ModelSerializer):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -176,7 +176,7 @@ def all_contributors(request):
     response_data = [
         (contributor.id, contributor.name)
         for contributor
-        in Contributor.objects.all()
+        in Contributor.objects.all().order_by('name')
     ]
     return Response(response_data)
 


### PR DESCRIPTION
## Overview

This PR adds a facilities list tab which will display a list of text search results as depicted below when the facilities results return from a search of the API. I also added a free text search which currently searches on the `name` `address` and `country_name` fields to narrow down the list of visible results, as well as a "Download CSV" functionality which downloads a list of CSV items.

Additionally, this PR also:

- replaces papaparse with a custom utility function to turn a 2d array into a string, which circumvents a bug whereby JSON.parse would sometimes try to parse the OAR ID as a number but fail and instead print `NaN` to the CSV
- adds tests for that newly added utility function
- adjusts the contributor list to list them in alphabetical order by name
- adjusts the app's DOM structure to make it possible to scroll subcomponents rather than scrolling the entire app
- changes the app name in `package.json` from "redpanda" (which was the legacy name?) to "open apparel registry"

Connects #209
Connects #227
Connects #127 
Connects #123 

## Demo

![facilities-list](https://user-images.githubusercontent.com/4165523/53747859-318c8f80-3e72-11e9-85a4-59ed271054f4.gif)

CSV: 
[facilities.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/2927348/facilities.csv.txt)

No results for a search:

![screen shot 2019-03-04 at 11 47 10 am](https://user-images.githubusercontent.com/4165523/53748396-474e8480-3e73-11e9-8807-6bbea0511f97.png)

## Notes

I made #244 for the map interactions because it will need some dedicated thought about how to handle the various possible kinds of interaction.

## Testing

- get this branch then `./scripts/update`
- run `./scripts/test` and verify that everything passes
- `./scripts/resetdb`
- visit the main map page and
    - verify that the contributors are now listed in alphabetical order by name
    - make a search and verify that you are navigated to the facilities tab on success
    - verify that the free text search works as expected
    - verify that you can download a list of facilities, filtered by your free text search
    - verify that you can scroll through the facilities and that clicking on any of the list items takes you to its details route
- on the Macbook-sized viewport, check that the following pages scroll correctly following the changes I made to the DOM:
   - `/auth/register`
   - `/contribute`
   - `/profile/:id/`
   - `/lists`
   - `/lists/:id`
- download a facility list and verify that that still works, following the changes to replace papaparse