### PR TITLE
Add AppGrid container to /claimed route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add claim a facility dashboard [#559](https://github.com/open-apparel-registry/open-apparel-registry/pull/559)
 
 ### Changed
+- Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)
 
 ### Deprecated
 

--- a/src/app/src/components/ClaimedFacilities.jsx
+++ b/src/app/src/components/ClaimedFacilities.jsx
@@ -4,6 +4,7 @@ import { Switch, Route } from 'react-router-dom';
 import ClaimedFacilitiesList from './ClaimedFacilitiesList';
 import ClaimedFacilitiesDetails from './ClaimedFacilitiesDetails';
 import RouteNotFound from './RouteNotFound';
+import AppGrid from './AppGrid';
 
 import {
     claimedFacilitiesRoute,
@@ -12,16 +13,30 @@ import {
 
 export default function ClaimedFacilities() {
     return (
-        <Switch>
-            <Route
-                path={claimedFacilitiesDetailRoute}
-                component={ClaimedFacilitiesDetails}
-            />
-            <Route
-                path={claimedFacilitiesRoute}
-                component={ClaimedFacilitiesList}
-            />
-            <Route render={() => <RouteNotFound />} />
-        </Switch>
+        <AppGrid
+            title={
+                (
+                    <Switch>
+                        <Route
+                            path={claimedFacilitiesDetailRoute}
+                            render={() => 'Claimed Facility Details'}
+                        />
+                        <Route render={() => 'Claimed Facilities'} />
+                    </Switch>
+                )
+            }
+        >
+            <Switch>
+                <Route
+                    path={claimedFacilitiesDetailRoute}
+                    component={ClaimedFacilitiesDetails}
+                />
+                <Route
+                    path={claimedFacilitiesRoute}
+                    component={ClaimedFacilitiesList}
+                />
+                <Route render={() => <RouteNotFound />} />
+            </Switch>
+        </AppGrid>
     );
 }

--- a/src/app/src/components/Dashboard.jsx
+++ b/src/app/src/components/Dashboard.jsx
@@ -84,7 +84,7 @@ function Dashboard({
                                             flag={CLAIM_A_FACILITY}
                                             alternative={DASHBOARD_TITLE}
                                         >
-                                            Dashboad / Facility Claim Details
+                                            Dashboard / Facility Claim Details
                                         </FeatureFlag>
                                     )
                                 }


### PR DESCRIPTION
## Overview

Add AppGrid container to /claimed route. This enables adding a
contextual page header while keeping the entire component from
unmounting/remounting on route changes.

Also fix a typo in the dashboard title.

Connects #518 

## Demo

![Screen Shot 2019-06-11 at 10 46 32 AM](https://user-images.githubusercontent.com/4165523/59282082-54c79780-8c36-11e9-81eb-6029356b7be6.png)
![Screen Shot 2019-06-11 at 10 46 41 AM](https://user-images.githubusercontent.com/4165523/59282083-54c79780-8c36-11e9-9f81-c93d0d9476e0.png)


## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- serve this branch, ensure the `claim_a_facility` feature is switched on then visit

http://localhost:6543/claimed

&

http://localhost:6543/claimed/hello

and verify that the components render with the usual AppGrid container

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
