### PR TITLE
Remove (beta) from page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Remove `"(beta)"` from page title [#418](https://github.com/open-apparel-registry/open-apparel-registry/pull/418)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Open Apparel Registry (beta)</title>
+    <title>Open Apparel Registry</title>
     <!-- Environment Variables -->
     <script src="%PUBLIC_URL%/web/environment.js"></script>
     <!-- Google Analytics -->


### PR DESCRIPTION
## Overview

Remove `(beta)` from page title.

Connects #415

## Demo

![Screen Shot 2019-03-28 at 10 55 51 AM](https://user-images.githubusercontent.com/4165523/55167845-15fe6700-5148-11e9-822d-4758ee9fe9b4.png)

## Testing Instructions

- ./scripts/server and verify that you don't see beta in the page title when you visit 6543
- ./scripts/cibuild and visit 8081 to verify you also don't see it there

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
