### PR TITLE
Enable FacilitiesMap to crash without crashing the rest of the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Add a new error boundary to enable the FacilitiesMap component to crash without crashing the rest of the app [#446](https://github.com/open-apparel-registry/open-apparel-registry/pull/446)
+
 ### Security
 
 ## [2.1.0] - 2019-04-01

--- a/src/app/src/components/FacilitiesMapErrorMessage.jsx
+++ b/src/app/src/components/FacilitiesMapErrorMessage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+const mapErrorMessageStyles = Object.freeze({
+    errorMessageContainerStyles: Object.freeze({
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    }),
+});
+
+export default function FacilitiesMapErrorMessage() {
+    return (
+        <div style={mapErrorMessageStyles.errorMessageContainerStyles}>
+            <Typography variant="title">
+                An error prevented loading the map.
+            </Typography>
+        </div>
+    );
+}

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -1,10 +1,11 @@
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 
 import FilterSidebar from './FilterSidebar';
 import FacilityDetailsSidebar from './FacilityDetailSidebar';
 import FacilitiesMap from './FacilitiesMap';
+import FacilitiesMapErrorMessage from './FacilitiesMapErrorMessage';
 
 import '../styles/css/Map.css';
 
@@ -12,41 +13,65 @@ import withQueryStringSync from '../util/withQueryStringSync';
 
 import { facilityDetailsRoute } from '../util/constants';
 
-function MapAndSidebar() {
-    return (
-        <Fragment>
-            <Grid container className="map-sidebar-container">
-                <Grid
-                    item
-                    xs={12}
-                    sm={4}
-                    id="panel-container"
-                >
-                    <Switch>
-                        <Route
-                            path={facilityDetailsRoute}
-                            component={FacilityDetailsSidebar}
-                        />
-                        <Route component={FilterSidebar} />
-                    </Switch>
+class MapAndSidebar extends Component {
+    state = { hasError: false };
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error) {
+        if (window.Rollbar) {
+            window.Rollbar.error(error);
+        }
+    }
+
+    render() {
+        return (
+            <Fragment>
+                <Grid container className="map-sidebar-container">
+                    <Grid
+                        item
+                        xs={12}
+                        sm={4}
+                        id="panel-container"
+                    >
+                        <Switch>
+                            <Route
+                                path={facilityDetailsRoute}
+                                component={FacilityDetailsSidebar}
+                            />
+                            <Route component={FilterSidebar} />
+                        </Switch>
+                    </Grid>
+                    <Grid
+                        item
+                        xs={12}
+                        sm={8}
+                        style={{ position: 'relative' }}
+                    >
+                        <Switch>
+                            <Route
+                                path={facilityDetailsRoute}
+                                component={
+                                    this.state.hasError
+                                        ? FacilitiesMapErrorMessage
+                                        : FacilitiesMap
+                                }
+                            />
+                            <Route
+                                component={
+                                    this.state.hasError
+                                        ? FacilitiesMapErrorMessage
+                                        : FacilitiesMap
+                                }
+                            />
+                        </Switch>
+                    </Grid>
                 </Grid>
-                <Grid
-                    item
-                    xs={12}
-                    sm={8}
-                    style={{ position: 'relative' }}
-                >
-                    <Switch>
-                        <Route
-                            path={facilityDetailsRoute}
-                            component={FacilitiesMap}
-                        />
-                        <Route component={FacilitiesMap} />
-                    </Switch>
-                </Grid>
-            </Grid>
-        </Fragment>
-    );
+            </Fragment>
+        );
+    }
 }
 
 export default withQueryStringSync(MapAndSidebar);


### PR DESCRIPTION
## Overview

Place a new error boundary in the MapAndSidebar component which will enable to map to crash for whatever reason without crashing the entire app. Map errors are logged to Rollbar conditionally using the same mechanism we use in the ErrorBoundary component, and application crashes issuing from elsewhere still take down the app and get caught by the ErrorBoundary.

Second commit here is just for testing and demos what happens when the map crashes when trying to render.  You can also try out throwing an error in its `componentDidUpdate` method with similar effect.

Connects #443 

## Demo

<img width="957" alt="Screen Shot 2019-04-01 at 1 06 16 PM" src="https://user-images.githubusercontent.com/4165523/55346862-70b5fc80-5481-11e9-9dd9-07ad8095edea.png">

## Testing Instructions

- serve this branch, then load the application and verify that you see the error thrown in the console and the UI updated as depicted above to handle the map crash
- add an error in the FilterSidebar component's `render` method and verify that that error does take down the whole app and that you see the standard error message UI displayed

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
