### PR TITLE
Add max_page_size setting to Facilities pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Set maximum page size for Facilities list API endpoint to 500 facilities per request. [#509](https://github.com/open-apparel-registry/open-apparel-registry/pull/509)
+
 ### Deprecated
 
 ### Removed

--- a/src/django/api/pagination.py
+++ b/src/django/api/pagination.py
@@ -12,3 +12,4 @@ class FacilitiesGeoJSONPagination(GeoJsonPagination):
     page_query_param = 'page'
     page_size_query_param = 'pageSize'
     page_size = 500
+    max_page_size = 500

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -395,6 +395,7 @@ class FacilitiesViewSet(ReadOnlyModelViewSet):
     def list(self, request):
         """
         Returns a list of facilities in GeoJSON format for a given query.
+        (Maximum of 500 facilities per page.)
 
         ### Sample Response
             {


### PR DESCRIPTION
## Overview

Add `max_page_size` setting of 500 to Facilities pagination. Update the
API docstring to indicate the endpoint will return a maximum of 500
facilities per page.

Connects #501 

## Demo

![Screen Shot 2019-05-13 at 5 21 09 PM](https://user-images.githubusercontent.com/4165523/57655096-d2e73e80-75a3-11e9-9c43-d80915372e5e.png)

![Screen Shot 2019-05-13 at 5 21 28 PM](https://user-images.githubusercontent.com/4165523/57655098-d2e73e80-75a3-11e9-9d60-a23f4706640d.png)

![Screen Shot 2019-05-13 at 5 21 39 PM](https://user-images.githubusercontent.com/4165523/57655097-d2e73e80-75a3-11e9-884b-5d7e175f3a04.png)

## Notes

Considered sending back a 400 when the page size was too high but indicating it via the docs and then just sending back 500 results seemed to give enough info for consumers to figure out what was happening.

## Testing Instructions

- on this branch, `./scripts/manage resetdb` and `./scripts/manage processfixtures`
- visit the app on 6543 and verify that you can request facilities through the search bar as before
- visit http://localhost:8081/api/docs/#!/facilities/facilities_list and try to request more than 500 facilities, verifying that you can't get back more results than that in a single request.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
