### PR TITLE
Free Text Search for Facility List Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add django-waffle and configure Django & React apps to enable feature flags [#531](https://github.com/open-apparel-registry/open-apparel-registry/pull/531)
 - Support uploading Excel files [#532](https://github.com/open-apparel-registry/open-apparel-registry/pull/532)
 - Fetch client country code based on IP [#541](https://github.com/open-apparel-registry/open-apparel-registry/pull/541)
+- Free text search filter for facility list items [#542](https://github.com/open-apparel-registry/open-apparel-registry/pull/542)
 - Add admin-authorized dashboard route: [#553](https://github.com/open-apparel-registry/open-apparel-registry/pull/553)
 
 ### Changed

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "dependencies": {
         "@google/markerclusterer": "1.0.3",
-        "@material-ui/core": "3.0.1",
+        "@material-ui/core": "3.1.0",
         "@material-ui/icons": "3.0.1",
         "@turf/turf": "5.1.6",
         "@turf/distance": "6.0.1",

--- a/src/app/src/components/FacilityListItemsFilterSearch.jsx
+++ b/src/app/src/components/FacilityListItemsFilterSearch.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { func, string } from 'prop-types';
 
+import trim from 'lodash/trim';
+
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import TextField from '@material-ui/core/TextField';
@@ -24,7 +26,9 @@ export default function FacilityListItemsTableSearch({
             return;
         }
 
-        onSearch(searchText);
+        const term = trim(searchText);
+        onSearch(term);
+        setSearchText(term);
     };
 
     const handleTextChange = (e) => {

--- a/src/app/src/components/FacilityListItemsFilterSearch.jsx
+++ b/src/app/src/components/FacilityListItemsFilterSearch.jsx
@@ -67,7 +67,6 @@ export default function FacilityListItemsTableSearch({
 
     return (
         <TextField
-            margin="dense"
             variant="outlined"
             type="text"
             label="Search"

--- a/src/app/src/components/FacilityListItemsFilterSearch.jsx
+++ b/src/app/src/components/FacilityListItemsFilterSearch.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { func, string } from 'prop-types';
+
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import TextField from '@material-ui/core/TextField';
+import Search from '@material-ui/icons/Search';
+import Close from '@material-ui/icons/Close';
+
+import { ENTER_KEY } from '../util/constants';
+
+export default function FacilityListItemsTableSearch({
+    currentValue,
+    onSearch,
+}) {
+    const [searchText, setSearchText] = useState(currentValue);
+    const isCurrent = searchText === currentValue;
+
+    // Update internal state if the prop is updated
+    useEffect(() => setSearchText(currentValue), [currentValue]);
+
+    const handleSearch = () => {
+        if (isCurrent) {
+            return;
+        }
+
+        onSearch(searchText);
+    };
+
+    const handleTextChange = (e) => {
+        setSearchText(e.target.value);
+    };
+
+    const handleReset = () => {
+        setSearchText('');
+        onSearch('');
+    };
+
+    const handleTextKeyDown = (e) => {
+        if (e.key === ENTER_KEY) {
+            handleSearch();
+        }
+    };
+
+    const searchButton = (
+        <IconButton
+            edge="end"
+            aria-label="Search"
+            onClick={handleSearch}
+        >
+            <Search />
+        </IconButton>
+    );
+    const resetButton = (
+        <IconButton
+            edge="end"
+            aria-label="Reset"
+            onClick={handleReset}
+        >
+            <Close />
+        </IconButton>
+    );
+
+    const adornment = (searchText !== '' && isCurrent)
+        ? resetButton
+        : searchButton;
+
+    return (
+        <TextField
+            margin="dense"
+            variant="outlined"
+            type="text"
+            label="Search"
+            onChange={handleTextChange}
+            onKeyDown={handleTextKeyDown}
+            value={searchText}
+            InputProps={{
+                endAdornment: (
+                    <InputAdornment position="end">
+                        {adornment}
+                    </InputAdornment>
+                ),
+            }}
+        />
+    );
+}
+
+FacilityListItemsTableSearch.propTypes = {
+    currentValue: string,
+    onSearch: func.isRequired,
+};
+
+FacilityListItemsTableSearch.defaultProps = {
+    currentValue: '',
+};

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -58,15 +58,15 @@ const facilityListItemsTableStyles = Object.freeze({
         lineHeight: '1.2',
     }),
     searchFilterStyles: Object.freeze({
-        display: 'inline-block',
         marginRight: '5px',
     }),
     statusFilterStyles: Object.freeze({
-        padding: '20px 0 0 20px',
+        padding: '10px 20px 0 20px',
+        display: 'flex',
+        alignItems: 'center',
     }),
     statusFilterSelectStyles: Object.freeze({
-        display: 'inline-block',
-        width: '40%',
+        flex: '2',
     }),
     statusFilterMessageStyles: Object.freeze({
         padding: '0 0 0 20px',
@@ -446,6 +446,19 @@ class FacilityListItemsTable extends Component {
                             placeholder="Filter by item status..."
                             value={createSelectedStatusChoicesFromParams(params)}
                             onChange={this.handleChangeStatusFilter}
+                            styles={{
+                                control: provided => ({
+                                    ...provided,
+                                    height: '56px',
+                                }),
+                            }}
+                            theme={theme => ({
+                                ...theme,
+                                colors: {
+                                    ...theme.colors,
+                                    primary: '#00319D',
+                                },
+                            })}
                         />
                     </div>
                     <ShowOnly when={!!(params && (params.status || params.search))}>

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -261,7 +261,7 @@ class FacilityListItemsTable extends Component {
         const params = createParamsFromQueryString(search);
 
         const newParams = update(params, {
-            $unset: ['status'],
+            $unset: ['status', 'search'],
         });
         replace(makePaginatedFacilityListItemsDetailLinkWithRowCount(
             listID,
@@ -448,7 +448,7 @@ class FacilityListItemsTable extends Component {
                             onChange={this.handleChangeStatusFilter}
                         />
                     </div>
-                    <ShowOnly when={!!(params && params.status)}>
+                    <ShowOnly when={!!(params && (params.status || params.search))}>
                         <span style={facilityListItemsTableStyles.statusFilterMessageStyles}>
                             Showing {filteredCount} of {list.item_count} items.
                         </span>

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -14,6 +14,7 @@ import TablePagination from '@material-ui/core/TablePagination';
 import ReactSelect from 'react-select';
 import ShowOnly from './ShowOnly';
 
+import FacilityListItemsFilterSearch from './FacilityListItemsFilterSearch';
 import FacilityListItemsTableRow from './FacilityListItemsTableRow';
 import FacilityListItemsConfirmationTableRow from './FacilityListItemsConfirmationTableRow';
 import FacilityListItemsErrorTableRow from './FacilityListItemsErrorTableRow';
@@ -56,6 +57,10 @@ const facilityListItemsTableStyles = Object.freeze({
         padding: '20px',
         lineHeight: '1.2',
     }),
+    searchFilterStyles: Object.freeze({
+        display: 'inline-block',
+        marginRight: '5px',
+    }),
     statusFilterStyles: Object.freeze({
         padding: '20px 0 0 20px',
     }),
@@ -74,7 +79,6 @@ const createSelectedStatusChoicesFromParams = (params) => {
     }
     return null;
 };
-
 
 class FacilityListItemsTable extends Component {
     componentDidUpdate(prevProps) {
@@ -173,6 +177,37 @@ class FacilityListItemsTable extends Component {
             params,
         ));
         fetchListItems(listID, page, getValueFromEvent(e), params);
+    }
+
+    handleChangeSearchTerm = (term) => {
+        const {
+            fetchListItems,
+            match: {
+                params: {
+                    listID,
+                },
+            },
+            history: {
+                replace,
+                location: {
+                    search,
+                },
+            },
+        } = this.props;
+
+        const { rowsPerPage } = createPaginationOptionsFromQueryString(search);
+        const params = createParamsFromQueryString(search);
+        const newParams = update(params, {
+            search: { $set: term !== '' ? term : null },
+        });
+
+        replace(makePaginatedFacilityListItemsDetailLinkWithRowCount(
+            listID,
+            1,
+            rowsPerPage,
+            newParams,
+        ));
+        fetchListItems(listID, 1, rowsPerPage, newParams);
     }
 
     handleChangeStatusFilter = (selected) => {
@@ -395,6 +430,12 @@ class FacilityListItemsTable extends Component {
         return (
             <Paper style={facilityListItemsTableStyles.containerStyles}>
                 <div style={facilityListItemsTableStyles.statusFilterStyles}>
+                    <div style={facilityListItemsTableStyles.searchFilterStyles}>
+                        <FacilityListItemsFilterSearch
+                            currentValue={params.search || ''}
+                            onSearch={this.handleChangeSearchTerm}
+                        />
+                    </div>
                     <div style={facilityListItemsTableStyles.statusFilterSelectStyles}>
                         <ReactSelect
                             isMulti

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -197,16 +197,21 @@ export const createParamsFromQueryString = (qs) => {
         : qs;
 
     const {
+        search,
         status,
     } = querystring.parse(qsToParse);
 
+    const params = {};
+
     if (status) {
-        return Array.isArray(status)
-            ? Object.freeze({ status })
-            : Object.freeze({ status: [status] });
+        params.status = Array.isArray(status) ? status : [status];
     }
 
-    return {};
+    if (search) {
+        params.search = search;
+    }
+
+    return params;
 };
 
 export const getTokenFromQueryString = (qs) => {

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -1572,10 +1572,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@material-ui/core@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.0.1.tgz#e8476394a42d89ae404355ddbc093db4d044b225"
-  integrity sha512-fefgeod+PIm95uak7cJkEs6IZgZSZ9X9neW58RIVEaD8zhyRjARetAphh3gS6KXYfEVJEJLYZlXrCNF57lBDag==
+"@material-ui/core@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.1.0.tgz#40c70e0764ef27dca5e149551577eba10c2e79ce"
+  integrity sha512-Tq9xO1CsaPq+TGQtMz7B0Hs2Wz9Sf2W8C9ydcZT8cP1ud9cuZZ/2izRvqNZEp1fCaL5+8K0DJvuu8Di98kNuJw==
   dependencies:
     "@babel/runtime" "7.0.0"
     "@types/jss" "^9.5.3"
@@ -1602,7 +1602,7 @@
     react-event-listener "^0.6.2"
     react-jss "^8.1.0"
     react-transition-group "^2.2.1"
-    recompose "^0.29.0"
+    recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
 "@material-ui/icons@3.0.1":
@@ -11064,6 +11064,18 @@ realpath-native@^1.0.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+"recompose@0.28.0 - 0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.30.0.tgz#82773641b3927e8c7d24a0d87d65aeeba18aabd0"
+  integrity sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^2.3.1"
+    react-lifecycles-compat "^3.0.2"
+    symbol-observable "^1.0.4"
 
 recompose@^0.29.0:
   version "0.29.0"

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -22,4 +22,5 @@ class FacilitiesQueryParams:
 
 
 class FacilityListItemsQueryParams:
+    SEARCH = 'search'
     STATUS = 'status'

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -297,6 +297,7 @@ class FacilityQueryParamsSerializer(Serializer):
 
 
 class FacilityListItemsQueryParamsSerializer(Serializer):
+    search = CharField(required=False)
     status = ListField(
         child=CharField(required=False),
         required=False,

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -822,6 +822,9 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         status = request.query_params.getlist(
             FacilityListItemsQueryParams.STATUS)
 
+        if search is not None:
+            search = search.strip()
+
         try:
             user_contributor = request.user.contributor
             facility_list = FacilityList \
@@ -831,7 +834,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             queryset = FacilityListItem \
                 .objects \
                 .filter(facility_list=facility_list)
-            if search is not None:
+            if search is not None and len(search) > 0:
                 queryset = queryset.filter(
                     Q(facility__name__icontains=search) |
                     Q(facility__address__icontains=search))

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -817,8 +817,11 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         if not params.is_valid():
             raise ValidationError(params.errors)
 
+        search = request.query_params.get(
+            FacilityListItemsQueryParams.SEARCH)
         status = request.query_params.getlist(
             FacilityListItemsQueryParams.STATUS)
+
         try:
             user_contributor = request.user.contributor
             facility_list = FacilityList \
@@ -828,6 +831,10 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             queryset = FacilityListItem \
                 .objects \
                 .filter(facility_list=facility_list)
+            if search is not None:
+                queryset = queryset.filter(
+                    Q(facility__name__icontains=search) |
+                    Q(facility__address__icontains=search))
             if status is not None and len(status) > 0:
                 q_statements = [make_q_from_status(s) for s in status]
                 queryset = queryset.filter(reduce(operator.or_, q_statements))


### PR DESCRIPTION
## Overview

Adds a free text search control to the facility list items table that allows filtering values with arbitrary text. Text search works in conjunction with the status filter, operating as an "AND" to the status filter. The search text itself is taken as a single phrase, and we look for an exact case-insensitive occurrence in the name or address for matches.

The control supports both mouse and keyboard events. Users can search by typing in the value and pressing "Enter" to search, or "Escape" to reset it. When entering a search term, there is a 🔍  button that can be pressed to start the search. Afterwards, there is a ✖️ button which can be used to reset the box.

Also upgrades Material UI to 3.1.0 which adds support for `outlined` and `filled` variants of controls such as `TextField`.

Connects #503 

## Demo

![2019-05-29 14 24 12](https://user-images.githubusercontent.com/1430060/58581535-c4dd2300-821d-11e9-9778-cf7560d4fc18.gif)

## Notes

During the search there should be a spinner, but often times the search is so fast that the spinner doesn't render. There may also be an issue with the parent table re-rendering resetting the spinner state of the search control.

The initial implementation is using the `useState` hook. There is an alternative implementation in the final commit that uses `useReducer` instead. We can choose between them. I have a slight preference for `useState`.

## Testing Instructions

* Check out this branch, `update` and `server`
* Go to a list
  - [x] Ensure you see a search control to the left of the status filter
* Type in a search term. Press <kbd>Enter</kbd>
  - [x] Ensure the list is updated to reflect the search
* ~~Focus on the search box. Press <kbd>Escape</kbd>~~
  - ~~Ensure the search is reset~~
* Try the above with the mouse
  - [x] Ensure using the 🔍 button triggers a search
  - [x] Ensure using the ✖️ button resets a search
* Try in combination with status filters
  - [x] Ensure the search and status filters work together
* Try refreshing the page with an active search
  - [x] Ensure the new page loads the correctly filtered items