### PR TITLE
Ensure that the contributors API returns distinct values

### DIFF
--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -1026,6 +1026,7 @@ class ContributorsListAPIEndpointTests(TestCase):
 
         self.country_code = 'US'
         self.list_one_name = 'one'
+        self.list_one_b_name = 'one-b'
         self.list_three_name = 'three'
         self.list_four_name = 'four'
 
@@ -1063,6 +1064,15 @@ class ContributorsListAPIEndpointTests(TestCase):
             .create(header="header",
                     file_name="one",
                     name=self.list_one_name,
+                    is_active=True,
+                    is_public=True,
+                    contributor=self.contrib_one)
+
+        self.list_one_b = FacilityList \
+            .objects \
+            .create(header="header",
+                    file_name="one-b",
+                    name=self.list_one_b_name,
                     is_active=True,
                     is_public=True,
                     contributor=self.contrib_one)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -278,7 +278,7 @@ def all_contributors(request):
         for contributor
         in Contributor.objects.filter(
             facilitylist__is_active=True,
-            facilitylist__is_public=True).order_by('name')
+            facilitylist__is_public=True).distinct().order_by('name')
     ]
 
     return Response(response_data)


### PR DESCRIPTION
## Overview

Contributors were appearing in the search box multiple times when they had
multiple active lists.

Connects #452 

## Testing Instructions

* `./scripts/manage resetdb` and `./scripts/manage processfixtures`
* On the home page verify that `Factory A` appears once.
* Log in as `c2@example.com`
* Upload a list
* Refresh the home page and verify that `Factory A` still appears one.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
