### PR TITLE
Add release pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ node {
 					withCredentials([[$class: 'StringBinding',
 									credentialsId: 'OAR_ROLLBAR_ACCESS_TOKEN',
 									variable: 'OAR_ROLLBAR_ACCESS_TOKEN']]) {
-						sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+						sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
 					}
 				}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,6 @@ node {
 
 		env.OAR_SETTINGS_BUCKET = 'openapparelregistry-testing-config-eu-west-1'
 
-	    // Execute `setup` wrapped within a plugin that translates
-	    // ANSI color codes to something that renders inside the Jenkins
-	    // console.
 		stage('setup') {
 			wrap([$class: 'AnsiColorBuildWrapper']) {
 				sh './scripts/bootstrap'
@@ -29,7 +26,7 @@ node {
 
 		env.OAR_SETTINGS_BUCKET = 'openapparelregistry-staging-config-eu-west-1'
 
-		if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('test/')) {
+		if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
 			// Publish container images built and tested during `cibuild`
 			// to the private Amazon Container Registry tagged with the
 			// first seven characters of the revision SHA.
@@ -44,10 +41,10 @@ node {
 				}
 			}
 
-			// Plan and apply the current state of the infrastructure as
-			// outlined by whatever branch of the `open-apparel-registry`
+			// Plan and apply the current state of the staging infrastructure
+			// as outlined by whatever branch of the `open-apparel-registry`
 			// repository passes the conditional above (`develop`, 
-			// `release/*`, `test/*`).
+			// `test/*`, `release/*`, `hotfix/*`).
 			stage('infra') {
 				// Use `git` to get the primary repository's current commmit SHA and
 		        // set it as the value of the `GIT_COMMIT` environment variable.

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -3,12 +3,14 @@
 node {
     properties([
         parameters([
-            string(
+            [
+                $class: 'ValidatingStringParameterDefinition',
                 defaultValue: '',
-                description: 'SHA of an existing container image. Usually what\'s currently on staging.', 
+                description: 'First 7 characters of the SHA for the commit you wish to deploy.',
+                failedValidationMessage: 'Invalid SHA.',
                 name: 'GIT_COMMIT',
-                trim: false
-            )
+                regex: /^[a-z0-9]{7}$/
+            ]
         ])
     ])
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,79 @@
+#!groovy
+
+node {
+    properties([
+        parameters([
+            string(
+                defaultValue: '',
+                description: 'SHA of an existing container image. Usually what\'s currently on staging.', 
+                name: 'GIT_COMMIT',
+                trim: false
+            )
+        ])
+    ])
+
+    try {
+        // Checkout the proper revision into the workspace.
+        stage('checkout') {
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: params.GIT_COMMIT]],
+                extensions: [[$class: 'PruneStaleBranch']],
+                userRemoteConfigs: [[
+                    credentialsId: 'azaveaci',
+                    url: 'git@github.com:open-apparel-registry/open-apparel-registry.git'
+                ]]
+            ])
+        }
+
+        env.AWS_PROFILE = 'open-apparel-registry'
+        env.AWS_DEFAULT_REGION = 'eu-west-1'
+
+        env.OAR_SETTINGS_BUCKET = 'openapparelregistry-testing-config-eu-west-1'
+
+        // If we don't do this, the showmigrations stage will throw
+        // django.core.exceptions.ImproperlyConfigured
+        stage('setup') {
+            wrap([$class: 'AnsiColorBuildWrapper']) {
+                sh './scripts/bootstrap'
+            }
+        }
+
+        env.OAR_SETTINGS_BUCKET = 'openapparelregistry-production-config-eu-west-1'
+
+        // Plan and apply the current state of the production infrastructure
+        // as outlined by whatever SHA is passed through as a build parameter.
+        stage('infra') {
+            // Environment used in Rollbar deploy notifications.
+            // https://docs.rollbar.com/reference#post-deploy
+            env.OAR_DEPLOYMENT_ENVIRONMENT = 'production'
+
+            wrap([$class: 'AnsiColorBuildWrapper']) {
+                sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+                withCredentials([[$class: 'StringBinding',
+                                credentialsId: 'OAR_ROLLBAR_ACCESS_TOKEN',
+                                variable: 'OAR_ROLLBAR_ACCESS_TOKEN']]) {
+                    sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+                }
+            }
+        }
+
+        // Kick off an ECS task to display any outstanding migrations.
+        stage('showmigrations') {
+            wrap([$class: 'AnsiColorBuildWrapper']) {
+                sh './scripts/manage ecsmanage -e production showmigrations'
+            }
+        }
+    } catch (err) {
+        // Some exception was raised in the `try` block above. Assemble
+        // an appropirate error message for Slack.
+        def slackMessage = ":jenkins-angry: *Open Apparel Registry (Release Pipeline) (${params.GIT_COMMIT}) #${env.BUILD_NUMBER}*"
+
+        slackMessage += "\n<${env.BUILD_URL}|View Build>"
+        //slackSend channel: '#oar', color: 'danger', message: slackMessage
+
+        // Re-raise the exception so that the failure is propagated to
+        // Jenkins.
+        throw err
+    }
+}

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -17,7 +17,7 @@ node {
         ":jenkins: deploying revision <https://github.com/open-apparel-registry/open-apparel-registry/tree/${params.GIT_COMMIT}|${params.GIT_COMMIT}> to *production*"
     startedMessage += "\n<${env.BUILD_URL}|View Build>"
 
-    slackSend channel: '#testingslackapps', color: 'warning', message: startedMessage
+    slackSend channel: '#oar', color: 'warning', message: startedMessage
 
     try {
         // Checkout the proper revision into the workspace.
@@ -80,7 +80,7 @@ node {
             ":jenkins-angry: failed to deploy revision <https://github.com/open-apparel-registry/open-apparel-registry/tree/${params.GIT_COMMIT}|${params.GIT_COMMIT}> to *production*"
         failedMessage += "\n<${env.BUILD_URL}|View Build>"
 
-        slackSend channel: '#testingslackapps', color: 'danger', message: failedMessage
+        slackSend channel: '#oar', color: 'danger', message: failedMessage
 
         // Re-raise the exception so that the failure is propagated to
         // Jenkins.

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -12,6 +12,13 @@ node {
         ])
     ])
 
+    // Notify Slack that we're starting a production deploy.
+    def startedMessage =
+        ":jenkins: deploying revision <https://github.com/open-apparel-registry/open-apparel-registry/tree/${params.GIT_COMMIT}|${params.GIT_COMMIT}> to *production*"
+    startedMessage += "\n<${env.BUILD_URL}|View Build>"
+
+    slackSend channel: '#testingslackapps', color: 'warning', message: startedMessage
+
     try {
         // Checkout the proper revision into the workspace.
         stage('checkout') {
@@ -50,10 +57,11 @@ node {
 
             wrap([$class: 'AnsiColorBuildWrapper']) {
                 sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+
                 withCredentials([[$class: 'StringBinding',
                                 credentialsId: 'OAR_ROLLBAR_ACCESS_TOKEN',
                                 variable: 'OAR_ROLLBAR_ACCESS_TOKEN']]) {
-                    sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+                    //sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
                 }
             }
         }
@@ -64,13 +72,15 @@ node {
                 sh './scripts/manage ecsmanage -e production showmigrations'
             }
         }
+
     } catch (err) {
         // Some exception was raised in the `try` block above. Assemble
         // an appropirate error message for Slack.
-        def slackMessage = ":jenkins-angry: *Open Apparel Registry (Release Pipeline) (${params.GIT_COMMIT}) #${env.BUILD_NUMBER}*"
+        def failedMessage =
+            ":jenkins-angry: failed to deploy revision <https://github.com/open-apparel-registry/open-apparel-registry/tree/${params.GIT_COMMIT}|${params.GIT_COMMIT}> to *production*"
+        failedMessage += "\n<${env.BUILD_URL}|View Build>"
 
-        slackMessage += "\n<${env.BUILD_URL}|View Build>"
-        //slackSend channel: '#oar', color: 'danger', message: slackMessage
+        slackSend channel: '#testingslackapps', color: 'danger', message: failedMessage
 
         // Re-raise the exception so that the failure is propagated to
         // Jenkins.

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -63,7 +63,7 @@ node {
                 withCredentials([[$class: 'StringBinding',
                                 credentialsId: 'OAR_ROLLBAR_ACCESS_TOKEN',
                                 variable: 'OAR_ROLLBAR_ACCESS_TOKEN']]) {
-                    //sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+                    sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
                 }
             }
         }

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -7,6 +7,7 @@
     "essential": true,
     "entryPoint": ["./manage.py"],
     "environment": [
+        { "name": "PYTHONUNBUFFERED", "value": "1"},
         { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },
         { "name": "POSTGRES_HOST", "value": "${postgres_host}" },
         { "name": "POSTGRES_PORT", "value": "${postgres_port}" },

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -7,7 +7,7 @@
     "essential": true,
     "entryPoint": ["./manage.py"],
     "environment": [
-        { "name": "PYTHONUNBUFFERED", "value": "1"},
+        { "name": "PYTHONUNBUFFERED", "value": "1" },
         { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },
         { "name": "POSTGRES_HOST", "value": "${postgres_host}" },
         { "name": "POSTGRES_PORT", "value": "${postgres_port}" },

--- a/scripts/infra
+++ b/scripts/infra
@@ -52,13 +52,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 terraform apply "${OAR_SETTINGS_BUCKET}.tfplan"
 
                 # Notify Rollbar of the deploy when running on Jenkins
-                if [[ -n "${OAR_ROLLBAR_ACCESS_TOKEN}" && -n "${OAR_DEPLOYMENT_ENVIRONMENT}" && -n "${BUILD_URL}" ]]; then
+                if [[ -n "${OAR_ROLLBAR_ACCESS_TOKEN}" && -n "${OAR_DEPLOYMENT_ENVIRONMENT}" ]]; then
                     curl -s https://api.rollbar.com/api/1/deploy/ \
                         -F "access_token=${OAR_ROLLBAR_ACCESS_TOKEN}" \
                         -F "environment=${OAR_DEPLOYMENT_ENVIRONMENT}" \
                         -F "revision=${GIT_COMMIT}" \
-                        -F "local_username=jenkins" \
-                        -F "comment=<${BUILD_URL}|View Build>"
+                        -F "local_username=jenkins"
                 fi
                 ;;
             *)

--- a/scripts/infra
+++ b/scripts/infra
@@ -52,12 +52,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 terraform apply "${OAR_SETTINGS_BUCKET}.tfplan"
 
                 # Notify Rollbar of the deploy when running on Jenkins
-                if [[ -n "${OAR_ROLLBAR_ACCESS_TOKEN}" && -n "${OAR_DEPLOYMENT_ENVIRONMENT}" ]]; then
+                if [[ -n "${OAR_ROLLBAR_ACCESS_TOKEN}" && -n "${OAR_DEPLOYMENT_ENVIRONMENT}" && -n "${BUILD_URL}" ]]; then
                     curl -s https://api.rollbar.com/api/1/deploy/ \
                         -F "access_token=${OAR_ROLLBAR_ACCESS_TOKEN}" \
                         -F "environment=${OAR_DEPLOYMENT_ENVIRONMENT}" \
                         -F "revision=${GIT_COMMIT}" \
-                        -F "local_username=jenkins"
+                        -F "local_username=jenkins" \
+                        -F "comment=<${BUILD_URL}|View Build>"
                 fi
                 ;;
             *)

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -15,11 +15,8 @@ import requests
 
 from django.core.exceptions import ImproperlyConfigured
 
-from django.core.exceptions import ImproperlyConfigured
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -198,6 +198,25 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTH_USER_MODEL = 'api.User'
 
+# Logging
+# https://docs.djangoproject.com/en/2.1/topics/logging/
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+        },
+    },
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/
 


### PR DESCRIPTION
## Overview

* Add `Jenkinsfile.release` which takes the SHA of an existing container image and runs the `infra` process against the production settings bucket
* Add [`Open Apparel Registry Release Pipeline`](http://civicci01.internal.azavea.com/view/oar/) scripted pipeline job to Jenkins
* Make sure `develop`, `test/`, `release/`, and `hotfix/` all go to staging
* Set `PYTHONUNBUFFERED=1` in AppCLI task def

Connects #224 

## Testing Instructions

See: http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/17/

You can also run your own build based off of the latest `develop` SHA.