### PR TITLE
Add Summary Status for Facility Lists

### DIFF
--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -55,6 +55,7 @@ const {
     makeSubmitFormOnEnterKeyPressFunction,
     makeFacilityListItemsRetrieveCSVItemsURL,
     makeFacilityListDataURLs,
+    makeFacilityListSummaryStatus,
 } = require('../util/util');
 
 const {
@@ -66,6 +67,8 @@ const {
     DEFAULT_PAGE,
     DEFAULT_ROWS_PER_PAGE,
     ENTER_KEY,
+    facilityListItemStatusChoicesEnum,
+    facilityListSummaryStatusMessages,
 } = require('../util/constants');
 
 it('creates a route for checking facility list items', () => {
@@ -1020,5 +1023,59 @@ it('creates a list of data URLs for retrieving facility list items data', () => 
     expect(isEqual(
         makeFacilityListDataURLs(smallerListID, smallerListCount),
         smallerExpectedURLs,
+    )).toBe(true);
+});
+
+it('creates a summary status message given a list of facility list item statuses', () => {
+    expect(isEqual(
+        makeFacilityListSummaryStatus([
+            facilityListItemStatusChoicesEnum.UPLOADED,
+            facilityListItemStatusChoicesEnum.GEOCODED,
+            facilityListItemStatusChoicesEnum.ERROR_GEOCODING,
+        ]),
+        `${facilityListSummaryStatusMessages.PROCESSING} ${facilityListSummaryStatusMessages.ERROR}`,
+    )).toBe(true);
+
+    expect(isEqual(
+        makeFacilityListSummaryStatus([
+            facilityListItemStatusChoicesEnum.UPLOADED,
+            facilityListItemStatusChoicesEnum.GEOCODED,
+        ]),
+        `${facilityListSummaryStatusMessages.PROCESSING}`,
+    )).toBe(true);
+
+    expect(isEqual(
+        makeFacilityListSummaryStatus([
+            facilityListItemStatusChoicesEnum.POTENTIAL_MATCH,
+            facilityListItemStatusChoicesEnum.ERROR_MATCHING,
+        ]),
+        `${facilityListSummaryStatusMessages.AWAITING} ${facilityListSummaryStatusMessages.ERROR}`,
+    )).toBe(true);
+
+    expect(isEqual(
+        makeFacilityListSummaryStatus([
+            facilityListItemStatusChoicesEnum.CONFIRMED_MATCH,
+            facilityListItemStatusChoicesEnum.MATCHED,
+        ]),
+        `${facilityListSummaryStatusMessages.COMPLETED}`,
+    )).toBe(true);
+
+    expect(isEqual(
+        makeFacilityListSummaryStatus([
+            facilityListItemStatusChoicesEnum.CONFIRMED_MATCH,
+            facilityListItemStatusChoicesEnum.MATCHED,
+            facilityListItemStatusChoicesEnum.ERROR,
+        ]),
+        `${facilityListSummaryStatusMessages.ERROR}`,
+    )).toBe(true);
+
+    expect(isEqual(
+        makeFacilityListSummaryStatus([
+            facilityListItemStatusChoicesEnum.POTENTIAL_MATCH,
+            facilityListItemStatusChoicesEnum.CONFIRMED_MATCH,
+            facilityListItemStatusChoicesEnum.MATCHED,
+            facilityListItemStatusChoicesEnum.ERROR,
+        ]),
+        `${facilityListSummaryStatusMessages.AWAITING} ${facilityListSummaryStatusMessages.ERROR}`,
     )).toBe(true);
 });

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -43,6 +43,10 @@ const facilityListItemsTableStyles = Object.freeze({
     tableWrapperStyles: Object.freeze({
         overflowX: 'auto',
     }),
+    summaryStatusStyles: Object.freeze({
+        fontSize: '1rem',
+        color: 'rgba(0, 0, 0, 0.87)',
+    }),
 });
 
 function FacilityListItemsTable({
@@ -89,7 +93,10 @@ function FacilityListItemsTable({
 
     const paginationControlsRow = (
         <TableRow>
-            <TableCell colSpan={3}>
+            <TableCell
+                colSpan={3}
+                style={facilityListItemsTableStyles.summaryStatusStyles}
+            >
                 {makeFacilityListSummaryStatus(list.statuses)}
             </TableCell>
             <TablePagination

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -8,6 +8,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
 
 import FacilityListItemsTableRow from './FacilityListItemsTableRow';
 import FacilityListItemsConfirmationTableRow from './FacilityListItemsConfirmationTableRow';
@@ -25,6 +26,7 @@ import {
     makePaginatedFacilityListItemsDetailLinkWithRowCount,
     getValueFromEvent,
     createPaginationOptionsFromQueryString,
+    makeFacilityListSummaryStatus,
 } from '../util/util';
 
 import {
@@ -87,6 +89,9 @@ function FacilityListItemsTable({
 
     const paginationControlsRow = (
         <TableRow>
+            <TableCell colSpan={3}>
+                {makeFacilityListSummaryStatus(list.statuses)}
+            </TableCell>
             <TablePagination
                 count={list.item_count}
                 rowsPerPage={Number(rowsPerPage)}

--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -92,6 +92,13 @@ const completeConfirmMatch = (state, payload) => {
             : state.selectedFacilityListItemsRowIndex;
 
     return update(state, {
+        list: {
+            data: {
+                statuses: {
+                    $set: payload.list_statuses,
+                },
+            },
+        },
         confirmOrRejectMatch: {
             fetching: { $set: false },
             error: { $set: null },

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -254,6 +254,13 @@ export const facilityListItemErrorStatuses = Object.freeze([
     facilityListItemStatusChoicesEnum.ERROR_MATCHING,
 ]);
 
+export const facilityListSummaryStatusMessages = Object.freeze({
+    ERROR: 'Some items failed to be processed.',
+    AWAITING: 'Some potential matches require your feedback.',
+    PROCESSING: 'The list is still being processed.',
+    COMPLETED: 'This list has been processed successfully.',
+});
+
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_ROWS_PER_PAGE = 20;
 export const rowsPerPageOptions = Object.freeze([

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -38,6 +38,9 @@ import {
     DEFAULT_PAGE,
     DEFAULT_ROWS_PER_PAGE,
     ENTER_KEY,
+    facilityListItemStatusChoicesEnum,
+    facilityListItemErrorStatuses,
+    facilityListSummaryStatusMessages,
 } from './constants';
 
 import { createListItemCSV } from './util.listItemCSV';
@@ -452,4 +455,30 @@ export const makeFacilityListDataURLs = (id, count) => {
 
     return range(1, maxCount + 1)
         .map(page => makeFacilityListItemsRetrieveCSVItemsURL(id, page));
+};
+
+export const makeFacilityListSummaryStatus = (statuses) => {
+    const errorMessage = facilityListItemErrorStatuses.some(s => statuses.includes(s)) ?
+        facilityListSummaryStatusMessages.ERROR : '';
+    const awaitingMessage = [
+        facilityListItemStatusChoicesEnum.POTENTIAL_MATCH,
+    ].some(s => statuses.includes(s)) ?
+        facilityListSummaryStatusMessages.AWAITING : '';
+    const processingMessage = statuses.some(s => [
+        facilityListItemStatusChoicesEnum.UPLOADED,
+        facilityListItemStatusChoicesEnum.PARSED,
+        facilityListItemStatusChoicesEnum.GEOCODED,
+        facilityListItemStatusChoicesEnum.GEOCODED_NO_RESULTS,
+    ].includes(s)) ?
+        facilityListSummaryStatusMessages.PROCESSING : '';
+    const completeMessage = statuses.every(s => [
+        facilityListItemStatusChoicesEnum.MATCHED,
+        facilityListItemStatusChoicesEnum.CONFIRMED_MATCH,
+    ].includes(s)) ?
+        facilityListSummaryStatusMessages.COMPLETED : '';
+
+    return `${completeMessage}
+            ${processingMessage}
+            ${awaitingMessage}
+            ${errorMessage}`.replace(/\s+/g, ' ').trim();
 };

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -158,12 +158,12 @@ class UserProfileSerializer(ModelSerializer):
 class FacilityListSerializer(ModelSerializer):
     item_count = SerializerMethodField()
     items_url = SerializerMethodField()
-    status = SerializerMethodField()
+    statuses = SerializerMethodField()
 
     class Meta:
         model = FacilityList
         fields = ('id', 'name', 'description', 'file_name', 'is_active',
-                  'is_public', 'item_count', 'items_url', 'status')
+                  'is_public', 'item_count', 'items_url', 'statuses')
 
     def get_item_count(self, facility_list):
         return facility_list.facilitylistitem_set.count()
@@ -172,41 +172,10 @@ class FacilityListSerializer(ModelSerializer):
         return reverse('facility-list-items',
                        kwargs={'pk': facility_list.pk})
 
-    def get_status(self, facility_list):
-        ERROR_STATUSES = set(
-            FacilityListItem.ERROR_STATUSES
-        )
-        PROCESSING_STATUSES = set([
-            FacilityListItem.UPLOADED,
-            FacilityListItem.PARSED,
-            FacilityListItem.GEOCODED,
-            FacilityListItem.GEOCODED_NO_RESULTS,
-        ])
-        PENDING_STATUSES = set([
-            FacilityListItem.POTENTIAL_MATCH,
-        ])
-        COMPLETE_STATUSES = set([
-            FacilityListItem.MATCHED,
-            FacilityListItem.CONFIRMED_MATCH,
-        ])
-
-        item_statuses = set(
-            facility_list.facilitylistitem_set
-            .values_list('status', flat=True)
-            .distinct())
-
-        if (item_statuses.intersection(ERROR_STATUSES)):
-            status = 'ERROR'
-        elif (item_statuses.issubset(PROCESSING_STATUSES)):
-            status = 'PROCESSING'
-        elif (item_statuses.issuperset(PENDING_STATUSES)):
-            status = 'PENDING'
-        elif (item_statuses.issubset(COMPLETE_STATUSES)):
-            status = 'COMPLETE'
-        else:
-            status = 'UNKNOWN'
-
-        return status
+    def get_statuses(self, facility_list):
+        return (facility_list.facilitylistitem_set
+                .values_list('status', flat=True)
+                .distinct())
 
 
 class FacilitySerializer(GeoFeatureModelSerializer):

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -158,11 +158,12 @@ class UserProfileSerializer(ModelSerializer):
 class FacilityListSerializer(ModelSerializer):
     item_count = SerializerMethodField()
     items_url = SerializerMethodField()
+    status = SerializerMethodField()
 
     class Meta:
         model = FacilityList
         fields = ('id', 'name', 'description', 'file_name', 'is_active',
-                  'is_public', 'item_count', 'items_url')
+                  'is_public', 'item_count', 'items_url', 'status')
 
     def get_item_count(self, facility_list):
         return facility_list.facilitylistitem_set.count()
@@ -170,6 +171,42 @@ class FacilityListSerializer(ModelSerializer):
     def get_items_url(self, facility_list):
         return reverse('facility-list-items',
                        kwargs={'pk': facility_list.pk})
+
+    def get_status(self, facility_list):
+        ERROR_STATUSES = set(
+            FacilityListItem.ERROR_STATUSES
+        )
+        PROCESSING_STATUSES = set([
+            FacilityListItem.UPLOADED,
+            FacilityListItem.PARSED,
+            FacilityListItem.GEOCODED,
+            FacilityListItem.GEOCODED_NO_RESULTS,
+        ])
+        PENDING_STATUSES = set([
+            FacilityListItem.POTENTIAL_MATCH,
+        ])
+        COMPLETE_STATUSES = set([
+            FacilityListItem.MATCHED,
+            FacilityListItem.CONFIRMED_MATCH,
+        ])
+
+        item_statuses = set(
+            facility_list.facilitylistitem_set
+            .values_list('status', flat=True)
+            .distinct())
+
+        if (item_statuses.intersection(ERROR_STATUSES)):
+            status = 'ERROR'
+        elif (item_statuses.issubset(PROCESSING_STATUSES)):
+            status = 'PROCESSING'
+        elif (item_statuses.issuperset(PENDING_STATUSES)):
+            status = 'PENDING'
+        elif (item_statuses.issubset(COMPLETE_STATUSES)):
+            status = 'COMPLETE'
+        else:
+            status = 'UNKNOWN'
+
+        return status
 
 
 class FacilitySerializer(GeoFeatureModelSerializer):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -846,6 +846,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 "facility_list": 1,
                 "country_name": "United States",
                 "processing_errors": null,
+                "list_statuses": ["CONFIRMED_MATCH"],
                 "matched_facility": {
                     "oar_id": "oar_id_1",
                     "name": "facility match name 1",
@@ -903,6 +904,12 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             facility_list_item.save()
 
             response_data = FacilityListItemSerializer(facility_list_item).data
+
+            response_data['list_statuses'] = (facility_list
+                                              .facilitylistitem_set
+                                              .values_list('status', flat=True)
+                                              .distinct())
+
             return Response(response_data)
         except FacilityList.DoesNotExist:
             raise NotFound()
@@ -1002,6 +1009,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 "matched_facility": null,
                 "processing_errors": null,
                 "facility_list": 1,
+                "list_statuses": ["POTENTIAL_MATCH"],
             }
         """
         try:
@@ -1070,6 +1078,12 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 facility_list_item.save()
 
             response_data = FacilityListItemSerializer(facility_list_item).data
+
+            response_data['list_statuses'] = (facility_list
+                                              .facilitylistitem_set
+                                              .values_list('status', flat=True)
+                                              .distinct())
+
             return Response(response_data)
         except FacilityList.DoesNotExist:
             raise NotFound()


### PR DESCRIPTION
## Overview

Adds a field to the facility list detail endpoint that is a DISTINCT list of all item statuses in the facility list. This list is inspected in the front-end and is used to show a status message in the pagination row.

Connects #327 

### Demo

Processing:

![image](https://user-images.githubusercontent.com/1430060/54946043-9e44f800-4f0d-11e9-9605-e658b34a5d28.png)

Error:

![image](https://user-images.githubusercontent.com/1430060/54946148-d6e4d180-4f0d-11e9-950a-f0ea6697ae0c.png)

## Testing

* Check out this branch and `server`
* Go to [:6543](http://localhost:6543/) and log in
* Upload a list
  - [ ] Ensure the list details page shows a summary status above the list items in the table
* `manage batch_process` the list
  - [ ] Ensure the list details page shows the correct summary status at each step