### PR TITLE
Do not search elements from inactive lists

### DIFF
--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -428,6 +428,7 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
                 .filter(status__in=[FacilityMatch.AUTOMATIC,
                                     FacilityMatch.CONFIRMED])
                 .filter(facility_list_item__facility_list__contributor__contrib_type__in=contributor_types) # NOQA
+                .filter(facility_list_item__facility_list__is_active=True)
                 .values('facility__id')
             ]
 
@@ -442,6 +443,7 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
                 .filter(status__in=[FacilityMatch.AUTOMATIC,
                                     FacilityMatch.CONFIRMED])
                 .filter(facility_list_item__facility_list__contributor__id__in=contributors) # NOQA
+                .filter(facility_list_item__facility_list__is_active=True)
                 .values('facility__id')
             ]
 


### PR DESCRIPTION
## Overview

Do not include results from inactive lists in search.

Connects #396 

## Demo

![image](https://user-images.githubusercontent.com/1430060/55022632-5b4c5880-4fd1-11e9-9cca-42ac5d9c2f45.png)

## Testing Instructions

* Check out this branch and `server`
* Follow the instructions in #396 to try and recreate the bug
  - [x] Ensure you see only one facility, not two