### PR TITLE
Allow facilities with inactive matches to be deleted

### DIFF
--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -702,12 +702,12 @@ class Facility(models.Model):
     def get_created_from_match(self):
         return self.facilitymatch_set.filter(
             facility_list_item=self.created_from
-        ).filter(is_active=True).first()
+        ).first()
 
     def get_other_matches(self):
         return self.facilitymatch_set.exclude(
             facility_list_item=self.created_from
-        ).filter(is_active=True).all()
+        ).all()
 
     def get_approved_claim(self):
         return self.facilityclaim_set.filter(


### PR DESCRIPTION
## Overview

When adding the ability to remove a `FacilityListItem`, which makes its related
`FacilityMatch` row inactive, we accidentally broke the ability to delete
facilities created from these inactive items.

Connects #628 	

## Testing Instructions

* Reset the database
  * ./scripts/manage resetdb
  * ./scripts/manage loadfixtures
  * ./scripts/manage processfixtures
* Log in as c8@example.com
* Browse http://localhost:6543/lists/8
* Search for `atlantis` and remove the item
* Browse localhost:6543, search for `atlantis` and copy the OAR ID.
* Log in as c1@example.com, browse https://localhost:6543/dashboard/deletefacility, and verify that you can successfully delete the facility

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] ~CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~ Skipped because this is a fix to a new unreleased feature 
