### PR TITLE
Return and display list item status counts on the facility lists page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Facility list items can be filtered by status [#507](https://github.com/open-apparel-registry/open-apparel-registry/pull/507)
+- Facility lists pages displays a count of item statuses [#511](https://github.com/open-apparel-registry/open-apparel-registry/pull/511)
 
 ### Changed
 
 - Set maximum page size for Facilities list API endpoint to 500 facilities per request. [#509](https://github.com/open-apparel-registry/open-apparel-registry/pull/509)
+- Upgraded React to 16.8.6 [#511](https://github.com/open-apparel-registry/open-apparel-registry/pull/511)
 
 ### Deprecated
 

--- a/src/app/.eslintrc
+++ b/src/app/.eslintrc
@@ -9,7 +9,8 @@
     "jest/globals": true
   },
   "plugins": [
-    "jest"
+      "jest",
+      "react-hooks"
   ],
   "rules": {
     "indent": [2, 4, { "SwitchCase": 1, "VariableDeclarator": 2 }],
@@ -32,6 +33,8 @@
     "react/jsx-one-expression-per-line": "off",
     "react/jsx-wrap-multilines": "off",
     "react/prop-types": "off",
-    "react/sort-comp": "off"
+    "react/sort-comp": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -17,9 +17,9 @@
         "lodash": "4.17.11",
         "moment": "2.24.0",
         "prop-types": "15.6.2",
-        "react": "16.7.0",
+        "react": "16.8.6",
         "react-copy-to-clipboard": "5.0.1",
-        "react-dom": "16.7.0",
+        "react-dom": "16.8.6",
         "react-map-gl": "3.2.8",
         "react-redux": "5.1.0",
         "react-router": "4.3.1",
@@ -52,7 +52,8 @@
         "eslint-plugin-import": "2.14.0",
         "eslint-plugin-jest": "21.27.2",
         "eslint-plugin-jsx-a11y": "6.1.2",
-        "eslint-plugin-react": "7.11.1"
+        "eslint-plugin-react": "7.11.1",
+        "eslint-plugin-react-hooks": "1.6.0"
     },
     "proxy": "http://django:8081",
     "browserslist": [

--- a/src/app/src/components/FacilityListsTable.jsx
+++ b/src/app/src/components/FacilityListsTable.jsx
@@ -7,9 +7,13 @@ import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
+import sum from 'lodash/sum';
+
+import FacilityListsTooltipTableCell from './FacilityListsTooltipTableCell';
 
 import { facilityListPropType } from '../util/propTypes';
 import { makeFacilityListItemsDetailLink } from '../util/util';
+import { facilitiesListTableTooltipTitles } from '../util/constants';
 
 const facilityListsTableStyles = Object.freeze({
     inactiveListStyles: Object.freeze({
@@ -44,7 +48,28 @@ function FacilityListsTable({
                         <TableCell>
                             File Name
                         </TableCell>
-                        <TableCell>
+                        <TableCell padding="dense">
+                            Total
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Uploaded
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Parsed
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Geocoded
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Matched
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Error
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Potential Match
+                        </TableCell>
+                        <TableCell padding="dense">
                             Active
                         </TableCell>
                     </TableRow>
@@ -72,7 +97,54 @@ function FacilityListsTable({
                                     <TableCell>
                                         {list.file_name}
                                     </TableCell>
-                                    <TableCell>
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={facilitiesListTableTooltipTitles.total}
+                                        tableCellText={list.item_count}
+                                    />
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={facilitiesListTableTooltipTitles.uploaded}
+                                        tableCellText={list.status_counts.UPLOADED}
+                                    />
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={facilitiesListTableTooltipTitles.parsed}
+                                        tableCellText={list.status_counts.PARSED}
+                                    />
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={facilitiesListTableTooltipTitles.geocoded}
+                                        tableCellText={
+                                            sum([
+                                                list.status_counts.GEOCODED,
+                                                list.status_counts.GEOCODED_NO_RESULTS,
+                                            ])
+                                        }
+                                    />
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={facilitiesListTableTooltipTitles.matched}
+                                        tableCellText={
+                                            sum([
+                                                list.status_counts.MATCHED,
+                                                list.status_counts.CONFIRMED_MATCH,
+                                            ])
+                                        }
+                                    />
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={facilitiesListTableTooltipTitles.error}
+                                        tableCellText={
+                                            sum([
+                                                list.status_counts.ERROR,
+                                                list.status_counts.ERROR_PARSING,
+                                                list.status_counts.ERROR_GEOCODING,
+                                                list.status_counts.ERROR_MATCHING,
+                                            ])
+                                        }
+                                    />
+                                    <FacilityListsTooltipTableCell
+                                        tooltipTitle={
+                                            facilitiesListTableTooltipTitles.potentialMatch
+                                        }
+                                        tableCellText={list.status_counts.POTENTIAL_MATCH}
+                                    />
+                                    <TableCell padding="dense">
                                         {list.is_active ? 'Active' : 'Inactive'}
                                     </TableCell>
                                 </TableRow>))

--- a/src/app/src/components/FacilityListsTooltipTableCell.jsx
+++ b/src/app/src/components/FacilityListsTooltipTableCell.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { node } from 'prop-types';
+import TableCell from '@material-ui/core/TableCell';
+import Tooltip from '@material-ui/core/Tooltip';
+
+const facilityListTooltipTableCellStyles = Object.freeze({
+    titleStyles: Object.freeze({
+        fontSize: '20px',
+        padding: '6px',
+        lineHeight: '24px',
+    }),
+});
+
+export default function FacilityListsTooltipTableCell({
+    tooltipTitle,
+    tableCellText,
+}) {
+    const [tooltipIsOpen, toggleTooltipIsOpen] = useState(false);
+
+    const openTooltip = () => toggleTooltipIsOpen(true);
+    const closeTooltip = () => toggleTooltipIsOpen(false);
+
+    const title = (
+        <div style={facilityListTooltipTableCellStyles.titleStyles}>
+            {tooltipTitle}
+        </div>
+    );
+
+    return (
+        <Tooltip
+            title={title}
+            open={tooltipIsOpen}
+        >
+            <TableCell
+                padding="dense"
+                onMouseEnter={openTooltip}
+                onMouseLeave={closeTooltip}
+            >
+                {tableCellText}
+            </TableCell>
+        </Tooltip>
+    );
+}
+
+FacilityListsTooltipTableCell.propTypes = {
+    tooltipTitle: node.isRequired,
+    tableCellText: node.isRequired,
+};

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -372,3 +372,13 @@ export const emptyFeatureCollection = Object.freeze({
 });
 
 export const ENTER_KEY = 'Enter';
+
+export const facilitiesListTableTooltipTitles = Object.freeze({
+    total: 'Total number of items in this list.',
+    uploaded: 'Number of items that have been uploaded but not yet processed.',
+    parsed: 'Number of items that have had their addresses parsed but have not yet been geocoded.',
+    geocoded: 'Number of items that have been geocoded but not yet matched.',
+    matched: 'Number of items that have been matched with an existing facility or created a new facility.',
+    error: 'Number of items that have encountered errors during processing',
+    potentialMatch: 'Number of items with potential matches to confirm or reject.',
+});

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -1,4 +1,6 @@
 import { arrayOf, bool, func, number, oneOf, oneOfType, shape, string } from 'prop-types';
+import mapValues from 'lodash/mapValues';
+import omitBy from 'lodash/omitBy';
 
 import {
     registrationFieldsEnum,
@@ -107,6 +109,15 @@ export const facilityListPropType = shape({
     is_active: bool.isRequired,
     is_public: bool.isRequired,
     item_count: number.isRequired,
+    items_url: string.isRequired,
+    statuses: arrayOf(oneOf(Object.values(facilityListItemStatusChoicesEnum))),
+    status_counts: shape(mapValues(
+        omitBy(
+            facilityListItemStatusChoicesEnum,
+            status => status === facilityListItemStatusChoicesEnum.NEW_FACILITY,
+        ),
+        () => number.isRequired,
+    )).isRequired,
 });
 
 export const contributorOptionsPropType = arrayOf(shape({

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -5581,6 +5581,11 @@ eslint-plugin-jsx-a11y@6.1.2:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-react-hooks@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
@@ -10758,15 +10763,15 @@ react-dev-utils@^7.0.1:
     strip-ansi "5.0.0"
     text-table "0.2.0"
 
-react-dom@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+react-dom@16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.6"
 
 react-error-overlay@^5.1.3:
   version "5.1.3"
@@ -10949,15 +10954,15 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
-  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
+react@16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.6"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -11523,10 +11528,10 @@ saxes@^3.1.5:
   dependencies:
     xmlchars "^1.3.1"
 
-scheduler@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
-  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## Overview

- return status counts from facility list serializer
- update facility lists table row to display cells for grouped status
counts
- add tooltips with descriptions of each status count
- update facilityListPropType
- upgrade React to 16.8.6 and add a eslint plugin related to hooks

Connects #502 

## Demo

![Screen Shot 2019-05-14 at 4 51 29 PM](https://user-images.githubusercontent.com/4165523/57731449-a5b09400-7668-11e9-9c9f-f69bd43ba193.png)
![Screen Shot 2019-05-14 at 4 51 37 PM](https://user-images.githubusercontent.com/4165523/57731450-a6492a80-7668-11e9-8335-26a79b651653.png)
![Screen Shot 2019-05-14 at 4 51 33 PM](https://user-images.githubusercontent.com/4165523/57731451-a6492a80-7668-11e9-9e65-54bc9f853b9d.png)

## Notes

Grouping the facility statuses together made it unnecessary to try to return `NEW_FACILITIES` from the API. However, I kept the other statuses as it made it easier to check for them using the existing enum constant.

## Testing Instructions

- get this branch then `./scripts/update`
- `./scripts/manage resetdb` and `./scripts/manage processfixtures`
- `./scripts/server` then login as c8@example.com
- visit the facilities list page and verify that the counts are displayed and the tooltips are visible on hover

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
