### PR TITLE
Update translate tab CSS rules

### DIFF
--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -50,17 +50,16 @@
 }
 
 .goog-te-gadget-simple {
-    font-size: 12px;
+    font-size: 12px !important;
     color: #0427a4;
-    cursor: pointer;
     text-decoration: none;
-    font-family: ff-tisa-sans-web-pro, sans-serif;
+    font-family: ff-tisa-sans-web-pro,sans-serif;
     font-weight: 500;
-    padding: 0 16px;
-    border: none;
+    padding: 0 16px !important;
+    border: none !important;
     text-transform: uppercase;
-    vertical-align: super;
-    display: flex;
+    background-color: unset !important;
+    vertical-align: middle !important;
 }
 
 .goog-te-menu-value {


### PR DESCRIPTION
## Overview

Remedy a styling bug on staging by updating the translate tab's CSS rules to
ensure the custom rules are applied.

Connects #322 

## Demo

![Screen Shot 2019-03-19 at 12 28 31 PM](https://user-images.githubusercontent.com/4165523/54623871-be267880-4a42-11e9-977f-fc9aafbe2f8d.png)

## Notes

Don't know exactly why this isn't working on staging, but I was guessing it may have something to do with the loading order of the CSS rules.

## Testing Instructions

- check this branch locally to verify that the translate nav tab appears correctly
- visit staging in the browser and manually apply the set of rules declared here to the CSS override in the inspector and verify that it corrects the style bug
