### PR TITLE
Prevent submitting > 1 pending facility claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)
 - Ensure at most one claim can be approved per facility [#585](https://github.com/open-apparel-registry/open-apparel-registry/pull/585)
 - Order facility claim notes from oldest to newest on dashboard [#596](https://github.com/open-apparel-registry/open-apparel-registry/pull/596)
+- Prevent users from submitting another claim for a facility when they have a first claim still pending [#601](https://github.com/open-apparel-registry/open-apparel-registry/pull/601)
 
 ### Deprecated
 

--- a/src/app/src/reducers/AuthReducer.js
+++ b/src/app/src/reducers/AuthReducer.js
@@ -41,6 +41,8 @@ import {
 
 import { completeUpdateUserProfile } from '../actions/profile';
 
+import { completeSubmitClaimAFacilityData } from '../actions/claimFacility';
+
 import { registrationFieldsEnum } from '../util/constants';
 
 const initialState = Object.freeze({
@@ -288,6 +290,13 @@ export default createReducer({
     [resetConfirmAccountRegistration]: state => update(state, {
         confirmRegistration: {
             $set: initialState.confirmRegistration,
+        },
+    }),
+    [completeSubmitClaimAFacilityData]: (state, claimedFacilityIDs) => update(state, {
+        user: {
+            user: {
+                claimed_facility_ids: { $set: claimedFacilityIDs },
+            },
         },
     }),
 }, initialState);

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -103,16 +103,33 @@ class UserSerializer(ModelSerializer):
 
     def get_claimed_facility_ids(self, user):
         if not switch_is_active('claim_a_facility'):
-            return []
+            return {
+                'approved': None,
+                'pending': None,
+            }
 
         try:
-            return FacilityClaim \
+            approved = FacilityClaim \
                 .objects \
                 .filter(status=FacilityClaim.APPROVED) \
                 .filter(contributor=user.contributor) \
                 .values_list('facility__id', flat=True)
+
+            pending = FacilityClaim \
+                .objects \
+                .filter(status=FacilityClaim.PENDING) \
+                .filter(contributor=user.contributor) \
+                .values_list('facility__id', flat=True)
+
+            return {
+                'pending': pending,
+                'approved': approved,
+            }
         except Contributor.DoesNotExist:
-            return []
+            return {
+                'approved': None,
+                'pending': None,
+            }
 
 
 class UserProfileSerializer(ModelSerializer):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -1361,6 +1361,33 @@ class FacilityClaimAdminDashboardTests(APITestCase):
                           password='superuser')
 
     @override_switch('claim_a_facility', active=True)
+    def test_user_cannot_submit_second_facility_claim_with_one_pending(self):
+        self.client.logout()
+        self.client.login(email=self.email,
+                          password=self.password)
+
+        error_response = self.client.post(
+            '/api/facilities/{}/claim/'.format(self.facility.id),
+            {
+                'contact_person': 'contact_person',
+                'email': 'example@example.com',
+                'phone_number': '12345',
+                'company_name': 'company_name',
+                'website': 'http://example.com',
+                'facility_description': 'facility_description',
+                'verification_method': 'verification_method',
+                'preferred_contact_method': FacilityClaim.EMAIL,
+            }
+        )
+
+        self.assertEqual(400, error_response.status_code)
+
+        self.assertEqual(
+            error_response.json()['detail'],
+            'User already has a pending claim on this facility'
+        )
+
+    @override_switch('claim_a_facility', active=True)
     def test_approve_facility_claim(self):
         self.assertEqual(len(mail.outbox), 0)
 


### PR DESCRIPTION
## Overview

- update API to return a bad request error if a user attempts to claim a
facility for which that user already has a pending claim
- update API to send back a lists of OAR IDs for which users have
pending and approved facility claims, both on sign in and also on
submitting a new claim
- adjust the facility details UI to prevent a user from seeing claim a
facility links when a claim is pending
- add facility details sidebar message indicating "You have a pending claim on this facility" when
appropriate

Connects #555 

## Demo

![Screen Shot 2019-06-14 at 11 45 08 AM](https://user-images.githubusercontent.com/4165523/59522204-116e6280-8e9c-11e9-925a-9ee61745b4fc.png)

## Testing Instructions

- sign in as c8@example and try to submit more than one claim for the same facility
- you cannot

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
