### PR TITLE
Download facility list items one page at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Change facility list CSV download to request one page at a time [#496](https://github.com/open-apparel-registry/open-apparel-registry/pull/496)
 
 ### Deprecated
 

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -167,19 +167,15 @@ export function assembleAndDownloadFacilityListCSV() {
             } = data;
 
             const dataURLs = makeFacilityListDataURLs(id, count);
-            const responseData = await Promise.all(
-                dataURLs.map(async (url) => {
-                    const {
-                        data: {
-                            results,
-                        },
-                    } = await csrfRequest.get(url);
-
-                    return results;
-                }),
-            );
-
-            const csvData = [].concat(...responseData);
+            let csvData = [];
+            for (let i = 0, len = dataURLs.length; i < len; i += 1) {
+                const {
+                    data: {
+                        results,
+                    },
+                } = await csrfRequest.get(dataURLs[i]); // eslint-disable-line no-await-in-loop
+                csvData = csvData.concat(results);
+            }
             downloadListItemCSV(data, csvData);
 
             return dispatch(completeAssembleAndDownloadFacilityListCSV(csvData));


### PR DESCRIPTION
## Overview

Downloading multiple pages in parallel was overloading the service in staging.
To decrease the load we have rewritten the page request loop to request pages of
results in series.

Connects #495

## Demo
![2019-04-25 14 56 04](https://user-images.githubusercontent.com/17363/56771120-ab524280-676a-11e9-9d38-562d4f1fb883.gif)


## Testing Instructions

* Log in and upload 
[large_list.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/3119009/large_list.csv.txt). Do not bother processing it.
* Open developer tools and download the list. Verify that only one request is made at a time. 


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
