### PR TITLE
adds a GDPR notification

### DIFF
--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -501,6 +501,17 @@ hr {
   right: 32px;
 }
 
+.gdpr-notification {
+  right: 0 !important;
+  bottom: 0 !important;
+}
+
+.gdpr-notification > div {
+  background: white;
+  color: black;
+  border-radius: 0;
+}
+
 
 
 /* @keyframes App-logo-spin {

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -18,6 +18,7 @@ import MapAndSidebar from './components/MapAndSidebar';
 import FacilityLists from './components/FacilityLists';
 import FacilityListItems from './components/FacilityListItems';
 import ErrorBoundary from './components/ErrorBoundary';
+import GDPRNotification from './components/GDPRNotification';
 
 import './App.css';
 
@@ -105,6 +106,7 @@ class App extends Component {
                             position="bottom-center"
                             transition={Slide}
                         />
+                        <GDPRNotification />
                     </div>
                 </Router>
             </ErrorBoundary>

--- a/src/app/src/components/GDPRNotification.jsx
+++ b/src/app/src/components/GDPRNotification.jsx
@@ -1,29 +1,25 @@
 import React, { PureComponent } from 'react';
-import Button from './Button';
 import Snackbar from '@material-ui/core/Snackbar';
+import Button from './Button';
 import ShowOnly from './ShowOnly';
 import COLOURS from '../util/COLOURS';
 
 const GDPRActions = (
-  <div>
-    <Button 
-      text="Reject"
-      style={{
-        background: COLOURS.LIGHT_BLUE,
-        marginRight: '10px'
-      }}
-      onClick={this.dismissGDPRAlert}
-    >
-    </Button>
-    <Button 
-      text="Accept"
-      onClick={this.dismissGDPRAlert}
-    >
-    </Button>
-  </div>
+    <div>
+        <Button
+            text="Reject"
+            style={{
+                background: COLOURS.LIGHT_BLUE,
+                marginRight: '10px',
+            }}
+            onClick={this.dismissGDPRAlert}
+        />
+        <Button text="Accept" onClick={this.dismissGDPRAlert} />
+    </div>
 );
 
-const GDPRMessage = "We use cookies to collect and analyze information on site performance and usage, and to enhance content. By clicking 'Accept', you agree to allow cookies to be placed. To find out more, visit our terms of service and our privacy policy.";
+const GDPRMessage =
+    'We use cookies to collect and analyze information on site performance and usage, and to enhance content. By clicking Accept, you agree to allow cookies to be placed. To find out more, visit our terms of service and our privacy policy.';
 
 class GDPRNotification extends PureComponent {
     state = { open: true };
@@ -43,17 +39,16 @@ class GDPRNotification extends PureComponent {
     render() {
         return (
             <ShowOnly when={this.state.open}>
-              <Snackbar
-                className="gdpr-notification"
-                open={this.state.open}
-                anchorOrigin={{
-                  vertical: 'bottom',
-                  horizontal: 'right',
-                }}
-                action={GDPRActions}
-                message={GDPRMessage}
-              >
-              </Snackbar>
+                <Snackbar
+                    className="gdpr-notification"
+                    open={this.state.open}
+                    anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'right',
+                    }}
+                    action={GDPRActions}
+                    message={GDPRMessage}
+                />
             </ShowOnly>
         );
     }

--- a/src/app/src/components/GDPRNotification.jsx
+++ b/src/app/src/components/GDPRNotification.jsx
@@ -1,0 +1,62 @@
+import React, { PureComponent } from 'react';
+import Button from './Button';
+import Snackbar from '@material-ui/core/Snackbar';
+import ShowOnly from './ShowOnly';
+import COLOURS from '../util/COLOURS';
+
+const GDPRActions = (
+  <div>
+    <Button 
+      text="Reject"
+      style={{
+        background: COLOURS.LIGHT_BLUE,
+        marginRight: '10px'
+      }}
+      onClick={this.dismissGDPRAlert}
+    >
+    </Button>
+    <Button 
+      text="Accept"
+      onClick={this.dismissGDPRAlert}
+    >
+    </Button>
+  </div>
+);
+
+const GDPRMessage = "We use cookies to collect and analyze information on site performance and usage, and to enhance content. By clicking 'Accept', you agree to allow cookies to be placed. To find out more, visit our terms of service and our privacy policy.";
+
+class GDPRNotification extends PureComponent {
+    state = { open: true };
+
+    componentDidMount() {
+        const dismissed = sessionStorage.getItem('dismissedGDPRAlert');
+        if (dismissed) {
+            this.setState({ open: false }); // eslint-disable-line react/no-did-mount-set-state
+        }
+    }
+
+    dismissGDPRAlert = () => {
+        this.setState({ open: false });
+        sessionStorage.setItem('dismissedGDPRAlert', true);
+    };
+
+    render() {
+        return (
+            <ShowOnly when={this.state.open}>
+              <Snackbar
+                className="gdpr-notification"
+                open={this.state.open}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'right',
+                }}
+                action={GDPRActions}
+                message={GDPRMessage}
+              >
+              </Snackbar>
+            </ShowOnly>
+        );
+    }
+}
+
+export default GDPRNotification;

--- a/src/app/src/components/GDPRNotification.jsx
+++ b/src/app/src/components/GDPRNotification.jsx
@@ -4,23 +4,6 @@ import Button from './Button';
 import ShowOnly from './ShowOnly';
 import COLOURS from '../util/COLOURS';
 
-const GDPRActions = (
-    <div>
-        <Button
-            text="Reject"
-            style={{
-                background: COLOURS.LIGHT_BLUE,
-                marginRight: '10px',
-            }}
-            onClick={this.dismissGDPRAlert}
-        />
-        <Button text="Accept" onClick={this.dismissGDPRAlert} />
-    </div>
-);
-
-const GDPRMessage =
-    'We use cookies to collect and analyze information on site performance and usage, and to enhance content. By clicking Accept, you agree to allow cookies to be placed. To find out more, visit our terms of service and our privacy policy.';
-
 class GDPRNotification extends PureComponent {
     state = { open: true };
 
@@ -37,6 +20,28 @@ class GDPRNotification extends PureComponent {
     };
 
     render() {
+        const GDPRActions = (
+            <div>
+                <Button
+                    text="Reject"
+                    style={{
+                        background: COLOURS.LIGHT_BLUE,
+                        marginRight: '10px',
+                    }}
+                    onClick={this.dismissGDPRAlert}
+                />
+                <Button text="Accept" onClick={this.dismissGDPRAlert} />
+            </div>
+        );
+
+        const GDPRMessage =
+            `We use cookies to collect and analyze
+            information on site performance and usage,
+            and to enhance content. By clicking Accept,
+            you agree to allow cookies to be placed.
+            To find out more, visit our terms of service
+            and our privacy policy.`;
+
         return (
             <ShowOnly when={this.state.open}>
                 <Snackbar


### PR DESCRIPTION
## Overview

Adds base functionality for displaying a GDPR compliance message.

Connects #218

## Demo

<img width="1510" alt="screen shot 2019-03-06 at 11 54 42 am" src="https://user-images.githubusercontent.com/1928955/53900073-b8c03b80-4009-11e9-9318-22e9c3595f69.png">

## Notes
- The text in the notification should be treated as placeholder. A further issue should be created for replacing text.
- Accepting and rejecting don't actually do anything beyond closing the message right now. A further issue should be created to make these function as expected.

## Testing Instructions

* Open the app
* Navigate to any page within the app, the notification should persist until rejected or accepted