### PR TITLE
Restore facility list items CSV download

### DIFF
--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -53,6 +53,8 @@ const {
     sortFacilitiesAlphabeticallyByName,
     updateListWithLabels,
     makeSubmitFormOnEnterKeyPressFunction,
+    makeFacilityListItemsRetrieveCSVItemsURL,
+    makeFacilityListDataURLs,
 } = require('../util/util');
 
 const {
@@ -970,4 +972,53 @@ it('does not call a given function when a non-enter key has been pressed in a fo
 
     enterKeyPressHandler(keyPressEvent);
     expect(dispatchSubmitForm).not.toHaveBeenCalled();
+});
+
+it('makes a link for retrieving a page of facility list items for downloading a CSV', () => {
+    const listID = 10;
+    const page = 5;
+
+    const expectedURL = '/api/facility-lists/10/items/?page=5&pageSize=100';
+
+    expect(makeFacilityListItemsRetrieveCSVItemsURL(listID, page))
+        .toBe(expectedURL);
+});
+
+it('creates a list of data URLs for retrieving facility list items data', () => {
+    const listID = 17;
+    const count = 1385;
+
+    const expectedURLs = [
+        '/api/facility-lists/17/items/?page=1&pageSize=100',
+        '/api/facility-lists/17/items/?page=2&pageSize=100',
+        '/api/facility-lists/17/items/?page=3&pageSize=100',
+        '/api/facility-lists/17/items/?page=4&pageSize=100',
+        '/api/facility-lists/17/items/?page=5&pageSize=100',
+        '/api/facility-lists/17/items/?page=6&pageSize=100',
+        '/api/facility-lists/17/items/?page=7&pageSize=100',
+        '/api/facility-lists/17/items/?page=8&pageSize=100',
+        '/api/facility-lists/17/items/?page=9&pageSize=100',
+        '/api/facility-lists/17/items/?page=10&pageSize=100',
+        '/api/facility-lists/17/items/?page=11&pageSize=100',
+        '/api/facility-lists/17/items/?page=12&pageSize=100',
+        '/api/facility-lists/17/items/?page=13&pageSize=100',
+        '/api/facility-lists/17/items/?page=14&pageSize=100',
+    ];
+
+    expect(isEqual(
+        makeFacilityListDataURLs(listID, count),
+        expectedURLs,
+    )).toBe(true);
+
+    const smallerListID = 14;
+    const smallerListCount = 25;
+
+    const smallerExpectedURLs = [
+        '/api/facility-lists/14/items/?page=1&pageSize=100',
+    ];
+
+    expect(isEqual(
+        makeFacilityListDataURLs(smallerListID, smallerListCount),
+        smallerExpectedURLs,
+    )).toBe(true);
 });

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -63,6 +63,12 @@ const facilityListItemsStyles = Object.freeze({
         justifyContent: 'center',
         alignItems: 'center',
     }),
