### PR TITLE
Add Google Analytics tracking if and only if a user has clicked "Accept" on the notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Google Analytics which activates only upon user's explicit consent [#409](https://github.com/open-apparel-registry/open-apparel-registry/pull/409)
+
 ### Changed
 
 ### Deprecated

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -15,6 +15,7 @@
         "google-map-react": "1.1.2",
         "immutability-helper": "2.9.0",
         "lodash": "4.17.11",
+        "moment": "2.24.0",
         "prop-types": "15.6.2",
         "react": "16.7.0",
         "react-copy-to-clipboard": "5.0.1",

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
     <meta http-equiv="pragma" content="no-cache" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    
+
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon/favicon-16x16.png">
@@ -32,15 +32,25 @@
     <title>Open Apparel Registry (beta)</title>
     <!-- Environment Variables -->
     <script src="%PUBLIC_URL%/web/environment.js"></script>
-    <!-- TODO: Replace with actual Google Tag Manager snippet -->
+    <!-- Google Analytics -->
     <script>
-      if (window.ENVIRONMENT &&
-          window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY &&
-          window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY !== "" &&
-          window.ENVIRONMENT.ENVIRONMENT !== 'development') {
-        console.log(window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY);
-      }
+        if (window.ENVIRONMENT &&
+            window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY &&
+            window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY !== "") {
+            // Initially disable tracking until we check that the user has accepted the notification
+            //
+            // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
+            //
+            // We will later delete this key and start Google Analytics tracking in the application code
+            // if it is verified that the user has selected "Accept" for the Google Analytics tracking
+            // notification. See: /src/app/src/util/util.ga.js
+            //
+            // Set for every environment to ensure it is always set.
+            var disableGAKey = 'ga-disable-' + window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY;
+            window[disableGAKey] = true;
+        }
     </script>
+    <!-- End Google Analytics -->
     <!--
       Rollbar Configuration
       https://docs.rollbar.com/docs/browser-js

