### PR TITLE
Email list contributors about facility claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ensure at most one claim can be approved per facility [#585](https://github.com/open-apparel-registry/open-apparel-registry/pull/585)
 - Order facility claim notes from oldest to newest on dashboard [#596](https://github.com/open-apparel-registry/open-apparel-registry/pull/596)
 - Prevent users from submitting another claim for a facility when they have a first claim still pending [#601](https://github.com/open-apparel-registry/open-apparel-registry/pull/601)
+- Email contributors when facility claims are approved or claim profiles are updated [#611](https://github.com/open-apparel-registry/open-apparel-registry/pull/611)
 
 ### Deprecated
 

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -2,6 +2,8 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.template.loader import get_template
 
+from api.countries import COUNTRY_NAMES
+
 
 def make_facility_url(request, facility):
     if settings.ENVIRONMENT == 'Development':
@@ -23,9 +25,12 @@ def send_claim_facility_confirmation_email(request, facility_claim):
     text_template = get_template('mail/claim_facility_submitted_body.txt')
     html_template = get_template('mail/claim_facility_submitted_body.html')
 
+    facility_country = COUNTRY_NAMES[facility_claim.facility.country_code]
+
     claim_dictionary = {
         'facility_name': facility_claim.facility.name,
         'facility_address': facility_claim.facility.address,
+        'facility_country': facility_country,
         'facility_url': make_facility_url(request, facility_claim.facility),
         'contact_person': facility_claim.contact_person,
         'email': facility_claim.email,
@@ -51,10 +56,13 @@ def send_claim_facility_approval_email(request, facility_claim):
     text_template = get_template('mail/claim_facility_approval_body.txt')
     html_template = get_template('mail/claim_facility_approval_body.html')
 
+    facility_country = COUNTRY_NAMES[facility_claim.facility.country_code]
+
     approval_dictionary = {
         'approval_reason': facility_claim.status_change_reason,
         'facility_name': facility_claim.facility.name,
         'facility_address': facility_claim.facility.address,
+        'facility_country': facility_country,
         'facility_url': make_facility_url(request, facility_claim.facility),
     }
 
@@ -72,10 +80,13 @@ def send_claim_facility_denial_email(request, facility_claim):
     text_template = get_template('mail/claim_facility_denial_body.txt')
     html_template = get_template('mail/claim_facility_denial_body.html')
 
+    facility_country = COUNTRY_NAMES[facility_claim.facility.country_code]
+
     denial_dictionary = {
         'denial_reason': facility_claim.status_change_reason,
         'facility_name': facility_claim.facility.name,
         'facility_address': facility_claim.facility.address,
+        'facility_country': facility_country,
         'facility_url': make_facility_url(request, facility_claim.facility),
     }
 
@@ -93,10 +104,13 @@ def send_claim_facility_revocation_email(request, facility_claim):
     text_template = get_template('mail/claim_facility_revocation_body.txt')
     html_template = get_template('mail/claim_facility_revocation_body.html')
 
+    facility_country = COUNTRY_NAMES[facility_claim.facility.country_code]
+
     revocation_dictionary = {
         'revocation_reason': facility_claim.status_change_reason,
         'facility_name': facility_claim.facility.name,
         'facility_address': facility_claim.facility.address,
+        'facility_country': facility_country,
         'facility_url': make_facility_url(request, facility_claim.facility),
     }
 
@@ -107,3 +121,81 @@ def send_claim_facility_revocation_email(request, facility_claim):
         [facility_claim.email],
         html_message=html_template.render(revocation_dictionary)
     )
+
+
+def send_approved_claim_notice_to_one_contributor(request, claim, contributor):
+    subj_template = get_template(
+        'mail/approved_facility_claim_contributor_notice_subject.txt')
+    text_template = get_template(
+        'mail/approved_facility_claim_contributor_notice_body.txt')
+    html_template = get_template(
+        'mail/approved_facility_claim_contributor_notice_body.html')
+
+    facility_country = COUNTRY_NAMES[claim.facility.country_code]
+
+    notice_dictionary = {
+        'facility_name': claim.facility.name,
+        'facility_address': claim.facility.address,
+        'facility_country': facility_country,
+        'facility_url': make_facility_url(request, claim.facility),
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(notice_dictionary),
+        settings.DEFAULT_FROM_EMAIL,
+        [contributor.admin.email],
+        html_message=html_template.render(notice_dictionary)
+    )
+
+
+def send_approved_claim_notice_to_list_contributors(request, facility_claim):
+    list_contributors = [
+        facility_list.contributor
+        for facility_list in
+        facility_claim.facility.contributors()
+    ]
+
+    for contributor in list_contributors:
+        send_approved_claim_notice_to_one_contributor(request,
+                                                      facility_claim,
+                                                      contributor)
+
+
+def send_claim_update_note_to_one_contributor(request, claim, contributor):
+    subj_template = get_template(
+        'mail/facility_claim_profile_update_contributor_notice_subject.txt')
+    text_template = get_template(
+        'mail/facility_claim_profile_update_contributor_notice_body.txt')
+    html_template = get_template(
+        'mail/facility_claim_profile_update_contributor_notice_body.html')
+
+    facility_country = COUNTRY_NAMES[claim.facility.country_code]
+
+    notice_dictionary = {
+        'facility_name': claim.facility.name,
+        'facility_address': claim.facility.address,
+        'facility_country': facility_country,
+        'facility_url': make_facility_url(request, claim.facility),
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(notice_dictionary),
+        settings.DEFAULT_FROM_EMAIL,
+        [contributor.admin.email],
+        html_message=html_template.render(notice_dictionary)
+    )
+
+
+def send_claim_update_notice_to_list_contributors(request, facility_claim):
+    list_contributors = [
+        facility_list.contributor
+        for facility_list in
+        facility_claim.facility.contributors()
+    ]
+
+    for contributor in list_contributors:
+        send_claim_update_note_to_one_contributor(request,
+                                                  facility_claim,
+                                                  contributor)

--- a/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.html
+++ b/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <title>
-            Your request to claim an Open Apparel Registry facility was approved
+            An OAR facility on one of your facility lists has been claimed
         </title>
     </head>
     <body>
@@ -10,8 +10,11 @@
             Hi,
         </p>
         <p>
-            You're receiving this email because we approved your request to claim this
-            Open Apparel Registry facility:
+            You're receiving this email because we approved a facility claim
+            for a facility appearing on one of your facility lists.
+        </p>
+        <p>
+            The facility is:
         </p>
         <ul>
             <li>
@@ -21,14 +24,6 @@
                 Facility URL: {{ facility_url }}
             </li>
         </ul>
-        {% if approval_reason|length %}
-        <p>
-            Here's the reason for the approval:
-        </p>
-        <p>
-            {{ approval_reason }}
-        </p>
-        {% endif %}
         <p>
             Sincerely,
         </p>

--- a/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.txt
+++ b/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.txt
@@ -1,0 +1,14 @@
+{% block content %}
+Hi,
+
+You're receiving this email because we approved a facility claim for a facility
+appearing on one of your facility lists.
+
+The facility is:
+
+  - Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
+  - Facility URL: {{ facility_url }}
+
+Sincerely,
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/approved_facility_claim_contributor_notice_subject.txt
+++ b/src/django/api/templates/mail/approved_facility_claim_contributor_notice_subject.txt
@@ -1,0 +1,1 @@
+An OAR facility on one of your facility lists has been claimed

--- a/src/django/api/templates/mail/claim_facility_approval_body.txt
+++ b/src/django/api/templates/mail/claim_facility_approval_body.txt
@@ -3,7 +3,7 @@ Hi,
 
 You're receiving this email because we approved your request to claim this Open Apparel Registry facility:
 
-- Facility: {{ facility_name }}, {{ facility_address }}
+- Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
 - Facility URL: {{ facility_url }}
 
 {% if approval_reason|length %}

--- a/src/django/api/templates/mail/claim_facility_denial_body.html
+++ b/src/django/api/templates/mail/claim_facility_denial_body.html
@@ -15,7 +15,7 @@
         </p>
         <ul>
             <li>
-                Facility: {{ facility_name }}, {{ facility_address }}
+                Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
                 Facility URL: {{ facility_url }}

--- a/src/django/api/templates/mail/claim_facility_denial_body.txt
+++ b/src/django/api/templates/mail/claim_facility_denial_body.txt
@@ -3,7 +3,7 @@ Hi,
 
 You're receiving this email because we denied your request to claim this Open Apparel Registry facility:
 
-- Facility: {{ facility_name }}, {{ facility_address }}
+- Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
 - Facility URL: {{ facility_url }}
 
 {% if denial_reason|length %}

--- a/src/django/api/templates/mail/claim_facility_revocation_body.html
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.html
@@ -15,7 +15,7 @@
         </p>
         <ul>
             <li>
-                Facility: {{ facility_name }}, {{ facility_address }}
+                Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
                 Facility URL: {{ facility_url }}

--- a/src/django/api/templates/mail/claim_facility_revocation_body.txt
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.txt
@@ -3,7 +3,7 @@ Hi,
 
 You're receiving this email because we revoked your request to claim this Open Apparel Registry facility:
 
-- Facility: {{ facility_name }}, {{ facility_address }}
+- Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
 - Facility URL: {{ facility_url }}
 
 {% if revocation_reason|length %}

--- a/src/django/api/templates/mail/claim_facility_submitted_body.html
+++ b/src/django/api/templates/mail/claim_facility_submitted_body.html
@@ -18,7 +18,7 @@
         </p>
         <ul>
             <li>
-                Facility: {{ facility_name }}, {{ facility_address }}
+                Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
                 Facility URL: {{ facility_url }}

--- a/src/django/api/templates/mail/claim_facility_submitted_body.txt
+++ b/src/django/api/templates/mail/claim_facility_submitted_body.txt
@@ -5,7 +5,7 @@ You're receiving this email because we received your request to claim an Open Ap
 
 Here is the information submitted with your request:
 
-- Facility: {{ facility_name }}, {{ facility_address }}
+- Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
 - Facility URL: {{ facility_url }}
 - Contact person: {{ contact_person }}
 - Email: {{ email }}

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.html
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.html
@@ -2,7 +2,8 @@
 <html lang="en">
     <head>
         <title>
-            Your request to claim an Open Apparel Registry facility was approved
+            An OAR facility on one of your facility lists has had its
+            facility claim data updated
         </title>
     </head>
     <body>
@@ -10,8 +11,11 @@
             Hi,
         </p>
         <p>
-            You're receiving this email because we approved your request to claim this
-            Open Apparel Registry facility:
+            You're receiving this email because a facility on one of your
+            facility lists has had its facility claim data updated.
+        </p>
+        <p>
+            The facility is:
         </p>
         <ul>
             <li>
@@ -21,14 +25,6 @@
                 Facility URL: {{ facility_url }}
             </li>
         </ul>
-        {% if approval_reason|length %}
-        <p>
-            Here's the reason for the approval:
-        </p>
-        <p>
-            {{ approval_reason }}
-        </p>
-        {% endif %}
         <p>
             Sincerely,
         </p>

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.txt
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.txt
@@ -1,0 +1,14 @@
+{% block content %}
+Hi,
+
+You're receiving this email because a facility on one of your facility lists
+has had its facility claim data updated.
+
+The facility is:
+
+  - Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
+  - Facility URL: {{ facility_url }}
+
+Sincerely,
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_subject.txt
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_subject.txt
@@ -1,0 +1,1 @@
+An OAR facility on one of your facility lists has had its facility claim data updated


### PR DESCRIPTION
## Overview

- email list contributors when a facility claim is approved
- email list contributors when an approved facility claim's profile
details have been updated
- update tests to check for facility claim emails to contributors

Connects #578 
Connects #577 

## Testing Instructions

- serve this branch with the default set of fixtures
- sign in as c2@example.com and claim a facility
- sign in as a superuser and approve the facility claim
- verify that you see email/s to the facility list contributors for a facility that has been claimed
- sign back in as c2@example.com
- update the claimed facility profile and save, then verify that you see email/s to the facility list contributors for the facility that has had its claim updated

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
