### PR TITLE
Update release checklist to keep default commit messages

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -32,7 +32,7 @@ $ git rev-parse --short HEAD
 $ ./scripts/manage.py ecsmanage -e production migrate
 ```
 - [ ] Finish and publish the release branch:
-    - When prompted, use `X.Y.Z` as the merge commit message
+    - When prompted, keep default commit messages
     - Use `X.Y.Z` as the tag message
 ```bash
 $ git flow release finish -p X.Y.Z 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Update release checklist to keep default commit messages [#451](https://github.com/open-apparel-registry/open-apparel-registry/pull/451)
 
 ### Deprecated
 


### PR DESCRIPTION
We should keep the default commit messages instead of overriding them. 

<img width="332" alt="image" src="https://user-images.githubusercontent.com/1774125/55417475-c69caa00-553e-11e9-8d3d-458d0d79433d.png">

vs 

<img width="306" alt="image" src="https://user-images.githubusercontent.com/1774125/55417498-cf8d7b80-553e-11e9-9f73-10fe0c3ea11a.png">

There was a miscommunication at first, we just want to make sure that the body of the "merge tag" commit contains the tag, which it already does by default.