### PR TITLE
Update CHANGELOG

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,6 @@ Optional. Screenshots, `curl` examples, etc.
 
 Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
 
-
 ## Testing Instructions
 
 * How to test this PR
@@ -21,3 +20,8 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output
 
+## Checklist
+
+- [ ] `fixup!` commits have been squashed
+- [ ] CI passes after rebase
+- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## 0.1.0 - 2019-03-26
+### Added
+
+- Summary status for facility lists [#378](https://github.com/open-apparel-registry/open-apparel-registry/pull/378)
+- Environment variables for Google Analytics [#395](https://github.com/open-apparel-registry/open-apparel-registry/pull/395)
+
+### Changed
+
+- Do not show facilities from inactive lists when searching [#401](https://github.com/open-apparel-registry/open-apparel-registry/pull/401)
+- Redirect to facility list upon successful upload [#404](https://github.com/open-apparel-registry/open-apparel-registry/pull/404)
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+- Handle geocodes with unescaped `#` character [#402](https://github.com/open-apparel-registry/open-apparel-registry/pull/402)
+
+### Security
+
+## [0.1.0] - 2019-03-26
 
 ### Added
 
 - Initial release.
 
 [unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/0.1.0


### PR DESCRIPTION
## Overview

Updates the CHANGELOG with updates from #378, #401, and #404. ~I did not include #395 and #402 because they seemed like under-the-hood changes. I also did not link to the specific PRs (as I tend to for MMW https://github.com/WikiWatershed/model-my-watershed/releases/tag/1.24.0) because that wasn't indicated in the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) demo.~ And #395 and #402.

Also linked the initial release.

Also adds placeholders for all relevant sections in Unreleased.

Also updates the Pull Request Template with a checklist of pre-merge tasks, one of which is updating the CHANGELOG.

Connects #400 