### PR TITLE
Ensure at most one approved claim per facility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)
+- Ensure at most one claim can be approved per facility [#585](https://github.com/open-apparel-registry/open-apparel-registry/pull/585)
 
 ### Deprecated
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1354,6 +1354,17 @@ class FacilityClaimViewSet(viewsets.ModelViewSet):
                     'Only PENDING claims can be approved.',
                 )
 
+            approved_claims_for_facility_count = FacilityClaim \
+                .objects \
+                .filter(status=FacilityClaim.APPROVED) \
+                .filter(facility=claim.facility) \
+                .count()
+
+            if approved_claims_for_facility_count > 0:
+                raise BadRequestException(
+                    'A facility may have at most one approved facility claim'
+                )
+
             claim.status_change_reason = request.data.get('reason', '')
             claim.status_change_by = request.user
             claim.status_change_date = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
## Overview

When attempting to approve a facility claim, check whether there are
already any other approved facility claims and, if so, return a bad
request response. Also add a test to demonstrate the feature
functionality.

Connects #581 

## Testing Instructions

It should suffice just to run the tests and verify that they continue to pass.

You can also go through the loop of:

- turn on claim a facility
- sign in as `c2@example.com`
- submit the claim form 2x for the same facility
- sign out, then sign in as a superuser
- visit /dashboard/claims
- approve one of the facilities and verify that it works
- attempt to approve the other facility and verify that it does not work and that you see an error

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
