### PR TITLE
Use all of `core-js` to polyfill for IE11

### DIFF
--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -1,10 +1,5 @@
 // polyfills for IE11
-// catalog of other is available at https://github.com/zloirock/core-js/tree/v2
-import 'core-js/fn/string/starts-with';
-import 'core-js/fn/object/values';
-import 'core-js/fn/array/find';
-import 'core-js/fn/array/find-index';
-import 'core-js/fn/object/assign';
+import 'core-js';
 
 import React from 'react';
 import { render } from 'react-dom';


### PR DESCRIPTION
## Overview

To prevent having to add & debug polyfills piecemeal, just import all of 'core-js'

Connects #297 

## Demo

![Screen Shot 2019-03-13 at 4 38 27 PM](https://user-images.githubusercontent.com/4165523/54312891-728d4e00-45ae-11e9-802e-ea97e1e1abe8.png)


## Notes

If it's necessary to try to reduce the bundle size later, we can try to prune this polyfill down to only the imports we need. This also potentially makes available some ES7+ syntax we don't habitually use, which I think we can just avoid introducing through a combination of restraint and code review:

https://github.com/zloirock/core-js/tree/v2#ecmascript-7-proposals

## Testing Instructions

- get this branch, then serve the app and visit in in IE11, FF, Chrome, and Safari
- verify that it works in each

