### PR TITLE
Recognize 'uae' as possible representation of UAE

### DIFF
--- a/src/django/api/countries.py
+++ b/src/django/api/countries.py
@@ -540,6 +540,7 @@ COUNTRY_CODES = {
     'turkmenistan': 'TM',
     'turks and caicos islands': 'TC',
     'tuvalu': 'TV',
+    'uae': 'AE',
     'uganda': 'UG',
     'ukraine': 'UA',
     'ungheria': 'HU',


### PR DESCRIPTION
## Overview

This mapping was previously missing from our standard list. By adding it, we ensure that it is recognized and classified correctly.

Connects #217 

## Demo

![screen shot 2019-03-01 at 18 36 07-fullpage](https://user-images.githubusercontent.com/1430060/53672576-27d81180-3c51-11e9-9428-b5ac67abbfd8.png)

```sql
SELECT row_index, raw_data, status, country_code, facility_list_id
FROM api_facilitylistitem
WHERE facility_list_id = 6
  AND raw_data LIKE 'UAE%'

 row_index |                                                        raw_data                                                        | status | country_code | facility_list_id
-----------+------------------------------------------------------------------------------------------------------------------------+--------+--------------+------------------
        34 | UAE,Indigo Garments Workshop,"Plot No. 236, Sector 1, near Emirates Gas New Industrial Area, Ajman"                    | PARSED | AE           |                6
        33 | UAE,Indigo Garments FZE,"Plot No. H1-03, 04 & 05 & P4-11, Sharjah Airport International Free Zone, Sharjah, Saif Zone" | PARSED | AE           |                6
        35 | UAE,Indigo Garments Workshop BR-2,"Plot no. 104, Jurf Industrial 1, Near Ajman Car Souq, Ajman"                        | PARSED | AE           |                6
(3 rows)
```

## Testing Instructions

* Go to [:6543/](http://localhost:6543/) and log in
* Go to [/contribute](http://localhost:6543/contribute) and upload [`4.csv`](https://github.com/open-apparel-registry/open-apparel-registry/blob/develop/src/django/api/management/commands/facility_lists/4.csv)
* Parse the list

    ```bash
    manage batch_process --list-id $LIST_ID --action parse
    ```
* Check that UAE entries have the correct country assigned to them
