### PR TITLE
fixes map sizing issues and table pagination

### DIFF
--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -572,7 +572,17 @@ hr {
   overflow: auto;
 }
 
+.facility-detail_map {
+  width: 385px;
+  max-width: 100%;
+  flex: none;
+  margin: 30px auto 0;
+  border-radius: 5px;
+}
 
+.word-break {
+  word-break: break-all;
+}
 
 /* @keyframes App-logo-spin {
   from { transform: rotate(0deg); }

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -50,7 +50,7 @@ const appStyles = Object.freeze({
         right: '0',
         left: '0',
         position: 'fixed',
-        bottom: '47px',
+        bottom: '51px',
     }),
 });
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -43,7 +43,7 @@ const unselectedMarkerURL = '/images/marker.png';
 
 const facilitiesMapStyles = Object.freeze({
     mapContainerStyles: Object.freeze({
-        height: '99.75%',
+        height: '100%',
         width: '100%',
     }),
     copySearchButtonStyle: Object.freeze({

--- a/src/app/src/components/FacilityDetailSidebarInfo.jsx
+++ b/src/app/src/components/FacilityDetailSidebarInfo.jsx
@@ -18,7 +18,7 @@ const FacilityDetailSidebarInfo = memo(({
 }) => {
     const makeContributorListItem =
         ([id, displayLabel]) => (
-            <li key={id}>
+            <li key={id} className="word-break">
                 <Link
                     to={makeProfileRouteLink(id)}
                     href={makeProfileRouteLink(id)}
@@ -29,7 +29,7 @@ const FacilityDetailSidebarInfo = memo(({
         );
 
     const makeStringListItem = item => (
-        <li key={item}>
+        <li key={item} className="word-break">
             {item}
         </li>);
 

--- a/src/app/src/components/FacilityDetailsStaticMap.jsx
+++ b/src/app/src/components/FacilityDetailsStaticMap.jsx
@@ -27,9 +27,9 @@ export default function FacilityDetailsStaticMap({
 }) {
     return (
         <img
-            style={{ width: '100%' }}
             src={makeGoogleMapsStaticMapURLFromLatLng({ lat, lng })}
             alt={`Facility ${name} at latitide ${lat} and longitude ${lng}`}
+            className="facility-detail_map"
         />
     );
 }

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import { arrayOf, func, number, shape, string } from 'prop-types';
 import { connect } from 'react-redux';
+import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
-import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
-import TableRow from '@material-ui/core/TableRow';
-import TableCell from '@material-ui/core/TableCell';
 
 import FacilityListItemsTableRow from './FacilityListItemsTableRow';
 import FacilityListItemsConfirmationTableRow from './FacilityListItemsConfirmationTableRow';
@@ -45,7 +43,10 @@ const facilityListItemsTableStyles = Object.freeze({
     }),
     summaryStatusStyles: Object.freeze({
         fontSize: '1rem',
+        fontWeight: '500',
         color: 'rgba(0, 0, 0, 0.87)',
+        padding: '20px',
+        lineHeight: '1.2',
     }),
 });
 
@@ -92,22 +93,36 @@ function FacilityListItemsTable({
     };
 
     const paginationControlsRow = (
-        <TableRow>
-            <TableCell
-                colSpan={3}
+        <Grid
+            container
+            direction="row"
+            justify="space-between"
+            alignItems="center"
+        >
+            <Grid
+                item
+                sm={12}
+                md={6}
                 style={facilityListItemsTableStyles.summaryStatusStyles}
             >
                 {makeFacilityListSummaryStatus(list.statuses)}
-            </TableCell>
-            <TablePagination
-                count={list.item_count}
-                rowsPerPage={Number(rowsPerPage)}
-                rowsPerPageOptions={rowsPerPageOptions}
-                onChangeRowsPerPage={handleChangeRowsPerPage}
-                page={page - 1}
-                onChangePage={handleChangePage}
-            />
-        </TableRow>
+            </Grid>
+            <Grid
+                item
+                sm={12}
+                md={6}
+            >
+                <TablePagination
+                    count={list.item_count}
+                    rowsPerPage={Number(rowsPerPage)}
+                    rowsPerPageOptions={rowsPerPageOptions}
+                    onChangeRowsPerPage={handleChangeRowsPerPage}
+                    page={page - 1}
+                    onChangePage={handleChangePage}
+                    component="div"
+                />
+            </Grid>
+        </Grid>
     );
 
     const tableRows = fetchingItems ? [] : items
@@ -205,10 +220,10 @@ function FacilityListItemsTable({
 
     return (
         <Paper style={facilityListItemsTableStyles.containerStyles}>
+            {paginationControlsRow}
             <div style={facilityListItemsTableStyles.tableWrapperStyles}>
                 <Table>
                     <TableHead>
-                        {paginationControlsRow}
                         <FacilityListItemsTableRow
                             rowIndex="CSV Row Index"
                             countryName="Country Name"
@@ -221,11 +236,9 @@ function FacilityListItemsTable({
                     <TableBody>
                         {tableRows}
                     </TableBody>
-                    <TableFooter>
-                        {paginationControlsRow}
-                    </TableFooter>
                 </Table>
             </div>
+            {paginationControlsRow}
         </Paper>
     );
 }

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -15,7 +15,7 @@ import { facilityDetailsRoute } from '../util/constants';
 function MapAndSidebar() {
     return (
         <Fragment>
-            <Grid container>
+            <Grid container className="map-sidebar-container">
                 <Grid
                     item
                     xs={12}

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -2,9 +2,13 @@
   background: #fff;
   box-shadow: 2px 0 4px rgba(0,0,0,.15);
   z-index: 1;
-  height: calc(100vh - 64px - 47px);
+  height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.map-sidebar-container {
+  height: 100%;
 }
 
 .panel-header {


### PR DESCRIPTION
## Overview

- fixes #328 
- fixes #314 
- fixes #313 
- added a class to contributor meta-data (in the map/sidebar layout) which will force a line break when the string is longer than the containing sidebar.

## Demo

<img width="854" alt="Screen Shot 2019-03-26 at 9 27 54 AM" src="https://user-images.githubusercontent.com/1928955/55000807-b2d6ce00-4fa9-11e9-878b-4881b923c628.png">
<img width="904" alt="Screen Shot 2019-03-26 at 9 28 14 AM" src="https://user-images.githubusercontent.com/1928955/55000808-b2d6ce00-4fa9-11e9-83d6-c96a16ef7c45.png">
<img width="927" alt="Screen Shot 2019-03-26 at 9 28 22 AM" src="https://user-images.githubusercontent.com/1928955/55000809-b36f6480-4fa9-11e9-9b29-df5c801b4b1e.png">

## Testing Instructions

* view a facility and check it's static map. 
  - Should no longer be warped.
* view a facility contributor list table, resize screen and scroll table.
  - Pagination should not scroll left or right.