### PR TITLE
Paginate facilities geojson

### DIFF
--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -178,6 +178,12 @@ function FilterSidebarFacilitiesTab({
     const orderedFacilities =
         sortFacilitiesAlphabeticallyByName(filteredFacilities);
 
+    const facilitiesCount = get(data, 'count', null);
+
+    const headerDisplayString = facilitiesCount && (facilitiesCount !== filteredFacilities.length)
+        ? `Displaying ${filteredFacilities.length} facilities of ${facilitiesCount} results`
+        : `Displaying ${filteredFacilities.length} facilities`;
+
     const listHeaderInsetComponent = (
         <div style={facilitiesTabStyles.listHeaderStyles}>
             <Typography
@@ -187,7 +193,7 @@ function FilterSidebarFacilitiesTab({
                 <div
                     style={facilitiesTabStyles.titleRowStyles}
                 >
-                    {`Displaying ${filteredFacilities.length} facilities`}
+                    {headerDisplayString}
                     <Button
                         variant="outlined"
                         color="primary"

--- a/src/django/api/pagination.py
+++ b/src/django/api/pagination.py
@@ -1,7 +1,14 @@
 from rest_framework.pagination import PageNumberPagination
+from rest_framework_gis.pagination import GeoJsonPagination
 
 
 class PageAndSizePagination(PageNumberPagination):
     page_query_param = 'page'
     page_size_query_param = 'pageSize'
     max_page_size = 100
+
+
+class FacilitiesGeoJSONPagination(GeoJsonPagination):
+    page_query_param = 'page'
+    page_size_query_param = 'pageSize'
+    page_size = 500


### PR DESCRIPTION
## Overview

Use django-rest-framework-gis's built-in geojson pagination to limit the
number of facilities returned from any given search to 500 for regular
requests.

Adjust the facilities tab header to display "n facilities of m results"
when m is larger than n.

Connects #346 

## Demo

All potential results have returned from the API:

![Screen Shot 2019-03-20 at 6 09 42 PM](https://user-images.githubusercontent.com/4165523/54722680-6e77a800-4b3b-11e9-8081-8312cd457216.png)

There are more results available on the next page in the API:

![Screen Shot 2019-03-20 at 6 05 03 PM](https://user-images.githubusercontent.com/4165523/54722683-6e77a800-4b3b-11e9-9774-adc066a565a7.png)

Narrowing the facilities even further with a search string:

![Screen Shot 2019-03-20 at 6 05 10 PM](https://user-images.githubusercontent.com/4165523/54722682-6e77a800-4b3b-11e9-801a-8a8db97241be.png)

## Notes

I set the default page size to 500 for now

## Testing Instructions

- serve this branch then resetdb and processfixtures
- from the main map page, click search and verify that you see 500 facilities returned and a count of 914
- run another search for "shoe" and verify that that returns 35 facilities, with no additional results
