### PR TITLE
Display total facilities on sidebar search tab

### DIFF
--- a/src/app/src/actions/facilityCount.js
+++ b/src/app/src/actions/facilityCount.js
@@ -1,0 +1,38 @@
+import { createAction } from 'redux-act';
+
+import csrfRequest from '../util/csrfRequest';
+
+import {
+    logErrorAndDispatchFailure,
+    makeGetFacilitiesCountURL,
+} from '../util/util';
+
+export const startFetchFacilityCount = createAction('START_FETCH_FACILITY_COUNT');
+export const failFetchFacilityCount = createAction('FAIL_FETCH_FACILITY_COUNT');
+export const completeFetchFacilityCount = createAction('COMPLETE_FETCH_FACILITY_COUNT');
+export const clearFacilityCount = createAction('CLEAR_FACILITY_COUNT');
+
+export function fetchFacilityCount() {
+    return (dispatch, getState) => {
+        dispatch(startFetchFacilityCount());
+
+        const {
+            facilityCount: {
+                data,
+            },
+        } = getState();
+
+        if (data) {
+            return dispatch(completeFetchFacilityCount(data));
+        }
+
+        return csrfRequest
+            .get(makeGetFacilitiesCountURL())
+            .then(({ data: { count } }) => dispatch(completeFetchFacilityCount(count)))
+            .catch(err => dispatch(logErrorAndDispatchFailure(
+                err,
+                'An error prevented fetching facility count',
+                failFetchFacilityCount,
+            )));
+    };
+}

--- a/src/app/src/components/FacilitySidebarSearchTabFacilitiesCount.jsx
+++ b/src/app/src/components/FacilitySidebarSearchTabFacilitiesCount.jsx
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import { arrayOf, bool, number, string } from 'prop-types';
+import { connect } from 'react-redux';
+
+import { fetchFacilityCount } from '../actions/facilityCount';
+
+class FacilitySidebarSearchTabFacilitiesCount extends Component {
+    componentDidMount() {
+        return this.props.fetchCount();
+    }
+
+    render() {
+        const {
+            data,
+            fetching,
+            error,
+        } = this.props;
+
+        if (!data || fetching || error) {
+            return null;
+        }
+
+        return (
+            <div style={{ textAlign: 'right' }}>
+                {`Total facilities: ${data}`}
+            </div>
+        );
+    }
+}
+
+FacilitySidebarSearchTabFacilitiesCount.defaultProps = {
+    data: null,
+    error: null,
+};
+
+FacilitySidebarSearchTabFacilitiesCount.propTypes = {
+    data: number,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+};
+
+function mapStateToProps({
+    facilityCount: {
+        data,
+        fetching,
+        error,
+    },
+}) {
+    return {
+        data,
+        fetching,
+        error,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        fetchCount: () => dispatch(fetchFacilityCount()),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+    FacilitySidebarSearchTabFacilitiesCount,
+);

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -7,6 +7,8 @@ import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import ReactSelect from 'react-select';
 
+import FacilitySidebarSearchTabFacilitiesCount from './FacilitySidebarSearchTabFacilitiesCount';
+
 import {
     updateFacilityNameFilter,
     updateContributorFilter,
@@ -227,6 +229,7 @@ function FilterSidebarSearchTab({
                 </div>
                 {noFacilitiesFoundMessage}
             </div>
+            <FacilitySidebarSearchTabFacilitiesCount />
         </div>
     );
 }

--- a/src/app/src/reducers/FacilityCountReducer.jsx
+++ b/src/app/src/reducers/FacilityCountReducer.jsx
@@ -1,0 +1,46 @@
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    startFetchFacilityCount,
+    failFetchFacilityCount,
+    completeFetchFacilityCount,
+    clearFacilityCount,
+} from '../actions/facilityCount';
+
+const initialState = Object.freeze({
+    data: null,
+    fetching: false,
+    error: null,
+});
+
+export default createReducer({
+    [startFetchFacilityCount]: state => update(state, {
+        fetching: {
+            $set: true,
+        },
+        error: {
+            $set: null,
+        },
+    }),
+    [failFetchFacilityCount]: (state, payload) => update(state, {
+        fetching: {
+            $set: false,
+        },
+        error: {
+            $set: payload,
+        },
+    }),
+    [completeFetchFacilityCount]: (state, count) => update(state, {
+        fetching: {
+            $set: false,
+        },
+        error: {
+            $set: null,
+        },
+        data: {
+            $set: count,
+        },
+    }),
+    [clearFacilityCount]: () => initialState,
+}, initialState);

--- a/src/app/src/reducers/index.js
+++ b/src/app/src/reducers/index.js
@@ -15,6 +15,7 @@ import FilterOptionsReducer from './FilterOptionsReducer';
 import FiltersReducer from './FiltersReducer';
 import UIReducer from './UIReducer';
 import FacilitiesReducer from './FacilitiesReducer';
+import FacilityCountReducer from './FacilityCountReducer';
 
 export default combineReducers({
     auth: AuthReducer,
@@ -26,4 +27,5 @@ export default combineReducers({
     filters: FiltersReducer,
     ui: UIReducer,
     facilities: FacilitiesReducer,
+    facilityCount: FacilityCountReducer,
 });

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -81,6 +81,8 @@ export const makeGetFacilitiesURL = () => '/api/facilities/';
 export const makeGetFacilityByOARIdURL = oarId => `/api/facilities/${oarId}/`;
 export const makeGetFacilitiesURLWithQueryString = qs => `/api/facilities/?${qs}`;
 
+export const makeGetFacilitiesCountURL = () => '/api/facilities/count/';
+
 export const getValueFromObject = ({ value }) => value;
 
 export const createQueryStringFromSearchFilters = ({

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -481,6 +481,18 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
         except Facility.DoesNotExist:
             raise NotFound()
 
+    @action(detail=False, methods=['get'])
+    def count(self, request):
+        """
+        Returns a count of total Facilities available in the Open Apparel
+        Registry.
+
+        ### Sample Response
+            { "count": 100000 }
+        """
+        count = Facility.objects.count()
+        return Response({"count": count})
+
 
 class FacilityListViewSet(viewsets.ModelViewSet):
     """


### PR DESCRIPTION
## Overview

- add an endpoint to get the total facilities count
- add a component + Redux actions for retrieving and displaying total facilities count

Connects #323

## Demo

![Screen Shot 2019-03-22 at 10 52 41 AM](https://user-images.githubusercontent.com/4165523/54831509-d4297880-4c90-11e9-92b0-f0ee8a5dd322.png)
![Screen Shot 2019-03-22 at 10 52 21 AM](https://user-images.githubusercontent.com/4165523/54831510-d4297880-4c90-11e9-8d54-4bd2ae41d9c2.png)


## Notes

Making a whole new reducer for this was probably a bit of overkill, but I wanted to limit the scope of the fetching/error state for this data since it doesn't impact anything else in the application.


## Testing Instructions

- serve this branch then visit the search tab
- verify that you see the total facilities count displayed in the bottom right when the facilities_count request returns
