### PR TITLE
Correct Contributor Filter Value

### DIFF
--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -52,6 +52,7 @@ const {
     joinDataIntoCSVString,
     caseInsensitiveIncludes,
     sortFacilitiesAlphabeticallyByName,
+    updateListWithLabels,
 } = require('../util/util');
 
 const {
@@ -905,4 +906,51 @@ it('sorts an array of facilities alphabetically by name without mutating the inp
         inputData,
         expectedSortedData,
     )).toBe(false);
+});
+
+it('updates a list of unlabeled values with the correct labels from a given source', () => {
+    const source = [
+        {
+            value: 67,
+            label: 'Aguilar, Stanley and Lewis',
+        },
+        {
+            value: 57,
+            label: 'Alvarez PLC',
+        },
+        {
+            value: 14,
+            label: 'Arnold-Adams',
+        },
+    ];
+    const unlabeled = [
+        {
+            value: 57,
+            label: '57', // Unlabeled, should be corrected
+        },
+        {
+            value: 14,
+            label: 'XYZ', // Mislabaled, should be corrected
+        },
+        {
+            value: 89,
+            label: 'ABC', // Does not exist in source, should be dropped
+        },
+    ];
+
+    const corrected = [
+        {
+            value: 57,
+            label: 'Alvarez PLC',
+        },
+        {
+            value: 14,
+            label: 'Arnold-Adams',
+        },
+    ];
+
+    expect(isEqual(
+        updateListWithLabels(unlabeled, source),
+        corrected,
+    )).toBe(true);
 });

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -1,6 +1,10 @@
+import update from 'immutability-helper';
 import { createAction } from 'redux-act';
 
-import { createFiltersFromQueryString } from '../util/util';
+import {
+    createFiltersFromQueryString,
+    updateListWithLabels,
+} from '../util/util';
 
 export const updateFacilityNameFilter = createAction('UPDATE_FACILITY_NAME_FILTER');
 export const updateContributorFilter = createAction('UPDATE_CONTRIBUTOR_FILTER');
