### PR TITLE
Resend confirmation email on login attempt

### DIFF
--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework.filters import BaseFilterBackend
 from rest_auth.views import LoginView, LogoutView
+from allauth.account.models import EmailAddress
 from allauth.account.utils import complete_signup
 import coreapi
 
@@ -116,6 +117,11 @@ class LoginToOARClient(LoginView):
         login(request, user)
 
         if not request.user.did_register_and_confirm_email:
+            # Mimic the behavior of django-allauth and resend the confirmation
+            # email if an unconfirmed user tries to log in.
+            email_address = EmailAddress.objects.get(email=email)
+            email_address.send_confirmation(request)
+
             raise AuthenticationFailed(
                 'Account is not verified. '
                 'Check your email for a confirmation link.'


### PR DESCRIPTION
## Overview

The default behavior of django-allauth is to resend a confirmation email when attempting to log in with an account that has not yet been confirmed. Since we are using django-rest-auth to log in, we are bypassing this logic and need to recreate it.

Connects #288

## Notes

After a user of the site reported not receiving a confirmation email, but could receive password reset emails, I did a deep dive into the django-allauth code to see how confirmation works.

By default the "key" portion of the confirmation link is not stored in the database. The key is instead, an HMAC signature of the ID of the row in the `account_emailaddress` table and a salt value.

I also found that django-allauth resends confirmation emails when a user attempts to log in to an unverified account. This is clever, but was not working in our app. It turns out that our use of django-rest-auth was routing around this behavior.

## Testing Instructions

* Register for a new account. Verify that the confirmation email is printed to the console. Do _not_ follow the link.
* Attempt to log in with the unconfirmed account. Verify that a second email is printed to the console.

