### PR TITLE
Add RouteNotFound component

### DIFF
--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -21,6 +21,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import GDPRNotification from './components/GDPRNotification';
 import ConfirmRegistration from './components/ConfirmRegistration';
 import AboutProcessing from './components/AboutProcessing';
+import RouteNotFound from './components/RouteNotFound';
 
 import './App.css';
 
@@ -111,6 +112,7 @@ class App extends Component {
                                     path={aboutProcessingRoute}
                                     component={AboutProcessing}
                                 />
+                                <Route component={RouteNotFound} />
                             </Switch>
                         </main>
                         <Footer />

--- a/src/app/src/components/RouteNotFound.jsx
+++ b/src/app/src/components/RouteNotFound.jsx
@@ -1,0 +1,18 @@
+import React, { memo } from 'react';
+import Grid from '@material-ui/core/Grid';
+
+import AppGrid from './AppGrid';
+
+const RouteNotFound = memo(() => (
+    <AppGrid title="Not found">
+        <Grid container className="margin-bottom-64">
+            <Grid item xs={12}>
+                <p>
+                    Not found
+                </p>
+            </Grid>
+        </Grid>
+    </AppGrid>
+));
+
+export default RouteNotFound;


### PR DESCRIPTION
## Overview

This PR adds an empty RouteNotFound component for @designmatty to use for creating a 404 page.

Connects #216 

## Demo

![Screen Shot 2019-03-25 at 12 10 37 PM](https://user-images.githubusercontent.com/4165523/54935619-05a37d80-4ef7-11e9-880d-1f548273db97.png)

## Testing Instructions

- get this branch then run `./scripts/cibuild`
- when that's done, run `./scripts/server` and:

- visit http://localhost:8081/hello and verify that you see the route not found component
- click on the OAR logo to go to the map page, then click "Search" and verify that facilities return
- visit http://localhost:8081/api/docs/ directly in the browser URL bar and verify that the Swagger docs load

