### PR TITLE
Create Swagger docs for public API endpoints

### DIFF
--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -9,6 +9,10 @@ import NavbarLoginButtonGroup from './NavbarLoginButtonGroup';
 
 import { contributeRoute } from '../util/constants';
 
+const apiDocumentationURL = process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8081/api/docs/'
+    : '/api/docs/';
+
 export default function Navbar() {
     const aboutLinks = [
         {
@@ -62,7 +66,7 @@ export default function Navbar() {
                         target="_blank"
                         className="navButton"
                         rel="noopener noreferrer"
-                        href="https://info.openapparel.org/apiinstructions"
+                        href={apiDocumentationURL}
                     >
                         API
                     </a>

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -179,7 +179,7 @@ class FacilitySerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Facility
         fields = ('id', 'name', 'address', 'country_code', 'location',
-                  'created_at', 'updated_at', 'oar_id', 'country_name')
+                  'oar_id', 'country_name')
         geo_field = 'location'
 
     # Added to ensure including the OAR ID in the geojson properties map
@@ -200,8 +200,8 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Facility
         fields = ('id', 'name', 'address', 'country_code', 'location',
-                  'created_at', 'updated_at', 'oar_id', 'other_names',
-                  'other_addresses', 'contributors', 'country_name')
+                  'oar_id', 'other_names', 'other_addresses', 'contributors',
+                  'country_name')
         geo_field = 'location'
 
     # Added to ensure including the OAR ID in the geojson properties map

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -250,6 +250,16 @@ class APIAuthToken(ObtainAuthToken):
 @api_view(['GET'])
 @permission_classes((AllowAny,))
 def all_contributors(request):
+    """
+    Returns a list of contributors as tuples of contributor IDs and names.
+
+    ## Sample Response
+
+        [
+            [1, "Contributor One"]
+            [2, "Contributor Two"]
+        ]
+    """
     response_data = [
         (contributor.id, contributor.name)
         for contributor
@@ -261,22 +271,90 @@ def all_contributors(request):
 @api_view(['GET'])
 @permission_classes((AllowAny,))
 def all_contributor_types(request):
+    """
+    Returns a list of contributor type choices as tuples of values and display
+    names.
+
+    ## Sample Response
+
+        [
+            ["Auditor", "Auditor"],
+            ["Brand/Retailer", "Brand/Retailer"],
+            ["Civil Society Organization", "Civil Society Organization"],
+            ["Factory / Facility", "Factory / Facility"]
+        ]
+    """
     return Response(Contributor.CONTRIB_TYPE_CHOICES)
 
 
 @api_view(['GET'])
 @permission_classes((AllowAny,))
 def all_countries(request):
+    """
+    Returns a list of country choices as tuples of country codes and names.
+
+    ## Sample Response
+
+        [
+            ["AF", "Afghanistan"],
+            ["AX", "Åland Islands"]
+            ["AL", "Albania"]
+        ]
+
+    """
     return Response(COUNTRY_CHOICES)
 
 
 class FacilitiesViewSet(ReadOnlyModelViewSet):
+    """
+    Get facilities in GeoJSON format.
+    """
     queryset = Facility.objects.all()
     serializer_class = FacilitySerializer
     permission_classes = (AllowAny,)
     pagination_class = FacilitiesGeoJSONPagination
 
     def list(self, request):
+        """
+        Returns a list of facilities in GeoJSON format for a given query.
+
+        ### Sample Response
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "id": "OAR_ID_1",
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [1, 1]
+                        },
+                        "properties": {
+                            "name": "facility_name_1",
+                            "address" "facility address_1",
+                            "country_code": "US",
+                            "country_name": "United States",
+                            "oar_id": "OAR_ID_1"
+                        }
+                    },
+                    {
+                        "id": "OAR_ID_2",
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [2, 2]
+                        },
+                        "properties": {
+                            "name": "facility_name_2",
+                            "address" "facility address_2",
+                            "country_code": "US",
+                            "country_name": "United States",
+                            "oar_id": "OAR_ID_2"
+                        }
+                    }
+                ]
+            }
+        """
         name = request.query_params.get(FacilitiesQueryParams.NAME,
                                         None)
         contributors = request.query_params \
@@ -333,6 +411,29 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
         return Response(response_data)
 
     def retrieve(self, request, pk=None):
+        """
+        Returns the facility specified by a given OAR ID in GeoJSON format.
+
+        ### Sample Response
+            {
+                "id": "OAR_ID",
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [1, 1]
+                },
+                "properties": {
+                    "name": "facility_name",
+                    "address" "facility address",
+                    "country_code": "US",
+                    "country_name": "United States",
+                    "oar_id": "OAR_ID",
+                    "other_names": [],
+                    "other_addresses": [],
+                    "contributors": [[1, "Contributor One"]]
+                }
+            }
+        """
         try:
             queryset = Facility.objects.get(pk=pk)
             response_data = FacilityDetailsSerializer(queryset).data
@@ -342,9 +443,13 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
 
 
 class FacilityListViewSet(viewsets.ModelViewSet):
+    """
+    Upload and update facility lists for an authenticated Contributor.
+    """
     queryset = FacilityList.objects.all()
     serializer_class = FacilityListSerializer
     permission_classes = [IsRegisteredAndConfirmed]
+    http_method_names = ['get', 'post', 'head', 'options', 'trace']
 
     def _validate_header(self, header):
         if header is None or header == '':
@@ -360,6 +465,9 @@ class FacilityListViewSet(viewsets.ModelViewSet):
 
     @transaction.atomic
     def create(self, request):
+        """
+        Upload a new Facility List.
+        """
         if 'file' not in request.data:
             raise ValidationError('No file specified.')
         csv_file = request.data['file']
@@ -461,6 +569,29 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     def list(self, request):
+        """
+        Returns Facility Lists for an authenticated Contributor.
+
+        ## Sample Response
+            [
+                {
+                    "id":16,
+                    "name":"11",
+                    "description":"list 11",
+                    "file_name":"11.csv",
+                    "is_active":true,
+                    "is_public":true
+                },
+                {
+                    "id":15,
+                    "name":"old list 11",
+                    "description":"old list 11",
+                    "file_name":"11.csv",
+                    "is_active":false,
+                    "is_public":true
+                }
+            ]
+        """
         try:
             contributor = request.user.contributor
             queryset = FacilityList.objects.filter(contributor=contributor)
@@ -470,6 +601,35 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             raise ValidationError('User contributor cannot be None')
 
     def retrieve(self, request, pk):
+        """
+        Returns a single Facility List for an authenticated Contributor.
+
+        ## Sample Response
+            {
+                "id": 16,
+                "name": "list 11",
+                "description": "list 11 description",
+                "file_name": "11.csv",
+                "is_active": true,
+                "is_public": true,
+                "items": [
+                    "id": 1,
+                    "matches": [],
+                    "country_name": "United States",
+                    "processing_errors": null,
+                    "matched_facility": null,
+                    "row_index": 1,
+                    "raw_data": "List item 1, List item address 1",
+                    "status": "GEOCODED",
+                    "processing_started_at": null,
+                    "processing_completed_at": null,
+                    "name": "List item 1",
+                    "address": "List item address 1",
+                    "country_code": "US",
+                    "facility_list": 16
+                ]
+            }
+        """
         try:
             user_contributor = request.user.contributor
             facility_list = FacilityList \
@@ -511,6 +671,101 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             methods=['post'],
             url_path='confirm')
     def confirm_match(self, request, pk=None):
+        """
+        Confirm a potential match between an existing Facility and a Facility
+        List Item from an authenticated Contributor's Facility List.
+
+        Returns an updated Facility List Item with the confirmed match's status
+        changed to `CONFIRMED` and the Facility List Item's status changed to
+        `CONFIRMED_MATCH`. On confirming a potential match, all other
+        potential matches will have their status changed to `REJECTED`.
+
+        ## Request Body
+
+        **Required**
+
+        `list_item_id` (`number`): ID for the Facility List Item rejecting a
+                       match with an existing Facility.
+
+        `facility_match_id` (`number`): ID for the potential Facility Match
+                            rejected as a match for the Facility List Item.
+
+        **Example**
+
+            {
+                "list_item_id": 1,
+                "facility_match_id": 1
+            }
+
+        ## Sample Response
+
+            {
+                "id": 1,
+                "matches": [
+                    {
+                        "id": 1,
+                        "status": "CONFIRMED",
+                        "confidence": 0.6,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "12asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_1",
+                        "name": "facility match name 1",
+                        "address": "facility match address 1",
+                        "location": {
+                            "lat": 1,
+                            "lng": 1
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "status": "REJECTED",
+                        "confidence": 0.7,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "34asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_2",
+                        "name": "facility match name 2",
+                        "address": "facility match address 2",
+                        "location": {
+                            "lat": 2,
+                            "lng": 2
+                        }
+                    }
+                ],
+                "row_index": 1,
+                "address": "facility list item address",
+                "name": "facility list item name",
+                "raw_data": "facility liste item name, facility list item address", # noqa
+                "status": "CONFIRMED_MATCH",
+                "processing_started_at": null,
+                "processing_completed_at": null,
+                "country_code": "US",
+                "facility_list": 1,
+                "country_name": "United States",
+                "processing_errors": null,
+                "matched_facility": {
+                    "oar_id": "oar_id_1",
+                    "name": "facility match name 1",
+                    "address": "facility match address 1",
+                    "location": {
+                        "lat": 1,
+                        "lng": 1
+                    },
+                    "created_from_id": 12345
+                }
+            }
+        """
         try:
             list_item_id = request.data.get('list_item_id')
             facility_match_id = request.data.get('facility_match_id')
@@ -569,6 +824,94 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             methods=['post'],
             url_path='reject')
     def reject_match(self, request, pk=None):
+        """
+        Reject a potential match between an existing Facility and a Facility
+        List Item from an authenticated Contributor's Facility List.
+
+        Returns an updated Facility List Item with the potential match's status
+        changed to `REJECTED`.
+
+        If all potential matches have been rejected and the Facility List Item
+        has been successfully geocoded, creates a new Facility from the
+        Facility List Item.
+
+        ## Request Body
+
+        **Required**
+
+        `list_item_id` (`number`): ID for the Facility List Item rejecting a
+                       match with an existing Facility.
+
+        `facility_match_id` (`number`): ID for the potential Facility Match
+                            rejected as a match for the Facility List Item.
+
+        **Example**
+
+            {
+                "list_item_id": 1,
+                "facility_match_id": 2
+            }
+
+        ## Sample Response
+
+            {
+                "id": 1,
+                "matches": [
+                    {
+                        "id": 1,
+                        "status": "PENDING",
+                        "confidence": 0.6,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "12asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_1",
+                        "name": "facility match name 1",
+                        "address": "facility match address 1",
+                        "location": {
+                            "lat": 1,
+                            "lng": 1
+                        }
+                    },
+                    {
+                        "id": 2,
+                        "status": "REJECTED",
+                        "confidence": 0.7,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "34asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_2",
+                        "name": "facility match name 2",
+                        "address": "facility match address 2",
+                        "location": {
+                            "lat": 2,
+                            "lng": 2
+                        }
+                    }
+                ]
+                "row_index": 1,
+                "address": "facility list item address",
+                "name": "facility list item name",
+                "raw_data": "facility liste item name, facility list item address", # noqa
+                "status": "POTENTIAL_MATCH",
+                "processing_started_at": null,
+                "processing_completed_at": null,
+                "country_code": "US",
+                "country_name": "United States",
+                "matched_facility": null,
+                "processing_errors": null,
+                "facility_list": 1,
+            }
+        """
         try:
             list_item_id = request.data.get('list_item_id')
             facility_match_id = request.data.get('facility_match_id')

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -147,6 +147,7 @@ SWAGGER_SETTINGS = {
     },
     'USE_SESSION_AUTH': False,
 }
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -90,6 +90,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'rest_framework_gis',
+    'rest_framework_swagger',
     'rest_auth',
     'allauth',
     'allauth.account',
