### PR TITLE
 Add optional password reset fields to the profile form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Password can be changed from the profile page [#469](https://github.com/open-apparel-registry/open-apparel-registry/pull/469)
 
 ### Changed
 - Update release checklist to keep default commit messages [#451](https://github.com/open-apparel-registry/open-apparel-registry/pull/451)

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -119,6 +119,9 @@ li.dropdown-list-item button {
 .form__field {
   margin-bottom: 32px;
 }
+.form__field-header {
+    margin-bottom: 32px;
+}
 .form__field--dense {
   margin-bottom: 16px;
 }

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -138,6 +138,7 @@ class UserProfile extends Component {
                     key={field.id}
                     id={field.id}
                     label={field.label}
+                    header={field.header}
                     type={field.type}
                     options={field.options}
                     value={profile[field.id]}

--- a/src/app/src/components/UserProfileField.jsx
+++ b/src/app/src/components/UserProfileField.jsx
@@ -3,6 +3,7 @@ import { arrayOf, bool, func, oneOf, string } from 'prop-types';
 
 import ControlledTextInput from './ControlledTextInput';
 import ControlledSelectInput from './ControlledSelectInput';
+import ShowOnly from './ShowOnly';
 
 import {
     inputTypesEnum,
@@ -34,6 +35,7 @@ export default function UserProfileField({
     hideOnViewOnlyProfile,
     submitFormOnEnterKeyPress,
     autoFocus,
+    header,
 }) {
     if (type === inputTypesEnum.checkbox) {
         window.console.warn(`checkbox not yet implemented for ${id}`);
@@ -112,6 +114,11 @@ export default function UserProfileField({
 
     return (
         <div className="control-panel__group">
+            <ShowOnly when={!!header}>
+                <div className="form__field-header">
+                    {header}
+                </div>
+            </ShowOnly>
             <div className="form__field">
                 <label
                     htmlFor={id}
@@ -139,11 +146,13 @@ UserProfileField.defaultProps = {
     isEditableProfile: false,
     hideOnViewOnlyProfile: false,
     autoFocus: false,
+    header: null,
 };
 
 UserProfileField.propTypes = {
     id: oneOf(Object.values(profileFieldsEnum)).isRequired,
     label: string.isRequired,
+    header: string,
     type: oneOf(Object.values(inputTypesEnum)).isRequired,
     options: arrayOf(oneOf(contributorTypeOptions)),
     value: string.isRequired,

--- a/src/app/src/reducers/ProfileReducer.js
+++ b/src/app/src/reducers/ProfileReducer.js
@@ -28,7 +28,7 @@ import {
     completeSubmitLogOut,
 } from '../actions/auth';
 
-import { registrationFieldsEnum } from '../util/constants';
+import { registrationFieldsEnum, profileFieldsEnum } from '../util/constants';
 
 const initialState = Object.freeze({
     profile: Object.freeze({
@@ -39,7 +39,9 @@ const initialState = Object.freeze({
         [registrationFieldsEnum.website]: '',
         [registrationFieldsEnum.contributorType]: '',
         [registrationFieldsEnum.otherContributorType]: '',
-        [registrationFieldsEnum.password]: '',
+        [profileFieldsEnum.currentPassword]: '',
+        [profileFieldsEnum.newPassword]: '',
+        [profileFieldsEnum.confirmNewPassword]: '',
     }),
     formSubmission: {
         fetching: false,
@@ -130,6 +132,9 @@ export default createReducer({
             website: { $set: payload.website || '' },
             contributorType: { $set: payload.contributor_type || '' },
             otherContributorType: { $set: payload.other_contributor_type || '' },
+            currentPassword: { $set: '' },
+            newPassword: { $set: '' },
+            confirmNewPassword: { $set: '' },
         },
         fetching: { $set: false },
         error: { $set: null },
@@ -170,7 +175,11 @@ export default createReducer({
             [registrationFieldsEnum.website]: { $set: payload.website },
             [registrationFieldsEnum.contributorType]: { $set: payload.contributor_type },
             [registrationFieldsEnum.otherContributorType]: { $set: payload.other_contributor_type },
-            [registrationFieldsEnum.password]: { $set: initialState.profile.password },
+            [profileFieldsEnum.currentPassword]: { $set: initialState.profile.currentPassword },
+            [profileFieldsEnum.newPassword]: { $set: initialState.profile.newPassword },
+            [profileFieldsEnum.confirmNewPassword]: {
+                $set: initialState.profile.confirmNewPassword,
+            },
         },
     }),
     [resetUserProfile]: () => initialState,

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -42,7 +42,9 @@ export const profileFieldsEnum = Object.freeze({
     [registrationFieldsEnum.wesbite]: registrationFieldsEnum.website,
     [registrationFieldsEnum.contributorType]: registrationFieldsEnum.contributorType,
     [registrationFieldsEnum.otherContributorType]: registrationFieldsEnum.otherContributorType,
-    [registrationFieldsEnum.password]: registrationFieldsEnum.password,
+    currentPassword: 'currentPassword',
+    newPassword: 'newPassword',
+    confirmNewPassword: 'confirmNewPassword',
 });
 
 const accountEmailField = Object.freeze({
@@ -120,6 +122,33 @@ const accountConfirmPasswordField = Object.freeze({
     modelFieldName: 'confirmPassword',
 });
 
+const accountCurrentPasswordField = Object.freeze({
+    id: profileFieldsEnum.currentPassword,
+    label: 'Current Password',
+    type: inputTypesEnum.password,
+    modelFieldName: 'current_password',
+    hideOnViewOnlyProfile: true,
+    required: false,
+});
+
+const accountNewPasswordField = Object.freeze({
+    id: profileFieldsEnum.newPassword,
+    label: 'New Password',
+    type: inputTypesEnum.password,
+    modelFieldName: 'new_password',
+    hideOnViewOnlyProfile: true,
+    required: false,
+});
+
+const accountConfirmNewPasswordField = Object.freeze({
+    id: profileFieldsEnum.confirmNewPassword,
+    label: 'Confirm New Password',
+    type: inputTypesEnum.password,
+    modelFieldName: 'confirm_new_password',
+    hideOnViewOnlyProfile: true,
+    required: false,
+});
+
 const accountNewsletterField = Object.freeze({
     id: registrationFieldsEnum.newsletter,
     label: 'Sign up for OAR newsletter',
@@ -159,7 +188,9 @@ export const profileFormFields = Object.freeze([
     accountContributorTypeField,
     accountOtherContributorTypeField,
     accountWebsiteField,
-    accountPasswordField,
+    accountCurrentPasswordField,
+    accountNewPasswordField,
+    accountConfirmNewPasswordField,
 ]);
 
 export const mainRoute = '/';

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -125,6 +125,7 @@ const accountConfirmPasswordField = Object.freeze({
 const accountCurrentPasswordField = Object.freeze({
     id: profileFieldsEnum.currentPassword,
     label: 'Current Password',
+    header: 'If you do not need to change your password leave these three password fields empty.',
     type: inputTypesEnum.password,
     modelFieldName: 'current_password',
     hideOnViewOnlyProfile: true,


### PR DESCRIPTION
## Overview

The previous password field was required, and was only verified. Checking the password is redundant, since the user already has an authenticated session, and it did not allow for updating the password.

In this PR we replace the required password field with a set of three optional fields that accept the previous password and a new password and modify the view to handle these fields.

Connects #463

## Demo

<img width="685" alt="Screen Shot 2019-04-10 at 1 38 18 PM" src="https://user-images.githubusercontent.com/17363/55911666-eca4f880-5b95-11e9-8d75-935f0747c301.png">

## Notes

The PR also adds inline documentation on the form explaining that the contributor can ignore the three password fields if they do not wish to change their password.

## Testing Instructions

* Log in
* Verify that you can save changes to profile fields without filling in the password fields
* Verify a validation error appears in these situations
  * Fill in a wrong current password and new password
  * Fill in a correct current password but two different new passwords
  * Fill in a correct current password and 'a' as a new password
* Verify that submitting all three password fields with valid values:
  * Shows success "toast"
  * Leaves the user logged in
  * Changes the user's password

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
