### PR TITLE
Zoom, Test Adjustments

### DIFF
--- a/src/app/src/util/constants.facilitiesMap.js
+++ b/src/app/src/util/constants.facilitiesMap.js
@@ -9,7 +9,7 @@ export const initialCenter = Object.freeze({
 
 export const initialZoom = 1;
 
-export const detailsZoomLevel = 18;
+export const detailsZoomLevel = 15;
 
 export const clusterMarkerStyles = Object.freeze([
     Object.freeze({

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -407,27 +407,23 @@ class FacilityListItemGeocodingTest(ProcessingTestCase):
             ('Items to be geocoded must be in the PARSED status',),
         )
 
-    # TODO: re-enable this test
-    # https://github.com/open-apparel-registry/open-apparel-registry/issues/311
-    # def test_successfully_geocoded_item_has_correct_results(self):
-    #     facility_list = FacilityList(header='address,country,name')
-    #     item = FacilityListItem(
-    #         raw_data='"City Hall, Philly, PA",us,Shirts!',
-    #         facility_list=facility_list
-    #     )
-    #     parse_facility_list_item(item)
-    #     geocode_facility_list_item(item)
+    def test_successfully_geocoded_item_has_correct_results(self):
+        facility_list = FacilityList(header='address,country,name')
+        item = FacilityListItem(
+            raw_data='"City Hall, Philly, PA",us,Shirts!',
+            facility_list=facility_list
+        )
 
-    #     self.assertEqual(
-    #         item.geocoded_address,
-    #         "1400 John F Kennedy Blvd, Philadelphia, PA 19107, USA",
-    #     )
-    #     self.assertIsInstance(item.geocoded_point, Point)
-    #     self.assertEqual(item.status, FacilityListItem.GEOCODED)
-    #     self.assertIn(
-    #         'results',
-    #         self.get_first_status(item, ProcessingAction.GEOCODE)['data']
-    #     )
+        parse_facility_list_item(item)
+        geocode_facility_list_item(item)
+
+        self.assertIsNotNone(item.geocoded_address)
+        self.assertIsInstance(item.geocoded_point, Point)
+        self.assertEqual(item.status, FacilityListItem.GEOCODED)
+        self.assertIn(
+            'results',
+            self.get_first_status(item, ProcessingAction.GEOCODE)['data']
+        )
 
     def test_failed_geocoded_item_has_no_resuts_status(self):
         facility_list = FacilityList(header='address,country,name')


### PR DESCRIPTION
## Overview

Adjusts default zoom level for facility detail view to be coarser, allowing facilities in isolated or low-density areas to not look broken.

Also adjusts a geocoding test to verify the presence of a field, rather than its specific value, which is unstable.

Connects #348 
Connects #321 

## Demo

Coarser default zoom in the detail view:

![image](https://user-images.githubusercontent.com/1430060/54848237-31382500-4cb7-11e9-9712-384b8db4d1d2.png)

Passing test:

```bash
$ manage test api.tests.FacilityListItemGeocodingTest.test_successfully_geocoded_item_has_correct_results

Starting vagrant_database_1 ... done
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.595s

OK
Destroying test database for alias 'default'...
```

## Notes

#348 also called for zooming out further, but this is currently not possible with the library we're using. For details see https://github.com/open-apparel-registry/open-apparel-registry/issues/348#issuecomment-475699950.

## Testing Instructions

* Check out this branch and `server`
* Go to [:6543/](http://localhost:6543/) and search for a remote facility, like "Phu Bai"
  - [x] Ensure the map has some features on it, and is not just a grey box
* Run `manage test` or `cibuild`
  - [x] Ensure all tests pass