### PR TITLE
Include public list suffix when generating supplier names

### DIFF
--- a/src/django/api/management/commands/create_accounts.py
+++ b/src/django/api/management/commands/create_accounts.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
                 )
 
                 contributor = Contributor(
-                    name=name,
+                    name='{} [Public List]'.format(name),
                     description='Public facility lists for {} '
                                 'managed by the OAR team'.format(name),
                     website='',


### PR DESCRIPTION
## Overview

We want to differentiate these accounts from real accounts that a contributor
may create in the future. This requirement was mistakenly omitted from the
initial feature request.

This suffix was approved by @katieashaw and @nataliegrillon 

Connects #240

## Demo

<img width="522" alt="Screen Shot 2019-03-22 at 12 04 46 PM" src="https://user-images.githubusercontent.com/17363/54847119-c1b43c80-4c9a-11e9-9c06-3d54e443dea9.png">

## Testing Instructions

* Run `manage create_accounts --contributors abc "D ef" "g.h.i" --type "Brand/Retailer" --password hunter2048` and verify that the accounts created appear in the contributor list with the proper suffix.

