### PR TITLE
Set non-confirmed/no-geocoding results error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Set ERROR_MATCHING status to non-geocoded list items for which all potential matches have been rejected [#437](https://github.com/open-apparel-registry/open-apparel-registry/pull/437)
 - Return 400/Bad Request error for /api/facilities request with invalid contributor parameter type. [#433](https://github.com/open-apparel-registry/open-apparel-registry/pull/433)
 - Avoid unhandled exception when matching a list with no geocoded items [#439](https://github.com/open-apparel-registry/open-apparel-registry/pull/439)
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -11,6 +11,7 @@ class ProcessingAction:
     GEOCODE = 'geocode'
     MATCH = 'match'
     SUBMIT_JOB = 'submitjob'
+    CONFIRM = 'confirm'
 
 
 class FacilitiesQueryParams:


### PR DESCRIPTION
## Overview

For list items for which no geocoding results have been created and
all proposed matches have been rejected, set the status to
ERROR_MATCHING and do not attempt to create a new facility on rejecting
the last remaining potential match

Connects #410 

## Notes

In the demo example, I did not see any error messages listed. Presumably these will be set via the geocoding error -- but if not, I can add a commit to push a new error result into the `processing_results` array.

## Testing Instructions

- serve this branch
- try to recreate the bug via the instructions on #410 
- verify that the IntegrityError does not occur

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
