### PR TITLE
Superusers Can View All Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add profile page and update form for approved facility claims [#575](https://github.com/open-apparel-registry/open-apparel-registry/pull/575)
 - Show a list of facilities successfully claimed by the current contributor [#573](https://github.com/open-apparel-registry/open-apparel-registry/pull/573)
 - Add GitHub issue template for "draft" issues [#590](https://github.com/open-apparel-registry/open-apparel-registry/pull/590)
+- Allow superusers to view all lists [#584](https://github.com/open-apparel-registry/open-apparel-registry/pull/584)
 
 ### Changed
 - Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -55,6 +55,7 @@ const {
     makeMyFacilitiesRoute,
     makeResetPasswordEmailURL,
     getTokenFromQueryString,
+    getContributorFromQueryString,
     makeResetPasswordConfirmURL,
     makeUserProfileURL,
     makeProfileRouteLink,
@@ -808,6 +809,15 @@ it('gets a `token` from a querystring', () => {
     const expectedMissingQueryStringMatch = '';
 
     expect(getTokenFromQueryString(missingQueryString)).toBe(expectedMissingQueryStringMatch);
+});
+
+it('gets a `contributor` from querystring', () => {
+    expect(getContributorFromQueryString('?contributor=5')).toBe(5);
+    expect(getContributorFromQueryString('?contributor=5&contributor=10')).toBe(5);
+    expect(getContributorFromQueryString('?contributor=five')).toBe(NaN);
+    expect(getContributorFromQueryString('?contributor=')).toBe(NaN);
+    expect(getContributorFromQueryString('?something=else')).toBe(NaN);
+    expect(getContributorFromQueryString('')).toBe(NaN);
 });
 
 it('joins a 2-d array into a correctly escaped CSV string', () => {

--- a/src/app/src/actions/dashboardLists.js
+++ b/src/app/src/actions/dashboardLists.js
@@ -1,0 +1,60 @@
+import { createAction } from 'redux-act';
+
+import csrfRequest from '../util/csrfRequest';
+
+import {
+    logErrorAndDispatchFailure,
+    makeGetContributorsURL,
+    makeDashboardFacilityListsURL,
+    mapDjangoChoiceTuplesToSelectOptions,
+} from '../util/util';
+
+export const startFetchDashboardListContributors =
+    createAction('START_FETCH_DASHBOARD_LIST_CONTRIBUTORS');
+export const failFetchDashboardListContributors =
+    createAction('FAIL_FETCH_DASHBOARD_LIST_CONTRIBUTORS');
+export const completeFetchDashboardListContributors =
+    createAction('COMPLETE_FETCH_DASHBOARD_LIST_CONTRIBUTORS');
+
+export function fetchDashboardListContributors() {
+    return (dispatch) => {
+        dispatch(startFetchDashboardListContributors());
+
+        return csrfRequest
+            .get(makeGetContributorsURL())
+            .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
+            .then(data => dispatch(completeFetchDashboardListContributors(data)))
+            .catch(err => dispatch(logErrorAndDispatchFailure(
+                err,
+                'An error prevented fetching dashboard list contributors',
+                failFetchDashboardListContributors,
+            )));
+    };
+}
+
+export const setDashboardListContributor =
+    createAction('SET_DASHBOARD_LIST_CONTRIBUTOR');
+
+export const startFetchDashboardFacilityLists =
+    createAction('START_FETCH_DASHBOARD_FACILITY_LISTS');
+export const failFetchDashboardFacilityLists =
+    createAction('FAIL_FETCH_DASHBOARD_FACILITY_LISTS');
+export const completeFetchDashboardFacilityLists =
+    createAction('COMPLETE_FETCH_DASHBOARD_FACILITY_LISTS');
+export const resetDashboardFacilityLists =
+    createAction('RESET_DASHBOARD_FACILITY_LISTS');
+
+export function fetchDashboardFacilityLists(contributor) {
+    return (dispatch) => {
+        dispatch(startFetchDashboardFacilityLists());
+
+        return csrfRequest
+            .get(makeDashboardFacilityListsURL(contributor))
+            .then(({ data }) => dispatch(completeFetchDashboardFacilityLists(data)))
+            .catch(err => dispatch(logErrorAndDispatchFailure(
+                err,
+                'An error prevented fetching facility lists',
+                failFetchDashboardFacilityLists,
+            )));
+    };
+}

--- a/src/app/src/components/DashboardLists.jsx
+++ b/src/app/src/components/DashboardLists.jsx
@@ -171,15 +171,6 @@ function DashboardLists({
                             Total
                         </TableCell>
                         <TableCell padding="dense">
-                            Uploaded
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Parsed
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Geocoded
-                        </TableCell>
-                        <TableCell padding="dense">
                             Matched
                         </TableCell>
                         <TableCell padding="dense">
@@ -221,23 +212,6 @@ function DashboardLists({
                                 <FacilityListsTooltipTableCell
                                     tooltipTitle={facilitiesListTableTooltipTitles.total}
                                     tableCellText={list.item_count}
-                                />
-                                <FacilityListsTooltipTableCell
-                                    tooltipTitle={facilitiesListTableTooltipTitles.uploaded}
-                                    tableCellText={list.status_counts.UPLOADED}
-                                />
-                                <FacilityListsTooltipTableCell
-                                    tooltipTitle={facilitiesListTableTooltipTitles.parsed}
-                                    tableCellText={list.status_counts.PARSED}
-                                />
-                                <FacilityListsTooltipTableCell
-                                    tooltipTitle={facilitiesListTableTooltipTitles.geocoded}
-                                    tableCellText={
-                                        sum([
-                                            list.status_counts.GEOCODED,
-                                            list.status_counts.GEOCODED_NO_RESULTS,
-                                        ])
-                                    }
                                 />
                                 <FacilityListsTooltipTableCell
                                     tooltipTitle={facilitiesListTableTooltipTitles.matched}

--- a/src/app/src/components/DashboardLists.jsx
+++ b/src/app/src/components/DashboardLists.jsx
@@ -1,9 +1,328 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { arrayOf, bool, func, shape, string } from 'prop-types';
+import ReactSelect from 'react-select';
+import { connect } from 'react-redux';
 
-export default function DashboardLists() {
+import sum from 'lodash/sum';
+import moment from 'moment';
+
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableHead from '@material-ui/core/TableHead';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+
+import FacilityListsTooltipTableCell from './FacilityListsTooltipTableCell';
+import ShowOnly from './ShowOnly';
+
+import {
+    fetchDashboardListContributors,
+    fetchDashboardFacilityLists,
+    setDashboardListContributor,
+} from '../actions/dashboardLists';
+
+import {
+    facilitiesListTableTooltipTitles,
+} from '../util/constants';
+
+import {
+    contributorOptionPropType,
+    contributorOptionsPropType,
+    facilityListPropType,
+} from '../util/propTypes';
+
+import {
+    getContributorFromQueryString,
+    makeDashboardContributorListLink,
+    makeFacilityListItemsDetailLink,
+} from '../util/util';
+
+const CONTRIBUTORS = 'CONTRIBUTORS';
+
+const styles = {
+    container: {
+        marginBottom: '60px',
+        width: '100%',
+    },
+    filterRow: {
+        padding: '20px',
+        display: 'flex',
+    },
+    filterContributors: {
+        flex: 1,
+    },
+    inactiveList: {
+        cursor: 'pointer',
+    },
+    activeList: {
+        backgroundColor: '#f3fafe',
+        outlineWidth: '0.75px',
+        outlineStyle: 'solid',
+        outlineColor: '#1a9fe3',
+        cursor: 'pointer',
+    },
+};
+
+function DashboardLists({
+    dashboardLists: { contributor, contributors, facilityLists },
+    history: { location: { search }, push, replace },
+    fetchContributors,
+    setContributor,
+    fetchLists,
+}) {
+    useEffect(() => {
+        // If contributors have not been initialized, fetch them
+        if (!contributors.data.length && !contributors.fetching) {
+            fetchContributors();
+        }
+
+        if (contributor) {
+            // If contributor is already set, e.g. when coming back from a
+            // list detail view, ensure it is reflected in URL
+
+            replace(makeDashboardContributorListLink(contributor.value));
+        } else {
+            // If contributor is not set, but an ID is present in the URL,
+            // e.g. when following a link or refreshing the page after
+            // selecting a contributor, set the contributor and fetch its lists
+
+            const contributorID = getContributorFromQueryString(search);
+
+            if (contributorID && contributors.data.length && !contributors.fetching) {
+                setContributor(contributors.data.find(c => c.value === contributorID));
+                if (!facilityLists.fetching) {
+                    fetchLists(contributorID);
+                }
+            }
+        }
+    }, [
+        contributor,
+        contributors.data,
+        contributors.fetching,
+        search,
+        facilityLists.fetching,
+        replace,
+        fetchContributors,
+        setContributor,
+        fetchLists,
+    ]);
+
+    const onContributorUpdate = (c) => {
+        replace(makeDashboardContributorListLink(c.value));
+        setContributor(c);
+        fetchLists(c.value);
+    };
+
+    const when = {
+        noContributorSelected: contributor === null,
+        contributorHasNoLists: contributor !== null
+            && !facilityLists.fetching
+            && facilityLists.data.length === 0,
+    };
+
     return (
-        <p>
-            Dashboard Lists
-        </p>
+        <Paper style={styles.container}>
+            <div style={styles.filterRow}>
+                <div style={styles.filterContributors}>
+                    <ReactSelect
+                        id={CONTRIBUTORS}
+                        name={CONTRIBUTORS}
+                        classNamePrefix="select"
+                        options={contributors.data}
+                        placeholder="Select a contributor..."
+                        value={contributor}
+                        onChange={onContributorUpdate}
+                        disabled={
+                            contributors.fetching || facilityLists.fetching
+                        }
+                        styles={{
+                            control: provided => ({
+                                ...provided,
+                                height: '56px',
+                            }),
+                        }}
+                        theme={theme => ({
+                            ...theme,
+                            colors: {
+                                ...theme.colors,
+                                primary: '#00319D',
+                            },
+                        })}
+                    />
+                </div>
+            </div>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>
+                            Date Created
+                        </TableCell>
+                        <TableCell>
+                            Name
+                        </TableCell>
+                        <TableCell>
+                            Description
+                        </TableCell>
+                        <TableCell>
+                            File Name
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Total
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Uploaded
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Parsed
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Geocoded
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Matched
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Error
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Potential Match
+                        </TableCell>
+                        <TableCell padding="dense">
+                            Active
+                        </TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {
+                        facilityLists.data.map(list => (
+                            <TableRow
+                                key={list.id}
+                                hover
+                                onClick={() => push(makeFacilityListItemsDetailLink(list.id))}
+                                style={
+                                    list.is_active
+                                        ? styles.activeList
+                                        : styles.inactiveList
+                                }
+                            >
+                                <TableCell>
+                                    {moment(list.created_at).format('L')}
+                                </TableCell>
+                                <TableCell>
+                                    {list.name}
+                                </TableCell>
+                                <TableCell>
+                                    {list.description}
+                                </TableCell>
+                                <TableCell>
+                                    {list.file_name}
+                                </TableCell>
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={facilitiesListTableTooltipTitles.total}
+                                    tableCellText={list.item_count}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={facilitiesListTableTooltipTitles.uploaded}
+                                    tableCellText={list.status_counts.UPLOADED}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={facilitiesListTableTooltipTitles.parsed}
+                                    tableCellText={list.status_counts.PARSED}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={facilitiesListTableTooltipTitles.geocoded}
+                                    tableCellText={
+                                        sum([
+                                            list.status_counts.GEOCODED,
+                                            list.status_counts.GEOCODED_NO_RESULTS,
+                                        ])
+                                    }
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={facilitiesListTableTooltipTitles.matched}
+                                    tableCellText={
+                                        sum([
+                                            list.status_counts.MATCHED,
+                                            list.status_counts.CONFIRMED_MATCH,
+                                        ])
+                                    }
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={facilitiesListTableTooltipTitles.error}
+                                    tableCellText={
+                                        sum([
+                                            list.status_counts.ERROR,
+                                            list.status_counts.ERROR_PARSING,
+                                            list.status_counts.ERROR_GEOCODING,
+                                            list.status_counts.ERROR_MATCHING,
+                                        ])
+                                    }
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.potentialMatch
+                                    }
+                                    tableCellText={list.status_counts.POTENTIAL_MATCH}
+                                />
+                                <TableCell padding="dense">
+                                    {list.is_active ? 'Active' : 'Inactive'}
+                                </TableCell>
+                            </TableRow>
+                        ))
+                    }
+                    <ShowOnly when={when.noContributorSelected}>
+                        <TableRow>
+                            <TableCell colSpan={12} style={{ textAlign: 'center' }}>
+                                Select a contributor to see their lists.
+                            </TableCell>
+                        </TableRow>
+                    </ShowOnly>
+                    <ShowOnly when={when.contributorHasNoLists}>
+                        <TableRow>
+                            <TableCell colSpan={12} style={{ textAlign: 'center' }}>
+                                This contributor has no lists.
+                            </TableCell>
+                        </TableRow>
+                    </ShowOnly>
+                </TableBody>
+            </Table>
+        </Paper>
     );
 }
+
+DashboardLists.propTypes = {
+    dashboardLists: shape({
+        contributor: contributorOptionPropType,
+        contributors: shape({
+            data: contributorOptionsPropType.isRequired,
+            fetching: bool.isRequired,
+            error: string,
+        }).isRequired,
+        facilityLists: shape({
+            data: arrayOf(facilityListPropType).isRequired,
+            fetching: bool.isRequired,
+            error: string,
+        }).isRequired,
+    }).isRequired,
+    history: shape({
+        replace: func.isRequired,
+    }).isRequired,
+    fetchContributors: func.isRequired,
+    setContributor: func.isRequired,
+    fetchLists: func.isRequired,
+};
+
+function mapStateToProps({ dashboardLists }) {
+    return { dashboardLists };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        fetchContributors: () => dispatch(fetchDashboardListContributors()),
+        setContributor: c => dispatch(setDashboardListContributor(c)),
+        fetchLists: c => dispatch(fetchDashboardFacilityLists(c)),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DashboardLists);

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -24,6 +24,7 @@ import {
     facilityListItemsRoute,
     aboutProcessingRoute,
     authLoginFormRoute,
+    dashboardListsRoute,
 } from '../util/constants';
 
 import { facilityListPropType } from '../util/propTypes';
@@ -94,6 +95,7 @@ class FacilityListItems extends Component {
             downloadingCSV,
             csvDownloadingError,
             userHasSignedIn,
+            readOnly,
         } = this.props;
 
         if (fetchingList) {
@@ -164,6 +166,8 @@ class FacilityListItems extends Component {
                     Download CSV
                 </Button>);
 
+        const backRoute = readOnly ? dashboardListsRoute : listsRoute;
+
         return (
             <AppOverflow>
                 <Grid
@@ -194,8 +198,8 @@ class FacilityListItems extends Component {
                                     <Button
                                         variant="outlined"
                                         component={Link}
-                                        to={listsRoute}
-                                        href={listsRoute}
+                                        to={backRoute}
+                                        href={backRoute}
                                         style={facilityListItemsStyles.buttonStyles}
                                     >
                                         Back to lists
@@ -230,6 +234,7 @@ FacilityListItems.defaultProps = {
     list: null,
     error: null,
     csvDownloadingError: null,
+    readOnly: false,
 };
 
 FacilityListItems.propTypes = {
@@ -243,6 +248,7 @@ FacilityListItems.propTypes = {
     downloadingCSV: bool.isRequired,
     csvDownloadingError: arrayOf(string),
     userHasSignedIn: bool.isRequired,
+    readOnly: bool,
 };
 
 function mapStateToProps({
@@ -273,6 +279,7 @@ function mapStateToProps({
         downloadingCSV,
         csvDownloadingError,
         userHasSignedIn: !!user,
+        readOnly: user && user.is_superuser && list && user.contributor_id !== list.contributor_id,
     };
 }
 

--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -23,6 +23,7 @@ function FacilityListItemsConfirmationTableRow({
     makeRejectMatchFunction,
     listID,
     fetching,
+    readOnly,
 }) {
     const [
         matchIDs,
@@ -127,6 +128,7 @@ function FacilityListItemsConfirmationTableRow({
                     data={matchConfirmOrRejectFunctions}
                     hasActions
                     fetching={fetching}
+                    readOnly={readOnly}
                 />
             </TableCell>
         </TableRow>
@@ -139,6 +141,7 @@ FacilityListItemsConfirmationTableRow.propTypes = {
     makeRejectMatchFunction: func.isRequired,
     listID: string.isRequired,
     fetching: bool.isRequired,
+    readOnly: bool.isRequired,
 };
 
 function mapStateToProps({

--- a/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
+++ b/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
@@ -4,6 +4,7 @@ import Typography from '@material-ui/core/Typography';
 import get from 'lodash/get';
 
 import CellElement from './CellElement';
+import ShowOnly from './ShowOnly';
 
 import { facilityMatchStatusChoicesEnum } from '../util/constants';
 
@@ -18,30 +19,33 @@ export default function FacilityListItemsDetailedTableRowCell({
     fetching,
     errorState,
     linkURLs,
+    readOnly,
 }) {
     return (
         <div style={confirmRejectMatchRowStyles.cellStyles}>
             <div style={confirmRejectMatchRowStyles.cellTitleStyles}>
                 {title}
             </div>
-            <div style={confirmRejectMatchRowStyles.cellSubtitleStyles}>
-                <Typography variant="body2">
-                    {subtitle}
-                </Typography>
-            </div>
-            {
-                data.map((item, index) => (
-                    <Fragment key={hasActions ? item.id : item}>
-                        <CellElement
-                            item={item}
-                            fetching={fetching}
-                            errorState={errorState}
-                            hasActions={hasActions}
-                            stringIsHidden={stringIsHidden}
-                            linkURL={get(linkURLs, [`${index}`], null)}
-                        />
-                    </Fragment>))
-            }
+            <ShowOnly when={!readOnly}>
+                <div style={confirmRejectMatchRowStyles.cellSubtitleStyles}>
+                    <Typography variant="body2">
+                        {subtitle}
+                    </Typography>
+                </div>
+                {
+                    data.map((item, index) => (
+                        <Fragment key={hasActions ? item.id : item}>
+                            <CellElement
+                                item={item}
+                                fetching={fetching}
+                                errorState={errorState}
+                                hasActions={hasActions}
+                                stringIsHidden={stringIsHidden}
+                                linkURL={get(linkURLs, [`${index}`], null)}
+                            />
+                        </Fragment>))
+                }
+            </ShowOnly>
         </div>
     );
 }
@@ -53,6 +57,7 @@ FacilityListItemsDetailedTableRowCell.defaultProps = {
     subtitle: ' ',
     errorState: false,
     linkURLs: null,
+    readOnly: false,
 };
 
 FacilityListItemsDetailedTableRowCell.propTypes = {
@@ -77,4 +82,5 @@ FacilityListItemsDetailedTableRowCell.propTypes = {
     fetching: bool,
     errorState: bool,
     linkURLs: arrayOf(string),
+    readOnly: bool,
 };

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { arrayOf, func, number, shape, string } from 'prop-types';
+import { arrayOf, bool, func, number, shape, string } from 'prop-types';
 import { connect } from 'react-redux';
 import update from 'immutability-helper';
 import Button from '@material-ui/core/Button';
@@ -290,6 +290,7 @@ class FacilityListItemsTable extends Component {
                     search,
                 },
             },
+            readOnly,
         } = this.props;
 
         const {
@@ -344,6 +345,7 @@ class FacilityListItemsTable extends Component {
                             key={item.row_index}
                             item={item}
                             listID={listID}
+                            readOnly={readOnly}
                         />
                     );
                 }
@@ -503,6 +505,7 @@ class FacilityListItemsTable extends Component {
 
 FacilityListItemsTable.defaultProps = {
     items: null,
+    readOnly: false,
 };
 
 FacilityListItemsTable.propTypes = {
@@ -518,6 +521,7 @@ FacilityListItemsTable.propTypes = {
     }).isRequired,
     selectedFacilityListItemsRowIndex: number.isRequired,
     makeSelectListItemTableRowFunction: func.isRequired,
+    readOnly: bool,
 };
 
 function mapStateToProps({
@@ -532,7 +536,11 @@ function mapStateToProps({
         filteredCount,
         selectedFacilityListItemsRowIndex,
     },
-
+    auth: {
+        user: {
+            user,
+        },
+    },
 }) {
     return {
         list,
@@ -540,6 +548,7 @@ function mapStateToProps({
         filteredCount,
         fetchingItems,
         selectedFacilityListItemsRowIndex,
+        readOnly: user && user.is_superuser && list && user.contributor_id !== list.contributor_id,
     };
 }
 

--- a/src/app/src/reducers/DashboardListsReducer.js
+++ b/src/app/src/reducers/DashboardListsReducer.js
@@ -1,0 +1,75 @@
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    startFetchDashboardListContributors,
+    failFetchDashboardListContributors,
+    completeFetchDashboardListContributors,
+    setDashboardListContributor,
+    startFetchDashboardFacilityLists,
+    failFetchDashboardFacilityLists,
+    completeFetchDashboardFacilityLists,
+    resetDashboardFacilityLists,
+} from '../actions/dashboardLists';
+
+import { completeSubmitLogOut } from '../actions/auth';
+
+const initialState = Object.freeze({
+    contributor: null,
+    contributors: Object.freeze({
+        data: Object.freeze([]),
+        fetching: false,
+        error: null,
+    }),
+    facilityLists: Object.freeze({
+        data: Object.freeze([]),
+        fetching: false,
+        error: null,
+    }),
+});
+
+export default createReducer({
+    [startFetchDashboardListContributors]: state => update(state, {
+        contributors: {
+            fetching: { $set: true },
+            error: { $set: null },
+        },
+    }),
+    [failFetchDashboardListContributors]: (state, payload) => update(state, {
+        contributors: {
+            fetching: { $set: false },
+            error: { $set: payload },
+        },
+    }),
+    [completeFetchDashboardListContributors]: (state, payload) => update(state, {
+        contributors: {
+            fetching: { $set: false },
+            error: { $set: null },
+            data: { $set: payload },
+        },
+    }),
+    [setDashboardListContributor]: (state, payload) => update(state, {
+        contributor: { $set: payload },
+    }),
+    [startFetchDashboardFacilityLists]: state => update(state, {
+        facilityLists: {
+            fetching: { $set: true },
+            error: { $set: null },
+        },
+    }),
+    [failFetchDashboardFacilityLists]: (state, payload) => update(state, {
+        facilityLists: {
+            fetching: { $set: false },
+            error: { $set: payload },
+        },
+    }),
+    [completeFetchDashboardFacilityLists]: (state, payload) => update(state, {
+        facilityLists: {
+            fetching: { $set: false },
+            error: { $set: null },
+            data: { $set: payload },
+        },
+    }),
+    [resetDashboardFacilityLists]: () => initialState,
+    [completeSubmitLogOut]: () => initialState,
+}, initialState);

--- a/src/app/src/reducers/index.js
+++ b/src/app/src/reducers/index.js
@@ -22,6 +22,7 @@ import ClaimFacilityReducer from './ClaimFacilityReducer';
 import ClaimFacilityDashboardReducer from './ClaimFacilityDashboardReducer';
 import ClaimedFacilityDetailsReducer from './ClaimedFacilityDetailsReducer';
 import ClaimedFacilitesReducer from './ClaimedFacilitesReducer';
+import DashboardListsReducer from './DashboardListsReducer';
 
 export default combineReducers({
     auth: AuthReducer,
@@ -40,4 +41,5 @@ export default combineReducers({
     claimFacilityDashboard: ClaimFacilityDashboardReducer,
     claimedFacilityDetails: ClaimedFacilityDetailsReducer,
     claimedFacilities: ClaimedFacilitesReducer,
+    dashboardLists: DashboardListsReducer,
 });

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -36,6 +36,7 @@ export const userPropType = shape({
     email: string.isRequired,
     id: number.isRequired,
     contributor_id: number,
+    is_superuser: bool.isRequired,
 });
 
 export const profileFormValuesPropType = shape(Object
@@ -107,6 +108,7 @@ export const facilityListPropType = shape({
     id: number.isRequired,
     name: string,
     description: string,
+    contributor_id: number,
     file_name: string.isRequired,
     is_active: bool.isRequired,
     is_public: bool.isRequired,

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -125,10 +125,14 @@ export const facilityListPropType = shape({
     created_at: string.isRequired,
 });
 
-export const contributorOptionsPropType = arrayOf(shape({
+export const contributorOptionPropType = shape({
     value: oneOfType([number, string]).isRequired,
     label: string.isRequired,
-}));
+});
+
+export const contributorOptionsPropType = arrayOf(
+    contributorOptionPropType,
+);
 
 export const contributorTypeOptionsPropType = arrayOf(shape({
     value: string.isRequired,

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -120,6 +120,7 @@ export const facilityListPropType = shape({
         ),
         () => number.isRequired,
     )).isRequired,
+    created_at: string.isRequired,
 });
 
 export const contributorOptionsPropType = arrayOf(shape({

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -83,6 +83,8 @@ export const makeFacilityListsURL = () => '/api/facility-lists/';
 export const makeSingleFacilityListURL = id => `/api/facility-lists/${id}/`;
 export const makeSingleFacilityListItemsURL = id => `/api/facility-lists/${id}/items/`;
 
+export const makeDashboardFacilityListsURL = contributorID => `/api/facility-lists/?contributor=${contributorID}`;
+
 export const makeAPITokenURL = () => '/api-token-auth/';
 
 export const makeGetContributorsURL = () => '/api/contributors/';
@@ -252,6 +254,18 @@ export const getTokenFromQueryString = (qs) => {
         : token;
 };
 
+export const getContributorFromQueryString = (qs) => {
+    const qsToParse = startsWith(qs, '?')
+        ? qs.slice(1)
+        : qs;
+
+    const {
+        contributor = null,
+    } = querystring.parse(qsToParse);
+
+    return parseInt(contributor, 10);
+};
+
 export const allFiltersAreEmpty = filters => values(filters)
     .reduce((acc, next) => {
         if (!isEmpty(next)) {
@@ -384,6 +398,8 @@ export const makeClaimFacilityLink = oarID => `${facilitiesRoute}/${oarID}/claim
 export const makeApprovedClaimDetailsLink = claimID => `/claimed/${claimID}`;
 
 export const makeFacilityClaimDetailsLink = claimID => `/dashboard/claims/${claimID}`;
+
+export const makeDashboardContributorListLink = contributorID => `/dashboard/lists/?contributor=${contributorID}`;
 
 export const makeProfileRouteLink = userID => `/profile/${userID}`;
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -21,6 +21,10 @@ class FacilitiesQueryParams:
     COUNTRIES = 'countries'
 
 
+class FacilityListQueryParams:
+    CONTRIBUTOR = 'contributor'
+
+
 class FacilityListItemsQueryParams:
     SEARCH = 'search'
     STATUS = 'status'

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -199,7 +199,7 @@ class FacilityListSerializer(ModelSerializer):
         model = FacilityList
         fields = ('id', 'name', 'description', 'file_name', 'is_active',
                   'is_public', 'item_count', 'items_url', 'statuses',
-                  'status_counts', 'created_at')
+                  'status_counts', 'contributor_id', 'created_at')
 
     def get_item_count(self, facility_list):
         return facility_list.facilitylistitem_set.count()

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -199,7 +199,7 @@ class FacilityListSerializer(ModelSerializer):
         model = FacilityList
         fields = ('id', 'name', 'description', 'file_name', 'is_active',
                   'is_public', 'item_count', 'items_url', 'statuses',
-                  'status_counts')
+                  'status_counts', 'created_at')
 
     def get_item_count(self, facility_list):
         return facility_list.facilitylistitem_set.count()
@@ -312,6 +312,10 @@ class FacilityQueryParamsSerializer(Serializer):
     )
     page = IntegerField(required=False)
     pageSize = IntegerField(required=False)
+
+
+class FacilityListQueryParamsSerializer(Serializer):
+    contributor = IntegerField(required=False)
 
 
 class FacilityListItemsQueryParamsSerializer(Serializer):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -856,11 +856,13 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             }
         """
         try:
-            user_contributor = request.user.contributor
-            facility_list = FacilityList \
-                .objects \
-                .filter(contributor=user_contributor) \
-                .get(pk=pk)
+            if request.user.is_superuser:
+                facility_lists = FacilityList.objects.all()
+            else:
+                facility_lists = FacilityList.objects.filter(
+                    contributor=request.user.contributor)
+
+            facility_list = facility_lists.get(pk=pk)
             response_data = self.serializer_class(facility_list).data
 
             return Response(response_data)
@@ -930,11 +932,13 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             search = search.strip()
 
         try:
-            user_contributor = request.user.contributor
-            facility_list = FacilityList \
-                .objects \
-                .filter(contributor=user_contributor) \
-                .get(pk=pk)
+            if request.user.is_superuser:
+                facility_lists = FacilityList.objects.all()
+            else:
+                facility_lists = FacilityList.objects.filter(
+                    contributor=request.user.contributor)
+
+            facility_list = facility_lists.get(pk=pk)
         except FacilityList.DoesNotExist:
             raise NotFound()
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -935,29 +935,30 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 .objects \
                 .filter(contributor=user_contributor) \
                 .get(pk=pk)
-            queryset = FacilityListItem \
-                .objects \
-                .filter(facility_list=facility_list)
-            if search is not None and len(search) > 0:
-                queryset = queryset.filter(
-                    Q(facility__name__icontains=search) |
-                    Q(facility__address__icontains=search))
-            if status is not None and len(status) > 0:
-                q_statements = [make_q_from_status(s) for s in status]
-                queryset = queryset.filter(reduce(operator.or_, q_statements))
-
-            queryset = queryset.order_by('row_index')
-
-            page_queryset = self.paginate_queryset(queryset)
-            if page_queryset is not None:
-                serializer = FacilityListItemSerializer(page_queryset,
-                                                        many=True)
-                return self.get_paginated_response(serializer.data)
-
-            serializer = FacilityListItemSerializer(queryset, many=True)
-            return Response(serializer.data)
         except FacilityList.DoesNotExist:
             raise NotFound()
+
+        queryset = FacilityListItem \
+            .objects \
+            .filter(facility_list=facility_list)
+        if search is not None and len(search) > 0:
+            queryset = queryset.filter(
+                Q(facility__name__icontains=search) |
+                Q(facility__address__icontains=search))
+        if status is not None and len(status) > 0:
+            q_statements = [make_q_from_status(s) for s in status]
+            queryset = queryset.filter(reduce(operator.or_, q_statements))
+
+        queryset = queryset.order_by('row_index')
+
+        page_queryset = self.paginate_queryset(queryset)
+        if page_queryset is not None:
+            serializer = FacilityListItemSerializer(page_queryset,
+                                                    many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = FacilityListItemSerializer(queryset, many=True)
+        return Response(serializer.data)
 
     @transaction.atomic
     @action(detail=True,


### PR DESCRIPTION
## Overview

Adds a list view in the dashboard for Superusers that allows them to see a read-only view of any list any contributor has uploaded. The view is very similar to that of My Lists, with the inclusion of the Date Created column. Upon clicking through to a list, they are presented with a "read-only" view of the list, that allows for searching and filtering as usual, but does not allow confirming or rejecting potential matches.

Connects #547 

## Demo

![image](https://user-images.githubusercontent.com/1430060/59391939-e7099180-8d43-11e9-8f98-a50393a34fa0.png)

![2019-06-12 18 21 43](https://user-images.githubusercontent.com/1430060/59390811-5d0bf980-8d40-11e9-9857-6fe4b8b41755.gif)

## Notes

To facilitate the front-end, a few fields were exposed in the back-end that were previously not included: `is_superuser` for the user, `created_at` and `contributor_id` for the lists. If there are any security implications for exposing these fields, we should consider and address them now.

Much of the front-end was copied from other parts of the app, leading to a lot of duplication and redundancy in terms of styling and table markup. This is a good candidate for refactoring and abstracting, that can be done in a future pass.

There is an edge case when a superuser accesses their own list from the Dashboard Lists page. In this case, when they click "Back to Lists", they will be taken to their My Lists page instead. This is unlikely to be a huge issue immediately, since most Superusers don't have their own lists, but should be kept in mind. This can be addressed by changing "Back to Lists" from a link to simulate the browser's "Back" button, but I don't know if React Router provides such facility. It could also be implemented by setting a flag somewhere (either in the URL or in Redux), but I did not deem it important enough to include in this pass. Please let me know if I should.

## Testing Instructions

- Check out this branch and `server`
- Go to [:6543](http://localhost:6543/) and sign in as a Superuser
  - A Superuser is any user that has `is_superuser=True` in the database
- Go to [:6543/dashboard/lists/](http://localhost:6543/dashboard/lists/)
  - [ ] Ensure you see a table and a select
- Open the select box
  - [ ] Ensure it is populated with a list of contributors
- Select a contributor
  - [ ] Ensure the contributor's lists are fetched from the server and populate the table
  - [ ] Ensure the lists are sorted newest first
  - [ ] Ensure the URL is updated with the selected contributor
- Click a list
  - [ ] Ensure you are taken to that list's detail page
- Observe that the view is "read-only"
  - [ ] Ensure searching / filtering works as usual
  - [ ] Ensure you cannot confirm or reject potential matches
- Click "Back to lists"
  - [ ] Ensure you are taken to Dashboard Lists, rather than your My Lists page
  - [ ] Ensure Dashboard Lists has the correct contributor selected in the view and the URL
- Refresh the page
  - [ ] Ensure the contributor is picked up from the URL and used to populate the select and the table
- Select a contributor that hasn't uploaded any lists
  - [ ] Ensure you see an empty message

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
