### PR TITLE
Skip Facility List CSV Header Row on Ingest

### DIFF
--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -69,9 +69,9 @@ class FacilityListCreateTest(APITestCase):
         self.assertEqual(FacilityList.objects.all().count(),
                          previous_list_count + 1)
         self.assertEqual(FacilityListItem.objects.all().count(),
-                         previous_item_count + len(self.test_csv_rows))
+                         previous_item_count + len(self.test_csv_rows) - 1)
         items = list(FacilityListItem.objects.all())
-        self.assertEqual(items[1].raw_data, self.test_csv_rows[1])
+        self.assertEqual(items[0].raw_data, self.test_csv_rows[1])
 
     def test_file_required(self):
         response = self.client.post(reverse('facility-list-list'))

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -336,12 +336,13 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             replaces.save()
 
         for idx, line in enumerate(csv_file):
-            new_item = FacilityListItem(
-                row_index=idx,
-                facility_list=new_list,
-                raw_data=line.decode().rstrip()
-            )
-            new_item.save()
+            if idx > 0:
+                new_item = FacilityListItem(
+                    row_index=(idx - 1),
+                    facility_list=new_list,
+                    raw_data=line.decode().rstrip()
+                )
+                new_item.save()
 
         if ENVIRONMENT in ('Staging', 'Production'):
             submit_jobs(ENVIRONMENT, new_list)


### PR DESCRIPTION
## Overview

Previously each line in the Facility List CSV would be added as a Facility List Item to the database, including the header row.

To make it so that only true data rows are added, we now skip the first line of the uploaded CSV file. The added facility list item's `row_index` field still starts with 0 though, to help make AWS Batch processing easier, which uses a 0-indexed scheme.

Connects #211 

## Demo

The first row no longer errors:

<img width="1142" alt="image" src="https://user-images.githubusercontent.com/1430060/53668847-14be4500-3c43-11e9-9c77-3ae65bd195dd.png">

and is no longer the header:

```sql
SELECT id, row_index, raw_data, status, facility_list_id
FROM api_facilitylistitem
WHERE row_index = 0;

 id  | row_index |                                                     raw_data                                                     |  status  | facility_list_id
-----+-----------+------------------------------------------------------------------------------------------------------------------+----------+------------------
   1 |         0 | country,name,address                                                                                             | ERROR    |                1
  83 |         0 | country,name,address                                                                                             | UPLOADED |                2
 114 |         0 | Bangladesh,KSI (Karnaphuli Shoes Industries- Garment Division),"Korean Export Processing Zone,Anwara,Chittagong" | UPLOADED |                4
(3 rows)
```

## Testing Instructions

* Go to [:6543/](http://localhost:6543/) and log in
* Go to [/contribute](http://localhost:6543/contribute) and upload a CSV
* In the console, look at the database:

    ```bash
    $ vagrant ssh -c 'cd /vagrant && ./scripts/manage dbshell'

    > SELECT id, row_index, raw_data, status, facility_list_id
      FROM api_facilitylistitem
      WHERE row_index = 0;
    ```

  and notice that the most recent upload's zeroth item doesn't have header values.
* Run `parse`, `geocode`, and `match` and ensure that the first row doesn't error out.
