### PR TITLE
WIP: Tooltip truncate component

### DIFF
--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -572,7 +572,12 @@ hr {
   overflow: auto;
 }
 
-
+.text-overflow {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  display: block;
+}
 
 /* @keyframes App-logo-spin {
   from { transform: rotate(0deg); }

--- a/src/app/src/components/CellElement.jsx
+++ b/src/app/src/components/CellElement.jsx
@@ -6,11 +6,12 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import Tooltip from '@material-ui/core/Tooltip';
 import isObject from 'lodash/isObject';
 
 import { facilityMatchStatusChoicesEnum } from '../util/constants';
-
 import { confirmRejectMatchRowStyles } from '../util/styles';
+import TruncateTooltip from './TruncateTooltip';
 
 const confirmRejectDialogStates = Object.freeze({
     none: 'none',
@@ -80,16 +81,21 @@ export default class CellElement extends Component {
 
                 if (linkURL) {
                     return (
-                        <Link
-                            to={linkURL}
-                            href={linkURL}
-                        >
-                            {item}
-                        </Link>
+                        <Tooltip title={item} placement="top">
+                            <Link
+                                to={linkURL}
+                                href={linkURL}
+                                className="text-overflow"
+                            >
+                                {item}
+                            </Link>
+                        </Tooltip>
                     );
                 }
 
-                return item;
+                return (
+                    <TruncateTooltip truncate={item} />
+                );
             })();
 
             return (
@@ -246,7 +252,7 @@ export default class CellElement extends Component {
         return (
             <div
                 key={item.id}
-                style={confirmRejectMatchRowStyles.cellRowStyles}
+                style={confirmRejectMatchRowStyles.cellRowActionStyles}
             >
                 <div style={confirmRejectMatchRowStyles.cellActionStyles}>
                     <Button

--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -17,6 +17,7 @@ import { listTableCellStyles } from '../util/styles';
 
 import { makeFacilityDetailLink } from '../util/util';
 
+
 function FacilityListItemsConfirmationTableRow({
     item,
     makeConfirmMatchFunction,

--- a/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
+++ b/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
@@ -5,6 +5,8 @@ import get from 'lodash/get';
 
 import CellElement from './CellElement';
 
+import TruncateTooltip from './TruncateTooltip';
+
 import { facilityMatchStatusChoicesEnum } from '../util/constants';
 
 import { confirmRejectMatchRowStyles } from '../util/styles';
@@ -22,7 +24,7 @@ export default function FacilityListItemsDetailedTableRowCell({
     return (
         <div style={confirmRejectMatchRowStyles.cellStyles}>
             <div style={confirmRejectMatchRowStyles.cellTitleStyles}>
-                {title}
+                <TruncateTooltip truncate={title} />
             </div>
             <div style={confirmRejectMatchRowStyles.cellSubtitleStyles}>
                 <Typography variant="body2">

--- a/src/app/src/components/FacilityListItemsTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsTableRow.jsx
@@ -11,6 +11,8 @@ import { listTableCellStyles } from '../util/styles';
 
 import { makeFacilityDetailLink } from '../util/util';
 
+import TruncateTooltip from './TruncateTooltip';
+
 const propsAreEqual = (prevProps, nextProps) =>
     isEqual(prevProps.rowIndex, nextProps.rowIndex)
     && isEqual(prevProps.countryCode, nextProps.countryCode)
@@ -75,7 +77,7 @@ const FacilityListItemsTableRow = memo(({
             padding="default"
             style={listTableCellStyles.addressCellStyles}
         >
-            {address}
+            <TruncateTooltip truncate={address} />
         </TableCell>
         <TableCell
             padding="default"

--- a/src/app/src/components/TruncateTooltip.jsx
+++ b/src/app/src/components/TruncateTooltip.jsx
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Tooltip from '@material-ui/core/Tooltip';
+
+class TruncateTooltip extends Component {
+    render() {
+        const insetComponent = (() => {
+            if (this.props.truncate.length > 40) {
+                return (
+                    <Tooltip title={this.props.truncate} placement="top">
+                        <span>
+                            {this.props.truncate.substring(0, 40)}...
+                        </span>
+                    </Tooltip>
+                );
+            }
+
+            return (this.props.truncate);
+        })();
+
+        return insetComponent;
+    }
+}
+
+TruncateTooltip.propTypes = {
+    truncate: PropTypes.node.isRequired,
+};
+
+export default TruncateTooltip;

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -48,6 +48,7 @@ export const confirmRejectMatchRowStyles = Object.freeze({
         flexDirection: 'column',
     }),
     cellRowStyles: Object.freeze({
+        height: '55px',
         minHeight: '55px',
         alignItems: 'top',
         maxWidth: '250px',

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -48,7 +48,12 @@ export const confirmRejectMatchRowStyles = Object.freeze({
         flexDirection: 'column',
     }),
     cellRowStyles: Object.freeze({
-        height: '55px',
+        minHeight: '55px',
+        alignItems: 'top',
+        maxWidth: '250px',
+        display: 'inline-block',
+    }),
+    cellRowActionStyles: Object.freeze({
         minHeight: '55px',
         display: 'flex',
         alignItems: 'top',


### PR DESCRIPTION
## Overview

This is an initial stab at fixing the problems stated in the connected issue. This component will check the length of the provided string, and if it is over 40 characters, the string truncates with an ellipsis and renders a `<Tooltip>` on hover of the full string.

Connects #389 

## Demo

<img width="992" alt="Screen Shot 2019-03-26 at 12 51 16 PM" src="https://user-images.githubusercontent.com/1928955/55016806-e0ca0b80-4fc5-11e9-8b30-6ea5994217d4.png">

## Testing Instructions

* Open a list
* Find an item with a long address and hover on it.
* Does a tooltip show up?

