### PR TITLE
Create new FacilityMatch when all matches rejected

### DIFF
--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -921,3 +921,30 @@ class ConfirmAndRejectFacilityMatchTest(TestCase):
 
         facilities = Facility.objects.all()
         self.assertEqual(facilities.count(), 3)
+
+    def test_rejecting_last_potential_match_creates_a_new_facility_match(self):
+        initial_facility_matches_count = FacilityMatch.objects.all().count()
+
+        reject_response_one = self.client.post(
+            self.reject_url,
+            {"list_item_id": self.current_list_item.id,
+             "facility_match_id": self.potential_facility_match_one.id},
+        )
+
+        reject_response_two = self.client.post(
+            self.reject_url,
+            {"list_item_id": self.current_list_item.id,
+             "facility_match_id": self.potential_facility_match_two.id},
+        )
+
+        self.assertEqual(reject_response_one.status_code, 200)
+        self.assertEqual(reject_response_two.status_code, 200)
+
+        facilities = Facility.objects.all()
+        self.assertEqual(facilities.count(), 3)
+
+        new_facility_matches_count = FacilityMatch.objects.all().count()
+        self.assertEqual(
+            initial_facility_matches_count + 1,
+            new_facility_matches_count,
+        )

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -493,6 +493,17 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                             location=facility_list_item.geocoded_point,
                             created_from=facility_list_item)
 
+                # also create a new facility match
+                FacilityMatch \
+                    .objects \
+                    .create(facility_list_item=facility_list_item,
+                            facility=new_facility,
+                            confidence=1.0,
+                            status=FacilityMatch.CONFIRMED,
+                            results={
+                                "match_type": "all_potential_matches_rejected",
+                            })
+
                 facility_list_item.facility = new_facility
 
                 facility_list_item.status = FacilityListItem.CONFIRMED_MATCH


### PR DESCRIPTION
## Overview

- create a new FacilityMatch record along with a new Facility record
when all other potential matches have been rejected through the UI
- add test to verify the FacilityMatch count increments on rejecting
all matches

Connects #255 

## Demo

![screen shot 2019-03-05 at 5 13 02 pm](https://user-images.githubusercontent.com/4165523/53841117-fb323b80-3f69-11e9-9cc5-63285c42a737.png)


## Testing Instructions

- get this branch, then run the tests to verify that they pass
- process a list, then reject all matches for one item in the UI. verify that it changes to `NEW_FACILITY` status and that it now has one more `FacilityMatch` than it did before: one created for the new facility
