### PR TITLE
Keyword search facility list item properties in addition to facility properties

### DIFF
--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1261,7 +1261,9 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         if search is not None and len(search) > 0:
             queryset = queryset.filter(
                 Q(facility__name__icontains=search) |
-                Q(facility__address__icontains=search))
+                Q(facility__address__icontains=search) |
+                Q(name__icontains=search) |
+                Q(address__icontains=search))
         if status is not None and len(status) > 0:
             q_statements = [make_q_from_status(s) for s in status]
             queryset = queryset.filter(reduce(operator.or_, q_statements))


### PR DESCRIPTION
## Overview

When filtering items on the facilities detail page we need to search the properties of the `FacilityListItem` in addition to the related `Facility` so that keyword searching still works if the `Facility` is deleted.

Connects #630

## Testing Instructions

* Reset the database
  * ./scripts/manage resetdb
  * ./scripts/manage loadfixtures
  * ./scripts/manage processfixtures
* Log in as c8@example.com
* Browse http://localhost:6543/lists/8
* Search for `composite`, follow the link to the facility, and copy the OAR ID.
* Log in as c1@example.com, browse https://localhost:6543/dashboard/deletefacility, and delete the facility
* Log back in as c8@example.com
* Browse http://localhost:6543/lists/8
* Verify that `One Composite Mills LTD.` is on the page.
* Search for `composite`. Verify that the list item appears in the filtered results.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] ~CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~ Skipped because this is a fix to an unreleased feature already in the changelog.
