### PR TITLE
Add /dashboard/lists and /dashboard/claims routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Free text search filter for facility list items [#542](https://github.com/open-apparel-registry/open-apparel-registry/pull/542)
 - Add admin-authorized dashboard route: [#553](https://github.com/open-apparel-registry/open-apparel-registry/pull/553)
 - Enabled hot reloading during development in React app [#556](https://github.com/open-apparel-registry/open-apparel-registry/pull/556)
+- Create `/dashboard/lists` and `/dashboard/claims` routes [#557](https://github.com/open-apparel-registry/open-apparel-registry/pull/557)
 
 ### Changed
 - Show active facility list names and descriptions on profile page [#534](https://github.com/open-apparel-registry/open-apparel-registry/pull/534)

--- a/src/app/src/components/Dashboard.jsx
+++ b/src/app/src/components/Dashboard.jsx
@@ -2,10 +2,23 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bool } from 'prop-types';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import { Link, Route, Switch } from 'react-router-dom';
+
+import DashboardLists from './DashboardLists';
+import DashboardClaims from './DashboardClaims';
+import FeatureFlag from './FeatureFlag';
 
 import { checkWhetherUserHasDashboardAccess } from '../util/util';
+import { CLAIM_A_FACILITY, dashboardListsRoute, dashboardClaimsRoute } from '../util/constants';
 
 import AppGrid from './AppGrid';
+
+const dashboardStyles = Object.freeze({
+    linkSectionStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+    }),
+});
 
 function Dashboard({
     userWithAccessHasSignedIn,
@@ -27,9 +40,38 @@ function Dashboard({
         );
     }
 
+    const linkSection = (
+        <div style={dashboardStyles.linkSectionStyles}>
+            <Link to={dashboardListsRoute}>
+                View Contributor Lists
+            </Link>
+            <FeatureFlag flag={CLAIM_A_FACILITY}>
+                <Link to={dashboardClaimsRoute}>
+                    View Facility Claims
+                </Link>
+            </FeatureFlag>
+        </div>
+    );
+
     return (
-        <AppGrid title="dashboard">
-            Dashboard
+        <AppGrid title="Dashboard">
+            <Switch>
+                <Route path={dashboardListsRoute} component={DashboardLists} />
+                <Route
+                    path={dashboardClaimsRoute}
+                    render={
+                        () => (
+                            <FeatureFlag
+                                flag={CLAIM_A_FACILITY}
+                                alternative={linkSection}
+                            >
+                                <Route component={DashboardClaims} />
+                            </FeatureFlag>
+                        )
+                    }
+                />
+                <Route render={() => linkSection} />
+            </Switch>
         </AppGrid>
     );
 }

--- a/src/app/src/components/DashboardClaims.jsx
+++ b/src/app/src/components/DashboardClaims.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function DashboardClaims() {
+    return (
+        <p>
+            Dashboard Claims
+        </p>
+    );
+}

--- a/src/app/src/components/DashboardLists.jsx
+++ b/src/app/src/components/DashboardLists.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function DashboardLists() {
+    return (
+        <p>
+            Dashboard Lists
+        </p>
+    );
+}

--- a/src/app/src/components/FeatureFlag.jsx
+++ b/src/app/src/components/FeatureFlag.jsx
@@ -10,10 +10,11 @@ import { convertFeatureFlagsObjectToListOfActiveFlags } from '../util/util';
 function FeatureFlag({
     flag,
     children,
+    alternative,
     activeFeatureFlags,
 }) {
     if (!includes(activeFeatureFlags, flag)) {
-        return null;
+        return alternative;
     }
 
     return (
@@ -23,9 +24,14 @@ function FeatureFlag({
     );
 }
 
+FeatureFlag.defaultProps = {
+    alternative: null,
+};
+
 FeatureFlag.propTypes = {
     flag: featureFlagPropType.isRequired,
     children: node.isRequired,
+    alternative: node,
     activeFeatureFlags: arrayOf(featureFlagPropType).isRequired,
 };
 

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -211,6 +211,8 @@ export const facilityDetailsRoute = '/facilities/:oarID';
 export const profileRoute = '/profile/:id';
 export const aboutProcessingRoute = '/about/processing';
 export const dashboardRoute = '/dashboard';
+export const dashboardListsRoute = '/dashboard/lists';
+export const dashboardClaimsRoute = '/dashboard/claims';
 
 export const contributeCSVTemplate =
     'country,name,address\nEgypt,Elite Merchandising Corp.,St. 8 El-Amrya Public Free Zone Alexandria Iskandariyah 23512 Egypt';


### PR DESCRIPTION
## Overview

To split work on #547 from work on #517 this PR sets up some routing for `/dashboard/lists` and `/dashboard/claims` routes, with the claims routes behind a feature flag. It also adds some placeholder components for each route.

- add /dashboard/lists and /dashboard/claims routing
- add placeholder DashboardLists and DashboardClaims components to
disentangle work on viewing contributor lists from work on viewing
facility claims
- add routing & links on main Dashboard components to lists and claims,
placing the claims route behind a feature flag

Connects #517 

## Demo

feature switch:

![Screen Shot 2019-06-04 at 12 25 55 PM](https://user-images.githubusercontent.com/4165523/58896572-3a387000-86c4-11e9-8c4f-c6e2265aefd8.png)

with feature switched off:

![Screen Shot 2019-06-04 at 12 26 03 PM](https://user-images.githubusercontent.com/4165523/58896576-3ad10680-86c4-11e9-9d24-ece701b0fa87.png)

with feature switched on:

![Screen Shot 2019-06-04 at 12 26 10 PM](https://user-images.githubusercontent.com/4165523/58896575-3ad10680-86c4-11e9-85d7-9fe28eeaecff.png)

/dashboard/lists:

![Screen Shot 2019-06-04 at 12 26 19 PM](https://user-images.githubusercontent.com/4165523/58896573-3ad10680-86c4-11e9-8ed8-0614d2158049.png)

/dashboard/claims:

![Screen Shot 2019-06-04 at 12 26 13 PM](https://user-images.githubusercontent.com/4165523/58896574-3ad10680-86c4-11e9-8a84-48f691e7ee13.png)

## Testing Instructions

- serve this branch, `./scripts/manage resetdb`, `./scripts/manage createsuperuser`, then sign in to the app as your superuser on 6543 and visit `/dashboard`
- if you haven't turned the feature flag for claim a facility on, you should only see the lists link on the dashboard page. Clicking it should take you to the placeholder component and update the route to `/dashboard/lists`
- with the feature flag still turned *off*, visit `/dashboard/claims` directly and verify that you just see the main dashboard page again
- turn the CLAIM_A_FACILITY switch *on* in the django-admin, save the change, then refresh `/dashboard/claims`. You should now see the claims placeholder component
- visit `/dashboard` again and verify that you now see two links, both of which work

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
