### PR TITLE
Add space between 'OAR' and 'for'

### DIFF
--- a/src/app/src/components/AboutProcessing.jsx
+++ b/src/app/src/components/AboutProcessing.jsx
@@ -25,7 +25,7 @@ export default () => (
 
                     <h2 id="Uploading-a-list">Uploading a list</h2>
 
-                    <p>Contributors submit their facility lists to the OARfor processing by uploading
+                    <p>Contributors submit their facility lists to the OAR for processing by uploading
                         lists in comma-separated value (CSV) format. All popular spreadsheet programs,
                         including Microsoft Excel, can save a sheet in CSV format. The OAR provides a
                         downloadable template, but any CSV can be read and processed if it meets the


### PR DESCRIPTION
## Overview

Fix a typo in the AboutProcessing component by placing a space between "OAR" and "for".

Connects #434 

## Demo

<img width="457" alt="Screen Shot 2019-03-29 at 12 54 51 PM" src="https://user-images.githubusercontent.com/4165523/55249176-dc9a2a00-5221-11e9-8241-259ab45f9b8e.png">

## Testing Instructions

- look at the change and verify that there is now a space between "OAR" and "for"

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
