### PR TITLE
Split facility and facilitydetails serializers

### DIFF
--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -19,7 +19,6 @@ const {
     createQueryStringFromSearchFilters,
     allFiltersAreEmpty,
     createFiltersFromQueryString,
-    getFeaturesFromFeatureCollection,
     getValueFromEvent,
     getCheckedFromEvent,
     getFileFromInputRef,
@@ -200,16 +199,6 @@ it('checks whether the filters object has only empty values', () => {
     };
 
     expect(allFiltersAreEmpty(nonEmptyStringFilter)).toBe(false);
-});
-
-it('gets a list of features from a feature collection', () => {
-    const featureCollection = { features: ['feature'] };
-    const expectedMatch = ['feature'];
-
-    expect(isEqual(
-        getFeaturesFromFeatureCollection(featureCollection),
-        expectedMatch,
-    )).toBe(true);
 });
 
 it('creates a set of filters from a querystring', () => {

--- a/src/app/src/actions/facilities.js
+++ b/src/app/src/actions/facilities.js
@@ -7,7 +7,6 @@ import {
     makeGetFacilitiesURLWithQueryString,
     makeGetFacilityByOARIdURL,
     createQueryStringFromSearchFilters,
-    getFeaturesFromFeatureCollection,
 } from '../util/util';
 
 export const startFetchFacilities = createAction('START_FETCH_FACILITIES');
@@ -42,7 +41,7 @@ export function fetchFacilities() {
 }
 
 export function fetchSingleFacility(oarID = null) {
-    return (dispatch, getState) => {
+    return (dispatch) => {
         dispatch(startFetchSingleFacility());
 
         if (!oarID) {
@@ -51,23 +50,6 @@ export function fetchSingleFacility(oarID = null) {
                 'No OAR ID was provided',
                 failFetchSingleFacility,
             ));
-        }
-
-        const {
-            facilities: {
-                facilities: {
-                    data: facilitiesData,
-                },
-            },
-        } = getState();
-
-        const facilityFromExistingData = facilitiesData
-            ? getFeaturesFromFeatureCollection(facilitiesData).find(({ id }) => id === oarID)
-            : null;
-
-        if (facilityFromExistingData) {
-            const singleFacility = Object.assign({}, facilityFromExistingData);
-            return dispatch(completeFetchSingleFacility(singleFacility));
         }
 
         return csrfRequest

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -40,7 +40,7 @@ const disambiguationMarkerPopupContent = 'disambiguation-marker-popup-content';
 
 const facilitiesMapStyles = Object.freeze({
     mapContainerStyles: Object.freeze({
-        height: '100%',
+        height: '99.75%',
         width: '100%',
     }),
     copySearchButtonStyle: Object.freeze({

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -15,7 +15,7 @@ import {
     resetSingleFacility,
 } from '../actions/facilities';
 
-import { facilityPropType } from '../util/propTypes';
+import { facilityDetailsPropType } from '../util/propTypes';
 
 import { makeReportADataIssueEmailLink } from '../util/util';
 
@@ -192,7 +192,7 @@ FacilityDetailSidebar.defaultProps = {
 };
 
 FacilityDetailSidebar.propTypes = {
-    data: facilityPropType,
+    data: facilityDetailsPropType,
     fetching: bool.isRequired,
     error: arrayOf(string),
     match: shape({

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -181,7 +181,7 @@ function FilterSidebarFacilitiesTab({
     const listHeaderInsetComponent = (
         <div style={facilitiesTabStyles.listHeaderStyles}>
             <Typography
-                variant="subtitle"
+                variant="subheading"
                 align="center"
             >
                 <div

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -136,12 +136,27 @@ export const facilityPropType = shape({
         address: string.isRequired,
         country_code: string.isRequired,
         country_name: string.isRequired,
-        other_names: arrayOf(string).isRequired,
-        other_addresses: arrayOf(string).isRequired,
+    }).isRequired,
+});
+
+export const facilityDetailsPropType = shape({
+    id: string.isRequired,
+    type: oneOf([FEATURE]).isRequired,
+    geometry: shape({
+        type: oneOf([POINT]).isRequired,
+        coordinates: arrayOf(number.isRequired).isRequired,
+    }).isRequired,
+    properties: shape({
+        name: string.isRequired,
+        address: string.isRequired,
+        country_code: string.isRequired,
+        country_name: string.isRequired,
+        other_names: arrayOf(string),
+        other_addresses: arrayOf(string),
         contributors: arrayOf(arrayOf(oneOfType([
             string,
             number,
-        ]).isRequired).isRequired).isRequired,
+        ]).isRequired).isRequired),
     }).isRequired,
 });
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -163,6 +163,24 @@ class FacilityListSerializer(ModelSerializer):
 
 class FacilitySerializer(GeoFeatureModelSerializer):
     oar_id = SerializerMethodField()
+    country_name = SerializerMethodField()
+
+    class Meta:
+        model = Facility
+        fields = ('id', 'name', 'address', 'country_code', 'location',
+                  'created_at', 'updated_at', 'oar_id', 'country_name')
+        geo_field = 'location'
+
+    # Added to ensure including the OAR ID in the geojson properties map
+    def get_oar_id(self, facility):
+        return facility.id
+
+    def get_country_name(self, facility):
+        return COUNTRY_NAMES.get(facility.country_code, '')
+
+
+class FacilityDetailsSerializer(GeoFeatureModelSerializer):
+    oar_id = SerializerMethodField()
     other_names = SerializerMethodField()
     other_addresses = SerializerMethodField()
     contributors = SerializerMethodField()

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -34,6 +34,7 @@ from api.processing import parse_csv_line
 from api.serializers import (FacilityListSerializer,
                              FacilityListItemSerializer,
                              FacilitySerializer,
+                             FacilityDetailsSerializer,
                              UserSerializer,
                              UserProfileSerializer)
 from api.countries import COUNTRY_CHOICES
@@ -325,7 +326,7 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
     def retrieve(self, request, pk=None):
         try:
             queryset = Facility.objects.get(pk=pk)
-            response_data = FacilitySerializer(queryset).data
+            response_data = FacilityDetailsSerializer(queryset).data
             return Response(response_data)
         except Facility.DoesNotExist:
             raise NotFound()


### PR DESCRIPTION
## Overview

To improve performance on the full facilities query, remove some
unrelated and expensive queries for other_name, other_contributors, and
other_addresses which are only needed for the details page.

Create a new FacilityDetailsSerializer and update the React app's
propTypes in tandem.

Update fetchSingleFacility Redux action to get data from the API
unconditionally rather than trying to get it from the existing
facilities data -- since the latter no longer containers some required
details data.

Remove unused utility function and test.

Connects #309

## Testing Instructions

- serve this branch then search from the main map and verify that it still works
- visit a facility details page and verify that that still works too

