### PR TITLE
Set accept/reject cookies value in localStorage via utility functions

### DIFF
--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    
+
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon/favicon-16x16.png">

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -32,15 +32,42 @@
     <title>Open Apparel Registry (beta)</title>
     <!-- Environment Variables -->
     <script src="%PUBLIC_URL%/web/environment.js"></script>
-    <!-- TODO: Replace with actual Google Tag Manager snippet -->
+    <!-- Google Analytics -->
     <script>
-      if (window.ENVIRONMENT &&
-          window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY &&
-          window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY !== "" &&
-          window.ENVIRONMENT.ENVIRONMENT !== 'development') {
-        console.log(window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY);
-      }
+        var GA_TRACKING = 'GA_TRACKING';
+        var HAS_ACCEPTED_GA_TRACKING = 'HAS_ACCEPTED_GA_TRACKING';
+
+        function setGADisableKey(key, value) {
+            var disableGAKey = 'ga-disable-' + key;
+            window[disableGAKey] = value || true;
+        }
+
+        if (window.ENVIRONMENT &&
+            window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY &&
+            window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY !== "" &&
+            window.ENVIRONMENT.ENVIRONMENT === 'development') {
+            // Initially disable tracking until we check that the user has accepted the notification
+            // see https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+            setGADisableKey(window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY, true);
+
+            if (window.localStorage && window.localStorage.getItem(GA_TRACKING) === HAS_ACCEPTED_GA_TRACKING) {
+                setGADisableKey(window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY, false);
+            }
+
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                                     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','https://www.google-analytics.com/analytics_debug.js','ga');
+
+            ga('create', window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY, 'auto');
+            ga('set', 'anonymizeIp', true);
+
+            if (window.localStorage && window.localStorage.getItem(GA_TRACKING) === HAS_ACCEPTED_GA_TRACKING) {
+                ga('send', 'pageview');
+            }
+        }
     </script>
+    <!-- End Google Analytics -->
     <!--
       Rollbar Configuration
       https://docs.rollbar.com/docs/browser-js

