### PR TITLE
Fix create_accounts management command

### DIFF
--- a/src/django/api/management/commands/create_accounts.py
+++ b/src/django/api/management/commands/create_accounts.py
@@ -65,7 +65,6 @@ class Command(BaseCommand):
                     is_superuser=False,
                     is_staff=False,
                     is_active=True,
-                    username=name,
                     should_receive_newsletter=False,
                     has_agreed_to_terms_of_service=True,
                 )


### PR DESCRIPTION


## Overview

Our real data includes account names longer than 20 characters. We are not using the username field and it is left on the model only for compatibility so it is safe to not populate it.

Connects #373

## Demo


## Testing Instructions

* Run `./scripts/manage create_accounts --type "Brand/Retailer" --password 1234pass --contributors "MEC (Material Manufacturers)"` and verify that it does not raise an exception.

