### PR TITLE
Make it so you can override OAR_SETTINGS_BUCKET

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,7 +12,7 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-open-apparel-registry}
       - GIT_COMMIT=${GIT_COMMIT:-latest}
       - OAR_DEBUG=1
-      - OAR_SETTINGS_BUCKET=openapparelregistry-staging-config-eu-west-1
+      - OAR_SETTINGS_BUCKET=${OAR_SETTINGS_BUCKET:-openapparelregistry-staging-config-eu-west-1}
       - OAR_ROLLBAR_ACCESS_TOKEN
       - OAR_DEPLOYMENT_ENVIRONMENT=${OAR_DEPLOYMENT_ENVIRONMENT:-staging}
     working_dir: /usr/local/src


### PR DESCRIPTION
## Overview

Make it so we can override the value of `$OAR_SETTINGS_BUCKET` in `docker-compose.ci.yml`.

## Testing Instructions

```bash
maiden:open-apparel-registry rbreslow (feature/jrb/fix-compose-file)$ OAR_SETTINGS_BUCKET=yo docker-compose -f docker-compose.ci.yml run --rm --entrypoint bash terraform -c env
GIT_COMMIT=latest
HOSTNAME=4f4a3724797c
AWS_PROFILE=open-apparel-registry
PWD=/usr/local/src
HOME=/root
TERM=xterm
OAR_SETTINGS_BUCKET=yo
SHLVL=1
OAR_DEBUG=1
OAR_DEPLOYMENT_ENVIRONMENT=staging
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
_=/usr/bin/env
maiden:open-apparel-registry rbreslow (feature/jrb/fix-compose-file)$
```