### PR TITLE
Google Analytics Environment Variable

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -62,6 +62,7 @@ bastion_instance_type = "t3.nano"
 
 google_server_side_api_key = ""
 google_client_side_api_key = ""
+google_analytics_key = ""
 
 rollbar_server_side_access_token = ""
 rollbar_client_side_access_token = ""

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -63,6 +63,8 @@ data "template_file" "default_job_definition" {
     django_secret_key          = "${var.django_secret_key}"
     google_server_side_api_key = "${var.google_server_side_api_key}"
 
+    rollbar_server_side_access_token = "${var.rollbar_server_side_access_token}"
+
     aws_region = "${var.aws_region}"
   }
 }

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -64,8 +64,6 @@ data "template_file" "default_job_definition" {
     google_server_side_api_key = "${var.google_server_side_api_key}"
 
     aws_region = "${var.aws_region}"
-
-    rollbar_client_side_access_token = "${var.rollbar_client_side_access_token}"
   }
 }
 

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -112,6 +112,7 @@ data "template_file" "app" {
 
     google_server_side_api_key = "${var.google_server_side_api_key}"
     google_client_side_api_key = "${var.google_client_side_api_key}"
+    google_analytics_key       = "${var.google_analytics_key}"
 
     rollbar_server_side_access_token = "${var.rollbar_server_side_access_token}"
     rollbar_client_side_access_token = "${var.rollbar_client_side_access_token}"
@@ -158,6 +159,7 @@ data "template_file" "app_cli" {
 
     google_server_side_api_key = "${var.google_server_side_api_key}"
     google_client_side_api_key = "${var.google_client_side_api_key}"
+    google_analytics_key       = "${var.google_analytics_key}"
 
     rollbar_server_side_access_token = "${var.rollbar_server_side_access_token}"
     rollbar_client_side_access_token = "${var.rollbar_client_side_access_token}"

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -13,6 +13,7 @@
       { "name": "DJANGO_ENV", "value": "${environment}" },
       { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
       { "name": "GOOGLE_SERVER_SIDE_API_KEY", "value": "${google_server_side_api_key}" },
+      { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
       { "name": "BATCH_MODE", "value": "True" }
   ]
 }

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -16,6 +16,7 @@
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
         { "name": "GOOGLE_SERVER_SIDE_API_KEY", "value": "${google_server_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY", "value": "${google_client_side_api_key}" },
+        { "name": "REACT_APP_GOOGLE_ANALYTICS_KEY", "value": "${google_analytics_key}" },
         { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
         { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" }
     ],

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -18,6 +18,8 @@
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
         { "name": "GOOGLE_SERVER_SIDE_API_KEY", "value": "${google_server_side_api_key}" },
+        { "name": "REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY", "value": "${google_client_side_api_key}" },
+        { "name": "REACT_APP_GOOGLE_ANALYTICS_KEY", "value": "${google_analytics_key}" },
         { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
         { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" }
     ],

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -198,6 +198,10 @@ variable "google_server_side_api_key" {}
 
 variable "google_client_side_api_key" {}
 
+variable "google_analytics_key" {
+  default = ""
+}
+
 variable "rollbar_server_side_access_token" {}
 
 variable "rollbar_client_side_access_token" {}

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -32,6 +32,15 @@
     <title>Open Apparel Registry (beta)</title>
     <!-- Environment Variables -->
     <script src="%PUBLIC_URL%/web/environment.js"></script>
+    <!-- TODO: Replace with actual Google Tag Manager snippet -->
+    <script>
+      if (window.ENVIRONMENT &&
+          window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY &&
+          window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY !== "" &&
+          window.ENVIRONMENT.ENVIRONMENT !== 'development') {
+        console.log(window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY);
+      }
+    </script>
     <!--
       Rollbar Configuration
       https://docs.rollbar.com/docs/browser-js


### PR DESCRIPTION
## Overview

Wires up Google Analytics code as an environment variable. Also updated `terraform.tfvars` in the production bucket with the real value.

I did not add it to the staging bucket because we should not be tracking that.

The final commit is for demoing, and will be dropped before the merge.

Connects #394 

## Notes

When wiring up Google Tag Manager, we should do something like what's done for Rollbar, where we check if the key is available:

https://github.com/open-apparel-registry/open-apparel-registry/blob/d9978b79474a6b06e4fd18846a9e919199c5b475/src/app/public/index.html#L40-L42

This will ensure that analytics are not captured for dev / test environments.

## Testing Instructions

* Check out this branch
* Add a value to `.env.backend` like this:

      REACT_APP_GOOGLE_ANALYTICS_KEY=UA-123456789-10

* Run `cibuild` and `server`
  - [x] Go to [:6543/](http://localhost:6543/) and ensure you see it logged to the console.
  - [x] Go to [:8081/](http://localhost:8081/) and ensure you see it logged to the console.