### PR TITLE
Add http:// protocol to profile website if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Add protocol to contributor website if mising [#445](https://github.com/open-apparel-registry/open-apparel-registry/pull/445)
 - Rename "Account Name" and "Account Description" registration form fields to "Contributor Name" and "Account Description" [#444](https://github.com/open-apparel-registry/open-apparel-registry/pull/444)
 - Filter contributors with no active and public lists from contributors search dropdown [#430](https://github.com/open-apparel-registry/open-apparel-registry/pull/430)
 - Remove `"(beta)"` from page title [#418](https://github.com/open-apparel-registry/open-apparel-registry/pull/418)

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -56,6 +56,7 @@ const {
     makeFacilityListItemsRetrieveCSVItemsURL,
     makeFacilityListDataURLs,
     makeFacilityListSummaryStatus,
+    addProtocolToWebsiteURLIfMissing,
 } = require('../util/util');
 
 const {
@@ -1078,4 +1079,24 @@ it('creates a summary status message given a list of facility list item statuses
         ]),
         `${facilityListSummaryStatusMessages.AWAITING} ${facilityListSummaryStatusMessages.ERROR}`,
     )).toBe(true);
+});
+
+it('adds a protocol to a website URL if the protocol is missing, but not if it is there', () => {
+    const urlWithHTTP = 'http://example.com';
+    const expectedResultForURLWithHTTP = 'http://example.com';
+
+    expect(addProtocolToWebsiteURLIfMissing(urlWithHTTP))
+        .toBe(expectedResultForURLWithHTTP);
+
+    const urlWithHTTPS = 'https://example.com';
+    const expectedResultForURLWithHTTPS = 'https://example.com';
+
+    expect(addProtocolToWebsiteURLIfMissing(urlWithHTTPS))
+        .toBe(expectedResultForURLWithHTTPS);
+
+    const urlWithNoProtocol = 'example.com';
+    const expectedResultForURLWithNoProtocol = 'http://example.com';
+
+    expect(addProtocolToWebsiteURLIfMissing(urlWithNoProtocol))
+        .toBe(expectedResultForURLWithNoProtocol);
 });

--- a/src/app/src/components/UserProfileField.jsx
+++ b/src/app/src/components/UserProfileField.jsx
@@ -11,6 +11,8 @@ import {
     contributorTypeOptions,
 } from '../util/constants';
 
+import { addProtocolToWebsiteURLIfMissing } from '../util/util';
+
 const userProfileFieldStyles = Object.freeze({
     viewOnlyStyles: Object.freeze({
         padding: '1rem 0',
@@ -64,7 +66,7 @@ export default function UserProfileField({
                             id === registrationFieldsEnum.website
                                 ? (
                                     <a
-                                        href={value}
+                                        href={addProtocolToWebsiteURLIfMissing(value)}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                     >

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -482,3 +482,15 @@ export const makeFacilityListSummaryStatus = (statuses) => {
             ${awaitingMessage}
             ${errorMessage}`.replace(/\s+/g, ' ').trim();
 };
+
+export const addProtocolToWebsiteURLIfMissing = (url) => {
+    if (startsWith(url, 'http://')) {
+        return url;
+    }
+
+    if (startsWith(url, 'https://')) {
+        return url;
+    }
+
+    return `http://${url}`;
+};


### PR DESCRIPTION
 ## Overview

If the website url provided for the contributor profile page does not
include https or http prefix, add "http://" to ensure the link works,
letting the user's browser handle the redirect

Connects #438 

## Demo

![Screen Shot 2019-04-01 at 11 46 26 AM](https://user-images.githubusercontent.com/4165523/55341033-e3b87680-5473-11e9-976e-77fffb55d311.png)

## Testing Instructions

- register for an account and use `azavea.com` as the website
- while signed out, visit the profile page and verify that the azavea.com link works
- sign in and update the link to `https://azavea.com`
- sign out and visit your profile page again
- verify that the link still works

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