@@ -129,6 +130,23 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 20,
 }
 
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'api_key': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization',
+        },
+    },
+    'doc_expansion': 'list',
+    'info': {
+        'description': 'Open Apparel Registry API',
+        'license': 'MIT',
+        'licenseUrl': 'https://github.com/open-apparel-registry/open-apparel-registry/blob/develop/LICENSE', # noqa
+        'title': 'Open Apparel Registry API',
+    },
+    'USE_SESSION_AUTH': False,
+}
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -23,6 +23,7 @@ from web.views import environment
 
 
 from rest_framework import routers
+from rest_framework_swagger.views import get_swagger_view
 
 from oar import settings
 
@@ -31,10 +32,22 @@ router.register('facility-lists', views.FacilityListViewSet, 'facility-list')
 router.register('facilities', views.FacilitiesViewSet, 'facility')
 
 
-urlpatterns = [
+public_apis = [
+    url(r'^api/', include(router.urls)),
+    url(r'^api/contributors/', views.all_contributors,
+        name='all_contributors'),
+    url(r'^api/contributor-types/', views.all_contributor_types,
+        name='all_contributor_types'),
+    url(r'^api/countries/', views.all_countries, name='all_countries'),
+]
+
+schema_view = get_swagger_view(title='Open Apparel Registry API Documentation',
+                               patterns=public_apis)
+
+internal_apis = [
     url(r'^', include('django.contrib.auth.urls')),
     url(r'^web/environment\.js', environment, name='environment'),
-    url(r'^api/', include(router.urls)),
+    url(r'^api/docs/', schema_view),
     path('admin/', admin.site.urls),
     re_path(r'^health-check/', include('watchman.urls')),
     url(r'^api-auth/', include('rest_framework.urls')),
@@ -50,9 +63,6 @@ urlpatterns = [
         name='get_and_update_user_profile'),
     url(r'^api-token-auth/', views.APIAuthToken.as_view(),
         name='api_token_auth'),
-    url(r'^api/contributors/', views.all_contributors,
-        name='all_contributors'),
-    url(r'^api/contributor-types/', views.all_contributor_types,
-        name='all_contributor_types'),
-    url(r'^api/countries/', views.all_countries, name='all_countries'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+urlpatterns = public_apis + internal_apis

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -5,6 +5,7 @@ django-amazon-ses==2.0.0
 django-extensions==2.1.4
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.3
+django-rest-swagger==2.1.2
 django-spa==0.2.0
 django-watchman==0.15.0
 djangorestframework-gis==0.14

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -1,5 +1,6 @@
 base32-crockford==0.3.0
 boto3==1.9.92
+coreapi==2.3.3
 dedupe==1.9.4
 django-amazon-ses==2.0.0
 django-extensions==2.1.4


### PR DESCRIPTION
## Overview

This PR creates a set of Swagger docs for the application's public API endpoints, accessible at `/api/docs`.

The inline docstrings are currently accurate for all endpoints, and the contributors, contributor types, countries, and facilities endpoints are both documented and working through the UI.

I had substantial trouble getting the facility lists documentation to work, so I delayed fleshing that out until #349. Django REST Swagger deprecated using inline YAML to declare a schema and fields for each endpoint in version 2, and lower versions are not compatible with our existing setup.

Conceivably we could just drop the `api/facilities-list` endpoints from the publicly documented API altogether for now and come up with a better solution later. The other interactive endpoints are working as expected.

Connects #88 

## Demo

<img width="1092" alt="Screen Shot 2019-03-19 at 5 54 59 PM" src="https://user-images.githubusercontent.com/4165523/54644638-28094700-4a70-11e9-8568-59a70ed22ce8.png">

## Testing

- get this branch then `./scripts/update`
- `./scripts/manage resetdb` and `./scripts/manage processfixtures`
- visit localhost:6543 and click on the API link in the navbar, verifying you are taken to the Swagger docs
- try out the interactive docs for facilities, countries, contributors, and contributor_types
- back on 6543, create an API token, then copy it to the clipboard
- return to the API docs and click the "Authorize" button, then enter `Token <YOUR_TOKEN>` as the auth and click authorize
- verify that the "/api/facility-lists` section is there
