### PR TITLE
Add encrypted RDS database and supporting security groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Update release checklist to keep default commit messages [#451](https://github.com/open-apparel-registry/open-apparel-registry/pull/451)
+- Add support for encrypted RDS for PostgreSQL storage [#461](https://github.com/open-apparel-registry/open-apparel-registry/pull/461)
 
 ### Deprecated
 

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -54,7 +54,7 @@ data "template_file" "default_job_definition" {
     image_url = "${module.ecr_repository_batch.repository_url}:${var.image_tag}"
 
     postgres_host     = "${aws_route53_record.database.name}"
-    postgres_port     = "${module.database.port}"
+    postgres_port     = "${module.database_enc.port}"
     postgres_user     = "${var.rds_database_username}"
     postgres_password = "${var.rds_database_password}"
     postgres_db       = "${var.rds_database_name}"

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -105,7 +105,7 @@ data "template_file" "app" {
     memory = "${var.app_fargate_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
-    postgres_port     = "${module.database.port}"
+    postgres_port     = "${module.database_enc.port}"
     postgres_user     = "${var.rds_database_username}"
     postgres_password = "${var.rds_database_password}"
     postgres_db       = "${var.rds_database_name}"
@@ -152,7 +152,7 @@ data "template_file" "app_cli" {
     memory = "${var.cli_fargate_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
-    postgres_port     = "${module.database.port}"
+    postgres_port     = "${module.database_enc.port}"
     postgres_user     = "${var.rds_database_username}"
     postgres_password = "${var.rds_database_password}"
     postgres_db       = "${var.rds_database_name}"

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -2,7 +2,7 @@
 # RDS resources
 #
 resource "aws_db_subnet_group" "default" {
-  name        = "${var.rds_database_identifier}"
+  name        = "${replace(var.rds_database_identifier, "-enc", "")}"
   description = "Private subnets for the RDS instances"
   subnet_ids  = ["${module.vpc.private_subnet_ids}"]
 
@@ -14,7 +14,7 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_parameter_group" "default" {
-  name        = "${var.rds_database_identifier}"
+  name        = "${replace(var.rds_database_identifier, "-enc", "")}"
   description = "Parameter group for the RDS instances"
   family      = "${var.rds_parameter_group_family}"
 
@@ -65,8 +65,8 @@ resource "aws_db_parameter_group" "default" {
   }
 }
 
-module "database" {
-  source = "github.com/azavea/terraform-aws-postgresql-rds?ref=2.6.0"
+module "database_enc" {
+  source = "github.com/azavea/terraform-aws-postgresql-rds?ref=2.5.0"
 
   vpc_id                     = "${module.vpc.id}"
   allocated_storage          = "${var.rds_allocated_storage}"
@@ -88,7 +88,6 @@ module "database" {
   storage_encrypted          = "${var.rds_storage_encrypted}"
   subnet_group               = "${aws_db_subnet_group.default.name}"
   parameter_group            = "${aws_db_parameter_group.default.name}"
-  monitoring_interval        = "${var.rds_monitoring_interval}"
 
   alarm_cpu_threshold                = "${var.rds_cpu_threshold_percent}"
   alarm_disk_queue_threshold         = "${var.rds_disk_queue_threshold}"

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -20,7 +20,7 @@ resource "aws_route53_record" "database" {
   name    = "database.service.${var.r53_private_hosted_zone}"
   type    = "CNAME"
   ttl     = "10"
-  records = ["${module.database.hostname}"]
+  records = ["${module.database_enc.hostname}"]
 }
 
 #

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -21,14 +21,14 @@ resource "aws_security_group_rule" "bastion_ssh_egress" {
   security_group_id = "${module.vpc.bastion_security_group_id}"
 }
 
-resource "aws_security_group_rule" "bastion_rds_egress" {
+resource "aws_security_group_rule" "bastion_rds_enc_egress" {
   type      = "egress"
-  from_port = "${module.database.port}"
-  to_port   = "${module.database.port}"
+  from_port = "${module.database_enc.port}"
+  to_port   = "${module.database_enc.port}"
   protocol  = "tcp"
 
   security_group_id        = "${module.vpc.bastion_security_group_id}"
-  source_security_group_id = "${module.database.database_security_group_id}"
+  source_security_group_id = "${module.database_enc.database_security_group_id}"
 }
 
 resource "aws_security_group_rule" "bastion_app_egress" {
@@ -90,33 +90,33 @@ resource "aws_security_group_rule" "alb_app_egress" {
 #
 # RDS security group resources
 #
-resource "aws_security_group_rule" "rds_app_ingress" {
+resource "aws_security_group_rule" "rds_enc_app_ingress" {
   type      = "ingress"
-  from_port = "${module.database.port}"
-  to_port   = "${module.database.port}"
+  from_port = "${module.database_enc.port}"
+  to_port   = "${module.database_enc.port}"
   protocol  = "tcp"
 
-  security_group_id        = "${module.database.database_security_group_id}"
+  security_group_id        = "${module.database_enc.database_security_group_id}"
   source_security_group_id = "${aws_security_group.app.id}"
 }
 
-resource "aws_security_group_rule" "rds_batch_ingress" {
+resource "aws_security_group_rule" "rds_enc_batch_ingress" {
   type      = "ingress"
-  from_port = "${module.database.port}"
-  to_port   = "${module.database.port}"
+  from_port = "${module.database_enc.port}"
+  to_port   = "${module.database_enc.port}"
   protocol  = "tcp"
 
-  security_group_id        = "${module.database.database_security_group_id}"
+  security_group_id        = "${module.database_enc.database_security_group_id}"
   source_security_group_id = "${aws_security_group.batch.id}"
 }
 
-resource "aws_security_group_rule" "rds_bastion_ingress" {
+resource "aws_security_group_rule" "rds_enc_bastion_ingress" {
   type      = "ingress"
-  from_port = "${module.database.port}"
-  to_port   = "${module.database.port}"
+  from_port = "${module.database_enc.port}"
+  to_port   = "${module.database_enc.port}"
   protocol  = "tcp"
 
-  security_group_id        = "${module.database.database_security_group_id}"
+  security_group_id        = "${module.database_enc.database_security_group_id}"
   source_security_group_id = "${module.vpc.bastion_security_group_id}"
 }
 
@@ -134,14 +134,14 @@ resource "aws_security_group_rule" "app_https_egress" {
   security_group_id = "${aws_security_group.app.id}"
 }
 
-resource "aws_security_group_rule" "app_rds_egress" {
+resource "aws_security_group_rule" "app_rds_enc_egress" {
   type      = "egress"
-  from_port = "${module.database.port}"
-  to_port   = "${module.database.port}"
+  from_port = "${module.database_enc.port}"
+  to_port   = "${module.database_enc.port}"
   protocol  = "tcp"
 
   security_group_id        = "${aws_security_group.app.id}"
-  source_security_group_id = "${module.database.database_security_group_id}"
+  source_security_group_id = "${module.database_enc.database_security_group_id}"
 }
 
 resource "aws_security_group_rule" "app_alb_ingress" {
@@ -177,14 +177,14 @@ resource "aws_security_group_rule" "batch_https_egress" {
   security_group_id = "${aws_security_group.batch.id}"
 }
 
-resource "aws_security_group_rule" "batch_rds_egress" {
+resource "aws_security_group_rule" "batch_rds_enc_egress" {
   type      = "egress"
-  from_port = "${module.database.port}"
-  to_port   = "${module.database.port}"
+  from_port = "${module.database_enc.port}"
+  to_port   = "${module.database_enc.port}"
   protocol  = "tcp"
 
   security_group_id        = "${aws_security_group.batch.id}"
-  source_security_group_id = "${module.database.database_security_group_id}"
+  source_security_group_id = "${module.database_enc.database_security_group_id}"
 }
 
 resource "aws_security_group_rule" "batch_bastion_ingress" {


### PR DESCRIPTION
## Overview

Create an additional RDS database with encrypted storage. Include all of the supporting security group resources to facilitate communication to it.

In addition, downgrade the Terraform RDS module to a version that does not support enhanced monitoring (the IAM role names collide) and mark all of the prior security groups for deletion.

Connects https://github.com/open-apparel-registry/open-apparel-registry/issues/412

## Demo

Navigate to https://staging.openapparel.org/ (it is currently pointed at the encrypted database).

## Testing Instructions

- Connect to the `openapparelregistry-enc-stg` database instance in a `psql` session

```console
$ psql -h openapparelregistry-enc-stg.ctdp4povekhv.eu-west-1.rds.amazonaws.com \
       -U openapparelregistry -d openapparelregistry
psql (11.2, server 10.6)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.
```

- Next, drop the `openapparelregistry` database

```sql
openapparelregistry=> \c postgres
psql (11.2, server 10.6)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
You are now connected to database "postgres" as user "openapparelregistry".
postgres=> DROP DATABASE openapparelregistry;
```

- Then, execute the following scripts to
  - Stop running ECS tasks
  - Migrate the contents of `openapparelregistry-stg` to `openapparelregistry-enc-stg`
  - Update the database private DNS record

(You should see a `postgis` extension error like the one below.)

```console
$ export PGPASSWORD=...
$ ./migrate-database.sh
```

`migrate-database.sh`

```bash
#!/bin/bash

set -x

# Stop all currently running ECS tasks to avoid writing
# data to the unencrypted database prior to the migration.
aws ecs list-tasks --output text --cluster ecsProductionCluster \
  | awk '{ print $2 }' \
  | xargs -n1 -I{} aws ecs stop-task --cluster ecsProductionCluster --task {}

# Disable background task queuing.
aws batch update-job-queue --job-queue queueProductionDefault --state DISABLED

# Pipe the contents of the existing staging database to
# an encrypted version via pg_dump/pg_restore.
pg_dump -Fc -h openapparelregistry-prd.ctdp4povekhv.eu-west-1.rds.amazonaws.com \
    -U openapparelregistry -T "geo*" -T "raster*" -T "spatial*" \
    -d openapparelregistry \
  | pv -t \
  | pg_restore -Fc -C -h openapparelregistry-enc-prd.ctdp4povekhv.eu-west-1.rds.amazonaws.com \
               -U openapparelregistry -d postgres &> >(tee restore.log)

# Update the internal database service DNS record
aws route53 change-resource-record-sets --hosted-zone-id Z29JIX2RSQCMTJ \
   --change-batch file:///home/ec2-user/change-resource-record-sets.json

# Enable background task queuing.
aws batch update-job-queue --job-queue queueProductionDefault --state ENABLED
```

`change-resource-record-sets.json`

```json
{
  "Changes": [
    {
      "Action": "UPSERT",
      "ResourceRecordSet": {
        "Name": "database.service.oar.internal",
        "Type": "CNAME",
        "TTL": 10,
        "ResourceRecords": [
          {
            "Value": "openapparelregistry-enc-prd.ctdp4povekhv.eu-west-1.rds.amazonaws.com"
          }
        ]
      }
    }
  ]
}
```

- Finally, execute the following SQL query against both database instances

```sql
SELECT schemaname,relname,n_live_tup
FROM pg_stat_user_tables
ORDER BY n_live_tup DESC, relname;
```

- Ensure that the counts line up

`openapparelregistry-stg`

```
 schemaname |            relname            | n_live_tup
------------+-------------------------------+------------
 public     | api_facilitylistitem          |      11094
 public     | api_facilitymatch             |      10339
 public     | api_facility                  |       9023
 public     | spatial_ref_sys               |       5757
 public     | api_user                      |         64
 public     | api_contributor               |         60
 public     | django_session                |         58
 public     | auth_permission               |         54
 public     | account_emailaddress          |         42
 public     | api_facilitylist              |         39
 public     | django_migrations             |         27
 public     | django_admin_log              |         19
 public     | django_content_type           |         18
 public     | django_site                   |          1
 public     | account_emailconfirmation     |          0
 public     | api_user_groups               |          0
 public     | api_user_user_permissions     |          0
 public     | auth_group                    |          0
 public     | auth_group_permissions        |          0
 public     | authtoken_token               |          0
 public     | socialaccount_socialaccount   |          0
 public     | socialaccount_socialapp       |          0
 public     | socialaccount_socialapp_sites |          0
 public     | socialaccount_socialtoken     |          0
(24 rows)
```

`openapparelregistry-enc-stg`

```
 schemaname |            relname            | n_live_tup
------------+-------------------------------+------------
 public     | api_facilitylistitem          |      11094
 public     | api_facilitymatch             |      10339
 public     | api_facility                  |       9023
 public     | spatial_ref_sys               |       5757
 public     | api_user                      |         64
 public     | api_contributor               |         60
 public     | django_session                |         58
 public     | auth_permission               |         54
 public     | account_emailaddress          |         42
 public     | api_facilitylist              |         39
 public     | django_migrations             |         27
 public     | django_admin_log              |         19
 public     | django_content_type           |         18
 public     | django_site                   |          1
 public     | account_emailconfirmation     |          0
 public     | api_user_groups               |          0
 public     | api_user_user_permissions     |          0
 public     | auth_group                    |          0
 public     | auth_group_permissions        |          0
 public     | authtoken_token               |          0
 public     | socialaccount_socialaccount   |          0
 public     | socialaccount_socialapp       |          0
 public     | socialaccount_socialapp_sites |          0
 public     | socialaccount_socialtoken     |          0
(24 rows)
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
