### PR TITLE
Use params dict rather than a template string for geocode requests

### DIFF
--- a/src/django/api/geocoding.py
+++ b/src/django/api/geocoding.py
@@ -4,15 +4,15 @@ import requests
 
 
 ZERO_RESULTS = "ZERO_RESULTS"
+GEOCODING_URL = "https://maps.googleapis.com/maps/api/geocode/json"
 
 
-def create_geocoding_api_url(address, country_code):
-    return (
-        "https://maps.googleapis.com/maps/api/geocode/json"
-        "?components=country:{0}"
-        "&address={1}"
-        "&key={2}"
-    ).format(country_code, address, settings.GOOGLE_SERVER_SIDE_API_KEY)
+def create_geocoding_params(address, country_code):
+    return {
+        'components': 'country:{}'.format(country_code),
+        'address': address,
+        'key': settings.GOOGLE_SERVER_SIDE_API_KEY
+    }
 
 
 def format_geocoded_address_data(data):
@@ -39,9 +39,8 @@ def format_no_geocode_results(data):
 
 
 def geocode_address(address, country_code):
-
-    request_url = create_geocoding_api_url(address, country_code)
-    r = requests.get(request_url)
+    params = create_geocoding_params(address, country_code)
+    r = requests.get(GEOCODING_URL, params=params)
 
     if r.status_code != 200:
         raise ValueError("Geocoding request failed with status"

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -18,7 +18,7 @@ from api.oar_id import make_oar_id, validate_oar_id
 from api.processing import (parse_facility_list_item,
                             geocode_facility_list_item,
                             match_facility_list_items)
-from api.geocoding import (create_geocoding_api_url,
+from api.geocoding import (create_geocoding_params,
                            format_geocoded_address_data,
                            geocode_address)
 from api.test_data import azavea_office_data, parsed_city_hall_data
@@ -359,13 +359,14 @@ class GeocodingUtilsTest(TestCase):
     def setUp(self):
         settings.GOOGLE_SERVER_SIDE_API_KEY = "world"
 
-    def test_geocoding_api_url_is_created_correctly(self):
+    def test_geocoding_params_are_created_correctly(self):
         self.assertEqual(
-            create_geocoding_api_url("hello", "US"),
-            (
-                "https://maps.googleapis.com/maps/api/geocode/json"
-                "?components=country:US&address=hello&key=world"
-            )
+            create_geocoding_params("hello", "US"),
+            {
+                'components': 'country:US',
+                'address': 'hello',
+                'key': 'world',
+            }
         )
 
     def test_geocoded_address_data_is_formatted_correctly(self):
@@ -380,7 +381,9 @@ class GeocodingTest(TestCase):
         self.assertDictEqual(geocoded_data, azavea_office_data)
 
     def test_ungeocodable_address_returns_zero_resusts(self):
-        results = geocode_address('hello world', '$#')
+        results = geocode_address('@#$^@#$^', 'XX')
+        from pprint import pprint
+        pprint(results)
         self.assertEqual(0, results['result_count'])
 
 


### PR DESCRIPTION
## Overview

An unescapped # character in the address was causing geocodes to fail. To avoid
this and other problems with URL encoding we are now making use of the `params`
argument to `requests.get`.

Connects #391

## Demo

Before

<img width="1447" alt="Screen Shot 2019-03-26 at 11 47 03 AM" src="https://user-images.githubusercontent.com/17363/55024931-1a4a4900-4fbd-11e9-9401-22dc9c73bdb7.png">

After

<img width="1454" alt="Screen Shot 2019-03-26 at 11 47 59 AM" src="https://user-images.githubusercontent.com/17363/55024940-1f0efd00-4fbd-11e9-842a-7ba9ca26cf88.png">

<img width="1343" alt="Screen Shot 2019-03-26 at 11 48 19 AM" src="https://user-images.githubusercontent.com/17363/55024948-22a28400-4fbd-11e9-907e-0317859155cf.png">

## Testing Instructions

* Start on the `develop` branch
* Run `./scripts/manage resetdb`
* Log in as c2@example.com and upload [geocode-test-list.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/3009720/geocode-test-list.csv.txt)
* Parse and geocode the list
  * ./scripts/manage batch_process --list-id 16 --action parse
  * ./scripts/manage batch_process --list-id 16 --action geocode
* Browse the list and verify that all the geocodes are errors
  * http://localhost:6543/lists/16
* Check out this PR branch
* Upload [geocode-test-list.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/3009720/geocode-test-list.csv.txt) again
* Parse and geocode the list
  * ./scripts/manage batch_process --list-id 17 --action parse
  * ./scripts/manage batch_process --list-id 17 --action geocode
* Browse the list and verify that all the geocodes succeeded
  * http://localhost:6543/lists/17
* Finish processing the list
  * ./scripts/manage batch_process --list-id 17 --action match
* Search all facilities on the map and verify that the geocodes are reasonable
