### PR TITLE
Handle CSV files with UTF-8 BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Change facility list CSV download to request one page at a time [#496](https://github.com/open-apparel-registry/open-apparel-registry/pull/496)
+- Handle CSV files that include a byte order mark [#498](https://github.com/open-apparel-registry/open-apparel-registry/pull/498)
 
 ### Deprecated
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -603,7 +603,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 'Uploaded file exceeds the maximum size of {:.1f}MB.'.format(
                     mb))
         try:
-            header = csv_file.readline().decode().rstrip()
+            header = csv_file.readline().decode(encoding='utf-8-sig').rstrip()
         except UnicodeDecodeError:
             ROLLBAR = getattr(settings, 'ROLLBAR', {})
             if ROLLBAR:
@@ -671,7 +671,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                     items.append(FacilityListItem(
                         row_index=(idx - 1),
                         facility_list=new_list,
-                        raw_data=line.decode().rstrip()
+                        raw_data=line.decode(encoding='utf-8-sig').rstrip()
                     ))
                 except UnicodeDecodeError:
                     ROLLBAR = getattr(settings, 'ROLLBAR', {})


### PR DESCRIPTION
## Overview

Some applications, when saving files with a UTF-8 encoding, will prepend a byte order mark (BOM) at the beginning of the file. By using the `utf-8-sig` encoding when reading files we will ignore the BOM if it is present.

Connects #473 

## Testing Instructions

* Log in
* Upload [single-row-with-bom.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/3122790/single-row-with-bom.csv.txt) and verify that there are no errors.
* Upload [single-row.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/3122792/single-row.csv.txt) and verify that there are no errors.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
