### PR TITLE
Help Django determine inbound request security

### DIFF
--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -66,11 +66,15 @@ if ENVIRONMENT in ['Production', 'Staging'] and BATCH_MODE == '':
         response = response.json()
 
         for container in response['Containers']:
-          for network in container['Networks']:
-            for addr in network['IPv4Addresses']:
-              ALLOWED_HOSTS.append(addr)
+            for network in container['Networks']:
+                for addr in network['IPv4Addresses']:
+                    ALLOWED_HOSTS.append(addr)
     else:
         raise ImproperlyConfigured('Unable to fetch instance metadata')
+
+    # Ensure Django knows to determine whether an inbound request was
+    # made over HTTPS by the ALBs HTTP_X_FORWARDED_PROTO header.
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Application definition
 


### PR DESCRIPTION
## Overview

Set `SECURE_PROXY_SSL_HEADER` to use the AWS ALB `HTTP_X_FORWARDED_PROTO` header to determine whether the inbound HTTP request occurred via HTTPS.

Connects https://github.com/open-apparel-registry/open-apparel-registry/issues/354

## Demo

![Screen Shot 2019-03-23 at 11 08 02](https://user-images.githubusercontent.com/43639/54867879-f50ad000-4d5b-11e9-9c40-f72c572060cb.png)

## Notes

See: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/how-elastic-load-balancing-works.html#http-headers

## Testing Instructions

* Ensure this change set is on staging
* Navigate to https://staging.openapparel.org/api/docs/#!/facilities/facilities_count
* Click **Try it out!**
* Ensure the API call returns a legitimate response

