### PR TITLE
Raise 400 error for invalid contributor param type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Return 400/Bad Request error for /api/facilities request with invalid contributor parameter type. [#433](https://github.com/open-apparel-registry/open-apparel-registry/pull/433)
+
 ### Security
 
 ## [2.0.0] - 2019-03-27

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -6,9 +6,11 @@ from django.contrib.auth import password_validation
 from django.urls import reverse
 from rest_framework.serializers import (CharField,
                                         EmailField,
+                                        IntegerField,
                                         ModelSerializer,
                                         SerializerMethodField,
-                                        ValidationError)
+                                        ValidationError,
+                                        Serializer)
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from rest_auth.serializers import (PasswordResetSerializer,
                                    PasswordResetConfirmSerializer)
@@ -176,6 +178,15 @@ class FacilityListSerializer(ModelSerializer):
         return (facility_list.facilitylistitem_set
                 .values_list('status', flat=True)
                 .distinct())
+
+
+class FacilityQueryParamsSerializer(Serializer):
+    name = CharField(required=False)
+    contributors = IntegerField(required=False)
+    contributor_types = CharField(required=False)
+    countries = CharField(required=False)
+    page = IntegerField(required=False)
+    pageSize = IntegerField(required=False)
 
 
 class FacilitySerializer(GeoFeatureModelSerializer):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -38,6 +38,7 @@ from api.models import (FacilityList,
 from api.processing import parse_csv_line
 from api.serializers import (FacilityListSerializer,
                              FacilityListItemSerializer,
+                             FacilityQueryParamsSerializer,
                              FacilitySerializer,
                              FacilityDetailsSerializer,
                              UserSerializer,
@@ -404,10 +405,16 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
                 ]
             }
         """
+        params = FacilityQueryParamsSerializer(data=request.query_params)
+
+        if not params.is_valid():
+            raise ValidationError(params.errors)
+
         name = request.query_params.get(FacilitiesQueryParams.NAME,
                                         None)
         contributors = request.query_params \
                               .getlist(FacilitiesQueryParams.CONTRIBUTORS)
+
         contributor_types = request \
             .query_params \
             .getlist(FacilitiesQueryParams.CONTRIBUTOR_TYPES)


### PR DESCRIPTION
## Overview

Raise a 400 error if not all of the contributor querystring parameters
are integers, sending back a detailed error response about the type.

The other custom parameters already expect strings, so they don't fail
in the same way, and the pagination params have their own error
handling. Therefore we don't need to add similar handling to the other
errors.

Connects #424 

## Demo

![Screen Shot 2019-03-28 at 4 25 35 PM](https://user-images.githubusercontent.com/4165523/55190458-31806680-5176-11e9-8afb-041aeed7b566.png)

![Screen Shot 2019-03-28 at 4 25 48 PM](https://user-images.githubusercontent.com/4165523/55190445-2decdf80-5176-11e9-91d5-2f01d0db79e1.png)

## Testing Instructions

- resetdb then processfixtures
- serve this branch
- visit http://localhost:8081/api/docs/#!/facilities/facilities_list and try entering a string value in the contributors input, then search and verify that it returns 400
- change the string value to and int, like 2, and verify that it returns 200 and that you see a FeatureCollection
- visit the main app on 6543 then search for facilities in various ways and verify that that also still works

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
