### PR TITLE
Return 400 if any query params in list is of invalid type

### DIFF
--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from rest_framework.serializers import (CharField,
                                         EmailField,
                                         IntegerField,
+                                        ListField,
                                         ModelSerializer,
                                         SerializerMethodField,
                                         ValidationError,
@@ -182,9 +183,18 @@ class FacilityListSerializer(ModelSerializer):
 
 class FacilityQueryParamsSerializer(Serializer):
     name = CharField(required=False)
-    contributors = IntegerField(required=False)
-    contributor_types = CharField(required=False)
-    countries = CharField(required=False)
+    contributors = ListField(
+        child=IntegerField(required=False),
+        required=False,
+    )
+    contributor_types = ListField(
+        child=CharField(required=False),
+        required=False,
+    )
+    countries = ListField(
+        child=CharField(required=False),
+        required=False,
+    )
     page = IntegerField(required=False)
     pageSize = IntegerField(required=False)
 


### PR DESCRIPTION
## Overview

Fixes a bug discovered in #430 whereby a list of queryparamters would
not typecheck correctly.

Connects #424 

## Demo

```
$ planck
cljs.user=> (require '[planck.http])
nil
cljs.user=> (-> (planck.http/get "http://localhost:8081/api/facilities/?contributors=6&contributors=8") (select-keys [:status]))                                                                                                      
{:status 200}
cljs.user=> (-> (planck.http/get "http://localhost:8081/api/facilities/?contributors=6&contributors=eight") (select-keys [:status]))                                                                                                  
{:status 400}
cljs.user=> (-> (planck.http/get "http://localhost:8081/api/facilities/?contributors=6") (select-keys [:status]))
{:status 200}
cljs.user=> (-> (planck.http/get "http://localhost:8081/api/facilities/") (select-keys [:status]))
{:status 200}
```

## Testing Instructions

- resetdb then processfixtures
- serve this branch
- visit http://localhost:8081/api/docs/#!/facilities/facilities_list and try entering a string value in the contributors input, then search and verify that it returns 400
 - change the string value to and int, like 2, and verify that it returns 200 and that you see a FeatureCollection
 - visit the main app on 6543 then search for facilities in various ways and verify that that also still works
- use httpie or insomnia or curl or planck or whatever to verify that the changes here fix the bug https://github.com/open-apparel-registry/open-apparel-registry/pull/433 described in your comment

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
