### PR TITLE
Order facility claim notes by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)
 - Ensure at most one claim can be approved per facility [#585](https://github.com/open-apparel-registry/open-apparel-registry/pull/585)
+- Order facility claim notes from oldest to newest on dashboard [#596](https://github.com/open-apparel-registry/open-apparel-registry/pull/596)
 
 ### Deprecated
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -495,7 +495,10 @@ class FacilityClaimDetailsSerializer(ModelSerializer):
         }
 
     def get_notes(self, claim):
-        notes = FacilityClaimReviewNote.objects.filter(claim=claim)
+        notes = FacilityClaimReviewNote \
+            .objects \
+            .filter(claim=claim) \
+            .order_by('id')
         data = FacilityClaimReviewNoteSerializer(notes, many=True).data
         return data
 


### PR DESCRIPTION
## Overview

This PR ensures that the facility claim notes are ordered by ID in ascending order, which remedies a bug I notice during RRP.

Connects #595 

## Demo

![Screen Shot 2019-06-13 at 4 57 10 PM](https://user-images.githubusercontent.com/4165523/59466921-6ce91380-8dfc-11e9-9d03-b840f7c1b07b.png)

## Testing Instructions

- serve this branch, then visit a dashboard claims details page and verify that the notes are in and remain in ascending order

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