--- a/src/app/src/__tests__/util.ga.tests.js
+++ b/src/app/src/__tests__/util.ga.tests.js
@@ -1,0 +1,91 @@
+/* eslint-env jest */
+/* eslint-disable object-shorthand */
+/* eslint-disable func-names */
+/* eslint-disable space-before-function-paren */
+
+import {
+    userHasAcceptedOrRejectedGATracking,
+    userHasAcceptedGATracking,
+    userHasRejectedGATracking,
+    rejectGATracking,
+    acceptGATrackingAndStartTracking,
+    clearGATrackingDecision,
+    createGADisableKey,
+} from '../util/util.ga.js';
+
+beforeEach(() => {
+    const window = {};
+
+    window.localStorage = {
+        store: {},
+        getItem: function(key) {
+            return this.store[key] || null;
+        },
+        setItem: function(key, value) {
+            this.store[key] = value.toString();
+        },
+        removeItem: function(key) {
+            delete this.store[key];
+        },
+        clear: function() {
+            this.store = {};
+        },
+    };
+
+    window.ENVIRONMENT = {
+        REACT_APP_GOOGLE_ANALYTICS_KEY: 'GA_KEY',
+    };
+
+    global.window = window;
+    jest.spyOn(global.window.localStorage, 'setItem');
+});
+
+afterEach(() => {
+    window.localStorage = null;
+});
+
+it('creates a `ga-disable-ID` key for opting out of tracking', () => {
+    const expectedGADisableKey = 'ga-disable-test-key';
+    const testGAKey = 'test-key';
+
+    expect(createGADisableKey(testGAKey)).toBe(expectedGADisableKey);
+});
+
+it('correctly sets a `HAS_REJECTED_GA_TRACKING` value in localStorage', () => {
+    rejectGATracking();
+
+    expect(window.localStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('GA_TRACKING', 'HAS_REJECTED_GA_TRACKING');
+    expect(window.localStorage.getItem('GA_TRACKING')).toBe('HAS_REJECTED_GA_TRACKING');
+
+    expect(userHasAcceptedOrRejectedGATracking()).toBe(true);
+    expect(userHasRejectedGATracking()).toBe(true);
+    expect(userHasAcceptedGATracking()).toBe(false);
+});
+
+it('correctly sets a `HAS_ACCEPTED_GA_TRACKING` value in localStorage', () => {
+    acceptGATrackingAndStartTracking();
+
+    expect(window.localStorage.setItem).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('GA_TRACKING', 'HAS_ACCEPTED_GA_TRACKING');
+    expect(window.localStorage.getItem('GA_TRACKING')).toBe('HAS_ACCEPTED_GA_TRACKING');
+
+    expect(userHasAcceptedOrRejectedGATracking()).toBe(true);
+    expect(userHasAcceptedGATracking()).toBe(true);
+    expect(userHasRejectedGATracking()).toBe(false);
+});
+
+it('correctly clears a `HAS_ACCEPTED_GA_TRACKING` decision value from localStorage', () => {
+    acceptGATrackingAndStartTracking();
+
+    expect(userHasAcceptedGATracking()).toBe(true);
+
+    jest.spyOn(window.localStorage, 'removeItem');
+    clearGATrackingDecision();
+
+    expect(window.localStorage.removeItem).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('GA_TRACKING');
+
+    expect(userHasAcceptedGATracking()).toBe(false);
+    expect(userHasAcceptedOrRejectedGATracking()).toBe(false);
+});

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -8942,6 +8942,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 monotone-convex-hull-2d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz#47f5daeadf3c4afd37764baa1aa8787a40eee08c"


### PR DESCRIPTION
## Overview

This PR configures the application to add Google Analytics tracking if -- and *only* if -- a user has clicked "Accept" on the Notification. To make this easier to prove & verify, I opted to initialize the GA tracking conditionally in a utility function around which I was able to set up some testing apparatus.

If a user clicks "Reject", we set a value for `GA_TRACKING` in localStorage to `"HAS_REJECTED_GA_TRACKING"` and then that sticks until the user clears localStorage.

If a user clicks "Accept", we set a value for `GA_TRACKING` in localStorage to
`"HAS_ACCEPTED_GA_TRACKING"` and then set up tracking for that visit. On subsequent visits, the application will check for the `GA_TRACKING` value and if it sees that there is a value *AND* that that value is `"HAS_ACCEPTED_GA_TRACKING"` then tracking starts.

For the following conditions, the application does not start GA Tracking at all:

- `window.localStorage` is unavailable for whatever reason
- `GA_TRACKING` has not been set at all in `window.localStorage`
- `GA_TRACKING` is in `window.localStorage` but does not have a value of `"HAS_ACCEPTED_GA_TRACKING"`.

As an additional guard, I set an initial global opt out value per https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out which is only deleted when all the acceptance conditions have been met.

Connects #265 
Connects #267

## Demo

![Screen Shot 2019-03-27 at 12 40 56 PM](https://user-images.githubusercontent.com/4165523/55094865-957b3000-508d-11e9-98fa-897d6540fc1d.png)

## Notes

The second commit here is entirely for testing and I will drop it before merging this in. GA provides a helpful debug library which logs actions to the console so you can easily see when it is called.

## Testing Instructions

- serve this branch, then visit the application in Chrome
- clear your cookies and your localStorage
- refresh the page and verify that you see the new GDPR notification in the Snackbar
- open the network tab

#### Rejection testing

- click "Reject"
- verify that you do not see any requests made to google analytics in the network tab
- switch to the console and verify that you *DO NOT* see a message like the following logged amidst the Redux logger actions:

![Screen Shot 2019-03-27 at 12 44 32 PM](https://user-images.githubusercontent.com/4165523/55095199-19cdb300-508e-11e9-80aa-9d789e040ee2.png)

- look at the application cookies and verify that no Google Analytics cookies have been set
- refresh the page and repeat these verification steps
- refresh a couple more times and repeat these verification steps

At no point prior to "Accepting" or after "Rejecting" should you see:

- requests made to Google Analytics in the Network tab
- cookies set by Google Anayltics


#### Acceptance testing

- clear cookies and localStorage
- refresh the app and click Accept
- verify that you do see a request made to GA in the network tab and that you also see something like this in the console with subequent info about settings:

![Screen Shot 2019-03-27 at 12 44 32 PM](https://user-images.githubusercontent.com/4165523/55095392-70d38800-508e-11e9-9188-fa147f5449b2.png)

- verify that you see this in the console and that that instruction matches the guidance here: https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization

![Screen Shot 2019-03-27 at 12 47 20 PM](https://user-images.githubusercontent.com/4165523/55095461-9365a100-508e-11e9-9398-36fefc7e872a.png)

- refresh the page and verify that you see the Google Analytics stuff load again along with the `"anonymizeIp"` setting 
- refresh the page again and verify the same

##### No localStorage testing

- open Firefox, then open `about:config`
- Follow these instructions to disable localStorage:

```
In FireFox: Type “about:config” in your address bar and hit enter to view your internal browser settings. Scroll down to „dom.storage.enabled”, right click on it and hit „Toggle” to disable the DOM Storage.
```

- visit the application in Firefox and verify that it doesn't crash and that Google Analytics tracking does not start

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
