### PR TITLE
Restyle lists table

### DIFF
--- a/src/app/src/components/FacilityListsTable.jsx
+++ b/src/app/src/components/FacilityListsTable.jsx
@@ -11,6 +11,19 @@ import TableCell from '@material-ui/core/TableCell';
 import { facilityListPropType } from '../util/propTypes';
 import { makeFacilityListItemsDetailLink } from '../util/util';
 
+const facilityListsTableStyles = Object.freeze({
+    inactiveListStyles: Object.freeze({
+        cursor: 'pointer',
+    }),
+    activeListStyles: Object.freeze({
+        backgroundColor: '#f3fafe',
+        outlineWidth: '0.75px',
+        outlineStyle: 'solid',
+        outlineColor: '#1a9fe3',
+        cursor: 'pointer',
+    }),
+});
+
 function FacilityListsTable({
     facilityLists,
     history: {
@@ -44,6 +57,11 @@ function FacilityListsTable({
                                     key={list.id}
                                     hover
                                     onClick={() => push(makeFacilityListItemsDetailLink(list.id))}
+                                    style={
+                                        list.is_active
+                                            ? facilityListsTableStyles.activeListStyles
+                                            : facilityListsTableStyles.inactiveListStyles
+                                    }
                                 >
                                     <TableCell>
                                         {list.name}

--- a/src/app/src/components/FacilityListsTable.jsx
+++ b/src/app/src/components/FacilityListsTable.jsx
@@ -34,9 +34,6 @@ function FacilityListsTable({
                         <TableCell>
                             Active
                         </TableCell>
-                        <TableCell>
-                            Public
-                        </TableCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
@@ -59,9 +56,6 @@ function FacilityListsTable({
                                     </TableCell>
                                     <TableCell>
                                         {list.is_active ? 'True' : 'False'}
-                                    </TableCell>
-                                    <TableCell>
-                                        {list.is_public ? 'True' : 'False'}
                                     </TableCell>
                                 </TableRow>))
                     }


### PR DESCRIPTION
## Overview

- hide the "Public" column on the lists table
- highlight the active list table row

Connects #274 

## Demo

![Screen Shot 2019-03-12 at 4 02 33 PM](https://user-images.githubusercontent.com/4165523/54232124-57eca380-44e0-11e9-88a1-9cbed990bdb7.png)

## Testing Instructions

- get this branch, then register and upload a list
- upload another list which replaces the first list
- visit the lists page and verify that you see what's depicted above

