### PR TITLE
Add AboutClaimedFacilities + disclaimer text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show a list of facilities successfully claimed by the current contributor [#573](https://github.com/open-apparel-registry/open-apparel-registry/pull/573)
 - Add GitHub issue template for "draft" issues [#590](https://github.com/open-apparel-registry/open-apparel-registry/pull/590)
 - Allow superusers to view all lists [#584](https://github.com/open-apparel-registry/open-apparel-registry/pull/584)
+- AboutClaimedFacilities component & disclaimer text [#608](https://github.com/open-apparel-registry/open-apparel-registry/pull/608)
 
 ### Changed
 - Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -28,6 +28,7 @@ import Translate from './components/Translate';
 import FeatureFlag from './components/FeatureFlag';
 import ClaimFacility from './components/ClaimFacility';
 import ClaimedFacilities from './components/ClaimedFacilities';
+import AboutClaimedFacilities from './components/AboutClaimedFacilities';
 
 import './App.css';
 
@@ -51,6 +52,7 @@ import {
     claimFacilityRoute,
     claimedFacilitiesRoute,
     CLAIM_A_FACILITY,
+    aboutClaimedFacilitiesRoute,
 } from './util/constants';
 
 const appStyles = Object.freeze({
@@ -153,6 +155,17 @@ class App extends Component {
                                 <Route
                                     path={aboutProcessingRoute}
                                     component={AboutProcessing}
+                                />
+                                <Route
+                                    path={aboutClaimedFacilitiesRoute}
+                                    render={() => (
+                                        <FeatureFlag
+                                            flag={CLAIM_A_FACILITY}
+                                            alternative={<RouteNotFound />}
+                                        >
+                                            <AboutClaimedFacilities />
+                                        </FeatureFlag>
+                                    )}
                                 />
                                 <Route render={() => <RouteNotFound />} />
                             </Switch>

--- a/src/app/src/components/AboutClaimedFacilities.jsx
+++ b/src/app/src/components/AboutClaimedFacilities.jsx
@@ -1,0 +1,53 @@
+import React, { memo } from 'react';
+import Grid from '@material-ui/core/Grid';
+
+import AppGrid from './AppGrid';
+import AppOverflow from './AppOverflow';
+
+const AboutClaimedFacilities = memo(() => (
+    <AppOverflow>
+        <AppGrid title="How OAR Facility Claims Are Verified">
+            <Grid container className="margin-bottom-64">
+                <Grid item xs={12}>
+                    <h2 id="introduction">
+                        Introduction
+                    </h2>
+                    <p>
+                        The Open Apparel Registry (OAR) enables facility owners
+                        or managers to claim facilities. Once a facility claim
+                        is verified by OAR staff, the facility claimant can add
+                        information about the facility such as a description of
+                        the facility, contact information, and production info
+                        which is displayed publicly on the facility details page.
+                    </p>
+                    <h2 id="verification-process">
+                        Verifying Facility Claims
+                    </h2>
+                    <p>
+                        The process for verifying a facility claim is x, y, z.
+                    </p>
+                    <h2 id="disclaimer">
+                        Disclaimer
+                    </h2>
+                    <p>
+                        For verified facility claims, OAR staff has verified that
+                        the claimant has a connection with the facility sufficient
+                        to give the claimant access to updating details about the
+                        facility. However, OAR staff does not verify each detail
+                        the claimant subsequently adds about a facility.
+                    </p>
+                    <p>
+                        If you believe that some claimed facility data is inaccurate
+                        or incorrect, please send an email to{' '}
+                        <a href="mailto:info@openapparel.org">
+                            info@openapparel.org
+                        </a> with a link to the facility details page and an explanation
+                        of the problem.
+                    </p>
+                </Grid>
+            </Grid>
+        </AppGrid>
+    </AppOverflow>
+));
+
+export default AboutClaimedFacilities;

--- a/src/app/src/components/FacilityDetailSidebarClaimedInfo.jsx
+++ b/src/app/src/components/FacilityDetailSidebarClaimedInfo.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { number, string, shape } from 'prop-types';
 import trim from 'lodash/trim';
 import Typography from '@material-ui/core/Typography';
+import { Link } from 'react-router-dom';
+
+import { aboutClaimedFacilitiesRoute } from '../util/constants';
 
 const ClaimInfoSection = ({ label, value }) =>
     trim(value) && (
@@ -34,6 +37,21 @@ export default function FacilityDetailsSidebarClaimedInfo({
             <Typography variant="title">
                 Claimed Facility Info
             </Typography>
+            <div className="control-panel__group">
+                <p>
+                    OAR staff has verified that the claimant is connected to the
+                    facility but has not verified the claimed facility details
+                    displayed below.
+                </p>
+                <Link
+                    to={aboutClaimedFacilitiesRoute}
+                    href={aboutClaimedFacilitiesRoute}
+                    className="link-underline small"
+                    style={{ fontSize: '16px' }}
+                >
+                    Learn more about claimed facilities
+                </Link>
+            </div>
             <ClaimInfoSection
                 label="Name"
                 value={facility.name}

--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -7,7 +7,10 @@ import logo from '../styles/images/OpenApparelRegistry_logo.png';
 import NavbarDropdown from './NavbarDropdown';
 import NavbarLoginButtonGroup from './NavbarLoginButtonGroup';
 
-import { contributeRoute } from '../util/constants';
+import {
+    contributeRoute,
+    aboutClaimedFacilitiesRoute,
+} from '../util/constants';
 
 const apiDocumentationURL = process.env.NODE_ENV === 'development'
     ? 'http://localhost:8081/api/docs/'
@@ -28,6 +31,11 @@ export default function Navbar() {
         {
             text: 'Processing',
             url: '/about/processing',
+            type: 'link',
+        },
+        {
+            text: 'Claimed Facilities',
+            url: aboutClaimedFacilitiesRoute,
             type: 'link',
         },
     ];

--- a/src/app/src/components/NavbarDropdown.jsx
+++ b/src/app/src/components/NavbarDropdown.jsx
@@ -9,7 +9,28 @@ import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 
+import FeatureFlag from './FeatureFlag';
+
+import {
+    aboutClaimedFacilitiesRoute,
+    CLAIM_A_FACILITY,
+} from '../util/constants';
+
 const itemMap = (item) => {
+    if (item.url === aboutClaimedFacilitiesRoute) {
+        return (
+            <FeatureFlag flag={CLAIM_A_FACILITY}>
+                <Link
+                    to={item.url}
+                    href={item.url}
+                    className="link full-width-height"
+                >
+                    {item.text}
+                </Link>
+            </FeatureFlag>
+        );
+    }
+
     switch (item.type) {
         case 'link':
             return (

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -226,6 +226,7 @@ export const dashboardClaimsRoute = '/dashboard/claims';
 export const claimedFacilitiesRoute = '/claimed';
 export const claimedFacilitiesDetailRoute = '/claimed/:claimID';
 export const dashboardClaimsDetailsRoute = '/dashboard/claims/:claimID';
+export const aboutClaimedFacilitiesRoute = '/about/claimedfacilities';
 
 export const contributeCSVTemplate =
     'country,name,address\nEgypt,Elite Merchandising Corp.,St. 8 El-Amrya Public Free Zone Alexandria Iskandariyah 23512 Egypt';


### PR DESCRIPTION
## Overview

- add AboutClaimedFacilities component as a place to explain what
facility claim verification does and does not represent
- add disclaimer text and link to AboutClaimedFacilities to the facility
details sidebar for claimed facilities

Connects #570 
Connects #588 

## Demo

![Screen Shot 2019-06-17 at 12 07 14 PM](https://user-images.githubusercontent.com/4165523/59619562-cbfaa100-90f8-11e9-96d3-0daeeb293995.png)

![Screen Shot 2019-06-17 at 12 07 32 PM](https://user-images.githubusercontent.com/4165523/59619563-cbfaa100-90f8-11e9-8822-8e0bc721c8cc.png)

![Screen Shot 2019-06-17 at 12 11 33 PM](https://user-images.githubusercontent.com/4165523/59619669-111ed300-90f9-11e9-81f7-3861b51d2bc0.png)


## Notes

The component and text are just placeholders for now and we'll need to update the text to accurately describe the facility claim verification process prior to releasing this.

## Testing Instructions

- `./scripts/server` with claim a facility on
- sign in as c2@example and claim a facility
- sign in as a superuser and approve the claim
- visit the facility and verify that you see the disclaimer text and that the link to `About Claimed Facilities" also works

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
