### PR TITLE
Add .prettierrc.json config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add profile page and update form for approved facility claims [#575](https://github.com/open-apparel-registry/open-apparel-registry/pull/575)
 - Show a list of facilities successfully claimed by the current contributor [#573](https://github.com/open-apparel-registry/open-apparel-registry/pull/573)
 - Add GitHub issue template for "draft" issues [#590](https://github.com/open-apparel-registry/open-apparel-registry/pull/590)
+- Add .prettierrc.json configuration file for JS code formatting during development [#592](https://github.com/open-apparel-registry/open-apparel-registry/pull/592)
 
 ### Changed
 - Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)

--- a/src/app/.prettierrc.json
+++ b/src/app/.prettierrc.json
@@ -1,0 +1,17 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "parser": "babylon",
+  "printWidth": 80,
+  "proseWrap": "always",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 4,
+  "trailingComma": "all",
+  "useTabs": false
+}


### PR DESCRIPTION
## Overview

Add a .prettierrc.json configuration file with rules which are
compatible with our existing set of ESLint rules. This enables
developers to run Prettier manually in their editors on new files while
working, saving the burden of having to manually format the code.

Connects #549 

## Notes

I intentionally did not set this up to run prettier on file saves,
although that is theoretically possible now that we are using
react-app-rewired. Setting it up to run on saves would cause a large
initial changeset because many of the project's files have not been
formatted with Prettier.

## Testing Instructions

Try running Prettier locally on this branch in one of the JSX files and verify that it reformats according to the formatting rules here.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
