### PR TITLE
Add GitHub issue template for releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,6 +14,7 @@ $ git flow release start X.Y.Z
 - [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
 - [ ] Ensure outstanding changes are committed:
 ```bash
+$ git status # Ensure we have a clean staging area
 $ git add CHANGELOG.md
 $ git commit -m "X.Y.Z"
 ```

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,36 @@
+---
+name: Release
+about: When ready to cut a release
+title: Release X.Y.Z
+labels: release
+assignees: ''
+
+---
+
+- [ ] Start a new release branch:
+```bash
+$ git flow release start X.Y.Z
+```
+- [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
+- [ ] Ensure outstanding changes are committed:
+```bash
+$ git add .
+$ git commit -m "X.Y.Z"
+```
+- [ ] Publish the release branch:
+```bash
+$ git flow release publish X.Y.Z
+```
+- [ ] Test the release branch on staging
+    - Wait for CI to cycle the release branch onto staging
+    - Thoroughly vet new features
+    - Commit any last-minute fixes
+- [ ] Start a new [release pipeline job](http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/build?delay=0sec) with the SHA of `release/X.Y.Z` that was tested on staging
+- [ ] Run migrations, if applicable (see the `showmigrations` release pipeline stage):
+```bash
+$ ./scripts/manage.py ecsmanage -e production migrate
+```
+- [ ] Finish and publish the release branch:
+```bash
+$ git flow release finish -p X.Y.Z 
+```

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -23,20 +23,14 @@ $ git commit -m "X.Y.Z"
 $ git flow release publish X.Y.Z
 ```
 - [ ] Test the release branch on staging
-    - Wait for CI to cycle the release branch onto staging
-    - Thoroughly vet new features
-    - If testing reveals bugs:
-        - [ ] Open a PR targeting the `release/X.Y.Z` branch
-        - [ ] Merge after review
-        - [ ] Re-test after the changes are deployed to staging
 - [ ] Start a new [release pipeline job](http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/build?delay=0sec) with the SHA of `release/X.Y.Z` that was tested on staging 
-    - You can find the latest commit at https://github.com/open-apparel-registry/open-apparel-registry/commits/release/X.Y.Z
+    - `$ git rev-parse --short HEAD`
 - [ ] Run migrations, if applicable (see the `showmigrations` release pipeline stage):
 ```bash
 $ ./scripts/manage.py ecsmanage -e production migrate
 ```
 - [ ] Finish and publish the release branch:
-    - When prompted, keep the default merge commit message
+    - When prompted, use `X.Y.Z` as the merge commit message
     - Use `X.Y.Z` as the tag message
 ```bash
 $ git flow release finish -p X.Y.Z 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,7 +14,7 @@ $ git flow release start X.Y.Z
 - [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
 - [ ] Ensure outstanding changes are committed:
 ```bash
-$ git add .
+$ git add CHANGELOG.md
 $ git commit -m "X.Y.Z"
 ```
 - [ ] Publish the release branch:
@@ -24,13 +24,19 @@ $ git flow release publish X.Y.Z
 - [ ] Test the release branch on staging
     - Wait for CI to cycle the release branch onto staging
     - Thoroughly vet new features
-    - Commit any last-minute fixes
-- [ ] Start a new [release pipeline job](http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/build?delay=0sec) with the SHA of `release/X.Y.Z` that was tested on staging
+    - If testing reveals bugs:
+        - [ ] Open a PR targeting the `release/X.Y.Z` branch
+        - [ ] Merge after review
+        - [ ] Re-test after the changes are deployed to staging
+- [ ] Start a new [release pipeline job](http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/build?delay=0sec) with the SHA of `release/X.Y.Z` that was tested on staging 
+    - You can find the latest commit at https://github.com/open-apparel-registry/open-apparel-registry/commits/release/X.Y.Z
 - [ ] Run migrations, if applicable (see the `showmigrations` release pipeline stage):
 ```bash
 $ ./scripts/manage.py ecsmanage -e production migrate
 ```
 - [ ] Finish and publish the release branch:
+    - When prompted, keep the default merge commit message
+    - Use `X.Y.Z` as the tag message
 ```bash
 $ git flow release finish -p X.Y.Z 
 ```

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,7 +14,7 @@ $ git flow release start X.Y.Z
 - [ ] Rotate `CHANGELOG.md` (following [Keep a Changelog](https://keepachangelog.com/) principles)
 - [ ] Ensure outstanding changes are committed:
 ```bash
-$ git status # Ensure we have a clean staging area
+$ git status # Is the git staging area clean?
 $ git add CHANGELOG.md
 $ git commit -m "X.Y.Z"
 ```
@@ -23,8 +23,10 @@ $ git commit -m "X.Y.Z"
 $ git flow release publish X.Y.Z
 ```
 - [ ] Test the release branch on staging
-- [ ] Start a new [release pipeline job](http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/build?delay=0sec) with the SHA of `release/X.Y.Z` that was tested on staging 
-    - `$ git rev-parse --short HEAD`
+- [ ] Start a new [release pipeline job](http://civicci01.internal.azavea.com/view/oar/job/Open%20Apparel%20Registry%20Release%20Pipeline/build?delay=0sec) with the SHA (see command below) of `release/X.Y.Z` that was tested on staging
+```bash
+$ git rev-parse --short HEAD
+```
 - [ ] Run migrations, if applicable (see the `showmigrations` release pipeline stage):
 ```bash
 $ ./scripts/manage.py ecsmanage -e production migrate


### PR DESCRIPTION
## Overview

I followed https://help.github.com/en/articles/creating-issue-templates-for-your-repository to create a GitHub issue template containing the release workflow for this repository. 

For each new release, an issue should be created, the person doing the release should assign themselves, and then the checklist should be worked through.

Closes #224 

## Demo

<img width="741" alt="image" src="https://user-images.githubusercontent.com/1774125/54871953-e095fa00-4d92-11e9-82f7-327eece0147c.png">


