### PR TITLE
Make Fargate task definition memory and CPU settings distinct

### DIFF
--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -59,8 +59,8 @@ data "template_file" "default_job_definition" {
     postgres_password = "${var.rds_database_password}"
     postgres_db       = "${var.rds_database_name}"
 
-    environment              = "${var.environment}"
-    django_secret_key        = "${var.django_secret_key}"
+    environment                = "${var.environment}"
+    django_secret_key          = "${var.django_secret_key}"
     google_server_side_api_key = "${var.google_server_side_api_key}"
 
     aws_region = "${var.aws_region}"

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -100,9 +100,9 @@ data "template_file" "app" {
   template = "${file("task-definitions/app.json")}"
 
   vars = {
-    cpu    = "${var.fargate_cpu}"
+    cpu    = "${var.fargate_app_cpu}"
     image  = "${local.app_image}"
-    memory = "${var.fargate_memory}"
+    memory = "${var.fargate_app_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database.port}"
@@ -133,8 +133,8 @@ resource "aws_ecs_task_definition" "app" {
   family                   = "${var.environment}App"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "${var.fargate_cpu}"
-  memory                   = "${var.fargate_memory}"
+  cpu                      = "${var.fargate_app_cpu}"
+  memory                   = "${var.fargate_app_memory}"
 
   task_role_arn      = "${aws_iam_role.app_task_role.arn}"
   execution_role_arn = "${aws_iam_role.ecs_task_execution_role.arn}"
@@ -146,9 +146,9 @@ data "template_file" "app_cli" {
   template = "${file("task-definitions/app_cli.json")}"
 
   vars = {
-    cpu    = "${var.fargate_cpu}"
+    cpu    = "${var.fargate_cli_cpu}"
     image  = "${local.app_image}"
-    memory = "${var.fargate_memory}"
+    memory = "${var.fargate_cli_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database.port}"
@@ -179,8 +179,8 @@ resource "aws_ecs_task_definition" "app_cli" {
   family                   = "${var.environment}AppCLI"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "${var.fargate_cpu}"
-  memory                   = "${var.fargate_memory}"
+  cpu                      = "${var.fargate_cli_cpu}"
+  memory                   = "${var.fargate_cli_memory}"
 
   task_role_arn      = "${aws_iam_role.app_task_role.arn}"
   execution_role_arn = "${aws_iam_role.ecs_task_execution_role.arn}"

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -100,9 +100,9 @@ data "template_file" "app" {
   template = "${file("task-definitions/app.json")}"
 
   vars = {
-    cpu    = "${var.fargate_app_cpu}"
+    cpu    = "${var.app_fargate_cpu}"
     image  = "${local.app_image}"
-    memory = "${var.fargate_app_memory}"
+    memory = "${var.app_fargate_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database.port}"
@@ -133,8 +133,8 @@ resource "aws_ecs_task_definition" "app" {
   family                   = "${var.environment}App"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "${var.fargate_app_cpu}"
-  memory                   = "${var.fargate_app_memory}"
+  cpu                      = "${var.app_fargate_cpu}"
+  memory                   = "${var.app_fargate_memory}"
 
   task_role_arn      = "${aws_iam_role.app_task_role.arn}"
   execution_role_arn = "${aws_iam_role.ecs_task_execution_role.arn}"
@@ -146,9 +146,9 @@ data "template_file" "app_cli" {
   template = "${file("task-definitions/app_cli.json")}"
 
   vars = {
-    cpu    = "${var.fargate_cli_cpu}"
+    cpu    = "${var.cli_fargate_cpu}"
     image  = "${local.app_image}"
-    memory = "${var.fargate_cli_memory}"
+    memory = "${var.cli_fargate_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database.port}"
@@ -179,8 +179,8 @@ resource "aws_ecs_task_definition" "app_cli" {
   family                   = "${var.environment}AppCLI"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "${var.fargate_cli_cpu}"
-  memory                   = "${var.fargate_cli_memory}"
+  cpu                      = "${var.cli_fargate_cpu}"
+  memory                   = "${var.cli_fargate_memory}"
 
   task_role_arn      = "${aws_iam_role.app_task_role.arn}"
   execution_role_arn = "${aws_iam_role.ecs_task_execution_role.arn}"
@@ -193,9 +193,9 @@ resource "aws_ecs_service" "app" {
   cluster         = "${aws_ecs_cluster.app.id}"
   task_definition = "${aws_ecs_task_definition.app.arn}"
 
-  desired_count                      = "${var.app_count}"
-  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
-  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
+  desired_count                      = "${var.app_ecs_desired_count}"
+  deployment_minimum_healthy_percent = "${var.app_ecs_deployment_min_percent}"
+  deployment_maximum_percent         = "${var.app_ecs_deployment_max_percent}"
 
   launch_type = "FARGATE"
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -40,11 +40,19 @@ variable "bastion_ami" {}
 
 variable "bastion_instance_type" {}
 
-variable "fargate_cpu" {
+variable "fargate_app_cpu" {
   default = "256"
 }
 
-variable "fargate_memory" {
+variable "fargate_app_memory" {
+  default = "512"
+}
+
+variable "fargate_cli_cpu" {
+  default = "256"
+}
+
+variable "fargate_cli_memory" {
   default = "512"
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -220,10 +220,6 @@ variable "batch_default_ce_min_vcpus" {
   default = "0"
 }
 
-variable "batch_default_ce_desired_vcpus" {
-  default = "0"
-}
-
 variable "batch_default_ce_max_vcpus" {
   default = "16"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -220,7 +220,9 @@ variable "batch_default_ce_min_vcpus" {
   default = "0"
 }
 
-variable "batch_default_ce_desired_vcpus" {}
+variable "batch_default_ce_desired_vcpus" {
+  default = "0"
+}
 
 variable "batch_default_ce_max_vcpus" {
   default = "16"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -220,6 +220,8 @@ variable "batch_default_ce_min_vcpus" {
   default = "0"
 }
 
+variable "batch_default_ce_desired_vcpus" {}
+
 variable "batch_default_ce_max_vcpus" {
   default = "16"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -40,52 +40,6 @@ variable "bastion_ami" {}
 
 variable "bastion_instance_type" {}
 
-variable "fargate_app_cpu" {
-  default = "256"
-}
-
-variable "fargate_app_memory" {
-  default = "512"
-}
-
-variable "fargate_cli_cpu" {
-  default = "256"
-}
-
-variable "fargate_cli_memory" {
-  default = "512"
-}
-
-variable "image_tag" {}
-
-variable "app_port" {
-  default = "8080"
-}
-
-variable "google_server_side_api_key" {}
-
-variable "google_client_side_api_key" {}
-
-variable "rollbar_server_side_access_token" {}
-
-variable "rollbar_client_side_access_token" {}
-
-variable "django_secret_key" {}
-
-variable "default_from_email" {}
-
-variable "app_count" {
-  default = "1"
-}
-
-variable "deployment_minimum_healthy_percent" {
-  default = "100"
-}
-
-variable "deployment_maximum_percent" {
-  default = "200"
-}
-
 variable "rds_allocated_storage" {
   default = "64"
 }
@@ -206,17 +160,51 @@ variable "rds_cpu_credit_balance_threshold" {
   default = "30"
 }
 
-variable "ec2_service_role_policy_arn" {
-  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+variable "app_ecs_desired_count" {
+  default = "1"
 }
 
-variable "batch_service_role_policy_arn" {
-  default = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+variable "app_ecs_deployment_min_percent" {
+  default = "100"
 }
 
-variable "spot_fleet_service_role_policy_arn" {
-  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+variable "app_ecs_deployment_max_percent" {
+  default = "200"
 }
+
+variable "app_fargate_cpu" {
+  default = "256"
+}
+
+variable "app_fargate_memory" {
+  default = "512"
+}
+
+variable "cli_fargate_cpu" {
+  default = "256"
+}
+
+variable "cli_fargate_memory" {
+  default = "512"
+}
+
+variable "image_tag" {}
+
+variable "app_port" {
+  default = "8080"
+}
+
+variable "google_server_side_api_key" {}
+
+variable "google_client_side_api_key" {}
+
+variable "rollbar_server_side_access_token" {}
+
+variable "rollbar_client_side_access_token" {}
+
+variable "django_secret_key" {}
+
+variable "default_from_email" {}
 
 variable "batch_default_ce_spot_fleet_bid_percentage" {
   default = "40"
@@ -247,4 +235,16 @@ variable "batch_default_ce_instance_types" {
     "c5",
     "m5",
   ]
+}
+
+variable "ec2_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+variable "batch_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+}
+
+variable "spot_fleet_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -185,7 +185,7 @@ variable "cli_fargate_cpu" {
 }
 
 variable "cli_fargate_memory" {
-  default = "512"
+  default = "1024"
 }
 
 variable "image_tag" {}

--- a/scripts/infra
+++ b/scripts/infra
@@ -37,6 +37,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         case "${1}" in
             plan)
+                DEFAULT_BATCH_CE_DESIRED_CPU=$(aws batch describe-compute-environments --output text --compute-environments "batch${OAR_DEPLOYMENT_ENVIRONMENT^}DefaultComputeEnvironment" --query "computeEnvironments[].computeResources.desiredvCpus")
+
                 # Clear stale modules & remote state, then re-initialize
                 rm -rf .terraform terraform.tfstate* 
                 terraform init \
@@ -45,6 +47,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
                 terraform plan \
                           -var="image_tag=\"${GIT_COMMIT}\"" \
+                          -var="batch_default_ce_desired_vcpus=${DEFAULT_BATCH_CE_DESIRED_CPU:-0}" \
                           -var-file="${OAR_SETTINGS_BUCKET}.tfvars" \
                           -out="${OAR_SETTINGS_BUCKET}.tfplan"
                 ;;


### PR DESCRIPTION
## Overview

* Move `fargate_cpu`to `fargate_app_cpu`
* Move `fargate_memory` to `fargate_app_memory`
* Add `fargate_cli_cpu` and `fargate_cli_memory`

Closes #318 

### Checklist

- [x] Update staging/production `.tfvars` file

## Testing Instructions

Apply the following diffs:

```diff
diff --git a/scripts/infra b/scripts/infra
index 9fb78b4..799a3da 100755
--- a/scripts/infra
+++ b/scripts/infra
@@ -33,7 +33,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [[ -n "${OAR_SETTINGS_BUCKET}" ]]; then
         pushd "${TERRAFORM_DIR}"

-        aws s3 cp "s3://${OAR_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${OAR_SETTINGS_BUCKET}.tfvars"
+        #aws s3 cp "s3://${OAR_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${OAR_SETTINGS_BUCKET}.tfvars"

         case "${1}" in
             plan)
```

```diff
diff --git a/deployment/terraform/openapparelregistry-staging-config-eu-west-1.tfvars.bak b/deployment/terraform/openapparelregistry-staging-config-eu-west-1.tfvars
index a3dc433..7928039 100644
--- a/deployment/terraform/openapparelregistry-staging-config-eu-west-1.tfvars.bak
+++ b/deployment/terraform/openapparelregistry-staging-config-eu-west-1.tfvars
@@ -29,8 +29,12 @@ django_secret_key = "q1+tw-uy_-#12s&-w)h553xu(%*(e3q1w*2d^0l61!$hoq3$4k"

 default_from_email = "noreply@staging.openapparel.org"

-fargate_cpu = "256"
-fargate_memory = "512"
+fargate_app_cpu = "512"
+fargate_app_memory = "1024"
+
+fargate_cli_cpu = "256"
+fargate_cli_memory = "512"
+
 app_count = "1"
 deployment_minimum_healthy_percent = "100"
 deployment_maximum_percent = "200"
```

Run `$ terraform plan` with the latest staging SHA:

```bash
vagrant@vagrant:/vagrant$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-4.4# export GIT_COMMIT=5e2cf39
bash-4.4# ./scripts/infra plan
...
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  ~ aws_ecs_service.app
      task_definition:                     "arn:aws:ecs:eu-west-1:249322298638:task-definition/StagingApp:42" => "${aws_ecs_task_definition.app.arn}"

-/+ aws_ecs_task_definition.app (new resource required)
      id:                                  "StagingApp" => <computed> (forces new resource)
      arn:                                 "arn:aws:ecs:eu-west-1:249322298638:task-definition/StagingApp:42" => <computed>
      container_definitions:               "[{\"cpu\":256,\"environment\":[{\"name\":\"POSTGRES_USER\",\"value\":\"openapparelregistry\"},{\"name\":\"GOOGLE_SERVER_SIDE_API_KEY\",\"value\":\"AIzaSyBILH4L7Cy0PCw9IvE3fZX1PTFTYpFtpJY\"},{\"name\":\"DJANGO_ENV\",\"value\":\"Staging\"},{\"name\":\"POSTGRES_HOST\",\"value\":\"database.service.oar.internal\"},{\"name\":\"ROLLBAR_SERVER_SIDE_ACCESS_TOKEN\",\"value\":\"0643f6d16c7f4bc88e4098ff52254b10\"},{\"name\":\"REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN\",\"value\":\"f6027f4bd8a34938a7eac320ca02e483\"},{\"name\":\"DJANGO_SECRET_KEY\",\"value\":\"q1+tw-uy_-#12s&-w)h553xu(%*(e3q1w*2d^0l61!$hoq3$4k\"},{\"name\":\"AWS_DEFAULT_REGION\",\"value\":\"eu-west-1\"},{\"name\":\"POSTGRES_PORT\",\"value\":\"5432\"},{\"name\":\"POSTGRES_PASSWORD\",\"value\":\"antigen-vocation-haiti-dubiety-tern-colonial\"},{\"name\":\"POSTGRES_DB\",\"value\":\"openapparelregistry\"},{\"name\":\"REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY\",\"value\":\"AIzaSyCWWFQRyaznEA_C9O9JUZr6Pkiz0KenwP8\"},{\"name\":\"DEFAULT_FROM_EMAIL\",\"value\":\"noreply@staging.openapparel.org\"}],\"essential\":true,\"image\":\"249322298638.dkr.ecr.eu-west-1.amazonaws.com/openapparelregistry:5e2cf39\",\"logConfiguration\":{\"logDriver\":\"awslogs\",\"options\":{\"awslogs-group\":\"logStagingApp\",\"awslogs-region\":\"eu-west-1\",\"awslogs-stream-prefix\":\"django\"}},\"memory\":512,\"mountPoints\":[],\"name\":\"django\",\"portMappings\":[{\"containerPort\":8080,\"hostPort\":8080,\"protocol\":\"tcp\"}],\"volumesFrom\":[]}]" => "[{\"cpu\":512,\"environment\":[{\"name\":\"AWS_DEFAULT_REGION\",\"value\":\"eu-west-1\"},{\"name\":\"POSTGRES_HOST\",\"value\":\"database.service.oar.internal\"},{\"name\":\"POSTGRES_PORT\",\"value\":\"5432\"},{\"name\":\"POSTGRES_USER\",\"value\":\"openapparelregistry\"},{\"name\":\"POSTGRES_PASSWORD\",\"value\":\"antigen-vocation-haiti-dubiety-tern-colonial\"},{\"name\":\"POSTGRES_DB\",\"value\":\"openapparelregistry\"},{\"name\":\"DJANGO_ENV\",\"value\":\"Staging\"},{\"name\":\"DJANGO_SECRET_KEY\",\"value\":\"q1+tw-uy_-#12s\\u0026-w)h553xu(%*(e3q1w*2d^0l61!$hoq3$4k\"},{\"name\":\"DEFAULT_FROM_EMAIL\",\"value\":\"noreply@staging.openapparel.org\"},{\"name\":\"GOOGLE_SERVER_SIDE_API_KEY\",\"value\":\"AIzaSyBILH4L7Cy0PCw9IvE3fZX1PTFTYpFtpJY\"},{\"name\":\"REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY\",\"value\":\"AIzaSyCWWFQRyaznEA_C9O9JUZr6Pkiz0KenwP8\"},{\"name\":\"ROLLBAR_SERVER_SIDE_ACCESS_TOKEN\",\"value\":\"0643f6d16c7f4bc88e4098ff52254b10\"},{\"name\":\"REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN\",\"value\":\"f6027f4bd8a34938a7eac320ca02e483\"}],\"image\":\"249322298638.dkr.ecr.eu-west-1.amazonaws.com/openapparelregistry:5e2cf39\",\"logConfiguration\":{\"logDriver\":\"awslogs\",\"options\":{\"awslogs-group\":\"logStagingApp\",\"awslogs-region\":\"eu-west-1\",\"awslogs-stream-prefix\":\"django\"}},\"memory\":1024,\"name\":\"django\",\"portMappings\":[{\"containerPort\":8080}]}]" (forces new resource)
      cpu:                                 "256" => "512" (forces new resource)
      execution_role_arn:                  "arn:aws:iam::249322298638:role/ecsStagingTaskExecutionRole" => "arn:aws:iam::249322298638:role/ecsStagingTaskExecutionRole"
      family:                              "StagingApp" => "StagingApp"
      memory:                              "512" => "1024" (forces new resource)
      network_mode:                        "awsvpc" => "awsvpc"
      requires_compatibilities.#:          "1" => "1"
      requires_compatibilities.3072437307: "FARGATE" => "FARGATE"
      revision:                            "42" => <computed>
      task_role_arn:                       "arn:aws:iam::249322298638:role/ecsStagingTaskRole" => "arn:aws:iam::249322298638:role/ecsStagingTaskRole"


Plan: 1 to add, 1 to change, 1 to destroy.

------------------------------------------------------------------------

This plan was saved to: openapparelregistry-staging-config-eu-west-1.tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "openapparelregistry-staging-config-eu-west-1.tfplan"

+ popd
/usr/local/src
bash-4.4#
```

Confirm that only API task definition is being modified.