### PR TITLE
Brand verification fixes

### DIFF
--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -12,6 +12,7 @@ import FacilityListSummary from './FacilityListSummary';
 import UserProfileField from './UserProfileField';
 import UserAPITokens from './UserAPITokens';
 import BadgeVerified from './BadgeVerified';
+import ShowOnly from './ShowOnly';
 import COLOURS from '../util/COLOURS';
 
 import '../styles/css/specialStates.css';
@@ -168,15 +169,15 @@ class UserProfile extends Component {
                 />));
 
 
-        const title = isEditableProfile
-            ? 'My Profile'
-            : (
-                <React.Fragment>
-                    {profile.name}
+        const title = (
+            <React.Fragment>
+                {isEditableProfile ? 'My Profile' : profile.name}
+                <ShowOnly when={profile.isVerified}>
                     <span title="Verified" style={profileStyles.badgeVerifiedStyles}>
                         <BadgeVerified color={COLOURS.NAVY_BLUE} />
                     </span>
-                </React.Fragment>);
+                </ShowOnly>
+            </React.Fragment>);
 
         const showErrorMessages = isEditableProfile
             && errorsUpdatingProfile

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -359,7 +359,7 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
     def get_contributors(self, facility):
         return [
             {
-                'id': facility_list.contributor.id,
+                'id': facility_list.contributor.admin.id,
                 'name': '{} ({})'.format(
                     facility_list.contributor.name,
                     facility_list.name),


### PR DESCRIPTION
## Overview

Corrects 2 issues with the initial brand verification implementation

* Links to profile pages from the facility details page were incorrect because we were using Contributor ID instead of User ID
* The verified badge was not shown on the profile of the currently logged in user.

Connects #545

## Demo

<img width="983" alt="Screen Shot 2019-06-07 at 12 23 50 PM" src="https://user-images.githubusercontent.com/17363/59128538-2b99c500-891f-11e9-98f3-e93672ec75ee.png">

## Testing Instructions

This assumes you have the fixture data loaded

* Log in as and admin (i.e. c1@example.com)
* Browse http://localhost:8081/admin/api/contributor/2/change/ and mark the contributor as verified.
* Log in as `c2@example.com` and browse http://localhost:6543/profile/2. Verify that the verified badge is displayed next to "My Profile"
* Browse http://localhost:6543 and open a facility detail page. Verify that the link to the profile page is correct.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [ ] ~CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~ Skipped because this is a fix to a previous feature.
