### PR TITLE
Text changes for claim a facility feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Require a token for all API endpoints [#644](https://github.com/open-apparel-registry/open-apparel-registry/pull/644)
 - Validate claimed facility website field and show as hyperlink [#647](https://github.com/open-apparel-registry/open-apparel-registry/pull/647)
+- Update app text in claim a facility workflow [#642](https://github.com/open-apparel-registry/open-apparel-registry/pull/642)
 
 ### Deprecated
 

--- a/src/app/src/components/AboutClaimedFacilities.jsx
+++ b/src/app/src/components/AboutClaimedFacilities.jsx
@@ -9,40 +9,34 @@ const AboutClaimedFacilities = memo(() => (
         <AppGrid title="How OAR Facility Claims Are Verified">
             <Grid container className="margin-bottom-64">
                 <Grid item xs={12}>
-                    <h2 id="introduction">
-                        Introduction
-                    </h2>
+                    <h2 id="introduction">Introduction</h2>
                     <p>
                         The Open Apparel Registry (OAR) enables facility owners
                         or managers to claim facilities. Once a facility claim
                         is verified by OAR staff, the facility claimant can add
                         information about the facility such as a description of
                         the facility, contact information, and production info
-                        which is displayed publicly on the facility details page.
+                        which is displayed publicly on the facility details
+                        page.
                     </p>
-                    <h2 id="verification-process">
-                        Verifying Facility Claims
-                    </h2>
+                    <h2 id="disclaimer">Disclaimer</h2>
                     <p>
-                        The process for verifying a facility claim is x, y, z.
-                    </p>
-                    <h2 id="disclaimer">
-                        Disclaimer
-                    </h2>
-                    <p>
-                        For verified facility claims, OAR staff has verified that
-                        the claimant has a connection with the facility sufficient
-                        to give the claimant access to updating details about the
-                        facility. However, OAR staff does not verify each detail
-                        the claimant subsequently adds about a facility.
+                        For verified facility claims, OAR staff has verified
+                        through a three-step process that the claimant has a
+                        genuine connection to the facility it is claiming and
+                        sufficient authority to make the claim. However, OAR
+                        staff does not verify each detail the claimant
+                        subsequently adds about a facility, e.g. production
+                        capabilities, certifications, MOQs etc.
                     </p>
                     <p>
-                        If you believe that some claimed facility data is inaccurate
-                        or incorrect, please send an email to{' '}
+                        If you believe that some claimed facility data is
+                        inaccurate or incorrect, please send an email to{' '}
                         <a href="mailto:info@openapparel.org">
                             info@openapparel.org
-                        </a> with a link to the facility details page and an explanation
-                        of the problem.
+                        </a>{' '}
+                        with a link to the facility details page and an
+                        explanation of the problem.
                     </p>
                 </Grid>
             </Grid>

--- a/src/app/src/components/ClaimFacilityConfirmationStep.jsx
+++ b/src/app/src/components/ClaimFacilityConfirmationStep.jsx
@@ -23,8 +23,9 @@ export default function ClaimFacilityConfirmationStep() {
         <div style={claimAFacilityFormStyles.inputGroupStyles}>
             <Typography variant="headline" style={confirmationMessageStyles}>
                 Your request to claim the facility was submitted successfully!
-                To manage your facility, we&#39;ll need to verify your
-                connection with the facility. Once verified you will be able to:
+                To manage the profile information for your facility, we&#39;ll
+                need to verify your connection with the facility. Once verified
+                you will be able to:
             </Typography>
             <List>
                 <ListItem>

--- a/src/app/src/components/ClaimFacilityIntroStep.jsx
+++ b/src/app/src/components/ClaimFacilityIntroStep.jsx
@@ -10,21 +10,31 @@ import { claimAFacilityFormStyles } from '../util/styles';
 
 import COLOURS from '../util/COLOURS';
 
-const confirmationMessageStyles = Object.freeze({
+const introMessageStyles = Object.freeze({
     width: '95%',
+    padding: '10px',
 });
 
 const checkIconStyles = Object.freeze({
     color: COLOURS.NAVY_BLUE,
 });
 
-export default function ClaimFacilityConfirmationStep() {
+export default function ClaimFacilityIntroStep() {
     return (
         <div style={claimAFacilityFormStyles.inputGroupStyles}>
-            <Typography variant="headline" style={confirmationMessageStyles}>
-                Your request to claim the facility was submitted successfully!
-                To manage your facility, we&#39;ll need to verify your
-                connection with the facility. Once verified you will be able to:
+            <Typography variant="headline" style={introMessageStyles}>
+                Owners or senior management at facilities listed on the OAR are
+                able to &quot;claim&quot; their facility&#39;s profile on the site and add
+                business information to it.
+            </Typography>
+            <Typography variant="headline" style={introMessageStyles}>
+                If you are a facility owner or senior management, please work
+                your way through the following three preliminary steps to
+                verify your identity. This process should take no more than 5
+                minutes to complete.
+            </Typography>
+            <Typography variant="headline" style={introMessageStyles}>
+                Once your claim has been reviewed and approved, you will be able to:
             </Typography>
             <List>
                 <ListItem>
@@ -63,12 +73,14 @@ export default function ClaimFacilityConfirmationStep() {
                     </ListItemIcon>
                     <ListItemText>
                         <Typography variant="headline">
-                            Add information about your head office and parent
-                            company
+                            Add information about your head office and parent company
                         </Typography>
                     </ListItemText>
                 </ListItem>
             </List>
+            <Typography variant="title" style={introMessageStyles}>
+                This information will be shown publicly on the facility details page.
+            </Typography>
         </div>
     );
 }

--- a/src/app/src/components/ClaimFacilityStepper.jsx
+++ b/src/app/src/components/ClaimFacilityStepper.jsx
@@ -9,8 +9,10 @@ import Typography from '@material-ui/core/Typography';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import clamp from 'lodash/clamp';
 import last from 'lodash/last';
+import stubTrue from 'lodash/stubTrue';
 
 import BadgeClaimed from './BadgeClaimed';
+import ClaimFacilityIntroStep from './ClaimFacilityIntroStep';
 import ClaimFacilityContactInfoStep from './ClaimFacilityContactInfoStep';
 import ClaimFacilityFacilityInfoStep from './ClaimFacilityFacilityInfoStep';
 import ClaimFacilityVerificationInfoStep from './ClaimFacilityVerificationInfoStep';
@@ -54,10 +56,18 @@ const SUBMIT_FORM = 'SUBMIT_FORM';
 
 const steps = Object.freeze([
     Object.freeze({
+        name: 'Claim this facility',
+        component: ClaimFacilityIntroStep,
+        next: 'Contact Information',
+        hasBackButton: false,
+        hasNextButton: true,
+        stepInputIsValid: stubTrue,
+    }),
+    Object.freeze({
         name: 'Contact Information',
         component: ClaimFacilityContactInfoStep,
         next: 'Facility Information',
-        hasBackButton: false,
+        hasBackButton: true,
         hasNextButton: true,
         stepInputIsValid: claimFacilityContactInfoStepIsValid,
     }),

--- a/src/app/src/components/ClaimedFacilitiesDetails.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetails.jsx
@@ -440,6 +440,9 @@ function ClaimedFacilitiesDetails({
                         Publicly visible
                     </span>
                 </Typography>
+                <aside style={claimedFacilitiesDetailsStyles.asideStyles}>
+                    If different from facility address
+                </aside>
                 <InputSection
                     label="Office name"
                     value={data.office_official_name}

--- a/src/app/src/components/ClaimedFacilitiesList.jsx
+++ b/src/app/src/components/ClaimedFacilitiesList.jsx
@@ -7,7 +7,10 @@ import Button from '@material-ui/core/Button';
 
 import ClaimedFacilitiesListTable from './ClaimedFacilitiesListTable';
 
-import { fetchClaimedFacilities, clearClaimedFacilities } from '../actions/claimedFacilities';
+import {
+    fetchClaimedFacilities,
+    clearClaimedFacilities,
+} from '../actions/claimedFacilities';
 
 import { facilityClaimsListPropType } from '../util/propTypes';
 
@@ -35,11 +38,7 @@ function ClaimedFacilitiesList({
     }
 
     if (error) {
-        return (
-            <Typography>
-                {error}
-            </Typography>
-        );
+        return <Typography>{error}</Typography>;
     }
 
     if (data === null) {
@@ -50,9 +49,12 @@ function ClaimedFacilitiesList({
         window.console.log(fetching, data);
         return (
             <div>
-                <Typography>
-                    You do not have any approved facility claims.
-                    Search for your facility and make a request to claim it.
+                <Typography variant="body" style={{ padding: '10px 0' }}>
+                    You do not have any approved facility claims. Search for
+                    your facility and make a request to claim it. Claiming your
+                    facility will enable you to add business information,
+                    including production details, certifications, minimum order
+                    quantities and lead times.
                 </Typography>
                 <Button
                     variant="contained"
@@ -83,13 +85,7 @@ ClaimedFacilitiesList.propTypes = {
     clearClaimed: func.isRequired,
 };
 
-function mapStateToProps({
-    claimedFacilities: {
-        data,
-        fetching,
-        error,
-    },
-}) {
+function mapStateToProps({ claimedFacilities: { data, fetching, error } }) {
     return {
         data,
         fetching,
@@ -104,4 +100,7 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ClaimedFacilitiesList);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(ClaimedFacilitiesList);

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -296,7 +296,7 @@ class FacilityDetailSidebar extends Component {
                                             href={makeApprovedClaimDetailsLink(facilityClaimID)}
                                             style={detailsSidebarStyles.linkStyle}
                                         >
-                                            Update claimed facility profile
+                                            Update facility details
                                         </Link>
                                     </FeatureFlag>
                                 </ShowOnly>

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -5,7 +5,7 @@ from django.template.loader import get_template
 from api.countries import COUNTRY_NAMES
 
 
-def make_facility_url(request, facility):
+def make_oar_url(request):
     if settings.ENVIRONMENT == 'Development':
         protocol = 'http'
         host = 'localhost:6543'
@@ -13,11 +13,18 @@ def make_facility_url(request, facility):
         protocol = 'https'
         host = request.get_host()
 
-    return '{}://{}/facilities/{}'.format(
-        protocol,
-        host,
+    return '{}://{}'.format(protocol, host)
+
+
+def make_facility_url(request, facility):
+    return '{}/facilities/{}'.format(
+        make_oar_url(request),
         facility.id,
     )
+
+
+def make_claimed_url(request):
+    return '{}/claimed'.format(make_oar_url(request))
 
 
 def send_claim_facility_confirmation_email(request, facility_claim):
@@ -64,6 +71,7 @@ def send_claim_facility_approval_email(request, facility_claim):
         'facility_address': facility_claim.facility.address,
         'facility_country': facility_country,
         'facility_url': make_facility_url(request, facility_claim.facility),
+        'claimed_url': make_claimed_url(request),
     }
 
     send_mail(

--- a/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.html
+++ b/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.html
@@ -25,7 +25,7 @@
             </li>
         </ul>
         <p>
-            Sincerely,
+            Best wishes,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.txt
+++ b/src/django/api/templates/mail/approved_facility_claim_contributor_notice_body.txt
@@ -9,6 +9,6 @@ The facility is:
   - Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
   - Facility URL: {{ facility_url }}
 
-Sincerely,
+Best wishes,
 {% include "mail/signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_approval_body.html
+++ b/src/django/api/templates/mail/claim_facility_approval_body.html
@@ -30,7 +30,7 @@
         </p>
         {% endif %}
         <p>
-            Sincerely,
+            Best wishes,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/claim_facility_approval_body.html
+++ b/src/django/api/templates/mail/claim_facility_approval_body.html
@@ -18,7 +18,7 @@
                 Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
-                Facility URL: {{ facility_url }}
+                Facility URL: <a href="{{ facility_url }}">{{ facility_url }}</a>
             </li>
         </ul>
         {% if approval_reason|length %}
@@ -29,6 +29,12 @@
             {{ approval_reason }}
         </p>
         {% endif %}
+        <p>
+            You are approved! You can now complete your profile, adding business information
+            including production capabilities, certifications, MOQs and more. Visit
+            <a href="{{ claimed_url }}">{{ claimed_url }}</a> to view your approved
+            facility and complete your profile.
+        </p>
         <p>
             Best wishes,
         </p>

--- a/src/django/api/templates/mail/claim_facility_approval_body.txt
+++ b/src/django/api/templates/mail/claim_facility_approval_body.txt
@@ -12,7 +12,7 @@ Here's the reason for the approval:
 {{ approval_reason }}
 {% endif %}
 
-Sincerely,
+Best wishes,
 
 {% include "mail/signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_approval_body.txt
+++ b/src/django/api/templates/mail/claim_facility_approval_body.txt
@@ -12,6 +12,8 @@ Here's the reason for the approval:
 {{ approval_reason }}
 {% endif %}
 
+You are approved! You can now complete your profile, adding business information including production capabilities, certifications, MOQs and more. Visit openapparel.org/claimed to view your approved facility and complete your profile.
+
 Best wishes,
 
 {% include "mail/signature_block.txt" %}

--- a/src/django/api/templates/mail/claim_facility_denial_body.html
+++ b/src/django/api/templates/mail/claim_facility_denial_body.html
@@ -18,7 +18,7 @@
                 Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
-                Facility URL: {{ facility_url }}
+                Facility URL: <a href="{{ facility_url }}">{{ facility_url }}</a>
             </li>
         </ul>
         {% if denial_reason|length %}
@@ -29,6 +29,12 @@
             {{ denial_reason }}
         </p>
         {% endif %}
+        <p>
+            The claim information is inaccurate. If you believe this denial to be inaccurate,
+            you can reach out to the OAR team to provide additional, clarifying information at:
+            <a href="mailto:info@openapparel.org">info@openapparel.org</a> The team will review
+            your claim and get back to you.
+        </p>
         <p>
             Best wishes,
         </p>

--- a/src/django/api/templates/mail/claim_facility_denial_body.html
+++ b/src/django/api/templates/mail/claim_facility_denial_body.html
@@ -30,7 +30,7 @@
         </p>
         {% endif %}
         <p>
-            Sincerely,
+            Best wishes,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/claim_facility_denial_body.txt
+++ b/src/django/api/templates/mail/claim_facility_denial_body.txt
@@ -12,6 +12,8 @@ Here's the reason for the denial:
 {{ denial_reason }}
 {% endif %}
 
+The claim information is inaccurate. If you believe this denial to be inaccurate, you can reach out to the OAR team to provide additional, clarifying information at: info@openapparel.org The team will review your claim and get back to you.
+
 Best wishes,
 
 {% include "mail/signature_block.txt" %}

--- a/src/django/api/templates/mail/claim_facility_denial_body.txt
+++ b/src/django/api/templates/mail/claim_facility_denial_body.txt
@@ -12,7 +12,7 @@ Here's the reason for the denial:
 {{ denial_reason }}
 {% endif %}
 
-Sincerely,
+Best wishes,
 
 {% include "mail/signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_revocation_body.html
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.html
@@ -30,7 +30,7 @@
         </p>
         {% endif %}
         <p>
-            Sincerely,
+            Best wishes,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/claim_facility_revocation_body.html
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.html
@@ -18,7 +18,7 @@
                 Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
             </li>
             <li>
-                Facility URL: {{ facility_url }}
+                Facility URL: <a href="{{ facility_url }}">{{ facility_url }}</a>
             </li>
         </ul>
         {% if revocation_reason|length %}
@@ -29,6 +29,12 @@
             {{ revocation_reason }}
         </p>
         {% endif %}
+        <p>
+            We have discovered your claim is actually inaccurate. If you believe your claim
+            should not have been revoked, you can reach out to the OAR team to provide additional,
+            clarifying information at: <a href="mailto:info@openapparel.org">info@openapparel.org</a>.
+            The team will review your claim and get back to you.
+        </p>
         <p>
             Best wishes,
         </p>

--- a/src/django/api/templates/mail/claim_facility_revocation_body.txt
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.txt
@@ -12,6 +12,8 @@ Here's the reason it was revoked:
 {{ revocation_reason }}
 {% endif %}
 
+We have discovered your claim is actually inaccurate. If you believe your claim should not have been revoked, you can reach out to the OAR team to provide additional, clarifying information at: info@openapparel.org The team will review your claim and get back to you.
+
 Best wishes,
 
 {% include "mail/signature_block.txt" %}

--- a/src/django/api/templates/mail/claim_facility_revocation_body.txt
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.txt
@@ -12,7 +12,7 @@ Here's the reason it was revoked:
 {{ revocation_reason }}
 {% endif %}
 
-Sincerely,
+Best wishes,
 
 {% include "mail/signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_submitted_body.html
+++ b/src/django/api/templates/mail/claim_facility_submitted_body.html
@@ -53,7 +53,7 @@
             need any additional information.
         </p>
         <p>
-            Sincerely,
+            Best wishes,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/claim_facility_submitted_body.txt
+++ b/src/django/api/templates/mail/claim_facility_submitted_body.txt
@@ -18,7 +18,7 @@ Here is the information submitted with your request:
 
 We'll review your request to claim the facility and get in touch if we need any additional information.
 
-Sincerely,
+Best wishes,
 
 {% include "mail/signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.html
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.html
@@ -26,7 +26,7 @@
             </li>
         </ul>
         <p>
-            Sincerely,
+            Best wishes,
         </p>
         {% include "mail/signature_block.html" %}
     </body>

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.txt
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.txt
@@ -9,6 +9,7 @@ The facility is:
   - Facility: {{ facility_name }}, {{ facility_address }}, {{ facility_country }}
   - Facility URL: {{ facility_url }}
 
-Sincerely,
+Best wishes,
+
 {% include "mail/signature_block.txt" %}
 {% endblock content %}


### PR DESCRIPTION
## Overview

Make the set of text changes described in #607 for claim a facility.

Connects #607 

## Notes

I interpreted the request to change the "approval reason" etc text in the status change emails to be a replacement for passing through the text that had been entered on the dashboard page when changing the status. The internal reason will still be stored for auditing but we will no longer propagate it to the claimant via email.

## Testing Instructions

- serve this branch with claim a facility on and go through the claim a facility workflow to verify that the set of text changes requested in #607 has been made here.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
