### PR TITLE
Submit forms on enter press

### DIFF
--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -52,6 +52,7 @@ const {
     caseInsensitiveIncludes,
     sortFacilitiesAlphabeticallyByName,
     updateListWithLabels,
+    makeSubmitFormOnEnterKeyPressFunction,
 } = require('../util/util');
 
 const {
@@ -62,6 +63,7 @@ const {
     profileFormFields,
     DEFAULT_PAGE,
     DEFAULT_ROWS_PER_PAGE,
+    ENTER_KEY,
 } = require('../util/constants');
 
 it('creates a route for checking facility list items', () => {
@@ -942,4 +944,30 @@ it('updates a list of unlabeled values with the correct labels from a given sour
         updateListWithLabels(unlabeled, source),
         corrected,
     )).toBe(true);
+});
+
+it('calls a given function when the enter key has been pressed in a form input', () => {
+    const dispatchSubmitForm = jest.fn();
+
+    const enterKeyPressHandler = makeSubmitFormOnEnterKeyPressFunction(dispatchSubmitForm);
+
+    const keyPressEvent = {
+        key: ENTER_KEY,
+    };
+
+    enterKeyPressHandler(keyPressEvent);
+    expect(dispatchSubmitForm).toHaveBeenCalled();
+});
+
+it('does not call a given function when a non-enter key has been pressed in a form input', () => {
+    const dispatchSubmitForm = jest.fn();
+
+    const enterKeyPressHandler = makeSubmitFormOnEnterKeyPressFunction(dispatchSubmitForm);
+
+    const keyPressEvent = {
+        key: 'a',
+    };
+
+    enterKeyPressHandler(keyPressEvent);
+    expect(dispatchSubmitForm).not.toHaveBeenCalled();
 });

--- a/src/app/src/components/ControlledTextInput.jsx
+++ b/src/app/src/components/ControlledTextInput.jsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import { bool, func, string } from 'prop-types';
+import noop from 'lodash/noop';
 
 import '../styles/css/specialStates.css';
 
