### PR TITLE
Add command to bulk create OAR managed accounts

### DIFF
--- a/src/django/api/management/commands/create_accounts.py
+++ b/src/django/api/management/commands/create_accounts.py
@@ -1,0 +1,88 @@
+import sys
+
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils.text import slugify
+
+from api.models import Contributor, User
+
+VALID_CONTRIBUTOR_TYPES = [k for k, v in Contributor.CONTRIB_TYPE_CHOICES]
+
+
+class Command(BaseCommand):
+    help = 'Create user and contributor accounts.'
+
+    def add_arguments(self, parser):
+        # Create a group of arguments explicitly labeled as required,
+        # because by default named arguments are considered optional.
+        group = parser.add_argument_group('required arguments')
+        group.add_argument('-c', '--contributors',
+                           required=True,
+                           nargs='+',
+                           help='Space separated list of double-quoted '
+                                'contributor names.')
+        group.add_argument('-t', '--type',
+                           required=True,
+                           help='Type of contributor. '
+                                'One of "{}".'.format(
+                                    '", "'.join(VALID_CONTRIBUTOR_TYPES)))
+        group.add_argument('-p', '--password',
+                           required=True,
+                           help='Password to set for all new accounts.')
+
+    def handle(self, *args, **options):
+        contributors = options['contributors']
+        contrib_type = options['type']
+        password = options['password']
+
+        # Crash if invalid contributor type specified
+        if contrib_type not in VALID_CONTRIBUTOR_TYPES:
+            self.stderr.write(
+                'Validation Error: Invalid contributor type "{0}". '
+                'Must be one of "{1}".'.format(
+                    contrib_type, '", "'.join(VALID_CONTRIBUTOR_TYPES)))
+
+            sys.exit(1)
+
+        # Crash if invalid password specified
+        try:
+            validate_password(password)
+        except ValidationError as e:
+            self.stderr.write(
+                'Validation Error: Password "{0}" is invalid. '
+                '\n{1}'.format(password, '\n'.join(list(e.messages))))
+
+            sys.exit(1)
+
+        with transaction.atomic():
+            for name in contributors:
+                user = User.objects._create_user(
+                    email='info+{}@openapparel.org'.format(
+                        slugify(name, allow_unicode=True)),
+                    password=password,
+                    is_superuser=False,
+                    is_staff=False,
+                    is_active=True,
+                    username=name,
+                    should_receive_newsletter=False,
+                    has_agreed_to_terms_of_service=True,
+                )
+
+                contributor = Contributor(
+                    name=name,
+                    description='Public facility lists for {} '
+                                'managed by the OAR team'.format(name),
+                    website='',
+                    contrib_type=contrib_type,
+                    other_contrib_type=(
+                        Contributor.OTHER_CONTRIB_TYPE
+                        if contrib_type == Contributor.OTHER_CONTRIB_TYPE
+                        else None),
+                    admin=user,
+                )
+                contributor.save()
+
+        self.stdout.write('Created accounts for {} contributors.'.format(
+            len(contributors)))


### PR DESCRIPTION
## Overview

Adds a command that takes a list of contributor names, a contributor type, and a password, and creates user and contributor accounts with those details and some defaults. These accounts will be added by OAR initially, but may be transferred to different owners in the future.

Validates that the specified contributor type is one of the allowed values, and that the password meets regular app requirements.

Connects #240 

## Demo

```bash
$ manage create_accounts --help

usage: manage.py create_accounts [-h] [--version] [-v {0,1,2,3}]
                                 [--settings SETTINGS]
                                 [--pythonpath PYTHONPATH] [--traceback]
                                 [--no-color] -c CONTRIBUTORS
                                 [CONTRIBUTORS ...] -t TYPE -p PASSWORD

Create user and contributor accounts.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.

required arguments:
  -c CONTRIBUTORS [CONTRIBUTORS ...], --contributors CONTRIBUTORS [CONTRIBUTORS ...]
                        Space separated list of double-quoted contributor
                        names.
  -t TYPE, --type TYPE  Type of contributor. One of "Auditor",
                        "Brand/Retailer", "Civil Society Organization",
                        "Factory / Facility", "Manufacturing Group / Supplier
                        / Vendor", "Multi Stakeholder Initiative", "Researcher
                        / Academic", "Service Provider", "Union", "Other".
  -p PASSWORD, --password PASSWORD
                        Password to set for all new accounts.
```

```bash
$ manage create_accounts --contributors abc "D ef" "g.h.i" --type "Brand/Retailer" --password hunter2048

Created accounts for 3 contributors.
```

```sql
SELECT id, password, is_superuser, is_staff, is_active, email, username
FROM api_user
WHERE email LIKE 'info%openapparel.org';

 id  |                                    password                                    | is_superuser | is_staff | is_active |           email           | username
-----+--------------------------------------------------------------------------------+--------------+----------+-----------+---------------------------+----------
 101 | pbkdf2_sha256$100000$RtN4IHPLe9gm$Z+zudufDP95ZlG7sD3Vx0F9KTe1xQCQAnuXuM0uyM9k= | f            | f        | t         | info+abc@openapparel.org  | abc
 102 | pbkdf2_sha256$100000$7HQJKxcSZTH9$k9ISfaFyE/nezjdOPLrlQYiB9QotU4EDFVNEgWJhljA= | f            | f        | t         | info+d-ef@openapparel.org | D ef
 103 | pbkdf2_sha256$100000$YQU9hIp3WtOh$3vmnCVD9LpxMmbRg8nFIwv55BxEh55SRfoFtmjx/vpk= | f            | f        | t         | info+ghi@openapparel.org  | g.h.i
(3 rows)
```

```sql
SELECT id, name, description, contrib_type
FROM api_contributor
WHERE admin_id IN (101, 102, 103);

 id  | name  |                       description                       |  contrib_type
-----+-------+---------------------------------------------------------+----------------
 100 | abc   | Public facility lists for abc managed by the OAR team   | Brand/Retailer
 101 | D ef  | Public facility lists for D ef managed by the OAR team  | Brand/Retailer
 102 | g.h.i | Public facility lists for g.h.i managed by the OAR team | Brand/Retailer
(3 rows)
```

## Testing Instructions

* Check out this branch
* Run `manage create_accounts --help` and read the instructions
  - [x] Ensure it covers all the necessary options and describes them correctly
* Try to run `manage create_accounts` with different options
  - [x] Ensures it crashes if `--contributors`, `--type`, or `--password` is not specified
  - [x] Ensure it crashes if `--type` doesn't match one of the existing types
  - [x] Ensure it crashes if `--password` doesn't satisfy password requirements
  - [x] Ensure that when everything is specified correctly, the correct accounts are created in `api_user` and `api_contributor` tables
* Try logging in as one of the created users in the UI
  - [x] Ensure that you can log in
  - [x] Ensure you can upload a facility list