### PR TITLE
Implement server side paging for facility list items

### DIFF
--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -2,6 +2,9 @@ import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
 import {
+    startFetchFacilityList,
+    failFetchFacilityList,
+    completeFetchFacilityList,
     startFetchFacilityListItems,
     failFetchFacilityListItems,
     completeFetchFacilityListItems,
@@ -20,9 +23,16 @@ import { completeSubmitLogOut } from '../actions/auth';
 import { facilityListItemStatusChoicesEnum } from '../util/constants';
 
 const initialState = Object.freeze({
-    data: null,
-    fetching: false,
-    error: null,
+    list: {
+        data: null,
+        fetching: false,
+        error: null,
+    },
+    items: {
+        data: null,
+        fetching: false,
+        error: null,
+    },
     confirmOrRejectMatch: Object.freeze({
         fetching: false,
         error: null,
@@ -58,14 +68,14 @@ const toggleSelectedRowIndex = (state, payload) => {
 
 const completeConfirmMatch = (state, payload) => {
     const indexForListItemToUpdate = state
-        .data
         .items
+        .data
         .findIndex(({ id }) => id === payload.id);
 
     const updatedItems = [
-        ...state.data.items.slice(0, indexForListItemToUpdate),
+        ...state.items.data.slice(0, indexForListItemToUpdate),
         payload,
-        ...state.data.items.slice(indexForListItemToUpdate + 1),
+        ...state.items.data.slice(indexForListItemToUpdate + 1),
     ];
 
     const updatedSelectedRowIndex =
@@ -78,8 +88,8 @@ const completeConfirmMatch = (state, payload) => {
             fetching: { $set: false },
             error: { $set: null },
         },
-        data: {
-            items: {
+        items: {
+            data: {
                 $set: updatedItems,
             },
         },
@@ -90,18 +100,59 @@ const completeConfirmMatch = (state, payload) => {
 };
 
 export default createReducer({
+    [startFetchFacilityList]: state => update(state, {
+        list: {
+            $merge: {
+                data: null,
+                fetching: true,
+                error: null,
+            },
+        },
+    }),
+    [failFetchFacilityList]: (state, payload) => update(state, {
+        list: {
+            $merge: {
+                data: null,
+                fetching: false,
+                error: payload,
+            },
+        },
+    }),
+    [completeFetchFacilityList]: (state, payload) => update(state, {
+        list: {
+            $merge: {
+                data: payload,
+                fetching: false,
+                error: null,
+            },
+        },
+    }),
     [startFetchFacilityListItems]: state => update(state, {
-        fetching: { $set: true },
-        error: { $set: null },
+        items: {
+            $merge: {
+                data: null,
+                fetching: true,
+                error: null,
+            },
+        },
     }),
     [failFetchFacilityListItems]: (state, payload) => update(state, {
-        fetching: { $set: false },
-        error: { $set: payload },
+        items: {
+            $merge: {
+                data: null,
+                fetching: false,
+                error: payload,
+            },
+        },
     }),
     [completeFetchFacilityListItems]: (state, payload) => update(state, {
-        data: { $set: payload },
-        fetching: { $set: false },
-        error: { $set: null },
+        items: {
+            $merge: {
+                data: payload,
+                fetching: false,
+                error: null,
+            },
+        },
     }),
     [resetFacilityListItems]: () => initialState,
     [startConfirmFacilityListItemPotentialMatch]: startConfirmOrRejectMatch,

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -106,7 +106,7 @@ export const facilityListPropType = shape({
     file_name: string.isRequired,
     is_active: bool.isRequired,
     is_public: bool.isRequired,
-    items: arrayOf(facilityListItemPropType),
+    item_count: number.isRequired,
 });
 
 export const contributorOptionsPropType = arrayOf(shape({

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -53,9 +53,9 @@ export function DownloadCSV(data, fileName) {
 export const downloadContributorTemplate = () =>
     DownloadCSV(contributeCSVTemplate, 'OAR_Contributor_Template.csv');
 
-export const downloadListItemCSV = list =>
+export const downloadListItemCSV = (list, items) =>
     DownloadCSV(
-        createListItemCSV(list.items),
+        createListItemCSV(items),
         `${list.id}_${list.name}_${(new Date()).toLocaleDateString()}.csv`,
     );
 
@@ -69,6 +69,7 @@ export const makeUserConfirmEmailURL = () => '/rest-auth/registration/verify-ema
 
 export const makeFacilityListsURL = () => '/api/facility-lists/';
 export const makeSingleFacilityListURL = id => `/api/facility-lists/${id}/`;
+export const makeSingleFacilityListItemsURL = id => `/api/facility-lists/${id}/items/`;
 
 export const makeAPITokenURL = () => '/api-token-auth/';
 

--- a/src/django/api/pagination.py
+++ b/src/django/api/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class PageAndSizePagination(PageNumberPagination):
+    page_query_param = 'page'
+    page_size_query_param = 'pageSize'
+    max_page_size = 100

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -3,6 +3,7 @@ from django.core import exceptions
 from django.db import transaction
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth import password_validation
+from django.urls import reverse
 from rest_framework.serializers import (CharField,
                                         EmailField,
                                         ModelSerializer,
@@ -155,10 +156,20 @@ class UserProfileSerializer(ModelSerializer):
 
 
 class FacilityListSerializer(ModelSerializer):
+    item_count = SerializerMethodField()
+    items_url = SerializerMethodField()
+
     class Meta:
         model = FacilityList
         fields = ('id', 'name', 'description', 'file_name', 'is_active',
-                  'is_public')
+                  'is_public', 'item_count', 'items_url')
+
+    def get_item_count(self, facility_list):
+        return facility_list.facilitylistitem_set.count()
+
+    def get_items_url(self, facility_list):
+        return reverse('facility-list-items',
+                       kwargs={'pk': facility_list.pk})
 
 
 class FacilitySerializer(GeoFeatureModelSerializer):

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -124,6 +124,8 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
+    'DEFAULT_PAGINATION_CLASS': 'api.pagination.PageAndSizePagination',
+    'PAGE_SIZE': 20,
 }
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Overview

We were running into gateway timeout issues when attempting to load all items for a large list (thousands of rows)

To solve this we have added a separate endpoint for fetching list items and implemented paging based on the built-in Django REST Framework paging support.

We were able to reuse the bulk of the client side paging logic but we now fetch new data when the page or page size is changed rather than just getting a slice of the full data in memory.

Connects #335

## Demo

![2019-03-20 10 01 43](https://user-images.githubusercontent.com/17363/54704028-33ec1c00-4af7-11e9-973f-1301b1c477f7.gif)


## Notes

This breaks the client side CSV downloading. This is logged as a separate issue (#344) and will be fixed in a follow up PR

## Testing Instructions

* Log in as c8@example.com
* Browse http://localhost:6543/lists/8
* Use the React tools in the developer console to verify that only 20 rows have been loaded into the state
* Use the page navigation and verify that the data is correctly paged.


