### PR TITLE
Bulk create list items and processing results / Process single row CSVs

### DIFF
--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -121,16 +121,18 @@ def submit_jobs(environment, facility_list):
 
     # GEOCODE
     started = str(datetime.utcnow())
+    row_count = facility_list.facilitylistitem_set.count()
+    is_array = row_count > 1
     geocode_job_id = submit_job('geocode',
                                 depends_on=[{'jobId': parse_job_id}],
-                                is_array=True)
+                                is_array=is_array)
     finished = str(datetime.utcnow())
     append_processing_result({
         'action': ProcessingAction.SUBMIT_JOB,
         'type': 'geocode',
         'job_id': geocode_job_id,
         'error': False,
-        'is_array': True,
+        'is_array': is_array,
         'started_at': started,
         'finished_at': finished,
     })

--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -1,9 +1,11 @@
 import boto3
+import json
 
 from datetime import datetime
-from django.db import transaction
+from django.db import connection
 
 from api.constants import ProcessingAction
+from api.models import FacilityListItem
 
 
 def fetch_batch_queue_arn(client, environment):
@@ -55,6 +57,10 @@ def submit_jobs(environment, facility_list):
     job_time = (datetime.utcnow().isoformat()
                 .replace(':', '-').replace('.', '-').replace('T', '-'))
 
+    item_table = FacilityListItem.objects.model._meta.db_table
+    results_column = 'processing_results'
+    list_id_column = 'facility_list_id'
+
     def submit_job(action, is_array=False, depends_on=None):
         if depends_on is None:
             depends_on = []
@@ -82,6 +88,20 @@ def submit_jobs(environment, facility_list):
             raise RuntimeError(
                 'Failed to submit job {0}. Response {1}'.format(job_name, job))
 
+    def append_processing_result(result_dict):
+        query = ("UPDATE {item_table} "
+                 "SET {results_column} = {results_column} || '{dict_json}' "
+                 "WHERE {list_id_column} = {list_id}")
+        query = query.format(
+            item_table=item_table,
+            results_column=results_column,
+            dict_json=json.dumps(result_dict),
+            list_id_column=list_id_column,
+            list_id=facility_list.id
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+
     # PARSE
     started = str(datetime.utcnow())
     # The parse task is just quick string manipulation. We submit it as a
@@ -89,17 +109,15 @@ def submit_jobs(environment, facility_list):
     # slows things down.
     parse_job_id = submit_job('parse')
     finished = str(datetime.utcnow())
-    with transaction.atomic():
-        for item in facility_list.facilitylistitem_set.all():
-            item.processing_results.append({
-                'action': ProcessingAction.SUBMIT_JOB,
-                'type': 'parse',
-                'job_id': parse_job_id,
-                'error': False,
-                'started_at': started,
-                'finished_at': finished,
-            })
-            item.save()
+    append_processing_result({
+        'action': ProcessingAction.SUBMIT_JOB,
+        'type': 'parse',
+        'job_id': parse_job_id,
+        'error': False,
+        'is_array': False,
+        'started_at': started,
+        'finished_at': finished,
+    })
 
     # GEOCODE
     started = str(datetime.utcnow())
@@ -107,33 +125,27 @@ def submit_jobs(environment, facility_list):
                                 depends_on=[{'jobId': parse_job_id}],
                                 is_array=True)
     finished = str(datetime.utcnow())
-    facility_list.refresh_from_db()
-    with transaction.atomic():
-        for item in facility_list.facilitylistitem_set.all():
-            item.processing_results.append({
-                'action': ProcessingAction.SUBMIT_JOB,
-                'type': 'geocode',
-                'job_id': '{0}:{1}'.format(geocode_job_id, item.row_index),
-                'error': False,
-                'started_at': started,
-                'finished_at': finished,
-            })
-            item.save()
+    append_processing_result({
+        'action': ProcessingAction.SUBMIT_JOB,
+        'type': 'geocode',
+        'job_id': geocode_job_id,
+        'error': False,
+        'is_array': True,
+        'started_at': started,
+        'finished_at': finished,
+    })
 
     # MATCH
     started = str(datetime.utcnow())
     match_job_id = submit_job('match',
                               depends_on=[{'jobId': geocode_job_id}])
     finished = str(datetime.utcnow())