@@ -10,11 +14,27 @@ export const resetAllFilters = createAction('RESET_ALL_FILTERS');
 export const updateAllFilters = createAction('UPDATE_ALL_FILTERS');
 
 export function setFiltersFromQueryString(qs = '') {
-    return (dispatch) => {
+    return (dispatch, getState) => {
         if (!qs) {
             return null;
         }
 
-        return dispatch(updateAllFilters(createFiltersFromQueryString(qs)));
+        // If contributor data already exists in the state, use it to match
+        // filters from the query string with labels. Otherwise, use the
+        // query string values directly. It will be updated later when the
+        // contributor data is loaded.
+
+        const filters = createFiltersFromQueryString(qs);
+        const { filterOptions: { contributors: { data } } } = getState();
+
+        const payload = data.length
+            ? update(filters, {
+                contributors: {
+                    $set: updateListWithLabels(filters.contributors, data),
+                },
+            })
+            : filters;
+
+        return dispatch(updateAllFilters(payload));
     };
 }

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -16,6 +16,10 @@ import {
     completeFetchCountryOptions,
 } from '../actions/filterOptions';
 
+import {
+    updateListWithLabels,
+} from '../util/util';
+
 const initialState = Object.freeze({
     facilityName: '',
     contributors: Object.freeze([]),
@@ -23,90 +27,17 @@ const initialState = Object.freeze({
     countries: Object.freeze([]),
 });
 
-const maybeSetContributorOptionsFromQueryString = (state, payload) => {
-    if (!state.contributors.length) {
+export const maybeSetFromQueryString = field => (state, payload) => {
+    if (!state[field].length) {
         return state;
     }
 
     // filter out any options set from the querystring which turn out
     // not to be valid according to the API's response
-    const updatedContributors = state
-        .contributors
-        .reduce((accumulator, { value }) => {
-            const validOption = payload
-                .find(({ value: otherValue }) => value === otherValue);
-
-            if (!validOption) {
-                return accumulator;
-            }
-
-            return accumulator
-                .concat(Object.freeze({
-                    value,
-                    label: validOption.label,
-                }));
-        }, []);
+    const updatedField = updateListWithLabels(state[field], payload);
 
     return update(state, {
-        contributors: { $set: updatedContributors },
-    });
-};
-
-const maybeSetContributorTypeOptionsFromQueryString = (state, payload) => {
-    if (!state.contributorTypes.length) {
-        return state;
-    }
-
-    // filter out any options set from the querystring which turn out
-    // not to be valid according to the API's response
-    const updatedContributorTypes = state
-        .contributorTypes
-        .reduce((accumulator, { value }) => {
-            const validOption = payload
-                .find(({ value: otherValue }) => value === otherValue);
-
-            if (!validOption) {
-                return accumulator;
-            }
-
-            return accumulator
-                .concat(Object.freeze({
-                    value,
-                    label: validOption.label,
-                }));
-        }, []);
-
-    return update(state, {
-        contributorTypes: { $set: updatedContributorTypes },
-    });
-};
-
-const maybeSetCountryOptionsFromQueryString = (state, payload) => {
-    if (!state.countries.length) {
-        return state;
-    }
-
-    // filter out any options set from the querystring which turn out
-    // not to be valid according to the API's response
-    const updatedCountries = state
-        .countries
-        .reduce((accumulator, { value }) => {
-            const validOption = payload
-                .find(({ value: otherValue }) => value === otherValue);
-
-            if (!validOption) {
-                return accumulator;
-            }
-
-            return accumulator
-                .concat(Object.freeze({
-                    value,
-                    label: validOption.label,
-                }));
-        }, []);
-
-    return update(state, {
-        countries: { $set: updatedCountries },
+        [field]: { $set: updatedField },
     });
 };
 
@@ -125,7 +56,7 @@ export default createReducer({
     }),
     [resetAllFilters]: () => initialState,
     [updateAllFilters]: (_state, payload) => payload,
-    [completeFetchContributorOptions]: maybeSetContributorOptionsFromQueryString,
-    [completeFetchContributorTypeOptions]: maybeSetContributorTypeOptionsFromQueryString,
-    [completeFetchCountryOptions]: maybeSetCountryOptionsFromQueryString,
+    [completeFetchContributorOptions]: maybeSetFromQueryString('contributors'),
+    [completeFetchContributorTypeOptions]: maybeSetFromQueryString('contributorTypes'),
+    [completeFetchCountryOptions]: maybeSetFromQueryString('countries'),
 }, initialState);

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -407,3 +407,23 @@ export const sortFacilitiesAlphabeticallyByName = data => data
 
         return (a < b) ? -1 : 1;
     });
+
+// Given a list where each item is like { label: 'ABCD', value: 123 }, and
+// a payload which is a list of items like { label: '123', value: 123 },
+// returns a list of items from the payload with their labels replaced with
+// matching items found in the list.
+export const updateListWithLabels = (list, payload) => list
+    .reduce((accumulator, { value }) => {
+        const validOption = payload
+            .find(({ value: otherValue }) => value === otherValue);
+
+        if (!validOption) {
+            return accumulator;
+        }
+
+        return accumulator
+            .concat(Object.freeze({
+                value,
+                label: validOption.label,
+            }));
+    }, []);


### PR DESCRIPTION
## Overview

Previously, the labels shown in the filter selection box would match the contributor name only if UPDATE_ALL_FILTERS fired before COMPLETE_FETCH_CONTRIBUTOR_OPTIONS. The former set the list of active filters from the query string, and the latter updated that list with labels after fetching the data from the API.

In cases when COMPLETE_FETCH_CONTRIBUTOR_OPTIONS fired before UPDATE_ALL_FILTERS, such as loading the home page, then going to "My Lists", then selecting "My Facilities", the filter selection box would show the contributor's ID, not the label.

By matching the query string filters to the list of saved contributors in the state before firing UPDATE_ALL_FILTERS, we ensure that correct label is used in the case when it fires after COMPLETE_FETCH_CONTRIBUTOR_OPTIONS.

This ensures that the filter selection box has the correct value when the page is loaded for the first time (e.g. full page refresh with the query string params), or if it is navigated to from within the app (e.g. clicking "My Facilities").

Connects #252 

## Demo

![2019-03-07 17 04 29](https://user-images.githubusercontent.com/1430060/53995062-ea1c3280-4101-11e9-85fa-2f663759ae0d.gif)

## Notes

I discovered #278 while working on this, but couldn't fix it easily, so spun it off into its own card.

## Testing Instructions

* Check out this branch and `server`
* Go to [:6543/](http://localhost:6543/) and log in to an account
* Go to My Lists, then My Facilities
* Inspect the contributor filter box. Ensure it shows your account name in its label, and not its ID.
* Do a full page refresh. Ensure it still shows the correct thing.