### PR TITLE
Delay loading map data until styles have loaded

### DIFF
--- a/src/app/src/components/OARMap.jsx
+++ b/src/app/src/components/OARMap.jsx
@@ -44,7 +44,7 @@ const OARMapStyles = Object.freeze({
     }),
 });
 
-const loadEvent = 'load';
+const styleLoadEvent = 'style.load';
 const moveEvent = 'move';
 const clickEvent = 'click';
 const mouseEnterEvent = 'mouseenter';
@@ -110,7 +110,7 @@ class OARMap extends Component {
         this.oarMap.on(moveEvent, this.handleMapMove);
         this.oarMap.on(clickEvent, this.handleMapClick);
 
-        this.oarMap.on(loadEvent, () => {
+        this.oarMap.on(styleLoadEvent, () => {
             if (data) {
                 this.oarMap.addSource(
                     FACILITIES_SOURCE,
@@ -173,7 +173,7 @@ class OARMap extends Component {
         if (this.oarMap.getSource(FACILITIES_SOURCE)) {
             this.oarMap.getSource(FACILITIES_SOURCE).setData(data);
             this.toggleHighlightedPoint();
-        } else {
+        } else if (this.oarMap) {
             this.oarMap.addSource(
                 FACILITIES_SOURCE,
                 createSourceFromData(data),


### PR DESCRIPTION
## Overview

- fixes a bug whereby the map would crash the app if the OARMap
component attempted to load data before the map's style was loaded

Connects #257

## Testing Instructions

- rebase work for #252 on this branch
- try this out for a bit and check that the app doesn't crash as it did before
