### PR TITLE
Use some read only fields in the Django admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Made some fields read only in the Django admin to prevent slow page loads resulting in service interruptions. [#527](https://github.com/open-apparel-registry/open-apparel-registry/pull/527)
+
 ### Security
 
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -1,5 +1,8 @@
+import json
+
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.utils.safestring import mark_safe
 from simple_history.admin import SimpleHistoryAdmin
 
 from api import models
@@ -15,12 +18,44 @@ class OarUserAdmin(UserAdmin):
 
 
 class FacilityHistoryAdmin(SimpleHistoryAdmin):
-    history_list_display = ['name', 'address', 'location']
+    history_list_display = ('name', 'address', 'location')
+
+    readonly_fields = ('created_from',)
+
+
+class FacilityListItemAdmin(admin.ModelAdmin):
+    exclude = ('processing_results',)
+    readonly_fields = ('facility_list', 'facility',
+                       'pretty_processing_results')
+
+    def pretty_processing_results(self, instance):
+        # The processing_results field is populated exclusively from processing
+        # code so we are not in danger of rendering potentially unsafe user
+        # submitted content
+        return mark_safe('<pre>{}</pre>'.format(
+            json.dumps(instance.processing_results, indent=2)))
+
+    pretty_processing_results.short_description = 'Processing results'
+
+
+class FacilityMatchAdmin(admin.ModelAdmin):
+    exclude = ('results',)
+    readonly_fields = ('facility_list_item', 'facility',
+                       'confidence', 'status', 'pretty_results')
+
+    def pretty_results(self, instance):
+        # The status field is populated exclusively from processing code so we
+        # are not in danger of rendering potentially unsafe user submitted
+        # content
+        return mark_safe('<pre>{}</pre>'.format(
+            json.dumps(instance.results, indent=2)))
+
+    pretty_results.short_description = 'Results'
 
 
 admin.site.register(models.User, OarUserAdmin)
 admin.site.register(models.Contributor)
 admin.site.register(models.FacilityList)
-admin.site.register(models.FacilityListItem)
+admin.site.register(models.FacilityListItem, FacilityListItemAdmin)
 admin.site.register(models.Facility, FacilityHistoryAdmin)
-admin.site.register(models.FacilityMatch)
+admin.site.register(models.FacilityMatch, FacilityMatchAdmin)


### PR DESCRIPTION
## Overview

The Facility, FacilityListItem, and FacilityMatch admin were loading combo boxes with all possible related objects. With a database populated with 10s of thousands of records this would make admin page requests so slow that the ECS task would be terminated.

This commit fixes that by simply making the related fields read only. This works because we would not want to adjust these specific foreign key relationships anyway.

While making some fields read only we also took the opportunity to also make the JSON status fields read only and add a helper to render them in a more readable way.

Connects #526

## Demo

### Facility

<img width="866" alt="Screen Shot 2019-05-17 at 1 18 25 PM" src="https://user-images.githubusercontent.com/17363/57954029-a3d41400-78a6-11e9-9fe8-c887928790be.png">

### FacilityListItem

<img width="886" alt="Screen Shot 2019-05-17 at 1 17 59 PM" src="https://user-images.githubusercontent.com/17363/57954040-ab93b880-78a6-11e9-8af2-bba6c446cc38.png">

### FacilityMatch

<img width="810" alt="Screen Shot 2019-05-17 at 1 18 40 PM" src="https://user-images.githubusercontent.com/17363/57954052-b2223000-78a6-11e9-8a03-3707c3781e75.png">



## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

This `test/` branch was tested on staging which has a stale copy of production data.

* Log in as an admin and verify that you can successfully load Facility, FacilityListItem, and FacilityMatch detail pages.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
