### PR TITLE
Add an API parameter and UI to filter facility list items by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 
+- Facility list items can be filtered by status [#507](https://github.com/open-apparel-registry/open-apparel-registry/pull/507)
+
 ### Changed
 
 - Set maximum page size for Facilities list API endpoint to 500 facilities per request. [#509](https://github.com/open-apparel-registry/open-apparel-registry/pull/509)

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -37,6 +37,7 @@ const {
     makeSliceArgumentsForTablePagination,
     getNumberFromParsedQueryStringParamOrUseDefault,
     createPaginationOptionsFromQueryString,
+    createParamsFromQueryString,
     makeReportADataIssueEmailLink,
     makeFeatureCollectionFromSingleFeature,
     createConfirmOrRejectMatchData,
@@ -659,6 +660,28 @@ it('creates a set of pagination options from a querystring', () => {
         createPaginationOptionsFromQueryString(complexQueryString),
         expectedComplexQueryStringValues,
     )).toBe(true);
+});
+
+it('creates params from a query string', () => {
+    const emptyQueryString = '';
+    const expectedParamsForEmptyQueryString = {};
+    expect(createParamsFromQueryString(emptyQueryString))
+        .toEqual(expectedParamsForEmptyQueryString);
+
+    const oneStatusQueryString = '?status=NEW_FACILITY';
+    const expectedParamsForOneStatus = { status: ['NEW_FACILITY'] };
+    expect(createParamsFromQueryString(oneStatusQueryString))
+        .toEqual(expectedParamsForOneStatus);
+
+    const twoStatusQueryString = '?status=NEW_FACILITY&status=MATCHED';
+    const expectedParamsForTwoStatus = { status: ['NEW_FACILITY', 'MATCHED'] };
+    expect(createParamsFromQueryString(twoStatusQueryString))
+        .toEqual(expectedParamsForTwoStatus);
+
+    const ignoredArgQueryString = '?foo=bar';
+    const expectedParamsForIgnoredArg = {};
+    expect(createParamsFromQueryString(ignoredArgQueryString))
+        .toEqual(expectedParamsForIgnoredArg);
 });
 
 it('creates an email link for reporting a data issue for a facility with a given OAR ID', () => {

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -69,7 +69,9 @@ export function fetchFacilityList(listID = null) {
     };
 }
 
-export function fetchFacilityListItems(listID = null, page = undefined, rowsPerPage = undefined) {
+export function fetchFacilityListItems(
+    listID = null, page = undefined, rowsPerPage = undefined, params = null,
+) {
     return (dispatch) => {
         dispatch(startFetchFacilityListItems());
 
@@ -82,12 +84,13 @@ export function fetchFacilityListItems(listID = null, page = undefined, rowsPerP
         }
 
         const url = makeSingleFacilityListItemsURL(listID);
-        const qs = page || rowsPerPage
-            ? `?${querystring.stringify({ page, pageSize: rowsPerPage })}`
-            : '';
+        const pageParams = page || rowsPerPage
+            ? { page, pageSize: rowsPerPage }
+            : null;
+        const qs = `?${querystring.stringify(Object.assign({}, params, pageParams))}`;
         return csrfRequest
             .get(`${url}${qs}`)
-            .then(({ data }) => dispatch(completeFetchFacilityListItems(data.results)))
+            .then(({ data }) => dispatch(completeFetchFacilityListItems(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
                 err,
                 `An error prevented fetching facility list items for ${listID}`,

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -28,7 +28,10 @@ import {
 
 import { facilityListPropType } from '../util/propTypes';
 
-import { createPaginationOptionsFromQueryString } from '../util/util';
+import {
+    createPaginationOptionsFromQueryString,
+    createParamsFromQueryString,
+} from '../util/util';
 
 const facilityListItemsStyles = Object.freeze({
     headerStyles: Object.freeze({
@@ -290,9 +293,11 @@ function mapDispatchToProps(dispatch, {
         rowsPerPage,
     } = createPaginationOptionsFromQueryString(search);
 
+    const params = createParamsFromQueryString(search);
+
     return {
         fetchList: () => dispatch(fetchFacilityList(listID)),
-        fetchListItems: () => dispatch(fetchFacilityListItems(listID, page, rowsPerPage)),
+        fetchListItems: () => dispatch(fetchFacilityListItems(listID, page, rowsPerPage, params)),
         clearListItems: () => dispatch(resetFacilityListItems()),
         downloadCSV: () => dispatch(assembleAndDownloadFacilityListCSV()),
     };

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -8,6 +8,8 @@ import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
 import TablePagination from '@material-ui/core/TablePagination';
 import ReactSelect from 'react-select';
 import ShowOnly from './ShowOnly';
@@ -221,6 +223,8 @@ class FacilityListItemsTable extends Component {
             </Grid>
         );
 
+        const listIsEmpty = !fetchingItems && items && items.length === 0;
+
         const tableRows = fetchingItems ? [] : items
             .map((item) => {
                 const handleSelectRow = makeSelectListItemTableRowFunction(item.row_index);
@@ -353,6 +357,13 @@ class FacilityListItemsTable extends Component {
                         </TableHead>
                         <TableBody>
                             {tableRows}
+                            <ShowOnly when={listIsEmpty}>
+                                <TableRow>
+                                    <TableCell colSpan={5} style={{ textAlign: 'center' }}>
+                                        No matching items.
+                                    </TableCell>
+                                </TableRow>
+                            </ShowOnly>
                         </TableBody>
                     </Table>
                 </div>

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -24,6 +24,7 @@ import {
     makePaginatedFacilityListItemsDetailLinkWithRowCount,
     getValueFromEvent,
     createPaginationOptionsFromQueryString,
+    createParamsFromQueryString,
     makeFacilityListSummaryStatus,
 } from '../util/util';
 
@@ -53,6 +54,7 @@ const facilityListItemsTableStyles = Object.freeze({
 function FacilityListItemsTable({
     list,
     items,
+    filteredCount,
     fetchingItems,
     selectedFacilityListItemsRowIndex,
     makeSelectListItemTableRowFunction,
@@ -74,13 +76,16 @@ function FacilityListItemsTable({
         rowsPerPage,
     } = createPaginationOptionsFromQueryString(search);
 
+    const params = createParamsFromQueryString(search);
+
     const handleChangePage = (_, newPage) => {
         push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
             listID,
             (newPage + 1),
             rowsPerPage,
+            params,
         ));
-        fetchListItems(listID, newPage + 1, rowsPerPage);
+        fetchListItems(listID, newPage + 1, rowsPerPage, params);
     };
 
     const handleChangeRowsPerPage = (e) => {
@@ -88,8 +93,9 @@ function FacilityListItemsTable({
             listID,
             page,
             getValueFromEvent(e),
+            params,
         ));
-        fetchListItems(listID, page, getValueFromEvent(e));
+        fetchListItems(listID, page, getValueFromEvent(e), params);
     };
 
     const paginationControlsRow = (
@@ -113,7 +119,7 @@ function FacilityListItemsTable({
                 md={6}
             >
                 <TablePagination
-                    count={list.item_count}
+                    count={filteredCount}
                     rowsPerPage={Number(rowsPerPage)}
                     rowsPerPageOptions={rowsPerPageOptions}
                     onChangeRowsPerPage={handleChangeRowsPerPage}
@@ -249,6 +255,7 @@ FacilityListItemsTable.defaultProps = {
 
 FacilityListItemsTable.propTypes = {
     items: arrayOf(facilityListItemPropType),
+    filteredCount: number.isRequired,
     match: shape({
         params: shape({
             listID: string.isRequired,
@@ -270,6 +277,7 @@ function mapStateToProps({
         list: {
             data: list,
         },
+        filteredCount,
         selectedFacilityListItemsRowIndex,
     },
 
@@ -277,6 +285,7 @@ function mapStateToProps({
     return {
         list,
         items,
+        filteredCount,
         fetchingItems,
         selectedFacilityListItemsRowIndex,
     };
@@ -286,8 +295,8 @@ function mapDispatchToProps(dispatch) {
     return {
         makeSelectListItemTableRowFunction: rowIndex =>
             () => dispatch(setSelectedFacilityListItemsRowIndex(rowIndex)),
-        fetchListItems: (listID, page, rowsPerPage) =>
-            dispatch(fetchFacilityListItems(listID, page, rowsPerPage)),
+        fetchListItems: (listID, page, rowsPerPage, params) =>
+            dispatch(fetchFacilityListItems(listID, page, rowsPerPage, params)),
     };
 }
 

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -115,14 +115,8 @@ class FacilityListItemsTable extends Component {
         }
     }
 
-    render() {
+    handleChangePage = (_, newPage) => {
         const {
-            list,
-            items,
-            filteredCount,
-            fetchingItems,
-            selectedFacilityListItemsRowIndex,
-            makeSelectListItemTableRowFunction,
             fetchListItems,
             match: {
                 params: {
@@ -136,59 +130,139 @@ class FacilityListItemsTable extends Component {
                 },
             },
         } = this.props;
+
+        const {
+            rowsPerPage,
+        } = createPaginationOptionsFromQueryString(search);
+
+        const params = createParamsFromQueryString(search);
+
+        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            (newPage + 1),
+            rowsPerPage,
+            params,
+        ));
+        fetchListItems(listID, newPage + 1, rowsPerPage, params);
+    }
+
+    handleChangeRowsPerPage = (e) => {
+        const {
+            fetchListItems,
+            match: {
+                params: {
+                    listID,
+                },
+            },
+            history: {
+                push,
+                location: {
+                    search,
+                },
+            },
+        } = this.props;
+
+        const { page } = createPaginationOptionsFromQueryString(search);
+
+        const params = createParamsFromQueryString(search);
+
+        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            page,
+            getValueFromEvent(e),
+            params,
+        ));
+        fetchListItems(listID, page, getValueFromEvent(e), params);
+    }
+
+    handleChangeStatusFilter = (selected) => {
+        const {
+            fetchListItems,
+            match: {
+                params: {
+                    listID,
+                },
+            },
+            history: {
+                push,
+                location: {
+                    search,
+                },
+            },
+        } = this.props;
+
+        const { rowsPerPage } = createPaginationOptionsFromQueryString(search);
+        const params = createParamsFromQueryString(search);
+        const newParams = update(params, {
+            status: { $set: selected ? selected.map(x => x.value) : null },
+        });
+
+        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            1,
+            rowsPerPage,
+            newParams,
+        ));
+        fetchListItems(listID, 1, rowsPerPage, newParams);
+    }
+
+    handleShowAllClicked = () => {
+        const {
+            fetchListItems,
+            match: {
+                params: {
+                    listID,
+                },
+            },
+            history: {
+                push,
+                location: {
+                    search,
+                },
+            },
+        } = this.props;
+
+        const { rowsPerPage } = createPaginationOptionsFromQueryString(search);
+        const params = createParamsFromQueryString(search);
+
+        const newParams = update(params, {
+            $unset: ['status'],
+        });
+        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            1,
+            rowsPerPage,
+            newParams,
+        ));
+        fetchListItems(listID, 1, rowsPerPage, newParams);
+    }
+
+    render() {
+        const {
+            list,
+            items,
+            filteredCount,
+            fetchingItems,
+            selectedFacilityListItemsRowIndex,
+            makeSelectListItemTableRowFunction,
+            match: {
+                params: {
+                    listID,
+                },
+            },
+            history: {
+                location: {
+                    search,
+                },
+            },
+        } = this.props;
+
         const {
             page,
             rowsPerPage,
         } = createPaginationOptionsFromQueryString(search);
 
         const params = createParamsFromQueryString(search);
-
-        const handleChangePage = (_, newPage) => {
-            push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
-                listID,
-                (newPage + 1),
-                rowsPerPage,
-                params,
-            ));
-            fetchListItems(listID, newPage + 1, rowsPerPage, params);
-        };
-
-        const handleChangeRowsPerPage = (e) => {
-            push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
-                listID,
-                page,
-                getValueFromEvent(e),
-                params,
-            ));
-            fetchListItems(listID, page, getValueFromEvent(e), params);
-        };
-
-        const handleChangeStatusFilter = (selected) => {
-            const newParams = update(params, {
-                status: { $set: selected ? selected.map(x => x.value) : null },
-            });
-            push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
-                listID,
-                1,
-                rowsPerPage,
-                newParams,
-            ));
-            fetchListItems(listID, 1, rowsPerPage, newParams);
-        };
-
-        const handleShowAllClicked = () => {
-            const newParams = update(params, {
-                $unset: ['status'],
-            });
-            push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
-                listID,
-                1,
-                rowsPerPage,
-                newParams,
-            ));
-            fetchListItems(listID, 1, rowsPerPage, newParams);
-        };
-
 
         const paginationControlsRow = (
             <Grid
@@ -214,9 +288,9 @@ class FacilityListItemsTable extends Component {
                         count={filteredCount}
                         rowsPerPage={Number(rowsPerPage)}
                         rowsPerPageOptions={rowsPerPageOptions}
-                        onChangeRowsPerPage={handleChangeRowsPerPage}
+                        onChangeRowsPerPage={this.handleChangeRowsPerPage}
                         page={page - 1}
-                        onChangePage={handleChangePage}
+                        onChangePage={this.handleChangePage}
                         component="div"
                     />
                 </Grid>
@@ -330,14 +404,14 @@ class FacilityListItemsTable extends Component {
                             options={facilityListStatusFilterChoices}
                             placeholder="Filter by item status..."
                             value={createSelectedStatusChoicesFromParams(params)}
-                            onChange={handleChangeStatusFilter}
+                            onChange={this.handleChangeStatusFilter}
                         />
                     </div>
                     <ShowOnly when={!!(params && params.status)}>
                         <span style={facilityListItemsTableStyles.statusFilterMessageStyles}>
                             Showing {filteredCount} of {list.item_count} items.
                         </span>
-                        <Button color="primary" onClick={handleShowAllClicked}>
+                        <Button color="primary" onClick={this.handleShowAllClicked}>
                             Show all items
                         </Button>
                     </ShowOnly>

--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -36,6 +36,7 @@ const initialState = Object.freeze({
         fetching: false,
         error: null,
     },
+    filteredCount: 0,
     confirmOrRejectMatch: Object.freeze({
         fetching: false,
         error: null,
@@ -161,9 +162,10 @@ export default createReducer({
         },
     }),
     [completeFetchFacilityListItems]: (state, payload) => update(state, {
+        filteredCount: { $set: payload.count },
         items: {
             $merge: {
-                data: payload,
+                data: payload.results,
                 fetching: false,
                 error: null,
             },

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -273,6 +273,7 @@ export const facilityListItemStatusChoicesEnum = Object.freeze({
     MATCHED: 'MATCHED',
     POTENTIAL_MATCH: 'POTENTIAL_MATCH',
     CONFIRMED_MATCH: 'CONFIRMED_MATCH',
+    NEW_FACILITY: 'NEW_FACILITY', // This is not a status that appears in the database
     ERROR: 'ERROR',
     ERROR_PARSING: 'ERROR_PARSING',
     ERROR_GEOCODING: 'ERROR_GEOCODING',
@@ -284,6 +285,57 @@ export const facilityListItemErrorStatuses = Object.freeze([
     facilityListItemStatusChoicesEnum.ERROR_PARSING,
     facilityListItemStatusChoicesEnum.ERROR_GEOCODING,
     facilityListItemStatusChoicesEnum.ERROR_MATCHING,
+]);
+
+export const facilityListStatusFilterChoices = Object.freeze([
+    {
+        label: facilityListItemStatusChoicesEnum.UPLOADED,
+        value: facilityListItemStatusChoicesEnum.UPLOADED,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.PARSED,
+        value: facilityListItemStatusChoicesEnum.PARSED,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.GEOCODED,
+        value: facilityListItemStatusChoicesEnum.GEOCODED,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.GEOCODED_NO_RESULTS,
+        value: facilityListItemStatusChoicesEnum.GEOCODED_NO_RESULTS,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.MATCHED,
+        value: facilityListItemStatusChoicesEnum.MATCHED,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.POTENTIAL_MATCH,
+        value: facilityListItemStatusChoicesEnum.POTENTIAL_MATCH,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.CONFIRMED_MATCH,
+        value: facilityListItemStatusChoicesEnum.CONFIRMED_MATCH,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.NEW_FACILITY,
+        value: facilityListItemStatusChoicesEnum.NEW_FACILITY,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.ERROR,
+        value: facilityListItemStatusChoicesEnum.ERROR,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.ERROR_PARSING,
+        value: facilityListItemStatusChoicesEnum.ERROR_PARSING,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.ERROR_GEOCODING,
+        value: facilityListItemStatusChoicesEnum.ERROR_GEOCODING,
+    },
+    {
+        label: facilityListItemStatusChoicesEnum.ERROR_MATCHING,
+        value: facilityListItemStatusChoicesEnum.ERROR_MATCHING,
+    },
 ]);
 
 export const facilityListSummaryStatusMessages = Object.freeze({

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -185,6 +185,22 @@ export const createPaginationOptionsFromQueryString = (qs) => {
     });
 };
 
+export const createParamsFromQueryString = (qs) => {
+    const qsToParse = startsWith(qs, '?')
+        ? qs.slice(1)
+        : qs;
+
+    const {
+        status,
+    } = querystring.parse(qsToParse);
+
+    if (status) {
+        return Object.freeze({ status });
+    }
+
+    return {};
+};
+
 export const getTokenFromQueryString = (qs) => {
     const qsToParse = startsWith(qs, '?')
         ? qs.slice(1)
@@ -332,8 +348,10 @@ export const getBBoxForArrayOfGeoJSONPoints = flow(
 );
 
 export const makeFacilityListItemsDetailLink = id => `/lists/${id}`;
-export const makePaginatedFacilityListItemsDetailLinkWithRowCount = (id, page, rowsPerPage) =>
-    `/lists/${id}?page=${page}&rowsPerPage=${rowsPerPage}`;
+export const makePaginatedFacilityListItemsDetailLinkWithRowCount = (
+    id, page, rowsPerPage, params,
+) =>
+    `/lists/${id}?${querystring.stringify(Object.assign({}, params, { page, rowsPerPage }))}`;
 
 export const makeSliceArgumentsForTablePagination = (page, rowsPerPage) => Object.freeze([
     page * rowsPerPage,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -195,7 +195,9 @@ export const createParamsFromQueryString = (qs) => {
     } = querystring.parse(qsToParse);
 
     if (status) {
-        return Object.freeze({ status });
+        return Array.isArray(status)
+            ? Object.freeze({ status })
+            : Object.freeze({ status: [status] });
     }
 
     return {};

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -19,3 +19,7 @@ class FacilitiesQueryParams:
     CONTRIBUTORS = 'contributors'
     CONTRIBUTOR_TYPES = 'contributor_types'
     COUNTRIES = 'countries'
+
+
+class FacilityListItemsQueryParams:
+    STATUS = 'status'

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -240,6 +240,11 @@ class FacilityListItem(models.Model):
     ERROR_GEOCODING = 'ERROR_GEOCODING'
     ERROR_MATCHING = 'ERROR_MATCHING'
 
+    # NEW_FACILITY is a meta status. If the `status` of a `FacilityListItem` is
+    # `MATCHED` or `CONFIRMED_MATCH` and the `facility` was `created_from` the
+    # `FacilityListItem` then the item represents a new facility.
+    NEW_FACILITY = 'NEW_FACILITY'
+
     # These status choices must be kept in sync with the client's
     # `facilityListItemStatusChoicesEnum`.
     STATUS_CHOICES = (

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -206,7 +206,8 @@ class FacilityListItemsQueryParamsSerializer(Serializer):
     )
 
     def validate_status(self, value):
-        valid_statuses = [c[0] for c in FacilityListItem.STATUS_CHOICES]
+        valid_statuses = ([c[0] for c in FacilityListItem.STATUS_CHOICES]
+                          + [FacilityListItem.NEW_FACILITY])
         for item in value:
             if item not in valid_statuses:
                 raise ValidationError(

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -199,6 +199,21 @@ class FacilityQueryParamsSerializer(Serializer):
     pageSize = IntegerField(required=False)
 
 
+class FacilityListItemsQueryParamsSerializer(Serializer):
+    status = ListField(
+        child=CharField(required=False),
+        required=False,
+    )
+
+    def validate_status(self, value):
+        valid_statuses = [c[0] for c in FacilityListItem.STATUS_CHOICES]
+        for item in value:
+            if item not in valid_statuses:
+                raise ValidationError(
+                    '{} is not a valid status. Must be one of {}'.format(
+                        item, ', '.join(valid_statuses)))
+
+
 class FacilitySerializer(GeoFeatureModelSerializer):
     oar_id = SerializerMethodField()
     country_name = SerializerMethodField()

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -1141,3 +1141,87 @@ class ContributorsListAPIEndpointTests(TestCase):
             1,
             len(contributor_names),
         )
+
+
+class FacilityListItemTests(APITestCase):
+    def setUp(self):
+        self.email = 'test@example.com'
+        self.password = 'example123'
+        self.user = User.objects.create(email=self.email)
+        self.user.set_password(self.password)
+        self.user.save()
+
+        self.contributor = Contributor \
+            .objects \
+            .create(admin=self.user,
+                    name='test contributor',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.facility_list = FacilityList \
+            .objects \
+            .create(header='header',
+                    file_name='one',
+                    name='test list',
+                    is_active=True,
+                    is_public=True,
+                    contributor=self.contributor)
+
+        statuses = [c[0] for c in FacilityListItem.STATUS_CHOICES]
+        for i, possible_status in enumerate(statuses):
+            FacilityListItem \
+                .objects \
+                .create(name='test name',
+                        address='test address',
+                        country_code='US',
+                        facility_list=self.facility_list,
+                        row_index=i,
+                        status=possible_status)
+
+        self.client.login(email=self.email,
+                          password=self.password)
+
+    def test_get_all_items(self):
+        response = self.client.get(
+            reverse('facility-list-items',
+                    kwargs={'pk': self.facility_list.pk}))
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(len(FacilityListItem.STATUS_CHOICES),
+                         len(content['results']))
+
+    def test_get_items_filtered_by_status(self):
+        url = reverse('facility-list-items',
+                      kwargs={'pk': self.facility_list.pk})
+
+        response = self.client.get('{}?status=GEOCODED'.format(url))
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(1, len(content['results']))
+        self.assertEqual('GEOCODED', content['results'][0]['status'])
+
+    def test_get_multiple_statuses(self):
+        url = reverse('facility-list-items',
+                      kwargs={'pk': self.facility_list.pk})
+
+        response = self.client.get(
+            '{}?status=GEOCODED&status=MATCHED'.format(url))
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(2, len(content['results']))
+
+    def test_invalid_status_returns_400(self):
+        url = reverse('facility-list-items',
+                      kwargs={'pk': self.facility_list.pk})
+
+        response = self.client.get('{}?status=FOO'.format(url))
+        self.assertEqual(400, response.status_code)
+        content = json.loads(response.content)
+        self.assertTrue('status' in content)
+
+    def test_empty_status_filter_returns_400(self):
+        url = reverse('facility-list-items',
+                      kwargs={'pk': self.facility_list.pk})
+        response = self.client.get('{}?status='.format(url))
+        self.assertEqual(400, response.status_code)
+        content = json.loads(response.content)
+        self.assertTrue('status' in content)


### PR DESCRIPTION
## Overview

Allow facility list items to be filtered by selecting one or more statuses. It is an uncommon situation in a thousand item list to only have a dozen potential matches. Having a filter makes it dramatically easier to find and act on these items.

Connects #504 

## Demo
<img width="1395" alt="Screen Shot 2019-05-08 at 10 31 47 AM" src="https://user-images.githubusercontent.com/17363/57395303-a0d97500-717c-11e9-9680-0f46d194cfe6.png">

<img width="1396" alt="Screen Shot 2019-05-08 at 10 31 59 AM" src="https://user-images.githubusercontent.com/17363/57395313-a8008300-717c-11e9-81b0-258bb202a289.png">

<img width="1396" alt="Screen Shot 2019-05-08 at 10 32 32 AM" src="https://user-images.githubusercontent.com/17363/57395317-ab940a00-717c-11e9-86ac-ce104e9c4c17.png">


## Testing Instructions

* Reset the database 
  * `./scripts/resetdb`
  * `./scripts/processfixtures`
* Log in as `c8@example.com`
* Browse http://localhost:6543/lists/8
* Filter by different statuses and verify that the list results match what is expected.
* Filter by `POTENTIAL_MATCH` and approve one of the matches. Verify that the item disappears from the table and the item count is correctly updated.
* Approve or reject the rest of the potential matches and verify that "No matching items" is displayed in the table.
* Verify that clicking the "SHOW ALL ITEMS" button works.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
