### PR TITLE
Explicitly set AWS_DEFAULT_REGION environment variable

### DIFF
--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -63,6 +63,8 @@ data "template_file" "default_job_definition" {
     django_secret_key        = "${var.django_secret_key}"
     google_geocoding_api_key = "${var.google_geocoding_api_key}"
 
+    aws_region = "${var.aws_region}"
+
     rollbar_client_side_access_token = "${var.rollbar_client_side_access_token}"
   }
 }

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -4,6 +4,7 @@
   "memory": 4096,
   "command": ["./manage.py", "batch_process", "--list-id" , "Ref::listid", "--action", "Ref::action"],
   "environment": [
+      { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },
       { "name": "POSTGRES_HOST", "value": "${postgres_host}" },
       { "name": "POSTGRES_PORT", "value": "${postgres_port}" },
       { "name": "POSTGRES_USER", "value": "${postgres_user}" },

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -5,6 +5,7 @@
     "cpu": ${cpu},
     "memory": ${memory},
     "environment": [
+        { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },
         { "name": "POSTGRES_HOST", "value": "${postgres_host}" },
         { "name": "POSTGRES_PORT", "value": "${postgres_port}" },
         { "name": "POSTGRES_USER", "value": "${postgres_user}" },

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -7,6 +7,7 @@
     "essential": true,
     "entryPoint": ["./manage.py"],
     "environment": [
+        { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },
         { "name": "POSTGRES_HOST", "value": "${postgres_host}" },
         { "name": "POSTGRES_PORT", "value": "${postgres_port}" },
         { "name": "POSTGRES_USER", "value": "${postgres_user}" },

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -206,6 +206,8 @@ USE_TZ = True
 # Email
 # https://docs.djangoproject.com/en/2.0/topics/email
 
+AWS_DEFAULT_REGION = os.getenv('AWS_DEFAULT_REGION', 'eu-west-1')
+
 if DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 else:


### PR DESCRIPTION
## Overview

The `AWS_DEFAULT_REGION` environment variable is used by AWS SDKs to determine the default AWS region to target, unless one is otherwise specified. These changes explicitly set that environment variable for all ECS and Batch task definitions.

Connects https://github.com/open-apparel-registry/open-apparel-registry/issues/298

## Notes

This does not 100% address the issue of sending emails. We're still in the Amazon SES sandbox for `eu-west-1`. A support ticket has been opened to get us out. This PR is more to make our use of `eu-west-1` as the target AWS region more explicit.

## Testing Instructions

(If these changes are currently on staging, feel free to jump to the steps that start at the ECS console.)

- First, ensure that the Terraform configuration changes apply cleanly:

```console
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-4.4# GIT_COMMIT="df202ca" ./scripts/infra plan
bash-4.4# GIT_COMMIT="df202ca" ./scripts/infra apply
```

- Then, use the [ECS console](https://eu-west-1.console.aws.amazon.com/ecs/home?region=eu-west-1#/taskDefinitions/StagingAppCLI) to execute a task with the newest task definition
  - **Launch type**: `FARGATE`
  - **Cluster**: `ecsStagingCluster`
  - **Cluster VPC**: `vpc-09227ff54cfc3fbbc`
  - **Subnets**: Any one with `PrivateSubnet` in the name
  - **Security groups**: `sg-06e95c8815ad18702`
  - **Auto-assign public IP**: `DISABLED`
- Finally, override the `command` for the `django` container with:

```
shell,-c,import os;print(os.getenv('AWS_DEFAULT_REGION'))
```

- Ensure that the task completes successfully and writes logs to [CloudWatch Logs](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logEventViewer:group=logStagingAppCLI;stream=management/django/f45cd23f-5301-4871-92d8-7bdd99f0e3c5;start=2019-03-12T15:31:13Z)