### PR TITLE
Fetch client country code and write to app state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add django-waffle and configure Django & React apps to enable feature flags [#531](https://github.com/open-apparel-registry/open-apparel-registry/pull/531)
 - Support uploading Excel files [#532](https://github.com/open-apparel-registry/open-apparel-registry/pull/532)
+- Fetch client country code based on IP [#541](https://github.com/open-apparel-registry/open-apparel-registry/pull/541)
 
 ### Changed
 - Show active facility list names and descriptions on profile page [#534](https://github.com/open-apparel-registry/open-apparel-registry/pull/534)

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -27,6 +27,7 @@ import './App.css';
 
 import { sessionLogin } from './actions/auth';
 import { fetchFeatureFlags } from './actions/featureFlags';
+import { fetchClientInfo } from './actions/clientInfo';
 
 import {
     mainRoute,
@@ -58,6 +59,7 @@ const appStyles = Object.freeze({
 class App extends Component {
     componentDidMount() {
         this.props.getFeatureFlags();
+        this.props.getClientInfo();
         return this.props.logIn();
     }
 
@@ -137,6 +139,7 @@ App.propTypes = {
 function mapDispatchToProps(dispatch) {
     return {
         getFeatureFlags: () => dispatch(fetchFeatureFlags()),
+        getClientInfo: () => dispatch(fetchClientInfo()),
         logIn: () => dispatch(sessionLogin()),
     };
 }

--- a/src/app/src/actions/clientInfo.js
+++ b/src/app/src/actions/clientInfo.js
@@ -1,0 +1,27 @@
+import { createAction } from 'redux-act';
+
+import csrfRequest from '../util/csrfRequest';
+
+import {
+    makeGetClientInfoURL,
+    logErrorAndDispatchFailure,
+} from '../util/util';
+
+export const startFetchClientInfo = createAction('START_FETCH_CLIENT_INFO');
+export const failFetchClientInfo = createAction('FAIL_FETCH_CLIENT_INFO');
+export const completeFetchClientInfo = createAction('COMPLETE_FETCH_CLIENT_INFO');
+
+export function fetchClientInfo() {
+    return (dispatch) => {
+        dispatch(startFetchClientInfo());
+
+        return csrfRequest
+            .get(makeGetClientInfoURL())
+            .then(({ data }) => dispatch(completeFetchClientInfo(data)))
+            .catch(err => dispatch(logErrorAndDispatchFailure(
+                err,
+                'An error prevented fetching client info',
+                failFetchClientInfo,
+            )));
+    };
+}

--- a/src/app/src/reducers/ClientInfoReducer.js
+++ b/src/app/src/reducers/ClientInfoReducer.js
@@ -1,0 +1,21 @@
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    startFetchClientInfo,
+    failFetchClientInfo,
+    completeFetchClientInfo,
+} from '../actions/clientInfo';
+
+const initialState = Object.freeze({ fetched: false, countryCode: null });
+
+export default createReducer({
+    [startFetchClientInfo]: () => initialState,
+    [failFetchClientInfo]: state => update(state, {
+        fetched: { $set: true },
+    }),
+    [completeFetchClientInfo]: (state, payload) => update(state, {
+        fetched: { $set: true },
+        countryCode: { $set: payload.country.code },
+    }),
+}, initialState);

--- a/src/app/src/reducers/index.js
+++ b/src/app/src/reducers/index.js
@@ -17,6 +17,7 @@ import UIReducer from './UIReducer';
 import FacilitiesReducer from './FacilitiesReducer';
 import FacilityCountReducer from './FacilityCountReducer';
 import FeatureFlagsReducer from './FeatureFlagsReducer';
+import ClientInfoReducer from './ClientInfoReducer';
 
 export default combineReducers({
     auth: AuthReducer,
@@ -30,4 +31,5 @@ export default combineReducers({
     facilities: FacilitiesReducer,
     facilityCount: FacilityCountReducer,
     featureFlags: FeatureFlagsReducer,
+    clientInfo: ClientInfoReducer,
 });

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -93,6 +93,8 @@ export const makeGetFacilitiesCountURL = () => '/api/facilities/count/';
 
 export const makeGetAPIFeatureFlagsURL = () => '/api-feature-flags/';
 
+export const makeGetClientInfoURL = () => 'https://api.userinfo.io/userinfos';
+
 export const getValueFromObject = ({ value }) => value;
 
 export const createQueryStringFromSearchFilters = ({


### PR DESCRIPTION


## Overview

We need to detect if someone is browsing the app from China so that we can
change the way in which we load our map components. To facilitate this we make a
request to the free userinfo.io service when the `App` component loads and save
the returned country to the app state.

Connects #538 	

## Demo

### The userinfo.io service returning the correct country with the China VPN connection.

<img width="1004" alt="Screen Shot 2019-05-28 at 2 51 26 PM" src="https://user-images.githubusercontent.com/17363/58515791-dad5df80-815a-11e9-9aeb-d3e66e8ea02f.png">

### Writing country to app state

<img width="653" alt="Screen Shot 2019-05-28 at 2 54 21 PM" src="https://user-images.githubusercontent.com/17363/58515844-fe992580-815a-11e9-8e9f-f580f267af6a.png">

### Setting fetched flag on failure

<img width="715" alt="Screen Shot 2019-05-28 at 2 56 54 PM" src="https://user-images.githubusercontent.com/17363/58515859-0658ca00-815b-11e9-8350-633de2c7d263.png">

## Testing Instructions

* Open developer tools and browse http://localhost:6543/. Verify that `clientInfo.countryCode` is set in the app state.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
