### PR TITLE
Display NEW_FACILITY when all matches are rejected

### DIFF
--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -105,7 +105,8 @@ function FacilityListItemsTable({
                 );
             }
 
-            if (item.status === facilityListItemStatusChoicesEnum.MATCHED
+            if ((item.status === facilityListItemStatusChoicesEnum.MATCHED
+                 || item.status === facilityListItemStatusChoicesEnum.CONFIRMED_MATCH)
                 && item.id === item.matched_facility.created_from_id) {
                 return (
                     <FacilityListItemsTableRow


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby list item rows for new facilities which were created by rejecting all potential matches were displayed in the `CONFIRMED_MATCH` style rather than in the `NEW_FACILITY` style.

Connects #253

## Demo

Potential matches:

![screen shot 2019-03-05 at 2 06 16 pm](https://user-images.githubusercontent.com/4165523/53830204-e8ab0880-3f4f-11e9-9d6a-3d9f6297579c.png)

After rejecting all potential matches:

![screen shot 2019-03-05 at 2 06 33 pm](https://user-images.githubusercontent.com/4165523/53830214-ef398000-3f4f-11e9-9987-868f1bcb3d80.png)

## Testing Instructions

- get this branch, register for an account, and upload then process a list
- for a list item with a set of proposed potential matches, reject each potential match
- verify that once all the matches are rejected, the row becomes a `NEW_FACILITY` row

