### PR TITLE
Use && rather than || for logout redirect logic

### DIFF
--- a/src/app/src/components/NavbarLoginButtonGroup.jsx
+++ b/src/app/src/components/NavbarLoginButtonGroup.jsx
@@ -161,7 +161,7 @@ function mapDispatchToProps(dispatch, {
         logout: () => {
             dispatch(submitLogOut());
 
-            if (pathname !== mainRoute || !startsWith(pathname, facilitiesRoute)) {
+            if (pathname !== mainRoute && !startsWith(pathname, facilitiesRoute)) {
                 push(facilitiesRoute);
             }
         },


### PR DESCRIPTION
## Overview

I noticed a bug in the logout redirect logic which is that a redirect
should happen if

- the current route is NOT the main route, '/'
AND
- the current route does NOT start with '/facilities`, as it would for
the facilities version of the main route and the facility details route

The previous OR logic would be true and cause a redirect if just
`pathname !== mainRoute` was true, which meant it would redirect from
the facilities and facility details routes.

Connects #343 

## Testing Instructions

- serve this branch and login
- on the `/` route, logout and verify that you are not redirected
- from `/facilities`, logout and verify that you are not redirected
- from a facilities details page, logout and verify that you are not redirected

From the following pages, logout and verify that you are redirected:

- contribute
- profile
- lists
- list details

