### PR TITLE
Require a token for all API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable administrators to split facility matches into new facilities [#633](https://github.com/open-apparel-registry/open-apparel-registry/pull/633)
 
 ### Changed
+- Require a token for all API endpoints [#644](https://github.com/open-apparel-registry/open-apparel-registry/pull/644)
 
 ### Deprecated
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -73,6 +73,8 @@ rds_database_identifier = "openapparelregistry"
 rds_database_name = "openapparelregistry"
 rds_database_username = "openapparelregistry"
 rds_database_password = "password"
+
+oar_client_key = ""
 ```
 
 This file lives at `s3://openapparelregistry-staging-config-eu-west-1/terraform/terraform.tfvars`.

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -62,6 +62,7 @@ data "template_file" "default_job_definition" {
     environment                = "${var.environment}"
     django_secret_key          = "${var.django_secret_key}"
     google_server_side_api_key = "${var.google_server_side_api_key}"
+    oar_client_key             = "${var.oar_client_key}"
 
     rollbar_server_side_access_token = "${var.rollbar_server_side_access_token}"
 

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -119,6 +119,8 @@ data "template_file" "app" {
 
     django_secret_key = "${var.django_secret_key}"
 
+    oar_client_key = "${var.oar_client_key}"
+
     default_from_email = "${var.default_from_email}"
 
     app_port = "${var.app_port}"
@@ -165,6 +167,8 @@ data "template_file" "app_cli" {
     rollbar_client_side_access_token = "${var.rollbar_client_side_access_token}"
 
     django_secret_key = "${var.django_secret_key}"
+
+    oar_client_key = "${var.oar_client_key}"
 
     default_from_email = "${var.default_from_email}"
 

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -14,6 +14,7 @@
       { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
       { "name": "GOOGLE_SERVER_SIDE_API_KEY", "value": "${google_server_side_api_key}" },
       { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
-      { "name": "BATCH_MODE", "value": "True" }
+      { "name": "BATCH_MODE", "value": "True" },
+      { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" }
   ]
 }

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -18,7 +18,8 @@
         { "name": "REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY", "value": "${google_client_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_ANALYTICS_KEY", "value": "${google_analytics_key}" },
         { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
-        { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" }
+        { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" },
+        { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" }
     ],
     "portMappings": [
       {

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -21,7 +21,8 @@
         { "name": "REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY", "value": "${google_client_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_ANALYTICS_KEY", "value": "${google_analytics_key}" },
         { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
-        { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" }
+        { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" },
+        { "name": "OAR_CLIENT_KEY", "value": "" }
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -256,3 +256,5 @@ variable "spot_fleet_service_role_policy_arn" {
 variable "aws_lambda_service_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
+
+variable "oar_client_key" {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
         - DJANGO_SECRET_KEY=secret
         - DJANGO_LOG_LEVEL=INFO
         - AWS_PROFILE=${AWS_PROFILE:-open-apparel-registry}
+        - OAR_CLIENT_KEY=
     build:
       context: ./src/django
       dockerfile: Dockerfile

--- a/src/app/src/actions/auth.js
+++ b/src/app/src/actions/auth.js
@@ -2,7 +2,7 @@ import { createAction } from 'redux-act';
 import isEmail from 'validator/lib/isEmail';
 import { toast } from 'react-toastify';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -96,7 +96,7 @@ export function submitSignUpForm() {
         const { confirmPassword, ...dataForAPI } = form;
         const signupData = createSignupRequestData(dataForAPI);
 
-        return csrfRequest
+        return apiRequest
             .post(makeUserSignupURL(), signupData)
             .then(({ data }) => dispatch(completeSubmitSignUpForm(data)))
             .catch(e => dispatch(logErrorAndDispatchFailure(
@@ -130,7 +130,7 @@ export function submitLoginForm() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(makeUserLoginURL(), { email, password })
             .then(({ data }) => dispatch(completeSubmitLoginForm(data)))
             .catch(e => dispatch(logErrorAndDispatchFailure(
@@ -145,7 +145,7 @@ export function sessionLogin() {
     return (dispatch) => {
         dispatch(startSessionLogin());
 
-        return csrfRequest
+        return apiRequest
             .get(makeUserLoginURL())
             .then(({ data }) => dispatch(completeSessionLogin(data)))
             .catch(e => dispatch(logErrorAndDispatchFailure(
@@ -186,7 +186,7 @@ export function requestForgotPasswordEmail() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(makeResetPasswordEmailURL(), { email })
             .then(() => {
                 toast('Check your email for password reset instructions');
@@ -204,7 +204,7 @@ export function submitLogOut() {
     return (dispatch) => {
         dispatch(startSubmitLogOut());
 
-        return csrfRequest
+        return apiRequest
             .post(makeUserLogoutURL())
             .then(({ data }) => dispatch(completeSubmitLogOut(data)))
             .catch(e => dispatch(logErrorAndDispatchFailure(
@@ -254,7 +254,7 @@ export function submitResetPassword() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(
                 makeResetPasswordConfirmURL(),
                 {
@@ -285,7 +285,7 @@ export function confirmAccountRegistration(key) {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(makeUserConfirmEmailURL(), { key })
             .then(() => dispatch(completeConfirmAccountRegistration()))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/claimFacility.js
+++ b/src/app/src/actions/claimFacility.js
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import snakeCase from 'lodash/snakeCase';
 import mapKeys from 'lodash/mapKeys';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -23,7 +23,7 @@ export function fetchClaimFacilityData(oarID) {
     return (dispatch) => {
         dispatch(startFetchClaimFacilityData());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityByOARIdURL(oarID))
             .then(({ data }) => dispatch(completeFetchClaimFacilityData(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -84,7 +84,7 @@ export function submitClaimAFacilityData(oarID) {
 
         dispatch(startSubmitClaimAFacilityData());
 
-        return csrfRequest
+        return apiRequest
             .post(makeClaimFacilityAPIURL(oarID), postData)
             .then(({ data }) => dispatch(completeSubmitClaimAFacilityData(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -108,7 +108,7 @@ export function fetchParentCompanyOptions() {
     return (dispatch) => {
         dispatch(startFetchParentCompanyOptions());
 
-        return csrfRequest
+        return apiRequest
             .get(makeParentCompanyOptionsAPIURL())
             .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
             .then(data => dispatch(completeFetchParentCompanyOptions(data)))

--- a/src/app/src/actions/claimFacilityDashboard.jsx
+++ b/src/app/src/actions/claimFacilityDashboard.jsx
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     makeGetFacilityClaimsURL,
@@ -21,7 +21,7 @@ export function fetchFacilityClaims() {
     return (dispatch) => {
         dispatch(startFetchFacilityClaims());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityClaimsURL())
             .then(({ data }) => dispatch(completeFetchFacilityClaims(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -46,7 +46,7 @@ export function fetchSingleFacilityClaim(claimID) {
 
         dispatch(startFetchSingleFacilityClaim());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityClaimByClaimIDURL(claimID))
             .then(({ data }) => dispatch(completeFetchSingleFacilityClaim(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -76,7 +76,7 @@ export function approveFacilityClaim(claimID, reason = '') {
 
         dispatch(startApproveFacilityClaim());
 
-        return csrfRequest
+        return apiRequest
             .post(makeApproveFacilityClaimByClaimIDURL(claimID), { reason })
             .then(({ data }) => dispatch(completeApproveFacilityClaim(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -95,7 +95,7 @@ export function denyFacilityClaim(claimID, reason = '') {
 
         dispatch(startDenyFacilityClaim());
 
-        return csrfRequest
+        return apiRequest
             .post(makeDenyFacilityClaimByClaimIDURL(claimID), { reason })
             .then(({ data }) => dispatch(completeDenyFacilityClaim(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -114,7 +114,7 @@ export function revokeFacilityClaim(claimID, reason = '') {
 
         dispatch(startRevokeFacilityClaim());
 
-        return csrfRequest
+        return apiRequest
             .post(makeRevokeFacilityClaimByClaimIDURL(claimID), { reason })
             .then(({ data }) => dispatch(completeRevokeFacilityClaim(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -150,7 +150,7 @@ export function addNewFacilityClaimReviewNote(claimID) {
 
         dispatch(startAddNewFacilityClaimReviewNote());
 
-        return csrfRequest
+        return apiRequest
             .post(makeAddNewFacilityClaimReviewNoteURL(claimID), { note })
             .then(({ data }) => dispatch(completeAddNewFacilityClaimReviewNote(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/claimedFacilities.jsx
+++ b/src/app/src/actions/claimedFacilities.jsx
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     makeGetClaimedFacilitiesURL,
@@ -16,7 +16,7 @@ export function fetchClaimedFacilities() {
     return (dispatch) => {
         dispatch(startFetchClaimedFacilities());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetClaimedFacilitiesURL())
             .then(({ data }) => dispatch(completeFetchClaimedFacilities(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/claimedFacilityDetails.js
+++ b/src/app/src/actions/claimedFacilityDetails.js
@@ -2,7 +2,7 @@ import { createAction } from 'redux-act';
 import mapValues from 'lodash/mapValues';
 import isNull from 'lodash/isNull';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -26,7 +26,7 @@ export function fetchClaimedFacilityDetails(claimID) {
 
         dispatch(startFetchClaimedFacilityDetails());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetOrUpdateApprovedFacilityClaimURL(claimID))
             .then(({ data }) => mapValues(data, (v) => {
                 if (isNull(v)) {
@@ -65,7 +65,7 @@ export function submitClaimedFacilityDetailsUpdate(claimID) {
 
         dispatch(startUpdateClaimedFacilityDetails());
 
-        return csrfRequest
+        return apiRequest
             .put(makeGetOrUpdateApprovedFacilityClaimURL(claimID), data)
             .then(({ data: responseData }) => mapValues(responseData, (v) => {
                 if (isNull(v)) {

--- a/src/app/src/actions/dashboardLists.js
+++ b/src/app/src/actions/dashboardLists.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -20,7 +20,7 @@ export function fetchDashboardListContributors() {
     return (dispatch) => {
         dispatch(startFetchDashboardListContributors());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetContributorsURL())
             .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
             .then(data => dispatch(completeFetchDashboardListContributors(data)))
@@ -48,7 +48,7 @@ export function fetchDashboardFacilityLists(contributor) {
     return (dispatch) => {
         dispatch(startFetchDashboardFacilityLists());
 
-        return csrfRequest
+        return apiRequest
             .get(makeDashboardFacilityListsURL(contributor))
             .then(({ data }) => dispatch(completeFetchDashboardFacilityLists(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/deleteFacility.js
+++ b/src/app/src/actions/deleteFacility.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-act';
 import get from 'lodash/get';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -30,7 +30,7 @@ export function fetchFacilityToDelete() {
 
         dispatch(startFetchFacilityToDelete());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityByOARIdURL(oarID))
             .then(({ data }) => dispatch(completeFetchFacilityToDelete(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -68,7 +68,7 @@ export function deleteFacility() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .delete(makeGetFacilityByOARIdURL(oarID))
             .then(() => dispatch(completeDeleteFacility()))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/facilities.js
+++ b/src/app/src/actions/facilities.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -29,7 +29,7 @@ export function fetchFacilities() {
 
         const qs = createQueryStringFromSearchFilters(filters);
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilitiesURLWithQueryString(qs))
             .then(({ data }) => dispatch(completeFetchFacilities(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -52,7 +52,7 @@ export function fetchSingleFacility(oarID = null) {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityByOARIdURL(oarID))
             .then(({ data }) => dispatch(completeFetchSingleFacility(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/facilityCount.js
+++ b/src/app/src/actions/facilityCount.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -26,7 +26,7 @@ export function fetchFacilityCount() {
             return dispatch(completeFetchFacilityCount(data));
         }
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilitiesCountURL())
             .then(({ data: { count } }) => dispatch(completeFetchFacilityCount(count)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-act';
 import querystring from 'querystring';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -59,7 +59,7 @@ export function fetchFacilityList(listID = null) {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .get(makeSingleFacilityListURL(listID))
             .then(({ data }) => dispatch(completeFetchFacilityList(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -89,7 +89,7 @@ export function fetchFacilityListItems(
             ? { page, pageSize: rowsPerPage }
             : null;
         const qs = `?${querystring.stringify(Object.assign({}, params, pageParams))}`;
-        return csrfRequest
+        return apiRequest
             .get(`${url}${qs}`)
             .then(({ data }) => dispatch(completeFetchFacilityListItems(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -112,7 +112,7 @@ export function confirmFacilityListItemMatch(facilityMatchID, listID, listItemID
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(
                 createConfirmFacilityListItemMatchURL(listID),
                 createConfirmOrRejectMatchData(listItemID, facilityMatchID),
@@ -138,7 +138,7 @@ export function rejectFacilityListItemMatch(facilityMatchID, listID, listItemID)
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(
                 createRejectFacilityListItemMatchURL(listID),
                 createConfirmOrRejectMatchData(listItemID, facilityMatchID),
@@ -177,7 +177,7 @@ export function assembleAndDownloadFacilityListCSV() {
                     data: {
                         results,
                     },
-                } = await csrfRequest.get(dataURLs[i]); // eslint-disable-line no-await-in-loop
+                } = await apiRequest.get(dataURLs[i]); // eslint-disable-line no-await-in-loop
                 csvData = csvData.concat(results);
             }
             downloadListItemCSV(data, csvData);
@@ -209,7 +209,7 @@ export function removeFacilityListItem(listID, listItemID) {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(
                 createRemoveFacilityListItemURL(listID),
                 { list_item_id: listItemID },

--- a/src/app/src/actions/facilityLists.js
+++ b/src/app/src/actions/facilityLists.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -16,7 +16,7 @@ export function fetchUserFacilityLists() {
     return (dispatch) => {
         dispatch(startFetchUserFacilityLists());
 
-        return csrfRequest
+        return apiRequest
             .get(makeFacilityListsURL())
             .then(({ data }) => dispatch(completeFetchUserFacilityLists(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/featureFlags.js
+++ b/src/app/src/actions/featureFlags.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     makeGetAPIFeatureFlagsURL,
@@ -16,7 +16,7 @@ export function fetchFeatureFlags() {
     return (dispatch) => {
         dispatch(startFetchFeatureFlags());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetAPIFeatureFlagsURL())
             .then(({ data }) => dispatch(completeFetchFeatureFlags(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -32,7 +32,7 @@ export function fetchContributorOptions() {
     return (dispatch) => {
         dispatch(startFetchContributorOptions());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetContributorsURL())
             .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
             .then(data => dispatch(completeFetchContributorOptions(data)))
@@ -48,7 +48,7 @@ export function fetchContributorTypeOptions() {
     return (dispatch) => {
         dispatch(startFetchContributorTypeOptions());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetContributorTypesURL())
             .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
             .then(data => dispatch(completeFetchContributorTypeOptions(data)))
@@ -64,7 +64,7 @@ export function fetchCountryOptions() {
     return (dispatch) => {
         dispatch(startFetchCountryOptions());
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetCountriesURL())
             .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
             .then(data => dispatch(completeFetchCountryOptions(data)))

--- a/src/app/src/actions/mergeFacilities.js
+++ b/src/app/src/actions/mergeFacilities.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-act';
 import get from 'lodash/get';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -48,7 +48,7 @@ export function fetchMergeTargetFacility() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityByOARIdURL(oarID))
             .then(({ data }) => dispatch(completeFetchMergeTargetFacility(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -94,7 +94,7 @@ export function fetchFacilityToMerge() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .get(makeGetFacilityByOARIdURL(oarID))
             .then(({ data }) => dispatch(completeFetchFacilityToMerge(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -136,7 +136,7 @@ export function mergeFacilities() {
             ));
         }
 
-        return csrfRequest
+        return apiRequest
             .post(makeMergeTwoFacilitiesAPIURL(targetOARID, toMergeOARID))
             .then(({ data }) => dispatch(completeMergeFacilities(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/profile.js
+++ b/src/app/src/actions/profile.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-act';
 import get from 'lodash/get';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     makeAPITokenURL,
@@ -39,7 +39,7 @@ export function fetchAPIToken() {
     return (dispatch) => {
         dispatch(startFetchAPIToken());
 
-        return csrfRequest
+        return apiRequest
             .get(makeAPITokenURL())
             // Return a list here to afford potentially retrieving and displaying
             // multiple API tokens per user.
@@ -57,7 +57,7 @@ export function deleteAPIToken() {
     return (dispatch) => {
         dispatch(startDeleteAPIToken());
 
-        return csrfRequest
+        return apiRequest
             .delete(makeAPITokenURL())
             .then(() => dispatch(completeDeleteAPIToken()))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -72,7 +72,7 @@ export function createAPIToken() {
     return (dispatch) => {
         dispatch(startCreateAPIToken());
 
-        return csrfRequest
+        return apiRequest
             .post(makeAPITokenURL())
             // Return a list here to afford potentially retrieving and displaying
             // multiple API tokens per user.
@@ -107,7 +107,7 @@ export function fetchUserProfile(userID) {
         const email = get(user, 'user.email', null);
         const id = get(user, 'user.id', null);
 
-        return csrfRequest
+        return apiRequest
             .get(makeUserProfileURL(userID))
             .then(({ data }) => {
                 if (id === userID && id === data.id) {
@@ -152,7 +152,7 @@ export function updateUserProfile(userID) {
 
         const profileUpdateData = createProfileUpdateRequestData(profile);
 
-        return csrfRequest
+        return apiRequest
             .put(makeUserProfileURL(userID), profileUpdateData)
             .then(({ data }) => dispatch(completeUpdateUserProfile(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/splitFacilityMatches.js
+++ b/src/app/src/actions/splitFacilityMatches.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -30,7 +30,7 @@ export function fetchFacilityToSplit() {
 
         dispatch(startFetchFacilityToSplit());
 
-        return csrfRequest
+        return apiRequest
             .get(makeSplitFacilityAPIURL(oarID))
             .then(({ data }) => dispatch(completeFetchFacilityToSplit(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -61,7 +61,7 @@ export function splitFacilityMatch(matchID) {
 
         dispatch(startSplitFacilityMatch());
 
-        return csrfRequest
+        return apiRequest
             .post(makeSplitFacilityAPIURL(oarID), { match_id: matchID })
             .then(({ data }) => dispatch(completeSplitFacilityMatch(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/actions/upload.js
+++ b/src/app/src/actions/upload.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-act';
 
-import csrfRequest from '../util/csrfRequest';
+import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
@@ -58,7 +58,7 @@ export function uploadFile(file = null, redirectToListDetail) {
             formData.append('replaces', replaces);
         }
 
-        return csrfRequest
+        return apiRequest
             .post(makeFacilityListsURL(), formData)
             .then(({ data: { id } }) => {
                 dispatch(completeUploadFile());

--- a/src/app/src/util/apiRequest.js
+++ b/src/app/src/util/apiRequest.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 // Used to make authenticated HTTP requests to Django
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 axios.defaults.xsrfCookieName = 'csrftoken';
-const csrfRequest = axios.create({
+const apiRequest = axios.create({
     headers: {
         credentials: 'same-origin',
     },
@@ -11,10 +11,10 @@ const csrfRequest = axios.create({
 
 // Not related to CSRF protection, but this is the appropriate place to set the
 // client key header used to authenticate anonymous API requests.
-csrfRequest.interceptors.request.use(config => Object.assign({}, config, {
+apiRequest.interceptors.request.use(config => Object.assign({}, config, {
     headers: Object.assign({}, config.headers, {
         'X-OAR-Client-Key': window.ENVIRONMENT.OAR_CLIENT_KEY,
     }),
 }));
 
-export default csrfRequest;
+export default apiRequest;

--- a/src/app/src/util/csrfRequest.js
+++ b/src/app/src/util/csrfRequest.js
@@ -9,4 +9,12 @@ const csrfRequest = axios.create({
     },
 });
 
+// Not related to CSRF protection, but this is the appropriate place to set the
+// client key header used to authenticate anonymous API requests.
+csrfRequest.interceptors.request.use(config => Object.assign({}, config, {
+    headers: Object.assign({}, config.headers, {
+        'X-OAR-Client-Key': window.ENVIRONMENT.OAR_CLIENT_KEY,
+    }),
+}));
+
 export default csrfRequest;

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
 COPY . /usr/local/src
 
 RUN GOOGLE_SERVER_SIDE_API_KEY="" \
+    OAR_CLIENT_KEY="" \
     python manage.py collectstatic --no-input
 
 CMD ["-b :8080", \

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -1,4 +1,20 @@
+from django.conf import settings
 from rest_framework import permissions
+
+
+class IsAuthenticatedOrWebClient(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return True
+
+        if settings.OAR_CLIENT_KEY == '':
+            return True
+
+        client_key = request.META.get('HTTP_X_OAR_CLIENT_KEY')
+        if client_key == settings.OAR_CLIENT_KEY:
+            return True
+
+        return False
 
 
 class IsRegisteredAndConfirmed(permissions.BasePermission):

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -1,5 +1,17 @@
+from urllib.parse import urlparse
+
 from django.conf import settings
+from django.utils.http import is_same_domain
 from rest_framework import permissions
+
+
+def is_referer_allowed(request):
+    referer = urlparse(request.META.get('HTTP_REFERER', ''))
+    host = referer.netloc.split(':')[0]
+    for pattern in settings.ALLOWED_HOSTS:
+        if is_same_domain(host, pattern):
+            return True
+    return False
 
 
 class IsAuthenticatedOrWebClient(permissions.BasePermission):
@@ -12,7 +24,7 @@ class IsAuthenticatedOrWebClient(permissions.BasePermission):
 
         client_key = request.META.get('HTTP_X_OAR_CLIENT_KEY')
         if client_key == settings.OAR_CLIENT_KEY:
-            return True
+            return is_referer_allowed(request)
 
         return False
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -27,7 +27,7 @@ from api.geocoding import (create_geocoding_params,
                            format_geocoded_address_data,
                            geocode_address)
 from api.test_data import parsed_city_hall_data
-from api.permissions import is_referer_allowed
+from api.permissions import referring_host_is_allowed, referring_host
 
 
 class FacilityListCreateTest(APITestCase):
@@ -2866,23 +2866,18 @@ class PermissionsTests(TestCase):
 
     @override_settings(ALLOWED_HOSTS=['.allowed.org'])
     def test_is_referer_allowed(self):
-        self.assertTrue(is_referer_allowed(
-            PermissionsTests.MockRequest('http://allowed.org')))
-        self.assertTrue(is_referer_allowed(
-            PermissionsTests.MockRequest('http://subdomain.allowed.org')))
-        self.assertTrue(is_referer_allowed(
-            PermissionsTests.MockRequest('http://allowed.org:6543')))
-        self.assertTrue(is_referer_allowed(
-            PermissionsTests.MockRequest(
-                'http://allowed.org:6543/api/countries')))
+        def check_host(url):
+            return referring_host_is_allowed(
+                referring_host(
+                    PermissionsTests.MockRequest(url)))
 
-        self.assertFalse(is_referer_allowed(
-            PermissionsTests.MockRequest('http://notallowed.org')))
-        self.assertFalse(is_referer_allowed(
-            PermissionsTests.MockRequest('http://allowed.com')))
-        self.assertFalse(is_referer_allowed(
-            PermissionsTests.MockRequest('')))
-        self.assertFalse(is_referer_allowed(
-            PermissionsTests.MockRequest(None)))
-        self.assertFalse(is_referer_allowed(
-            PermissionsTests.MockRequest('foo')))
+        self.assertTrue(check_host('http://allowed.org'))
+        self.assertTrue(check_host('http://subdomain.allowed.org'))
+        self.assertTrue(check_host('http://allowed.org:6543'))
+        self.assertTrue(check_host('http://allowed.org:6543/api/countries'))
+
+        self.assertFalse(check_host('http://notallowed.org'))
+        self.assertFalse(check_host('http://allowed.com'))
+        self.assertFalse(check_host(''))
+        self.assertFalse(check_host(None))
+        self.assertFalse(check_host('foo'))

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -95,7 +95,6 @@ def _report_facility_claim_email_error_to_rollbar(claim):
         )
 
 
-@permission_classes((AllowAny,))
 class SubmitNewUserForm(CreateAPIView):
     serializer_class = UserSerializer
 
@@ -146,7 +145,6 @@ class SubmitNewUserForm(CreateAPIView):
 
 class LoginToOARClient(LoginView):
     serializer_class = UserSerializer
-    permission_classes = [AllowAny]
 
     def post(self, request, *args, **kwargs):
         email = request.data.get('email')
@@ -326,7 +324,6 @@ class APIAuthToken(ObtainAuthToken):
 
 
 @api_view(['GET'])
-@permission_classes((AllowAny,))
 def all_contributors(request):
     """
     Returns list contributors as a list of tuples of contributor IDs and names.
@@ -350,7 +347,6 @@ def all_contributors(request):
 
 
 @api_view(['GET'])
-@permission_classes((AllowAny,))
 def all_contributor_types(request):
     """
     Returns a list of contributor type choices as tuples of values and display
@@ -369,7 +365,6 @@ def all_contributor_types(request):
 
 
 @api_view(['GET'])
-@permission_classes((AllowAny,))
 def all_countries(request):
     """
     Returns a list of country choices as tuples of country codes and names.
@@ -450,7 +445,6 @@ class FacilitiesViewSet(mixins.ListModelMixin,
     """
     queryset = Facility.objects.all()
     serializer_class = FacilitySerializer
-    permission_classes = (AllowAny,)
     pagination_class = FacilitiesGeoJSONPagination
     filter_backends = (FacilitiesAPIFilterBackend,)
 

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -343,6 +343,7 @@ if not DEBUG:
         'access_token': os.getenv('ROLLBAR_SERVER_SIDE_ACCESS_TOKEN'),
         'environment': ENVIRONMENT.lower(),
         'root': BASE_DIR,
+        'suppress_reinit_warning': True,
     }
     import rollbar
     rollbar.init(**ROLLBAR)

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -341,3 +341,8 @@ if not DEBUG:
     }
     import rollbar
     rollbar.init(**ROLLBAR)
+
+OAR_CLIENT_KEY = os.getenv('OAR_CLIENT_KEY')
+if OAR_CLIENT_KEY is None:
+    raise ImproperlyConfigured(
+        'Invalid OAR_CLIENT_KEY provided, must be set')

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -130,6 +130,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'api.permissions.IsAuthenticatedOrWebClient',
+    ),
     'DEFAULT_PAGINATION_CLASS': 'api.pagination.PageAndSizePagination',
     'PAGE_SIZE': 20,
 }

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -44,10 +44,12 @@ GIT_COMMIT = os.getenv('GIT_COMMIT', 'UNKNOWN')
 DEBUG = (ENVIRONMENT == 'Development')
 
 ALLOWED_HOSTS = [
-    'localhost',
-    'django',
     '.openapparel.org'
 ]
+
+if ENVIRONMENT == 'Development':
+    ALLOWED_HOSTS.append('localhost')
+    ALLOWED_HOSTS.append('django')
 
 if ENVIRONMENT in ['Production', 'Staging'] and BATCH_MODE == '':
     # Within EC2, the Elastic Load Balancer HTTP health check will use the

--- a/src/django/web/views.py
+++ b/src/django/web/views.py
@@ -12,6 +12,8 @@ environment = {k: v
 # One of `development`, `testing`, `staging`, `production`
 environment['ENVIRONMENT'] = settings.ENVIRONMENT.lower()
 
+environment['OAR_CLIENT_KEY'] = settings.OAR_CLIENT_KEY
+
 context = {'environment': environment}
 
 


### PR DESCRIPTION
## Overview

Adds an authentication requirement to all API endpoints.

- Required for accurately reporting on API usage.
- Allows for disabling accounts that accidentally or maliciously overuse the APIs.

Maintains the ability for the web application to make API requests on behalf of unauthenticated users.

Connects #636

## Demo

<img width="1016" alt="Screen Shot 2019-07-02 at 9 24 56 AM" src="https://user-images.githubusercontent.com/17363/60529368-4a377580-9cab-11e9-85a8-ae8576be716a.png">

<img width="1071" alt="Screen Shot 2019-07-02 at 9 20 21 AM" src="https://user-images.githubusercontent.com/17363/60529297-283df300-9cab-11e9-8cd1-42464dc1bee5.png">

<img width="1072" alt="Screen Shot 2019-07-02 at 9 20 02 AM" src="https://user-images.githubusercontent.com/17363/60529305-2d02a700-9cab-11e9-8550-02b98c2a4646.png">


## Notes

I have added an `OAR_CLIENT_KEY` to the staging tfvars file. There is a checklist item on this PR to make sure the next release issue includes updating the production tfvars file.

## Testing Instructions

### Setup

* `./scripts/manage resetdb`
* `./scripts/manage loadfixtures`
* `./scripts/manage processfixtures`

#### Enable Rollbar in development

* Set the `ROLLBAR_SERVER_SIDE_ACCESS_TOKEN` value in `.env.backend`
* Enable Rollbar in `settings.py`
```diff
diff --git a/src/django/oar/settings.py b/src/django/oar/settings.py
index 10c2f02..bb0a11e 100644
--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -338,7 +338,7 @@ if GOOGLE_SERVER_SIDE_API_KEY is None:
     raise ImproperlyConfigured(
         'Invalid GOOGLE_SERVER_SIDE_API_KEY provided, must be set')
 
-if not DEBUG:
+if True:
     ROLLBAR = {
         'access_token': os.getenv('ROLLBAR_SERVER_SIDE_ACCESS_TOKEN'),
         'environment': ENVIRONMENT.lower(),
```

### Test

* Start `./scripts/server`.
* Ensure that you are not logged in to the application
* Verify that you can use the application as normal.
* Verify that `curl http://localhost:6543/api/countries/` returns a response.
* Set an `OAR_CLIENT_KEY` env var in `docker-compose.yml` and restart `./scripts/server`

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index a769732..1f477a4 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         - DJANGO_SECRET_KEY=secret
         - DJANGO_LOG_LEVEL=INFO
         - AWS_PROFILE=${AWS_PROFILE:-open-apparel-registry}
-        - OAR_CLIENT_KEY=
+        - OAR_CLIENT_KEY=clientkey
     build:
       context: ./src/django
       dockerfile: Dockerfile
```
* Verify that you can still use the application as normal. 
* Verify that `curl http://localhost:6543/api/countries/` now returns an error message and that an "Incorrect client key submitted with API request" occurrence is logged to Rollbar
```javascript
{"detail":"Authentication credentials were not provided."}
```
* Make a request with a client key header
```
curl \
  -H "X-OAR-Client-Key: clientkey" \
  http://localhost:6543/api/countries/
````
* Verify that the same authentication error is returned, but an "Unallowed referring host passed with API request" warning is logged in Rollbar.
* Make a request with a client key and a referrer
```
curl \
  -H "X-OAR-Client-Key: clientkey" \
  -H "Referer: http://localhost:6543" \
  http://localhost:6543/api/countries/
```
* Verify that it is sucessful
* Log in to the web app as `c2@example.com`. 
* Browse http://localhost:6543/profile/2 and generate an API token
* Make an authenticated request with the token and verify that it succeeds.
```
curl \
  -H "Authorization: Token {{API-TOKEN}}" \
  http://localhost:6543/api/countries/
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] Add a checklist item to the next release issue for adding an `oar_client_key` to  the tfvars.