+    buttonGroupWithErrorStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignContent: 'center',
+    }),
 });
 
 class FacilityListItems extends Component {
@@ -82,6 +88,7 @@ class FacilityListItems extends Component {
             error,
             downloadCSV,
             downloadingCSV,
+            csvDownloadingError,
         } = this.props;
 
         if (fetchingList) {
@@ -115,6 +122,13 @@ class FacilityListItems extends Component {
                 </AppGrid>
             );
         }
+
+        const csvDownloadErrorMessage = (csvDownloadingError && csvDownloadingError.length)
+            ? (
+                <p style={{ color: 'red', textAlign: 'right' }}>
+                    An error prevented downloading the CSV.
+                </p>)
+            : null;
 
         const csvDownloadButton = downloadingCSV
             ? (
@@ -154,17 +168,21 @@ class FacilityListItems extends Component {
                                     {list.description || ''}
                                 </Typography>
                             </div>
-                            <div style={facilityListItemsStyles.buttonGroupStyles}>
-                                {csvDownloadButton}
-                                <Button
-                                    variant="outlined"
-                                    component={Link}
-                                    to={listsRoute}
-                                    href={listsRoute}
-                                    style={facilityListItemsStyles.buttonStyles}
-                                >
-                                    Back to lists
-                                </Button>
+                            <div style={facilityListItemsStyles.buttonGroupWithErrorStyles}>
+                                {csvDownloadErrorMessage}
+                                <div style={facilityListItemsStyles.buttonGroupStyles}>
+
+                                    {csvDownloadButton}
+                                    <Button
+                                        variant="outlined"
+                                        component={Link}
+                                        to={listsRoute}
+                                        href={listsRoute}
+                                        style={facilityListItemsStyles.buttonStyles}
+                                    >
+                                        Back to lists
+                                    </Button>
+                                </div>
                             </div>
                         </div>
                         <div style={facilityListItemsStyles.subheadStyles}>
@@ -193,6 +211,7 @@ class FacilityListItems extends Component {
 FacilityListItems.defaultProps = {
     list: null,
     error: null,
+    csvDownloadingError: null,
 };
 
 FacilityListItems.propTypes = {
@@ -204,6 +223,7 @@ FacilityListItems.propTypes = {
     clearListItems: func.isRequired,
     downloadCSV: func.isRequired,
     downloadingCSV: bool.isRequired,
+    csvDownloadingError: arrayOf(string),
 };
 
 function mapStateToProps({
@@ -218,6 +238,7 @@ function mapStateToProps({
         },
         downloadCSV: {
             fetching: downloadingCSV,
+            error: csvDownloadingError,
         },
     },
 }) {
@@ -226,6 +247,7 @@ function mapStateToProps({
         fetchingList,
         error: listError || itemsError,
         downloadingCSV,
+        csvDownloadingError,
     };
 }
 

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -16,6 +16,7 @@ import {
     fetchFacilityList,
     fetchFacilityListItems,
     resetFacilityListItems,
+    assembleAndDownloadFacilityListCSV,
 } from '../actions/facilityListDetails';
 
 import {
@@ -24,12 +25,9 @@ import {
     aboutProcessingRoute,
 } from '../util/constants';
 
-import { facilityListPropType, facilityListItemPropType } from '../util/propTypes';
+import { facilityListPropType } from '../util/propTypes';
 
-import {
-    downloadListItemCSV,
-    createPaginationOptionsFromQueryString,
-} from '../util/util';
+import { createPaginationOptionsFromQueryString } from '../util/util';
 
 const facilityListItemsStyles = Object.freeze({
     headerStyles: Object.freeze({
@@ -60,6 +58,11 @@ const facilityListItemsStyles = Object.freeze({
     buttonStyles: Object.freeze({
         marginLeft: '20px',
     }),
+    buttonGroupStyles: Object.freeze({
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    }),
 });
 
 class FacilityListItems extends Component {
@@ -75,9 +78,10 @@ class FacilityListItems extends Component {
     render() {
         const {
             list,
-            items,
             fetchingList,
             error,
+            downloadCSV,
+            downloadingCSV,
         } = this.props;
 
         if (fetchingList) {
@@ -112,6 +116,22 @@ class FacilityListItems extends Component {
             );
         }
 
+        const csvDownloadButton = downloadingCSV
+            ? (
+                <div>
+                    <CircularProgress size={25} />
+                </div>)
+            : (
+                <Button
+                    variant="outlined"
+                    color="primary"
+                    style={facilityListItemsStyles.buttonStyles}
+                    onClick={downloadCSV}
+                    disabled={downloadingCSV}
+                >
+                    Download CSV
+                </Button>);
+
         return (
             <AppOverflow>
                 <Grid
@@ -134,15 +154,8 @@ class FacilityListItems extends Component {
                                     {list.description || ''}
                                 </Typography>
                             </div>
-                            <div>
-                                <Button
-                                    variant="outlined"
-                                    color="primary"
-                                    style={facilityListItemsStyles.buttonStyles}
-                                    onClick={() => downloadListItemCSV(list, items)}
-                                >
-                                    Download CSV
-                                </Button>
+                            <div style={facilityListItemsStyles.buttonGroupStyles}>
+                                {csvDownloadButton}
                                 <Button
                                     variant="outlined"
                                     component={Link}
@@ -179,18 +192,18 @@ class FacilityListItems extends Component {
 
 FacilityListItems.defaultProps = {
     list: null,
-    items: null,
     error: null,
 };
 
 FacilityListItems.propTypes = {
     list: facilityListPropType,
-    items: arrayOf(facilityListItemPropType),
     fetchingList: bool.isRequired,
     error: arrayOf(string),
     fetchList: func.isRequired,
     fetchListItems: func.isRequired,
     clearListItems: func.isRequired,
+    downloadCSV: func.isRequired,
+    downloadingCSV: bool.isRequired,
 };
 
 function mapStateToProps({
@@ -201,16 +214,18 @@ function mapStateToProps({
             error: listError,
         },
         items: {
-            data: items,
             error: itemsError,
+        },
+        downloadCSV: {
+            fetching: downloadingCSV,
         },
     },
 }) {
     return {
         list,
-        items,
         fetchingList,
         error: listError || itemsError,
+        downloadingCSV,
     };
 }
 
@@ -235,6 +250,7 @@ function mapDispatchToProps(dispatch, {
         fetchList: () => dispatch(fetchFacilityList(listID)),
         fetchListItems: () => dispatch(fetchFacilityListItems(listID, page, rowsPerPage)),
         clearListItems: () => dispatch(resetFacilityListItems()),
+        downloadCSV: () => dispatch(assembleAndDownloadFacilityListCSV()),
     };
 }
 

--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -16,6 +16,9 @@ import {
     failRejectFacilityListItemPotentialMatch,
     completeRejectFacilityListItemPotentialMatch,
     setSelectedFacilityListItemsRowIndex,
+    startAssembleAndDownloadFacilityListCSV,
+    failAssembleAndDownloadFacilityListCSV,
+    completeAssembleAndDownloadFacilityListCSV,
 } from '../actions/facilityListDetails';
 
 import { completeSubmitLogOut } from '../actions/auth';
@@ -38,6 +41,11 @@ const initialState = Object.freeze({
         error: null,
     }),
     selectedFacilityListItemsRowIndex: -1,
+    downloadCSV: Object.freeze({
+        data: null,
+        fetching: false,
+        error: null,
+    }),
 });
 
 const startConfirmOrRejectMatch = state => update(state, {
@@ -152,6 +160,26 @@ export default createReducer({
                 fetching: false,
                 error: null,
             },
+        },
+    }),
+    [startAssembleAndDownloadFacilityListCSV]: state => update(state, {
+        downloadCSV: {
+            data: { $set: null },
+            fetching: { $set: true },
+            error: { $set: null },
+        },
+    }),
+    [failAssembleAndDownloadFacilityListCSV]: (state, payload) => update(state, {
+        downloadCSV: {
+            fetching: { $set: false },
+            error: { $set: payload },
+        },
+    }),
+    [completeAssembleAndDownloadFacilityListCSV]: (state, payload) => update(state, {
+        downloadCSV: {
+            data: { $set: payload },
+            fetching: { $set: false },
+            error: { $set: null },
         },
     }),
     [resetFacilityListItems]: () => initialState,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -20,6 +20,9 @@ import replace from 'lodash/replace';
 import trimEnd from 'lodash/trimEnd';
 import includes from 'lodash/includes';
 import lowerCase from 'lodash/lowerCase';
+import range from 'lodash/range';
+import ceil from 'lodash/ceil';
+import toInteger from 'lodash/toInteger';
 import { featureCollection, bbox } from '@turf/turf';
 import { saveAs } from 'file-saver';
 
@@ -439,4 +442,14 @@ export const makeSubmitFormOnEnterKeyPressFunction = fn => ({ key }) => {
     }
 
     return noop();
+};
+
+export const makeFacilityListItemsRetrieveCSVItemsURL = (id, page) =>
+    `${makeSingleFacilityListItemsURL(id)}?page=${page}&pageSize=100`;
+
+export const makeFacilityListDataURLs = (id, count) => {
+    const maxCount = toInteger(ceil(count, -2) / 100);
+
+    return range(1, maxCount + 1)
+        .map(page => makeFacilityListItemsRetrieveCSVItemsURL(id, page));
 };


### PR DESCRIPTION

## Overview

In #341 we temporarily broke downloading facility list items CSVs by switching to server side paging. This PR restores the download functionality by adding a Redux action that:

- creates a list of all the URLs for the paginated CSV list items, with 100 items per page
- maps over that list with a Promise.all that resolves everything into an array of the `results` values from each facilities list item page
- concats that into an array structured like the CSV download functionality expected before
- downloads it as it did before

The pagination and map operation preserves the order of the list items, so the CSV will end up running from 0 - 1385 or whatever sequentially.

I also added some unit tests to check for large-ish and small-ish list item counts. In particular:

- for 1385 items we want to request 14 pages
- for < 100 items, we want to request 1 page

I also added a loading indicator to the download button since it now takes longer than it did, especially for longer lists.

Connects #344

## Testing Instructions

- serve this branch then download a few CSVs of varying sizes and ensure that the resulting downloads has a complete set of the list items and that they are ordered correctly

