### PR TITLE
Fix "My Facilities" navigation bug

### DIFF
--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
-import { Link } from 'react-router-dom';
+import { Link, Route } from 'react-router-dom';
 
 import logo from '../styles/images/OpenApparelRegistry_logo.png';
 import NavbarDropdown from './NavbarDropdown';
@@ -84,7 +84,7 @@ export default function Navbar() {
                     </Link>
                 </div>
                 <div id="google_translate_element" />
-                <NavbarLoginButtonGroup />
+                <Route component={NavbarLoginButtonGroup} />
             </Toolbar>
         </AppBar>
     );

--- a/src/app/src/components/NavbarDropdown.jsx
+++ b/src/app/src/components/NavbarDropdown.jsx
@@ -30,7 +30,7 @@ const itemMap = (item) => {
             );
         default:
             return (
-                <Button color="primary" onClick={item.action}>
+                <Button color="primary" onClick={item.action} style={{ border: 'none' }}>
                     {item.text}
                 </Button>
             );

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -11,10 +11,7 @@ import {
 
 import { filtersPropType } from '../util/propTypes';
 
-import {
-    createQueryStringFromSearchFilters,
-    allFiltersAreEmpty,
-} from '../util/util';
+import { createQueryStringFromSearchFilters } from '../util/util';
 
 export default function withQueryStringSync(WrappedComponent) {
     const componentWithWrapper = class extends Component {
@@ -30,7 +27,7 @@ export default function withQueryStringSync(WrappedComponent) {
                 hydrateFiltersFromQueryString,
             } = this.props;
 
-            return (search && allFiltersAreEmpty(filters))
+            return search
                 ? hydrateFiltersFromQueryString(search)
                 : replace(`?${createQueryStringFromSearchFilters(filters)}`);
         }


### PR DESCRIPTION
## Overview

Previously clicking a "My Facilities" link would not work as expected
because the `?contributors=id` querystring would get vaporized by the
`withQueryStringSync` component before it became a filter in the the
Redux store. Since there were two links -- one from the list page, the
other from the navbar dropdown -- there are two fixes here:

First, for the lists page link I removed a condition from
`withQueryStringSync` that would skip hydrating from the querystring in
`componentDidMount` if there were already some filters in the app.

Secondly, for the navbar dropdown I replaced the `Link` element with a
call to `setFiltersFromQueryString`, giving it a custom querystring
parameter, and an ensuring call to `fetchFacilities`.

This second thing feels a little hacky, but the alternative I considered was
writing a brand new function that was exactly like `setFiltersFromQueryString`
except that it took a parameter of a different form and was meant to be
used only for internal links. The existing function seemed to work well
enough for now.

Connects #361 

## Demo

![dropdown-link](https://user-images.githubusercontent.com/4165523/54860475-0074e180-4cf1-11e9-8835-80bfe5d897ea.gif)

![list-page-link](https://user-images.githubusercontent.com/4165523/54860477-05399580-4cf1-11e9-843b-03f2fc0f8018.gif)

![regular-searches](https://user-images.githubusercontent.com/4165523/54860484-0b2f7680-4cf1-11e9-89eb-75ff0308d673.gif)

## Testing Instructions

- serve this branch, then verify that the bugs described in #361 have been fixed
- use the search inputs on the search tab and verify that they work as before: the querystring should remain in sync with the selected filters
- use the "Share this Search" button to get a search querystring and open it in a new tab and verify that that works