-    facility_list.refresh_from_db()
-    with transaction.atomic():
-        for item in facility_list.facilitylistitem_set.all():
-            item.processing_results.append({
-                'action': ProcessingAction.SUBMIT_JOB,
-                'type': 'match',
-                'job_id': '{0}'.format(match_job_id),
-                'error': False,
-                'started_at': started,
-                'finished_at': finished,
-            })
-            item.save()
+    append_processing_result({
+        'action': ProcessingAction.SUBMIT_JOB,
+        'type': 'match',
+        'job_id': match_job_id,
+        'error': False,
+        'is_array': False,
+        'started_at': started,
+        'finished_at': finished,
+    })

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -618,15 +618,15 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             replaces.is_active = False
             replaces.save()
 
+        items = []
         for idx, line in enumerate(csv_file):
             if idx > 0:
                 try:
-                    new_item = FacilityListItem(
+                    items.append(FacilityListItem(
                         row_index=(idx - 1),
                         facility_list=new_list,
                         raw_data=line.decode().rstrip()
-                    )
-                    new_item.save()
+                    ))
                 except UnicodeDecodeError:
                     ROLLBAR = getattr(settings, 'ROLLBAR', {})
                     if ROLLBAR:
@@ -639,6 +639,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                                 'file_name': csv_file.name})
                     raise ValidationError('Unsupported file encoding. Please '
                                           'submit a UTF-8 CSV.')
+        FacilityListItem.objects.bulk_create(items)
 
         if ENVIRONMENT in ('Staging', 'Production'):
             submit_jobs(ENVIRONMENT, new_list)


### PR DESCRIPTION
## Overview

Large list uploads to staging were timing out. For a list with 4000 items, we were running 4,000 insert statements to create rows and 12,000 individual update queries
just to append the AWS Batch job IDs to the `processing_results`. Switching to `bulk_create` and raw SQL we can drop from 16,000 queries down to 4.

We were also failing to process single-row CSVs because AWS Batch does not allow creating array jobs with a single row. We now use array jobs conditionally.

Connects #336 
Connects #368

## Demo

<img width="1374" alt="Screen Shot 2019-03-22 at 10 47 29 PM" src="https://user-images.githubusercontent.com/17363/54862350-c8709d00-4cf6-11e9-8226-69e14f4f1463.png">

<img width="1073" alt="Screen Shot 2019-03-22 at 10 40 40 PM" src="https://user-images.githubusercontent.com/17363/54862353-ceff1480-4cf6-11e9-837f-16744ab36bb4.png">

<img width="1175" alt="Screen Shot 2019-03-22 at 10 56 56 PM" src="https://user-images.githubusercontent.com/17363/54862359-e63e0200-4cf6-11e9-94d2-0ac2cef4fd17.png">



## Notes

The tradeoffs involved with using raw SQL are breaking out of the ORM, which we mitigate by using `_meta` to dynamically fetch the table name, and no longer writing the job ID with a row index suffix the way it appears in the AWS Batch console, which is not really required because we have access to the `row_id` and we are adding an additional `is_array` flag to the processing result.


## Testing Instructions

All testing needs to be done on staging because the timeouts only appeared on staging and the fixes involve AWS Batch processing.

I pushed this branch as `test/bulk-create-list-items` to deploy it to staging and create the screenshots

I used these two files for testing 

[OAR Amfori  3.22 JW double length.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/2999063/OAR.Amfori.3.22.JW.double.length.csv.txt)

[amfori-one-row.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/2999062/amfori-one-row.csv.txt)

After successfully uploading the 8600+ row CSV I went into the AWS Batch console and terminated the related jobs to prevent day long geocoding.

