### PR TITLE
Filter out contributors with no active and public lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Filter contributors with no active and public lists from contributors search dropdown [#430](https://github.com/open-apparel-registry/open-apparel-registry/pull/430)
 - Remove `"(beta)"` from page title [#418](https://github.com/open-apparel-registry/open-apparel-registry/pull/418)
 
 ### Deprecated

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -259,7 +259,7 @@ class APIAuthToken(ObtainAuthToken):
 @permission_classes((AllowAny,))
 def all_contributors(request):
     """
-    Returns a list of contributors as tuples of contributor IDs and names.
+    Returns list contributors as a list of tuples of contributor IDs and names.
 
     ## Sample Response
 
@@ -271,8 +271,11 @@ def all_contributors(request):
     response_data = [
         (contributor.id, contributor.name)
         for contributor
-        in Contributor.objects.all().order_by('name')
+        in Contributor.objects.filter(
+            facilitylist__is_active=True,
+            facilitylist__is_public=True).order_by('name')
     ]
+
     return Response(response_data)
 
 


### PR DESCRIPTION
## Overview

Update the contributors endpoint to filter out contributors with

- no lists
- no active lists
- no public lists

Continue displaying contributors with active, public lists that have no matches.

Add test for contributors list endpoint.

Connects https://github.com/open-apparel-registry/open-apparel-registry/issues/413

## Testing Instructions

- `./scripts/manage resetdb`
- `./scripts/server` then visit the app and register for a new account
- confirm your account
- visit the search page and check the search box and verify that you do not see your contributor name listed among the available options
- upload a list then return to the search page and refresh the page to verify that you do see your name listed among the available options
- run the tests to verify that they pass

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
