### PR TITLE
Make miscellaneous bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Miscellaneous bugfixes [#622](https://github.com/open-apparel-registry/open-apparel-registry/pull/622)
 
 ### Security
 

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -136,7 +136,7 @@ li.dropdown-list-item button {
 .form__hint {
   margin: 8px 0;
   font-weight: 400;
-  font-size: 12px;
+  font-size: 15px;
 }
 
 .form__select-input-container {

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -32,7 +32,10 @@ import {
     makeApprovedClaimDetailsLink,
 } from '../util/util';
 
-import { CLAIM_A_FACILITY } from '../util/constants';
+import {
+    CLAIM_A_FACILITY,
+    facilitiesRoute,
+} from '../util/constants';
 
 import COLOURS from '../util/COLOURS';
 
@@ -83,7 +86,7 @@ class FacilityDetailSidebar extends Component {
             match: {
                 params: { oarID },
             },
-            history: { goBack, push },
+            history: { push },
             facilityIsClaimedByCurrentUser,
             userHasPendingFacilityClaim,
         } = this.props;
@@ -136,7 +139,7 @@ class FacilityDetailSidebar extends Component {
                         aria-label="ArrowBack"
                         className="color-white"
                         style={detailsSidebarStyles.headerButtonStyle}
-                        onClick={goBack}
+                        onClick={() => push(facilitiesRoute)}
                         disabled={fetching}
                     >
                         <ArrowBackIcon />

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -137,7 +137,7 @@ function FilterSidebarSearchTab({
                         isMulti
                         id={CONTRIBUTORS}
                         name={CONTRIBUTORS}
-                        className="basic-multi-select"
+                        className="basic-multi-select notranslate"
                         classNamePrefix="select"
                         options={contributorOptions}
                         value={contributors}
@@ -157,7 +157,7 @@ function FilterSidebarSearchTab({
                         isMulti
                         id={CONTRIBUTOR_TYPES}
                         name="contributorTypes"
-                        className="basic-multi-select"
+                        className="basic-multi-select notranslate"
                         classNamePrefix="select"
                         options={contributorTypeOptions}
                         value={contributorTypes}

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -13,6 +13,7 @@ import UserProfileField from './UserProfileField';
 import UserAPITokens from './UserAPITokens';
 import BadgeVerified from './BadgeVerified';
 import ShowOnly from './ShowOnly';
+import RouteNotFound from './RouteNotFound';
 import COLOURS from '../util/COLOURS';
 
 import '../styles/css/specialStates.css';
@@ -124,6 +125,7 @@ class UserProfile extends Component {
             updatingProfile,
             errorsUpdatingProfile,
             submitFormOnEnterKeyPress,
+            errorFetchingProfile,
             match: {
                 params: {
                     id,
@@ -137,6 +139,10 @@ class UserProfile extends Component {
 
         if (!profile) {
             return null;
+        }
+
+        if (errorFetchingProfile) {
+            return <RouteNotFound />;
         }
 
         const isEditableProfile =
@@ -248,6 +254,7 @@ class UserProfile extends Component {
 UserProfile.defaultProps = {
     user: null,
     errorsUpdatingProfile: null,
+    errorFetchingProfile: null,
 };
 
 UserProfile.propTypes = {
@@ -266,6 +273,7 @@ UserProfile.propTypes = {
     updatingProfile: bool.isRequired,
     errorsUpdatingProfile: arrayOf(string),
     submitFormOnEnterKeyPress: func.isRequired,
+    errorFetchingProfile: arrayOf(string),
 };
 
 function mapStateToProps({
@@ -281,6 +289,7 @@ function mapStateToProps({
     profile: {
         profile,
         fetching,
+        error: errorFetchingProfile,
         formSubmission: {
             fetching: updatingProfile,
             error: errorsUpdatingProfile,
@@ -293,6 +302,7 @@ function mapStateToProps({
         profile,
         updatingProfile,
         errorsUpdatingProfile,
+        errorFetchingProfile,
     };
 }
 

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -75,9 +75,10 @@ const accountNameField = Object.freeze({
     label: 'Contributor Name',
     type: inputTypesEnum.text,
     required: true,
-    hint: `Your contributor name will appear publicly on all
-facilities that you upload as the data source for each facility
-contributed.`,
+    hint: `If you are uploading a supplier list on behalf of the organisation
+you work for, you should add the organisation name here, not your personal name.
+Your contributor name will appear publicly on all facilities that you upload as
+the data source for each facility contributed.`,
     modelFieldName: 'name',
 });
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -430,6 +430,9 @@ class FacilitiesAutoSchema(AutoSchema):
         if 'merge' in path:
             return None
 
+        if 'claim' in path:
+            return None
+
         return super(FacilitiesAutoSchema, self).get_link(
             path, method, base_url)
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1686,6 +1686,12 @@ def api_feature_flags(request):
     return Response(response_data)
 
 
+class FacilityClaimsAutoSchema(AutoSchema):
+    def get_link(self, path, method, base_url):
+        return None
+
+
+@schema(FacilityClaimsAutoSchema())
 class FacilityClaimViewSet(viewsets.ModelViewSet):
     """
     Viewset for admin operations on FacilityClaims.


### PR DESCRIPTION
## Overview

- show RouteNotFound for non-existent profiles
- don't translate contributor name and type in search menus
- suppress `claim/` route from facilities API documentation
- adjust facility details back button to go back to the main facilities/ route
- update contributor name hint text on registration form

Connects #565 
Connects #606
Connects #613 
Connects #569 
Connects #120 

## Testing Instructions

- serve this branch
- visit http://localhost:6543/profile/70000 and verify that you see the route not found component
- visit http://localhost:6543 and change the language to Esperanto and verify that the contributor names and contributor types sections aren't translated
- sign in as c1@example.com then visit localhost:8081/admin and turn on the claim a facility switch
- visit http://localhost:8081/api/docs/#/facilities and verify that you do not see a POST endpoint for `claim/`
- sign out then sign in as c2@example, search for a facility, and claim it
- fill out the claim form completely; when you reach the last page, click the in-app back button on the claim form
- when you return to the facility details page, click that in-app back button and verify that it takes you to the main facilities search

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
