### PR TITLE
Show list description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Show active facility list names and descriptions on profile page [#534](https://github.com/open-apparel-registry/open-apparel-registry/pull/534)
 
 ### Deprecated
 

--- a/src/app/src/components/FacilityListSummary.jsx
+++ b/src/app/src/components/FacilityListSummary.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { string } from 'prop-types';
+
+const facilityListSummaryStyles = Object.freeze({
+    nameStyles: Object.freeze({
+        color: '#000 !important',
+        fontWeight: 500,
+        fontSize: '20px',
+        margin: '8px 0',
+    }),
+    descriptionStyles: Object.freeze({
+        color: '#000 !important',
+        marginBottom: '24px',
+    }),
+});
+
+
+function FacilityListSummary({ name, description }) {
+    return (
+        <div>
+            <p style={facilityListSummaryStyles.nameStyles}>{name}</p>
+            <p style={facilityListSummaryStyles.descriptionStyles}>{description}</p>
+        </div>
+    );
+}
+
+FacilityListSummary.defaultProps = {
+    description: '',
+};
+
+FacilityListSummary.propTypes = {
+    name: string.isRequired,
+    description: string,
+};
+
+export default FacilityListSummary;

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -8,6 +8,7 @@ import { toast } from 'react-toastify';
 import AppGrid from './AppGrid';
 import AppOverflow from './AppOverflow';
 import Button from './Button';
+import FacilityListSummary from './FacilityListSummary';
 import UserProfileField from './UserProfileField';
 import UserAPITokens from './UserAPITokens';
 
@@ -191,6 +192,16 @@ class UserProfile extends Component {
                 </div>)
             : null;
 
+        const facilityLists = !isEditableProfile && profile.facilityLists.length > 0
+            ? (
+                <React.Fragment>
+                    <h3>Facility Lists</h3>
+                    {profile.facilityLists.map(
+                        list => <FacilityListSummary key={list.id} {...list} />,
+                    )}
+                </React.Fragment>)
+            : null;
+
         const apiTokensSection = isEditableProfile
             ? <UserAPITokens />
             : null;
@@ -203,6 +214,7 @@ class UserProfile extends Component {
                 >
                     <Grid item xs={12} sm={7}>
                         {profileInputs}
+                        {facilityLists}
                         {errorMessages}
                         {submitButton}
                         {apiTokensSection}

--- a/src/app/src/reducers/ProfileReducer.js
+++ b/src/app/src/reducers/ProfileReducer.js
@@ -28,7 +28,11 @@ import {
     completeSubmitLogOut,
 } from '../actions/auth';
 
-import { registrationFieldsEnum, profileFieldsEnum } from '../util/constants';
+import {
+    registrationFieldsEnum,
+    profileFieldsEnum,
+    profileSummaryFieldsEnum,
+} from '../util/constants';
 
 const initialState = Object.freeze({
     profile: Object.freeze({
@@ -42,6 +46,7 @@ const initialState = Object.freeze({
         [profileFieldsEnum.currentPassword]: '',
         [profileFieldsEnum.newPassword]: '',
         [profileFieldsEnum.confirmNewPassword]: '',
+        [profileSummaryFieldsEnum.facilityLists]: [],
     }),
     formSubmission: {
         fetching: false,
@@ -135,6 +140,10 @@ export default createReducer({
             currentPassword: { $set: '' },
             newPassword: { $set: '' },
             confirmNewPassword: { $set: '' },
+            facilityLists: {
+                $set: payload.facility_lists
+                    || initialState[profileSummaryFieldsEnum.facilityLists],
+            },
         },
         fetching: { $set: false },
         error: { $set: null },

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -47,6 +47,10 @@ export const profileFieldsEnum = Object.freeze({
     confirmNewPassword: 'confirmNewPassword',
 });
 
+export const profileSummaryFieldsEnum = Object.freeze({
+    facilityLists: 'facilityLists',
+});
+
 const accountEmailField = Object.freeze({
     id: registrationFieldsEnum.email,
     label: 'Email Address',

--- a/src/django/api/fixtures/facility_lists.json
+++ b/src/django/api/fixtures/facility_lists.json
@@ -4,13 +4,14 @@
         "pk": 2,
         "fields": {
             "contributor": 2,
-            "name": "Winter 2019 Compliance List",
-            "file_name": "Winter 2019 Compliance List.csv",
+            "name": "Spring 2019 Compliance List",
+            "description": "This is the detailed description of the list named Spring 2019 Compliance List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Spring 2019 Compliance List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-12T01:24:11+00:00",
-            "updated_at": "2019-03-14T21:59:08.605650+00:00"
+            "created_at": "2019-05-21T20:28:53+00:00",
+            "updated_at": "2019-05-22T21:42:47.852880+00:00"
         }
     },
     {
@@ -18,13 +19,14 @@
         "pk": 3,
         "fields": {
             "contributor": 3,
-            "name": "Winter 2017 Affiliate List",
-            "file_name": "Winter 2017 Affiliate List.csv",
+            "name": "Fall 2018 Affiliate List",
+            "description": null,
+            "file_name": "Fall 2018 Affiliate List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-09T19:32:04+00:00",
-            "updated_at": "2019-03-14T21:59:08.305503+00:00"
+            "created_at": "2019-05-15T20:03:20+00:00",
+            "updated_at": "2019-05-22T21:42:47.298485+00:00"
         }
     },
     {
@@ -32,13 +34,14 @@
         "pk": 4,
         "fields": {
             "contributor": 4,
-            "name": "Spring 2019 Apparel List",
-            "file_name": "Spring 2019 Apparel List.csv",
+            "name": "Spring 2018 Compliance List",
+            "description": "This is the detailed description of the list named Spring 2018 Compliance List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Spring 2018 Compliance List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-14T18:13:24+00:00",
-            "updated_at": "2019-03-14T21:59:08.168094+00:00"
+            "created_at": "2019-05-15T13:04:50+00:00",
+            "updated_at": "2019-05-22T21:42:47.838226+00:00"
         }
     },
     {
@@ -46,13 +49,14 @@
         "pk": 5,
         "fields": {
             "contributor": 5,
-            "name": "Winter 2019 Apparel List",
-            "file_name": "Winter 2019 Apparel List.csv",
+            "name": "Winter 2017 Apparel List",
+            "description": null,
+            "file_name": "Winter 2017 Apparel List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-13T09:44:23+00:00",
-            "updated_at": "2019-03-14T21:59:08.996885+00:00"
+            "created_at": "2019-05-21T23:37:32+00:00",
+            "updated_at": "2019-05-22T21:42:47.773436+00:00"
         }
     },
     {
@@ -60,13 +64,14 @@
         "pk": 6,
         "fields": {
             "contributor": 6,
-            "name": "Fall 2019 Affiliate List",
-            "file_name": "Fall 2019 Affiliate List.csv",
+            "name": "Fall 2018 Apparel List",
+            "description": "This is the detailed description of the list named Fall 2018 Apparel List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Fall 2018 Apparel List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-12T08:20:34+00:00",
-            "updated_at": "2019-03-14T21:59:08.854117+00:00"
+            "created_at": "2019-05-20T10:04:24+00:00",
+            "updated_at": "2019-05-22T21:42:47.954648+00:00"
         }
     },
     {
@@ -74,13 +79,14 @@
         "pk": 7,
         "fields": {
             "contributor": 7,
-            "name": "Winter 2019 Affiliate List",
-            "file_name": "Winter 2019 Affiliate List.csv",
+            "name": "Summer 2019 Affiliate List",
+            "description": null,
+            "file_name": "Summer 2019 Affiliate List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-13T20:00:54+00:00",
-            "updated_at": "2019-03-14T21:59:08.043911+00:00"
+            "created_at": "2019-05-19T11:06:58+00:00",
+            "updated_at": "2019-05-22T21:42:47.793898+00:00"
         }
     },
     {
@@ -88,13 +94,14 @@
         "pk": 8,
         "fields": {
             "contributor": 8,
-            "name": "Fall 2018 Affiliate List",
-            "file_name": "Fall 2018 Affiliate List.csv",
+            "name": "Spring 2019 Compliance List",
+            "description": "This is the detailed description of the list named Spring 2019 Compliance List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Spring 2019 Compliance List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-13T03:12:46+00:00",
-            "updated_at": "2019-03-14T21:59:08.849912+00:00"
+            "created_at": "2019-05-14T07:33:17+00:00",
+            "updated_at": "2019-05-22T21:42:47.032889+00:00"
         }
     },
     {
@@ -102,13 +109,14 @@
         "pk": 9,
         "fields": {
             "contributor": 9,
-            "name": "Summer 2017 Apparel List",
-            "file_name": "Summer 2017 Apparel List.csv",
+            "name": "Fall 2019 Compliance List",
+            "description": null,
+            "file_name": "Fall 2019 Compliance List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-13T04:46:47+00:00",
-            "updated_at": "2019-03-14T21:59:08.391597+00:00"
+            "created_at": "2019-05-20T09:41:38+00:00",
+            "updated_at": "2019-05-22T21:42:47.570810+00:00"
         }
     },
     {
@@ -116,13 +124,14 @@
         "pk": 10,
         "fields": {
             "contributor": 10,
-            "name": "Summer 2018 Apparel List",
-            "file_name": "Summer 2018 Apparel List.csv",
+            "name": "Summer 2018 Affiliate List",
+            "description": "This is the detailed description of the list named Summer 2018 Affiliate List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Summer 2018 Affiliate List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-14T07:36:44+00:00",
-            "updated_at": "2019-03-14T21:59:08.969163+00:00"
+            "created_at": "2019-05-15T05:51:34+00:00",
+            "updated_at": "2019-05-22T21:42:47.721080+00:00"
         }
     },
     {
@@ -130,13 +139,14 @@
         "pk": 11,
         "fields": {
             "contributor": 11,
-            "name": "Winter 2018 Compliance List",
-            "file_name": "Winter 2018 Compliance List.csv",
+            "name": "Summer 2018 Compliance List",
+            "description": null,
+            "file_name": "Summer 2018 Compliance List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-07T22:46:45+00:00",
-            "updated_at": "2019-03-14T21:59:08.910720+00:00"
+            "created_at": "2019-05-22T20:54:49+00:00",
+            "updated_at": "2019-05-22T21:42:47.039142+00:00"
         }
     },
     {
@@ -144,13 +154,14 @@
         "pk": 12,
         "fields": {
             "contributor": 12,
-            "name": "Summer 2019 Compliance List",
-            "file_name": "Summer 2019 Compliance List.csv",
+            "name": "Winter 2019 Compliance List",
+            "description": "This is the detailed description of the list named Winter 2019 Compliance List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Winter 2019 Compliance List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-12T12:29:55+00:00",
-            "updated_at": "2019-03-14T21:59:08.637881+00:00"
+            "created_at": "2019-05-19T05:23:16+00:00",
+            "updated_at": "2019-05-22T21:42:47.008913+00:00"
         }
     },
     {
@@ -158,13 +169,14 @@
         "pk": 13,
         "fields": {
             "contributor": 13,
-            "name": "Summer 2018 Apparel List",
-            "file_name": "Summer 2018 Apparel List.csv",
+            "name": "Summer 2019 Affiliate List",
+            "description": null,
+            "file_name": "Summer 2019 Affiliate List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-06T22:11:40+00:00",
-            "updated_at": "2019-03-14T21:59:08.156573+00:00"
+            "created_at": "2019-05-21T01:22:52+00:00",
+            "updated_at": "2019-05-22T21:42:47.976337+00:00"
         }
     },
     {
@@ -172,13 +184,14 @@
         "pk": 14,
         "fields": {
             "contributor": 14,
-            "name": "Winter 2018 Affiliate List",
-            "file_name": "Winter 2018 Affiliate List.csv",
+            "name": "Fall 2017 Apparel List",
+            "description": "This is the detailed description of the list named Fall 2017 Apparel List. Descriptions can be pretty long. This one is not that long, but it is long enough so that when designing an interface to display the description we will be sure to leave enough space.",
+            "file_name": "Fall 2017 Apparel List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-10T05:05:59+00:00",
-            "updated_at": "2019-03-14T21:59:08.137936+00:00"
+            "created_at": "2019-05-21T17:22:38+00:00",
+            "updated_at": "2019-05-22T21:42:47.535184+00:00"
         }
     },
     {
@@ -186,13 +199,14 @@
         "pk": 15,
         "fields": {
             "contributor": 15,
-            "name": "Fall 2018 Compliance List",
-            "file_name": "Fall 2018 Compliance List.csv",
+            "name": "Fall 2017 Affiliate List",
+            "description": null,
+            "file_name": "Fall 2017 Affiliate List.csv",
             "header": "country,name,address,lat,lng",
             "is_active": true,
             "is_public": true,
-            "created_at": "2019-03-12T11:21:04+00:00",
-            "updated_at": "2019-03-14T21:59:08.428458+00:00"
+            "created_at": "2019-05-19T15:41:37+00:00",
+            "updated_at": "2019-05-22T21:42:47.864057+00:00"
         }
     }
 ]

--- a/src/django/api/management/commands/makefixtures.py
+++ b/src/django/api/management/commands/makefixtures.py
@@ -208,6 +208,19 @@ def make_facility_list_name():
                                      random.choice(options))
 
 
+def make_facility_list_description(pk, name):
+    description = (
+        'This is the detailed description of the list named {}. Descriptions '
+        'can be pretty long. This one is not that long, but it is long enough '
+        'so that when designing an interface to display the description we '
+        'will be sure to leave enough space.'
+    )
+    if pk % 2 == 0:
+        return description.format(name)
+    else:
+        return None
+
+
 def make_facility_list(pk, contributor_pk=None):
     (created_at, updated_at) = make_created_updated()
     if contributor_pk is not None:
@@ -215,12 +228,14 @@ def make_facility_list(pk, contributor_pk=None):
     else:
         contributor = pk
     name = make_facility_list_name()
+    description = make_facility_list_description(pk, name)
     return {
         'model': 'api.facilitylist',
         'pk': pk,
         'fields': {
             'contributor': contributor,
             'name': name,
+            'description': description,
             'file_name': name + '.csv',
             'header': 'country,name,address,lat,lng',
             'is_active': True,

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -118,43 +118,37 @@ class UserProfileSerializer(ModelSerializer):
 
     def get_name(self, user):
         try:
-            user_contributor = Contributor.objects.get(admin=user)
-            return user_contributor.name
+            return user.contributor.name
         except Contributor.DoesNotExist:
             return None
 
     def get_description(self, user):
         try:
-            user_contributor = Contributor.objects.get(admin=user)
-            return user_contributor.description
+            return user.contributor.description
         except Contributor.DoesNotExist:
             return None
 
     def get_website(self, user):
         try:
-            user_contributor = Contributor.objects.get(admin=user)
-            return user_contributor.website
+            return user.contributor.website
         except Contributor.DoesNotExist:
             return None
 
     def get_contributor_type(self, user):
         try:
-            user_contributor = Contributor.objects.get(admin=user)
-            return user_contributor.contrib_type
+            return user.contributor.contrib_type
         except Contributor.DoesNotExist:
             return None
 
     def get_other_contributor_type(self, user):
         try:
-            user_contributor = Contributor.objects.get(admin=user)
-            return user_contributor.other_contrib_type
+            return user.contributor.other_contrib_type
         except Contributor.DoesNotExist:
             return None
 
     def get_contributor_id(self, user):
         try:
-            user_contributor = Contributor.objects.get(admin=user)
-            return user_contributor.id
+            return user.contributor.id
         except Contributor.DoesNotExist:
             return None
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -110,11 +110,12 @@ class UserProfileSerializer(ModelSerializer):
     website = SerializerMethodField()
     contributor_type = SerializerMethodField()
     other_contributor_type = SerializerMethodField()
+    facility_lists = SerializerMethodField()
 
     class Meta:
         model = User
         fields = ('id', 'name', 'description', 'website', 'contributor_type',
-                  'other_contributor_type')
+                  'other_contributor_type', 'facility_lists')
 
     def get_name(self, user):
         try:
@@ -151,6 +152,23 @@ class UserProfileSerializer(ModelSerializer):
             return user.contributor.id
         except Contributor.DoesNotExist:
             return None
+
+    def get_facility_lists(self, user):
+        try:
+            contributor = user.contributor
+            return FacilityListSummarySerializer(
+                contributor.facilitylist_set.filter(
+                    is_active=True, is_public=True).order_by('-created_at'),
+                many=True,
+            ).data
+        except Contributor.DoesNotExist:
+            return []
+
+
+class FacilityListSummarySerializer(ModelSerializer):
+    class Meta:
+        model = FacilityList
+        fields = ('id', 'name', 'description')
 
 
 class FacilityListSerializer(ModelSerializer):


### PR DESCRIPTION
## Overview

We currently allow contributors to specify a detailed description for a list but prior to this PR we were not displaying that description publicly. From the facility detail page we link to the profile page of any contributors associated with that facility so the profile page is a suitable place to display the facility lists and their descriptions.

Connects #356

## Demo

<img width="757" alt="Screen Shot 2019-05-22 at 2 57 10 PM" src="https://user-images.githubusercontent.com/17363/58213566-8092d580-7ca7-11e9-80a7-110f15d82437.png">


## Notes

Contributors have a dedicated UI for viewing their own lists so we are only showing the list details on public profile pages, not the profile page of the logged in contributor.

We have added descriptions to some of the fixture facility lists to allow for easier testing of facility list UI elements in both the presence and absence of a description value.

While reviewing the profile serialization I took the opportunity to eliminate some redundant database calls.

## Testing Instructions

* Reset the DB
  * `./scripts/manage resetdb`
  * `./scripts/manage loadfixtures`
  * `./scripts/manage processfixtures`
* Make sure you are logged out
* Browse http://localhost:6543/profile/2 and verify that the facility list description is displayed.
* Browse http://localhost:6543/profile/3 and verify that the page displays normally without a facility list description
* Register and confirm an account
* Ensure you are not logged in, browse http://localhost:6543/profile/101, and verify that the Facility Lists section is not displayed. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
