### PR TITLE
Reset filter options state on logout

### DIFF
--- a/src/app/src/reducers/FacilitiesReducer.js
+++ b/src/app/src/reducers/FacilitiesReducer.js
@@ -26,6 +26,8 @@ import {
 
 import { makeFeatureCollectionFromSingleFeature } from '../util/util';
 
+import { completeSubmitLogOut } from '../actions/auth';
+
 const initialState = Object.freeze({
     facilities: Object.freeze({
         data: null,
@@ -126,4 +128,5 @@ export default createReducer({
     [updateCountryFilter]: clearFacilitiesDataOnFilterChange,
     [resetAllFilters]: clearFacilitiesDataOnFilterChange,
     [updateAllFilters]: clearFacilitiesDataOnFilterChange,
+    [completeSubmitLogOut]: clearFacilitiesDataOnFilterChange,
 }, initialState);

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -16,6 +16,8 @@ import {
     completeFetchCountryOptions,
 } from '../actions/filterOptions';
 
+import { completeSubmitLogOut } from '../actions/auth';
+
 import {
     updateListWithLabels,
 } from '../util/util';
@@ -59,4 +61,5 @@ export default createReducer({
     [completeFetchContributorOptions]: maybeSetFromQueryString('contributors'),
     [completeFetchContributorTypeOptions]: maybeSetFromQueryString('contributorTypes'),
     [completeFetchCountryOptions]: maybeSetFromQueryString('countries'),
+    [completeSubmitLogOut]: () => initialState,
 }, initialState);

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -11,6 +11,8 @@ import {
 
 import { completeFetchFacilities } from '../actions/facilities';
 
+import { completeSubmitLogOut } from '../actions/auth';
+
 import { filterSidebarTabsEnum } from '../util/constants';
 
 const initialState = Object.freeze({
@@ -65,4 +67,5 @@ export default createReducer({
             },
         },
     }),
+    [completeSubmitLogOut]: () => initialState,
 }, initialState);


### PR DESCRIPTION
## Overview

Resets the filter options state on logging out to fix a bug whereby the
facilities list link was being incorrectly set.

Connects #278

## Testing Instructions

- try to recreate the bug described in #278 and verify that it's fixed

