### PR TITLE
Restore initial map bbox on reset button click

### DIFF
--- a/src/app/src/actions/ui.js
+++ b/src/app/src/actions/ui.js
@@ -8,3 +8,6 @@ export const updateSidebarFacilitiesTabTextFilter =
     createAction('UPDATE_SIDEBAR_FACILITIES_TAB_TEXT_FILTER');
 export const resetSidebarFacilitiesTabTextFilter =
     createAction('RESET_SIDEBAR_FACILITIES_TAB_TEXT_FILTER');
+
+export const recordSearchTabResetButtonClick =
+    createAction('RECORD_SEARCH_TAB_RESET_BUTTON_CLICK');

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { func } from 'prop-types';
+import { func, number } from 'prop-types';
 import GoogleMapReact from 'google-map-react';
 import MarkerClusterer from '@google/markerclusterer';
 import isEqual from 'lodash/isEqual';
@@ -86,13 +86,18 @@ class FacilitiesMap extends Component {
                 },
             },
             facilityDetailsData,
+            resetButtonClickCount,
         } = this.props;
 
         if (!this.googleMapElement) {
             return null;
         }
 
-        if (!data && this.googleMapElement.data) {
+        if (resetButtonClickCount > prevProps.resetButtonClickCount) {
+            this.resetMapZoom();
+        }
+
+        if (!data && prevProps.data) {
             return this.removeFeatureMarkers();
         }
 
@@ -156,6 +161,17 @@ class FacilitiesMap extends Component {
     createMapOptions = () => ({
         fullscreenControl: false,
     });
+
+    resetMapZoom = () => {
+        if (!this.googleMapElement) {
+            return null;
+        }
+
+        this.googleMapElement.setCenter(initialCenter);
+        this.googleMapElement.setZoom(initialZoom);
+
+        return null;
+    };
 
     createFeatureMarkers = () => {
         const { data } = this.props;
@@ -330,6 +346,7 @@ FacilitiesMap.propTypes = {
     data: facilityCollectionPropType,
     navigateToFacilityDetails: func.isRequired,
     facilityDetailsData: facilityPropType,
+    resetButtonClickCount: number.isRequired,
 };
 
 function mapStateToProps({
@@ -341,10 +358,16 @@ function mapStateToProps({
             data: facilityDetailsData,
         },
     },
+    ui: {
+        facilitiesSidebarTabSearch: {
+            resetButtonClickCount,
+        },
+    },
 }) {
     return {
         data,
         facilityDetailsData,
+        resetButtonClickCount,
     };
 }
 

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -17,6 +17,8 @@ import {
 
 import { fetchFacilities } from '../actions/facilities';
 
+import { recordSearchTabResetButtonClick } from '../actions/ui';
+
 import {
     contributorOptionsPropType,
     contributorTypeOptionsPropType,
@@ -302,7 +304,10 @@ function mapDispatchToProps(dispatch) {
         updateContributor: v => dispatch(updateContributorFilter(v)),
         updateContributorType: v => dispatch(updateContributorTypeFilter(v)),
         updateCountry: v => dispatch(updateCountryFilter(v)),
-        resetFilters: () => dispatch(resetAllFilters()),
+        resetFilters: () => {
+            dispatch(recordSearchTabResetButtonClick());
+            return dispatch(resetAllFilters());
+        },
         searchForFacilities: () => dispatch(fetchFacilities()),
         submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
             () => dispatch(fetchFacilities()),

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -7,11 +7,10 @@ import {
     makeSidebarFacilitiesTabActive,
     updateSidebarFacilitiesTabTextFilter,
     resetSidebarFacilitiesTabTextFilter,
+    recordSearchTabResetButtonClick,
 } from '../actions/ui';
 
 import { completeFetchFacilities } from '../actions/facilities';
-
-import { completeSubmitLogOut } from '../actions/auth';
 
 import { filterSidebarTabsEnum } from '../util/constants';
 
@@ -19,10 +18,18 @@ const initialState = Object.freeze({
     activeFilterSidebarTab: filterSidebarTabsEnum.search,
     facilitiesSidebarTabSearch: Object.freeze({
         filterText: '',
+        resetButtonClickCount: 0,
     }),
 });
 
 export default createReducer({
+    [recordSearchTabResetButtonClick]: state => update(state, {
+        facilitiesSidebarTabSearch: {
+            resetButtonClickCount: {
+                $set: (state.facilitiesSidebarTabSearch.resetButtonClickCount + 1),
+            },
+        },
+    }),
     [makeSidebarGuideTabActive]: state => update(state, {
         activeFilterSidebarTab: {
             $set: filterSidebarTabsEnum.guide,
@@ -67,5 +74,4 @@ export default createReducer({
             },
         },
     }),
-    [completeSubmitLogOut]: () => initialState,
 }, initialState);


### PR DESCRIPTION
## Overview

Restore the initial map bbox position when the search tab's reset button
is clicked.

Disable the reset button altogether when there are no active filters and
there is no facilities data in the app state.

## Testing Instructions

- serve this branch, then search for some facilities
- verify that resetting the filter state repositions the map to its initial bbox