@@ -11,6 +12,7 @@ export default function ControlledTextInput({
     onChange,
     placeholder,
     disabled,
+    submitFormOnEnterKeyPress,
 }) {
     return (
         <Fragment>
@@ -25,6 +27,7 @@ export default function ControlledTextInput({
                 onChange={onChange}
                 placeholder={placeholder}
                 disabled={disabled}
+                onKeyPress={submitFormOnEnterKeyPress}
             />
         </Fragment>
     );
@@ -35,6 +38,7 @@ ControlledTextInput.defaultProps = {
     hint: '',
     placeholder: '',
     disabled: false,
+    submitFormOnEnterKeyPress: noop,
 };
 
 ControlledTextInput.propTypes = {
@@ -45,4 +49,5 @@ ControlledTextInput.propTypes = {
     onChange: func.isRequired,
     placeholder: string,
     disabled: bool,
+    submitFormOnEnterKeyPress: func,
 };

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -26,7 +26,10 @@ import {
 
 import { filterSidebarStyles } from '../util/styles';
 
-import { getValueFromEvent } from '../util/util';
+import {
+    getValueFromEvent,
+    makeSubmitFormOnEnterKeyPressFunction,
+} from '../util/util';
 
 const filterSidebarSearchTabStyles = Object.freeze({
     formStyle: Object.freeze({
@@ -64,6 +67,7 @@ function FilterSidebarSearchTab({
     searchForFacilities,
     facilities,
     fetchingOptions,
+    submitFormOnEnterKeyPress,
 }) {
     if (fetchingOptions) {
         return (
@@ -114,6 +118,7 @@ function FilterSidebarSearchTab({
                         className="full-width margin-bottom-16 form__text-input"
                         value={facilityName}
                         onChange={updateFacilityName}
+                        onKeyPress={submitFormOnEnterKeyPress}
                     />
                 </div>
                 <div className="form__field">
@@ -299,6 +304,9 @@ function mapDispatchToProps(dispatch) {
         updateCountry: v => dispatch(updateCountryFilter(v)),
         resetFilters: () => dispatch(resetAllFilters()),
         searchForFacilities: () => dispatch(fetchFacilities()),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
+            () => dispatch(fetchFacilities()),
+        ),
     };
 }
 

--- a/src/app/src/components/LoginForm.jsx
+++ b/src/app/src/components/LoginForm.jsx
@@ -18,7 +18,10 @@ import {
     resetAuthFormState,
 } from '../actions/auth';
 
-import { getValueFromEvent } from '../util/util';
+import {
+    getValueFromEvent,
+    makeSubmitFormOnEnterKeyPressFunction,
+} from '../util/util';
 
 import { userPropType } from '../util/propTypes';
 
@@ -54,6 +57,7 @@ class LoginForm extends Component {
             updateEmail,
             updatePassword,
             submitForm,
+            submitFormOnEnterKeyPress,
             sessionFetching,
         } = this.props;
 
@@ -91,6 +95,7 @@ class LoginForm extends Component {
                                 type="email"
                                 value={email}
                                 onChange={updateEmail}
+                                submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                             />
                         </div>
                         <div className="form__field">
@@ -105,6 +110,7 @@ class LoginForm extends Component {
                                 type="password"
                                 value={password}
                                 onChange={updatePassword}
+                                submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                             />
                         </div>
                         <SendResetPasswordEmailForm />
@@ -145,6 +151,7 @@ LoginForm.propTypes = {
     updateEmail: func.isRequired,
     updatePassword: func.isRequired,
     submitForm: func.isRequired,
+    submitFormOnEnterKeyPress: func.isRequired,
     clearForm: func.isRequired,
     user: userPropType,
     history: shape({
@@ -187,6 +194,9 @@ function mapDispatchToProps(dispatch) {
         updatePassword: e => dispatch(updateLoginFormPassword(getValueFromEvent(e))),
         submitForm: () => dispatch(submitLoginForm()),
         clearForm: () => dispatch(resetAuthFormState()),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
+            () => dispatch(submitLoginForm()),
+        ),
     };
 }
 

--- a/src/app/src/components/RegisterForm.jsx
+++ b/src/app/src/components/RegisterForm.jsx
@@ -29,7 +29,10 @@ import {
     registrationFormInputHandlersPropType,
 } from '../util/propTypes';
 
-import { getStateFromEventForEventType } from '../util/util';
+import {
+    getStateFromEventForEventType,
+    makeSubmitFormOnEnterKeyPressFunction,
+} from '../util/util';
 
 import { formValidationErrorMessageStyle } from '../util/styles';
 
@@ -74,6 +77,7 @@ class RegisterForm extends Component {
             form,
             inputUpdates,
             submitForm,
+            submitFormOnEnterKeyPress,
             sessionFetching,
         } = this.props;
 
@@ -110,6 +114,7 @@ class RegisterForm extends Component {
                         form.contributorType !== OTHER &&
                         field.id === registrationFieldsEnum.otherContributorType
                     }
+                    submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                 />));
 
         return (
@@ -171,6 +176,7 @@ RegisterForm.propTypes = {
     form: registrationFormValuesPropType.isRequired,
     inputUpdates: registrationFormInputHandlersPropType.isRequired,
     submitForm: func.isRequired,
+    submitFormOnEnterKeyPress: func.isRequired,
     sessionFetching: bool.isRequired,
 };
 
@@ -216,6 +222,9 @@ const mapDispatchToProps = memoize((dispatch) => {
         inputUpdates,
         submitForm: () => dispatch(submitSignUpForm()),
         clearForm: () => dispatch(resetAuthFormState()),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
+            () => dispatch(submitSignUpForm()),
+        ),
     };
 });
 

--- a/src/app/src/components/RegisterFormField.jsx
+++ b/src/app/src/components/RegisterFormField.jsx
@@ -22,6 +22,7 @@ export default function RegisterFormField({
     value,
     handleChange,
     isHidden,
+    submitFormOnEnterKeyPress,
 }) {
     if (isHidden) {
         return null;
@@ -83,6 +84,7 @@ export default function RegisterFormField({
                 id={id}
                 hint={hint}
                 type={type}
+                submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
             />
         </div>
     );
@@ -110,4 +112,5 @@ RegisterFormField.propTypes = {
         prefixText: string,
         url: string.isRequired,
     }),
+    submitFormOnEnterKeyPress: func.isRequired,
 };

--- a/src/app/src/components/ResetPasswordForm.jsx
+++ b/src/app/src/components/ResetPasswordForm.jsx
@@ -23,6 +23,7 @@ import { formValidationErrorMessageStyle } from '../util/styles';
 import {
     getValueFromEvent,
     getTokenFromQueryString,
+    makeSubmitFormOnEnterKeyPressFunction,
 } from '../util/util';
 
 import { authLoginFormRoute } from '../util/constants';
@@ -50,6 +51,7 @@ class ResetPasswordForm extends Component {
             updatePassword,
             updateConfirmPassword,
             submitForm,
+            submitFormOnEnterKeyPress,
         } = this.props;
 
         if (confirmationResponse) {
@@ -87,6 +89,7 @@ class ResetPasswordForm extends Component {
                             type="password"
                             value={newPassword}
                             onChange={updatePassword}
+                            submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                         />
                     </div>
                     <div className="form__field">
@@ -101,6 +104,7 @@ class ResetPasswordForm extends Component {
                             type="password"
                             value={newPasswordConfirmation}
                             onChange={updateConfirmPassword}
+                            submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                         />
                     </div>
                     <ShowOnly when={!!(error && error.length)}>
@@ -185,6 +189,9 @@ function mapDispatchToProps(dispatch, {
         updateConfirmPassword: e =>
             dispatch(updateResetPasswordFormPasswordConfirmation(getValueFromEvent(e))),
         submitForm: () => dispatch(submitResetPassword()),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
+            () => dispatch(submitResetPassword()),
+        ),
         resetForm: () => dispatch(resetResetPasswordFormState()),
     };
 }

--- a/src/app/src/components/SendResetPasswordEmailForm.jsx
+++ b/src/app/src/components/SendResetPasswordEmailForm.jsx
@@ -17,7 +17,10 @@ import {
     closeForgotPasswordDialog,
 } from '../actions/auth';
 
-import { getValueFromEvent } from '../util/util';
+import {
+    getValueFromEvent,
+    makeSubmitFormOnEnterKeyPressFunction,
+} from '../util/util';
 
 function SendResetPasswordEmailForm({
     dialogIsOpen,
@@ -28,6 +31,7 @@ function SendResetPasswordEmailForm({
     email,
     updateEmail,
     submitForm,
+    submitFormOnEnterKeyPress,
 }) {
     const errorMessages = error && error.length
         ? (
@@ -73,6 +77,7 @@ function SendResetPasswordEmailForm({
                         fullWidth
                         value={email}
                         onChange={updateEmail}
+                        onKeyPress={submitFormOnEnterKeyPress}
                     />
                     {errorMessages}
                 </DialogContent>
@@ -108,6 +113,7 @@ SendResetPasswordEmailForm.propTypes = {
     fetching: bool.isRequired,
     updateEmail: func.isRequired,
     submitForm: func.isRequired,
+    submitFormOnEnterKeyPress: func.isRequired,
     email: string.isRequired,
 };
 
@@ -137,6 +143,9 @@ function mapDispatchToProps(dispatch) {
         submitForm: () => dispatch(requestForgotPasswordEmail()),
         handleOpen: () => dispatch(openForgotPasswordDialog()),
         handleClose: () => dispatch(closeForgotPasswordDialog()),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
+            () => dispatch(requestForgotPasswordEmail()),
+        ),
     };
 }
 

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -25,7 +25,10 @@ import {
     profileFormInputHandlersPropType,
 } from '../util/propTypes';
 
-import { getStateFromEventForEventType } from '../util/util';
+import {
+    getStateFromEventForEventType,
+    makeSubmitFormOnEnterKeyPressFunction,
+} from '../util/util';
 
 import {
     updateProfileFormInput,
@@ -109,6 +112,7 @@ class UserProfile extends Component {
             updateProfile,
             updatingProfile,
             errorsUpdatingProfile,
+            submitFormOnEnterKeyPress,
             match: {
                 params: {
                     id,
@@ -141,6 +145,7 @@ class UserProfile extends Component {
                     required={field.required}
                     hideOnViewOnlyProfile={field.hideOnViewOnlyProfile}
                     isEditableProfile={isEditableProfile}
+                    submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                 />));
 
         const title = isEditableProfile
@@ -222,6 +227,7 @@ UserProfile.propTypes = {
     updateProfile: func.isRequired,
     updatingProfile: bool.isRequired,
     errorsUpdatingProfile: arrayOf(string),
+    submitFormOnEnterKeyPress: func.isRequired,
 };
 
 function mapStateToProps({
@@ -280,6 +286,9 @@ const mapDispatchToProps = (dispatch, {
         fetchProfile: () => dispatch(fetchUserProfile(Number(profileID))),
         resetProfile: () => dispatch(resetUserProfile()),
         updateProfile: () => dispatch(updateUserProfile(Number(profileID))),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
+            () => dispatch(updateUserProfile(Number(profileID))),
+        ),
     };
 };
 

--- a/src/app/src/components/UserProfileField.jsx
+++ b/src/app/src/components/UserProfileField.jsx
@@ -30,6 +30,7 @@ export default function UserProfileField({
     isHidden,
     isEditableProfile,
     hideOnViewOnlyProfile,
+    submitFormOnEnterKeyPress,
 }) {
     if (type === inputTypesEnum.checkbox) {
         window.console.warn(`checkbox not yet implemented for ${id}`);
@@ -122,6 +123,7 @@ export default function UserProfileField({
                     onChange={handleChange}
                     disabled={disabled}
                     type={type}
+                    submitFormOnEnterKeyPress={submitFormOnEnterKeyPress}
                 />
             </div>
         </div>
@@ -146,4 +148,5 @@ UserProfileField.propTypes = {
     isHidden: bool.isRequired,
     isEditableProfile: bool,
     hideOnViewOnlyProfile: bool,
+    submitFormOnEnterKeyPress: func.isRequired,
 };

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -278,3 +278,5 @@ export const emptyFeatureCollection = Object.freeze({
     type: FEATURE_COLLECTION,
     features: Object.freeze([]),
 });
+
+export const ENTER_KEY = 'Enter';

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -34,6 +34,7 @@ import {
     facilitiesRoute,
     DEFAULT_PAGE,
     DEFAULT_ROWS_PER_PAGE,
+    ENTER_KEY,
 } from './constants';
 
 import { createListItemCSV } from './util.listItemCSV';
@@ -428,3 +429,11 @@ export const updateListWithLabels = (list, payload) => list
                 label: validOption.label,
             }));
     }, []);
+
+export const makeSubmitFormOnEnterKeyPressFunction = fn => ({ key }) => {
+    if (key === ENTER_KEY) {
+        return fn();
+    }
+
+    return noop();
+};


### PR DESCRIPTION
## Overview

Create utility function for enter key press handlers & add tests for
utility function.

Add handlers to the following forms to call a given submit form function
on pressing enter in a text input:

- register
- login
- request reset password
- confirm reset password
- profile
- search tab text search filter

This does not add the same handler to the search tab's multiselect
dropdowns, as their idiom is that an enter press selects one of the
options from the input. In other words: they're more like select
dropdowns searchable via text input than regular text inputs.

Connects #183

## Testing

Get this branch, then try out the following forms to verify that pressing enter in any of their text input fields submits the form:

- register
- login
- request reset password
- confirm reset password
- profile
- search tab text search filter

Also run the tests and verify that they pass.
