### PR TITLE
Run Django model validation when parsing CSV lines

### DIFF
--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -295,7 +295,8 @@ class FacilityListItemParseTest(ProcessingTestCase):
         self.assertRaises(ValueError, parse_facility_list_item, item)
 
     def test_parses_using_header(self):
-        facility_list = FacilityList(header='address,country,name')
+        facility_list = FacilityList.objects.create(
+            header='address,country,name')
         item = FacilityListItem(raw_data='1234 main st,de,Shirts!',
                                 facility_list=facility_list)
         parse_facility_list_item(item)
@@ -305,7 +306,8 @@ class FacilityListItemParseTest(ProcessingTestCase):
         self.assertEqual('1234 main st', item.address)
 
     def test_converts_country_name_to_code(self):
-        facility_list = FacilityList(header='address,country,name')
+        facility_list = FacilityList.objects.create(
+            header='address,country,name')
         item = FacilityListItem(raw_data='1234 main st,ChInA,Shirts!',
                                 facility_list=facility_list)
         parse_facility_list_item(item)
@@ -408,7 +410,8 @@ class FacilityListItemGeocodingTest(ProcessingTestCase):
         )
 
     def test_successfully_geocoded_item_has_correct_results(self):
-        facility_list = FacilityList(header='address,country,name')
+        facility_list = FacilityList.objects.create(
+            header='address,country,name')
         item = FacilityListItem(
             raw_data='"City Hall, Philly, PA",us,Shirts!',
             facility_list=facility_list
@@ -426,7 +429,8 @@ class FacilityListItemGeocodingTest(ProcessingTestCase):
         )
 
     def test_failed_geocoded_item_has_no_resuts_status(self):
-        facility_list = FacilityList(header='address,country,name')
+        facility_list = FacilityList.objects.create(
+            header='address,country,name')
         item = FacilityListItem(
             raw_data='"hello, world, foo, bar, baz",us,Shirts!',
             facility_list=facility_list


### PR DESCRIPTION
## Overview

Prior to this PR a CSV row with a value that exceeded the length of one of the `FacilityListItem` fields was causing the parse task to fail with an unhandled
exception at the ORM level. By running a `full_clean` on the model we can catch
and report the validation errors on that specific line and safely save them to
the database where the contributor can see them.

Connects #366

## Demo

<img width="1678" alt="Screen Shot 2019-03-22 at 2 49 33 PM" src="https://user-images.githubusercontent.com/17363/54854932-c0dad500-4cb1-11e9-8abe-283d27b39c5f.png">

## Testing Instructions

This assumes you have run `resetdb`. Adjust the list IDs accordingly if you have not.

* Log in
* Upload [row-2-address-201-characters.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/2998380/row-2-address-201-characters.csv.txt)
* Parse the uploaded list and verify that parsing does not crash
    * `./scripts/manage batch_process --list-id 15 --action parse`
* View the list and verify that the problematic line is in the `ERROR_PARSING` status and has an error message like the demo screenshot above.