--- a/src/app/src/__tests__/util.ga.tests.js
+++ b/src/app/src/__tests__/util.ga.tests.js
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+/* eslint-disable object-shorthand */
+/* eslint-disable func-names */
+/* eslint-disable space-before-function-paren */
+
+import {
+    userHasAcceptedOrRejectedGATracking,
+    userHasAcceptedGATracking,
+    userHasRejectedGATracking,
+    rejectGATracking,
+    acceptGATracking,
+    clearGATrackingDecision,
+} from '../util/util.ga.js';
+
+beforeEach(() => {
+    const localStorageMock = {
+        store: {},
+        getItem: function(key) {
+            return this.store[key] || null;
+        },
+        setItem: function(key, value) {
+            this.store[key] = value.toString();
+        },
+        removeItem: function(key) {
+            delete this.store[key];
+        },
+        clear: function() {
+            this.store = {};
+        },
+    };
+
+    global.localStorage = localStorageMock;
+    jest.spyOn(global.localStorage, 'setItem');
+});
+
+afterEach(() => {
+    global.localStorage = null;
+});
+
+it('correctly sets a `HAS_REJECTED_GA_TRACKING` value in localStorage', () => {
+    rejectGATracking();
+
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith('GA_TRACKING', 'HAS_REJECTED_GA_TRACKING');
+    expect(localStorage.getItem('GA_TRACKING')).toBe('HAS_REJECTED_GA_TRACKING');
+
+    expect(userHasAcceptedOrRejectedGATracking()).toBe(true);
+    expect(userHasRejectedGATracking()).toBe(true);
+    expect(userHasAcceptedGATracking()).toBe(false);
+});
+
+it('correctly sets a `HAS_REJECTED_GA_TRACKING` value in localStorage', () => {
+    acceptGATracking();
+
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(localStorage.setItem).toHaveBeenCalledWith('GA_TRACKING', 'HAS_ACCEPTED_GA_TRACKING');
+    expect(localStorage.getItem('GA_TRACKING')).toBe('HAS_ACCEPTED_GA_TRACKING');
+
+    expect(userHasAcceptedOrRejectedGATracking()).toBe(true);
+    expect(userHasAcceptedGATracking()).toBe(true);
+    expect(userHasRejectedGATracking()).toBe(false);
+});
+
+it('correctly clears a `HAS_ACCEPTED_GA_TRACKING` decision value from localStorage', () => {
+    acceptGATracking();
+
+    expect(userHasAcceptedGATracking()).toBe(true);
+
+    jest.spyOn(global.localStorage, 'removeItem');
+    clearGATrackingDecision();
+
+    expect(localStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(localStorage.removeItem).toHaveBeenCalledWith('GA_TRACKING');
+
+    expect(userHasAcceptedGATracking()).toBe(false);
+    expect(userHasAcceptedOrRejectedGATracking()).toBe(false);
+});

--- a/src/app/src/components/GDPRNotification.jsx
+++ b/src/app/src/components/GDPRNotification.jsx
@@ -1,23 +1,37 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import Snackbar from '@material-ui/core/Snackbar';
 import Button from './Button';
 import ShowOnly from './ShowOnly';
 import COLOURS from '../util/COLOURS';
 
-class GDPRNotification extends PureComponent {
-    state = { open: true };
+import {
+    userHasAcceptedOrRejectedGATracking,
+    acceptGATracking,
+    rejectGATracking,
+} from '../util/util.ga';
+
+export default class GDPRNotification extends Component {
+    state = { open: false };
 
     componentDidMount() {
-        const dismissed = localStorage.getItem('dismissedGDPRAlert');
-        if (dismissed) {
-            this.setState({ open: false }); // eslint-disable-line react/no-did-mount-set-state
+        if (userHasAcceptedOrRejectedGATracking()) {
+            return null;
         }
+
+        return this.setState(state => Object.assign({}, state, {
+            open: true,
+        }));
     }
 
-    dismissGDPRAlert = () => {
-        this.setState({ open: false });
-        localStorage.setItem('dismissedGDPRAlert', true);
-    };
+    acceptGDPRAlertAndDismissSnackbar = () => this.setState(
+        state => Object.assign({}, state, { open: false }),
+        acceptGATracking,
+    );
+
+    rejectGDPRAlertAndDismissSnackbar = () => this.setState(
+        state => Object.assign({}, state, { open: false }),
+        rejectGATracking,
+    );
 
     render() {
         const GDPRActions = (
@@ -28,9 +42,12 @@ class GDPRNotification extends PureComponent {
                         background: COLOURS.LIGHT_BLUE,
                         marginRight: '10px',
                     }}
-                    onClick={this.dismissGDPRAlert}
+                    onClick={this.rejectGDPRAlertAndDismissSnackbar}
                 />
-                <Button text="Accept" onClick={this.dismissGDPRAlert} />
+                <Button
+                    text="Accept"
+                    onClick={this.acceptGDPRAlertAndDismissSnackbar}
+                />
             </div>
         );
 
@@ -58,5 +75,3 @@ class GDPRNotification extends PureComponent {
         );
     }
 }
-
-export default GDPRNotification;

--- a/src/app/src/components/GDPRNotification.jsx
+++ b/src/app/src/components/GDPRNotification.jsx
@@ -51,13 +51,21 @@ export default class GDPRNotification extends Component {
             </div>
         );
 
-        const GDPRMessage =
-            `We use cookies to collect and analyze
-            information on site performance and usage,
-            and to enhance content. By clicking Accept,
-            you agree to allow cookies to be placed.
-            To find out more, visit our terms of service
-            and our privacy policy.`;
+        const snackbarMessage = (
+            <div>
+                The Open Apparel Registry uses cookies to collect and analyze
+                site performance and usage. By clicking the Accept button, you
+                agree to allow us to place cookies and share information with
+                Google Analytics. For more information, please visit our{` `}
+                <a
+                    href="https://info.openapparel.org/tos/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Terms and Conditions of Use and Privacy Policy.
+                </a>
+            </div>
+        );
 
         return (
             <ShowOnly when={this.state.open}>
@@ -69,7 +77,7 @@ export default class GDPRNotification extends Component {
                         horizontal: 'right',
                     }}
                     action={GDPRActions}
-                    message={GDPRMessage}
+                    message={snackbarMessage}
                 />
             </ShowOnly>
         );

--- a/src/app/src/util/util.ga.js
+++ b/src/app/src/util/util.ga.js
@@ -1,0 +1,27 @@
+export const GA_TRACKING = 'GA_TRACKING';
+export const HAS_ACCEPTED_GA_TRACKING = 'HAS_ACCEPTED_GA_TRACKING';
+export const HAS_REJECTED_GA_TRACKING = 'HAS_REJECTED_GA_TRACKING';
+
+export const userHasAcceptedOrRejectedGATracking = () =>
+    Boolean(localStorage.getItem(GA_TRACKING));
+
+export const userHasAcceptedGATracking = () =>
+    localStorage.getItem(GA_TRACKING) === HAS_ACCEPTED_GA_TRACKING;
+
+export const userHasRejectedGATracking = () =>
+    localStorage.getItem(GA_TRACKING) === HAS_REJECTED_GA_TRACKING;
+
+export const rejectGATracking = () => {
+    localStorage.setItem(GA_TRACKING, HAS_REJECTED_GA_TRACKING);
+};
+
+export const acceptGATracking = () => {
+    // If user has already rejected GA tracking, this is a noop
+    if (!userHasRejectedGATracking()) {
+        localStorage.setItem(GA_TRACKING, HAS_ACCEPTED_GA_TRACKING);
+    }
+};
+
+export const clearGATrackingDecision = () => {
+    localStorage.removeItem(GA_TRACKING);
+};

--- a/src/app/src/util/util.ga.js
+++ b/src/app/src/util/util.ga.js
@@ -1,3 +1,7 @@
+import env from './env';
+
+const REACT_APP_GOOGLE_ANALYTICS_KEY = 'REACT_APP_GOOGLE_ANALYTICS_KEY';
+
 export const GA_TRACKING = 'GA_TRACKING';
 export const HAS_ACCEPTED_GA_TRACKING = 'HAS_ACCEPTED_GA_TRACKING';
 export const HAS_REJECTED_GA_TRACKING = 'HAS_REJECTED_GA_TRACKING';
@@ -15,10 +19,24 @@ export const rejectGATracking = () => {
     localStorage.setItem(GA_TRACKING, HAS_REJECTED_GA_TRACKING);
 };
 
+export const enableGATracking = () => {
+    const gaKey = env(REACT_APP_GOOGLE_ANALYTICS_KEY);
+
+    if (gaKey) {
+        const disableKey = `ga-disable-${gaKey}`;
+        window[disableKey] = false;
+    }
+
+    if (window.ga) {
+        window.ga('send', 'pageview');
+    }
+};
+
 export const acceptGATracking = () => {
     // If user has already rejected GA tracking, this is a noop
     if (!userHasRejectedGATracking()) {
         localStorage.setItem(GA_TRACKING, HAS_ACCEPTED_GA_TRACKING);
+        enableGATracking();
     }
 };
 


### PR DESCRIPTION
## Overview

This is a preliminary PR for #267 which updates the GDPRNotification component to set specific values for `GA_TRACKING` in localstorage via some testable utility functions. 

Clicking "Accept" will set `GA_TRACKING` to `HAS_ACCEPTED_GA_TRACKING`.

Clicking "Reject" will set `GA_TRACKING` to `HAS_REJECTED_GA_TRACKING`.

I also added some tests which check the value of localStorage, using a mock version of localStorage described here: https://github.com/facebook/jest/issues/2098#issuecomment-395233511

Prior to writing the custom mock for localStorage, I tried out a Jest plugin. It turns out that Create React App does not let you use Jest plugins without ejecting, ergo the custom mock.

Connects #267

## Testing Instructions

- get this branch then run `./scripts/test --app` to verify the new tests pass
- `./scripts/server`, visit localhost:6543 and run `localStorage.clear()` in the browser console when the app loads
- refresh the page and click "Reject" in the notification Snackbar
- refresh the page again
- type `localStorage` into the browser console and verify that the object looks like:

```
Storage { GA_TRACKING: "HAS_REJECTED_GA_TRACKING", length: 1 }
```

- run `localStorage.clear()` again, then refresh the page
- this time choose "Accept" from the Snackbar, then type `localStorage` and verify that the state is now:

```
Storage { GA_TRACKING: "HAS_ACCEPTED_GA_TRACKING", length: 1 }
```

- refresh the page, then type `localStorage` again and verify that the state is still

```
Storage { GA_TRACKING: "HAS_ACCEPTED_GA_TRACKING", length: 1 }
```

