### PR TITLE
Fix icon anchors

### DIFF
--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -182,7 +182,6 @@ class FacilitiesMap extends Component {
                     lng,
                 ),
                 icon: {
-                    anchor: new this.mapMethods.Point(lat, lng),
                     url: '/images/marker.png',
                     scaledSize: new this.mapMethods.Size(30, 40),
                 },


### PR DESCRIPTION
## Overview

Remove the `anchor` property from the icons to fix a zooming bug. The
anchor had incorrectly been set to the latlng, when it should be a
point relative to the image. By default it is located along the center
point of the bottom of the image.

## Demo

![icon-anchors](https://user-images.githubusercontent.com/4165523/54398091-1d753900-468f-11e9-850d-2789bae65668.gif)

## Testing Instructions

- serve this branch, load some facilities, then search for them and verify that the zoom issue has been remedied
