### PR TITLE
Add claimed/ routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Enable submitting claim a facility form [#540](https://github.com/open-apparel-registry/open-apparel-registry/pull/540)
 - Allow contributors to be verified [#563](https://github.com/open-apparel-registry/open-apparel-registry/pull/563)
+- Add routing to enable users to view claimed facilities [#572](https://github.com/open-apparel-registry/open-apparel-registry/pull/572)
 
 ### Changed
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -27,6 +27,7 @@ import Dashboard from './components/Dashboard';
 import Translate from './components/Translate';
 import FeatureFlag from './components/FeatureFlag';
 import ClaimFacility from './components/ClaimFacility';
+import ClaimedFacilities from './components/ClaimedFacilities';
 
 import './App.css';
 
@@ -48,6 +49,7 @@ import {
     aboutProcessingRoute,
     dashboardRoute,
     claimFacilityRoute,
+    claimedFacilitiesRoute,
     CLAIM_A_FACILITY,
 } from './util/constants';
 
@@ -94,6 +96,17 @@ class App extends Component {
                                             alternative={<Route component={MapAndSidebar} />}
                                         >
                                             <Route component={ClaimFacility} />
+                                        </FeatureFlag>
+                                    )}
+                                />
+                                <Route
+                                    path={claimedFacilitiesRoute}
+                                    render={() => (
+                                        <FeatureFlag
+                                            flag={CLAIM_A_FACILITY}
+                                            alternative={<RouteNotFound />}
+                                        >
+                                            <Route component={ClaimedFacilities} />
                                         </FeatureFlag>
                                     )}
                                 />

--- a/src/app/src/components/ClaimedFacilities.jsx
+++ b/src/app/src/components/ClaimedFacilities.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+import ClaimedFacilitiesList from './ClaimedFacilitiesList';
+import ClaimedFacilitiesDetails from './ClaimedFacilitiesDetails';
+import RouteNotFound from './RouteNotFound';
+
+import {
+    claimedFacilitiesRoute,
+    claimedFacilitiesDetailRoute,
+} from '../util/constants';
+
+export default function ClaimedFacilities() {
+    return (
+        <Switch>
+            <Route
+                path={claimedFacilitiesDetailRoute}
+                component={ClaimedFacilitiesDetails}
+            />
+            <Route
+                path={claimedFacilitiesRoute}
+                component={ClaimedFacilitiesList}
+            />
+            <Route render={() => <RouteNotFound />} />
+        </Switch>
+    );
+}

--- a/src/app/src/components/ClaimedFacilitiesDetails.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetails.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ClaimedFacilitiesDetails() {
+    return (
+        <p>
+            Claimed facilities details
+        </p>
+    );
+}

--- a/src/app/src/components/ClaimedFacilitiesList.jsx
+++ b/src/app/src/components/ClaimedFacilitiesList.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function ClaimedFacilitiesList() {
+    return (
+        <p>
+            Claimed facilities list
+        </p>
+    );
+}

--- a/src/app/src/components/FeatureFlag.jsx
+++ b/src/app/src/components/FeatureFlag.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { arrayOf, node } from 'prop-types';
+import { arrayOf, bool, node } from 'prop-types';
 import { connect } from 'react-redux';
 import includes from 'lodash/includes';
 
@@ -12,7 +12,12 @@ function FeatureFlag({
     children,
     alternative,
     activeFeatureFlags,
+    fetching,
 }) {
+    if (fetching) {
+        return null;
+    }
+
     if (!includes(activeFeatureFlags, flag)) {
         return alternative;
     }
@@ -33,13 +38,18 @@ FeatureFlag.propTypes = {
     children: node.isRequired,
     alternative: node,
     activeFeatureFlags: arrayOf(featureFlagPropType).isRequired,
+    fetching: bool.isRequired,
 };
 
 function mapStateToProps({
-    featureFlags,
+    featureFlags: {
+        fetching,
+        flags,
+    },
 }) {
     return {
-        activeFeatureFlags: convertFeatureFlagsObjectToListOfActiveFlags(featureFlags),
+        activeFeatureFlags: convertFeatureFlagsObjectToListOfActiveFlags(flags),
+        fetching,
     };
 }
 

--- a/src/app/src/reducers/FeatureFlagsReducer.js
+++ b/src/app/src/reducers/FeatureFlagsReducer.js
@@ -1,4 +1,5 @@
 import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
 
 import {
     startFetchFeatureFlags,
@@ -7,11 +8,21 @@ import {
     clearFeatureFlags,
 } from '../actions/featureFlags';
 
-const initialState = Object.freeze({});
+const initialState = Object.freeze({
+    fetching: false,
+    flags: Object.freeze({}),
+});
 
 export default createReducer({
-    [startFetchFeatureFlags]: () => initialState,
-    [failFetchFeatureFlags]: () => initialState,
+    [startFetchFeatureFlags]: state => update(state, {
+        fetching: { $set: true },
+    }),
+    [failFetchFeatureFlags]: state => update(state, {
+        fetching: { $set: false },
+    }),
     [clearFeatureFlags]: () => initialState,
-    [completeFetchFeatureFlags]: (_, payload) => Object.freeze(payload),
+    [completeFetchFeatureFlags]: (state, data) => Object.freeze(update(state, {
+        fetching: { $set: false },
+        flags: { $set: data },
+    })),
 }, initialState);

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -214,6 +214,8 @@ export const aboutProcessingRoute = '/about/processing';
 export const dashboardRoute = '/dashboard';
 export const dashboardListsRoute = '/dashboard/lists';
 export const dashboardClaimsRoute = '/dashboard/claims';
+export const claimedFacilitiesRoute = '/claimed';
+export const claimedFacilitiesDetailRoute = '/claimed/:claimID';
 
 export const contributeCSVTemplate =
     'country,name,address\nEgypt,Elite Merchandising Corp.,St. 8 El-Amrya Public Free Zone Alexandria Iskandariyah 23512 Egypt';


### PR DESCRIPTION
## Overview

- add React routing for `/claimed` and `/claimed/:claimID`, along with
components for routing
- update FeatureFlag component & Redux actions to display nothing while
the fetching is underway. This fixes a bug whereby the `alternative`
node would get rendered while the request to get all feature flags was
underway.

Connects #543 
Connects #518 

## Demo

![Screen Shot 2019-06-10 at 2 12 52 PM](https://user-images.githubusercontent.com/4165523/59216579-e4633c80-8b89-11e9-83ef-73535a8382ed.png)
![Screen Shot 2019-06-10 at 2 13 07 PM](https://user-images.githubusercontent.com/4165523/59216580-e4633c80-8b89-11e9-9ded-b7650976b580.png)

## Testing Instructions

- serve this branch then visit `/claimed` and `/claimed/hello`, respectively, with the claim a facility feature flag on and verify that the routes both work -- and that nothing renders until the feature flag request returns
- switch off the claim a facility feature, then refresh the `/claimed` route and verify that you see the route not found message:

![Screen Shot 2019-06-10 at 2 14 58 PM](https://user-images.githubusercontent.com/4165523/59216712-2e4c2280-8b8a-11e9-8d0f-43d8d499ca3c.png)


## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
