### PR TITLE
Clear file input on successful upload

### DIFF
--- a/src/app/src/components/ContributeForm.jsx
+++ b/src/app/src/components/ContributeForm.jsx
@@ -81,6 +81,7 @@ class ContributeForm extends Component {
         }
 
         this.props.fetchLists();
+        this.fileInput.current.value = null;
         return toast('Your facility list has been uploaded successfully!');
     }
 


### PR DESCRIPTION
## Overview

Clear file input on successful upload from contributor page to prevent
a bug whereby the file would still be attached to the input & would
upload again on clicking submit another time.

Connects #290 

## Demo

![Screen Shot 2019-03-18 at 6 03 24 PM](https://user-images.githubusercontent.com/4165523/54566742-24aa8880-49a8-11e9-8d4a-d0e8ccc631f1.png)


## Testing Instructions

- ./scripts/server
- register for an account, then visit the contributor page and upload a file
- when the file has succeeded, click the "Submit" button again and verify it does not resubmit the prior file but instead displays an error message