### PR TITLE
Replace facility list detail urls when changing pages or filters

### DIFF
--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -124,7 +124,7 @@ class FacilityListItemsTable extends Component {
                 },
             },
             history: {
-                push,
+                replace,
                 location: {
                     search,
                 },
@@ -137,7 +137,7 @@ class FacilityListItemsTable extends Component {
 
         const params = createParamsFromQueryString(search);
 
-        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+        replace(makePaginatedFacilityListItemsDetailLinkWithRowCount(
             listID,
             (newPage + 1),
             rowsPerPage,
@@ -155,7 +155,7 @@ class FacilityListItemsTable extends Component {
                 },
             },
             history: {
-                push,
+                replace,
                 location: {
                     search,
                 },
@@ -166,7 +166,7 @@ class FacilityListItemsTable extends Component {
 
         const params = createParamsFromQueryString(search);
 
-        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+        replace(makePaginatedFacilityListItemsDetailLinkWithRowCount(
             listID,
             page,
             getValueFromEvent(e),
@@ -184,7 +184,7 @@ class FacilityListItemsTable extends Component {
                 },
             },
             history: {
-                push,
+                replace,
                 location: {
                     search,
                 },
@@ -197,7 +197,7 @@ class FacilityListItemsTable extends Component {
             status: { $set: selected ? selected.map(x => x.value) : null },
         });
 
-        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+        replace(makePaginatedFacilityListItemsDetailLinkWithRowCount(
             listID,
             1,
             rowsPerPage,
@@ -215,7 +215,7 @@ class FacilityListItemsTable extends Component {
                 },
             },
             history: {
-                push,
+                replace,
                 location: {
                     search,
                 },
@@ -228,7 +228,7 @@ class FacilityListItemsTable extends Component {
         const newParams = update(params, {
             $unset: ['status'],
         });
-        push(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+        replace(makePaginatedFacilityListItemsDetailLinkWithRowCount(
             listID,
             1,
             rowsPerPage,


### PR DESCRIPTION
## Overview

Each change to the page number of filter was pushing an item onto the navigation
history. This had some drawbacks:

- It is redundant, because the list items page has its own page navigation.
- The using the back button would change the url but not the content of the
page.

Rather than fix the back button we simply treat paging and filtering more like
local state by using `replace` instead of `push`.

Connects #523 

## Testing Instructions

* Log in as a user with an uploaded and processed list. If you have freshly processed fixture data, `c8@example.com` is a good choice.
* Browse a list details page, move through 2 pages of results, then verify that the browser back button returns you to the previous application page rather than staying on the list items page.
* Repeat the test but apply different filters instead of changing pages.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
