### PR TITLE
Bump DRF to a version not impacted by WS-2019-0037

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-
 - Add django-waffle and configure Django & React apps to enable feature flags [#531](https://github.com/open-apparel-registry/open-apparel-registry/pull/531)
 
 ### Changed
@@ -20,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed script name in release issue template [#529](https://github.com/open-apparel-registry/open-apparel-registry/pull/529)
 
 ### Security
+- Bumped Django REST framework to version not impacted by [WS-2019-0037](https://github.com/encode/django-rest-framework/commit/75a489150ae24c2f3c794104a8e98fa43e2c9ce9) [#536](https://github.com/open-apparel-registry/open-apparel-registry/pull/536)
 
 ## [2.4.0] - 2019-05-20
 ### Added

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -13,7 +13,7 @@ django-spa==0.2.0
 django-waffle==0.16.0
 django-watchman==0.15.0
 djangorestframework-gis==0.14
-djangorestframework==3.9.0
+djangorestframework==3.9.4
 flake8==3.6.0
 mccabe==0.6.1
 pycodestyle==2.4.0


### PR DESCRIPTION
## Overview

Bumps the version constraint for DRF from 3.9.0 to 3.9.4 (the latest patch release for the 3.9.x series).

See:

- https://github.com/encode/django-rest-framework/blob/master/docs/community/release-notes.md#39x-series
- https://github.com/encode/django-rest-framework/commit/75a489150ae24c2f3c794104a8e98fa43e2c9ce9

Fixes https://github.com/open-apparel-registry/open-apparel-registry/issues/535

## Testing Instructions

TBD

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
