### PR TITLE
Add facility merge API

### DIFF
--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -390,6 +390,7 @@ export const facilityMatchStatusChoicesEnum = Object.freeze({
     AUTOMATIC: 'AUTOMATIC',
     CONFIRMED: 'CONFIRMED',
     REJECTED: 'REJECTED',
+    MERGED: 'MERGED',
 });
 
 export const emptyFeatureCollection = Object.freeze({

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -30,3 +30,8 @@ class FacilityListQueryParams:
 class FacilityListItemsQueryParams:
     SEARCH = 'search'
     STATUS = 'status'
+
+
+class FacilityMergeQueryParams:
+    TARGET = 'target'
+    MERGE = 'merge'

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -14,6 +14,7 @@ class ProcessingAction:
     CONFIRM = 'confirm'
     DELETE_FACILITY = 'delete_facility'
     PROMOTE_MATCH = 'promote_match'
+    MERGE_FACILITY = 'merge_facility'
 
 
 class FacilitiesQueryParams:

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -623,7 +623,8 @@ class Facility(models.Model):
             in self
             .facilitymatch_set
             .filter(status__in=[FacilityMatch.AUTOMATIC,
-                                FacilityMatch.CONFIRMED])
+                                FacilityMatch.CONFIRMED,
+                                FacilityMatch.MERGED])
             .values_list('facility_list_item')
         ]
 
@@ -645,7 +646,8 @@ class Facility(models.Model):
             in self
             .facilitymatch_set
             .filter(status__in=[FacilityMatch.AUTOMATIC,
-                                FacilityMatch.CONFIRMED])
+                                FacilityMatch.CONFIRMED,
+                                FacilityMatch.MERGED])
             .values_list('facility_list_item')
         ]
 
@@ -667,19 +669,21 @@ class Facility(models.Model):
             in self
             .facilitymatch_set
             .filter(status__in=[FacilityMatch.AUTOMATIC,
-                                FacilityMatch.CONFIRMED])
+                                FacilityMatch.CONFIRMED,
+                                FacilityMatch.MERGED])
             .order_by('updated_at')
             .values_list('facility_list_item')
         ]
 
-        return [
+        # Converting from a list back to a set ensures the items are distinct
+        return list(set([
             match.facility_list
             for match
             in facility_list_item_matches
             if match.facility_list.is_active
             and match.facility_list.is_public
             and match.facility_list.contributor is not None
-        ]
+        ]))
 
     def get_created_from_match(self):
         return self.facilitymatch_set.filter(
@@ -707,6 +711,7 @@ class FacilityMatch(models.Model):
     AUTOMATIC = 'AUTOMATIC'
     CONFIRMED = 'CONFIRMED'
     REJECTED = 'REJECTED'
+    MERGED = 'MERGED'
 
     # These values must stay in sync with the `facilityMatchStatusChoicesEnum`
     # in the client's constants.js file.
@@ -715,6 +720,7 @@ class FacilityMatch(models.Model):
         (AUTOMATIC, AUTOMATIC),
         (CONFIRMED, CONFIRMED),
         (REJECTED, REJECTED),
+        (MERGED, MERGED),
     )
 
     facility_list_item = models.ForeignKey(

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -694,3 +694,18 @@ class UserPasswordResetConfirmSerializer(PasswordResetConfirmSerializer):
         self.user.save()
 
         return self.set_password_form.save()
+
+
+class FacilityMergeQueryParamsSerializer(Serializer):
+    target = CharField(required=True)
+    merge = CharField(required=True)
+
+    def validate_target(self, target_id):
+        if not Facility.objects.filter(id=target_id).exists():
+            raise ValidationError(
+                'Facility {} does not exist.'.format(target_id))
+
+    def validate_merge(self, merge_id):
+        if not Facility.objects.filter(id=merge_id).exists():
+            raise ValidationError(
+                'Facility {} does not exist.'.format(merge_id))

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -2300,3 +2300,35 @@ class FacilityDeleteTest(APITestCase):
                           password=self.superuser_password)
         response = self.client.delete(self.facility_url)
         self.assertEqual(204, response.status_code)
+
+
+class FacilityMergeTest(APITestCase):
+    def setUp(self):
+        self.user_email = 'test@example.com'
+        self.user_password = 'example123'
+        self.user = User.objects.create(email=self.user_email)
+        self.user.set_password(self.user_password)
+        self.user.save()
+
+        self.superuser_email = 'super@example.com'
+        self.superuser_password = 'example123'
+        self.superuser = User.objects.create_superuser(
+            email=self.superuser_email,
+            password=self.superuser_password)
+
+        self.merge_url = '/api/facilities/merge/'
+
+    def test_requires_auth(self):
+        response = self.client.post(self.merge_url)
+        self.assertEqual(401, response.status_code)
+
+    def test_requires_superuser(self):
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+        response = self.client.post(self.merge_url)
+        self.assertEqual(403, response.status_code)
+
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+        response = self.client.post(self.merge_url)
+        self.assertEqual(501, response.status_code)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -425,6 +425,8 @@ class FacilitiesAutoSchema(AutoSchema):
     def get_link(self, path, method, base_url):
         if method == 'DELETE':
             return None
+        if 'merge' in path:
+            return None
 
         return super(FacilitiesAutoSchema, self).get_link(
             path, method, base_url)
@@ -849,6 +851,15 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             raise NotFound(
                 'The current User does not have an associated Contributor')
         return Response(FacilityClaimSerializer(claims, many=True).data)
+
+    @action(detail=False, methods=['POST'],
+            permission_classes=(IsRegisteredAndConfirmed,))
+    @transaction.atomic
+    def merge(self, request):
+        if not request.user.is_superuser:
+            raise PermissionDenied()
+
+        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 
 
 class FacilityListViewSetSchema(AutoSchema):


### PR DESCRIPTION
## Overview

Add facility merge API

Connects #600

## Demo

<img width="552" alt="Screen Shot 2019-06-21 at 11 40 26 AM" src="https://user-images.githubusercontent.com/17363/59944351-66205900-9419-11e9-984c-8aa4c8cc66d4.png">


![2019-06-21 11 25 44](https://user-images.githubusercontent.com/17363/59943674-af6fa900-9417-11e9-9435-8475f58badf3.gif)


## Notes

We merge a facility by:
- Updating all the `FacilityMatch` records and their related `FacilityListItem`s to point to the the target `Facility`
- Changing the `FacilityMatch status to `MERGED` and adding a processing result item to the `FacilityListItem` with a `MERGE_FACILITY` action
- Creating a `FacilityAlias` with a type of `MERGE` pointing the merged OAR ID to the target facility
- Deleting the merged facility record.

We needed to update the filters used by the `Facility` serialization process so that `MERGED` facilities would show up properly in on the facility details page.

## Testing Instructions

This assumes fixture data is loaded.

* Verify that the merge API does not appear on http://localhost:8081/api/docs/#/facilities
* Browse the map and copy 2 OAR IDs from different contributors.
* Call the merge API
```
curl --request POST \
  --url 'http://localhost:6543/api/facilities/merge/?target={{TARGET OAR ID}}&merge={{MERGE OAR ID}}' \
  --header 'authorization: Token {{TOKEN}}'
```
* Verify that `http://localhost:6543/facilities/{{MERGE OAR ID}}` is not found.
* Verify that `http://localhost:6543/facilities/{{TARGET OAR ID}}` shows the details of the merged facility.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] ~CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~ SKIPPED because this is a non-public API and the CHANGELOG item for the merge UI covers the announcement of the new feature.


