### PR TITLE
Fix script name in release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -29,7 +29,7 @@ $ git rev-parse --short HEAD
 ```
 - [ ] Run migrations, if applicable (see the `showmigrations` release pipeline stage):
 ```bash
-$ ./scripts/manage.py ecsmanage -e production migrate
+$ ./scripts/manage ecsmanage -e production migrate
 ```
 - [ ] Finish and publish the release branch:
     - When prompted, keep default commit messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Fixed script name in release issue template [#529](https://github.com/open-apparel-registry/open-apparel-registry/pull/529)
 
 ### Security
 


### PR DESCRIPTION
## Overview

The script is named `manage` not `manage.py`.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
