### PR TITLE
Display RouteNotFound component on unmatched routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Validate claimed facility website field and show as hyperlink [#647](https://github.com/open-apparel-registry/open-apparel-registry/pull/647)
 - Update app text in claim a facility workflow [#642](https://github.com/open-apparel-registry/open-apparel-registry/pull/642)
 - Make "Dashboard" text on dashboard screens a clickable link [#667](https://github.com/open-apparel-registry/open-apparel-registry/pull/667)
+- Display RouteNotFound component for unmatched routes [#657](https://github.com/open-apparel-registry/open-apparel-registry/pull/657)
 
 ### Deprecated
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -86,11 +86,6 @@ class App extends Component {
                             <Switch>
                                 <Route
                                     exact
-                                    path={mainRoute}
-                                    component={MapAndSidebar}
-                                />
-                                <Route
-                                    exact
                                     path={claimFacilityRoute}
                                     render={() => (
                                         <FeatureFlag
@@ -117,26 +112,32 @@ class App extends Component {
                                     component={MapAndSidebar}
                                 />
                                 <Route
+                                    exact
                                     path={authRegisterFormRoute}
                                     component={RegisterForm}
                                 />
                                 <Route
+                                    exact
                                     path={authLoginFormRoute}
                                     component={LoginForm}
                                 />
                                 <Route
+                                    exact
                                     path={authResetPasswordFormRoute}
                                     component={ResetPasswordForm}
                                 />
                                 <Route
+                                    exact
                                     path={authConfirmRegistrationRoute}
                                     component={ConfirmRegistration}
                                 />
                                 <Route
+                                    exact
                                     path={profileRoute}
                                     component={UserProfile}
                                 />
                                 <Route
+                                    exact
                                     path={contributeRoute}
                                     component={Contribute}
                                 />
@@ -153,10 +154,12 @@ class App extends Component {
                                     component={FacilityLists}
                                 />
                                 <Route
+                                    exact
                                     path={aboutProcessingRoute}
                                     component={AboutProcessing}
                                 />
                                 <Route
+                                    exact
                                     path={aboutClaimedFacilitiesRoute}
                                     render={() => (
                                         <FeatureFlag
@@ -166,6 +169,11 @@ class App extends Component {
                                             <AboutClaimedFacilities />
                                         </FeatureFlag>
                                     )}
+                                />
+                                <Route
+                                    exact
+                                    path={mainRoute}
+                                    component={MapAndSidebar}
                                 />
                                 <Route render={() => <RouteNotFound />} />
                             </Switch>

--- a/src/app/src/components/ClaimedFacilities.jsx
+++ b/src/app/src/components/ClaimedFacilities.jsx
@@ -20,20 +20,27 @@ export default function ClaimedFacilities() {
                     (
                         <Switch>
                             <Route
+                                exact
                                 path={claimedFacilitiesDetailRoute}
                                 render={() => 'Claimed Facility Details'}
                             />
-                            <Route render={() => 'My Facilities'} />
+                            <Route
+                                exact
+                                path={claimedFacilitiesRoute}
+                                render={() => 'My Claimed Facilities'}
+                            />
                         </Switch>
                     )
                 }
             >
                 <Switch>
                     <Route
+                        exact
                         path={claimedFacilitiesDetailRoute}
                         render={() => <Route component={ClaimedFacilitiesDetails} />}
                     />
                     <Route
+                        exact
                         path={claimedFacilitiesRoute}
                         component={ClaimedFacilitiesList}
                     />

--- a/src/app/src/components/Dashboard.jsx
+++ b/src/app/src/components/Dashboard.jsx
@@ -96,10 +96,12 @@ function Dashboard({
                     (
                         <Switch>
                             <Route
+                                exact
                                 path={dashboardListsRoute}
                                 render={makeClickableDashboardLinkFn('Contributor Lists')}
                             />
                             <Route
+                                exact
                                 path={dashboardClaimsDetailsRoute}
                                 render={
                                     () => (
@@ -113,6 +115,7 @@ function Dashboard({
                                 }
                             />
                             <Route
+                                exact
                                 path={dashboardClaimsRoute}
                                 render={
                                     () => (
@@ -126,40 +129,52 @@ function Dashboard({
                                 }
                             />
                             <Route
+                                exact
                                 path={dashboardDeleteFacilityRoute}
                                 render={makeClickableDashboardLinkFn('Delete Facility')}
                             />
                             <Route
+                                exact
                                 path={dashboardMergeFacilitiesRoute}
                                 render={makeClickableDashboardLinkFn('Merge Facilities')}
                             />
                             <Route
+                                exact
                                 path={dashboardSplitFacilityMatchesRoute}
                                 render={makeClickableDashboardLinkFn('Split Facility Matches')}
                             />
-                            <Route render={() => DASHBOARD_TITLE} />
+                            <Route
+                                exact
+                                path={dashboardRoute}
+                                render={() => 'Dashboard'}
+                            />
                         </Switch>
                     )
                 }
             >
                 <Switch>
                     <Route
+                        exact
                         path={dashboardListsRoute}
                         component={DashboardLists}
                     />
                     <Route
+                        exact
                         path={dashboardDeleteFacilityRoute}
                         component={DashboardDeleteFacility}
                     />
                     <Route
+                        exact
                         path={dashboardMergeFacilitiesRoute}
                         component={DashboardMergeFacilities}
                     />
                     <Route
+                        exact
                         path={dashboardSplitFacilityMatchesRoute}
                         component={DashboardSplitFacilityMatches}
                     />
                     <Route
+                        exact
                         path={dashboardClaimsDetailsRoute}
                         render={
                             () => (
@@ -173,6 +188,7 @@ function Dashboard({
                         }
                     />
                     <Route
+                        exact
                         path={dashboardClaimsRoute}
                         render={
                             () => (
@@ -185,7 +201,12 @@ function Dashboard({
                             )
                         }
                     />
-                    <Route render={() => linkSection} />
+                    <Route
+                        exact
+                        path={dashboardRoute}
+                        render={() => linkSection}
+                    />
+                    <Route render={() => <RouteNotFound />} />
                 </Switch>
             </AppGrid>
         </AppOverflow>

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
 import { connect } from 'react-redux';
-import { Link, Switch, Route } from 'react-router-dom';
+import { Link, Route } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
@@ -215,12 +215,10 @@ class FacilityListItems extends Component {
                         {
                             list.item_count
                                 ? (
-                                    <Switch>
-                                        <Route
-                                            path={facilityListItemsRoute}
-                                            component={FacilityListItemsTable}
-                                        />
-                                    </Switch>)
+                                    <Route
+                                        path={facilityListItemsRoute}
+                                        component={FacilityListItemsTable}
+                                    />)
                                 : <FacilityListItemsEmpty />
                         }
                     </Grid>

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -6,12 +6,72 @@ import FilterSidebar from './FilterSidebar';
 import FacilityDetailsSidebar from './FacilityDetailSidebar';
 import FacilitiesMap from './FacilitiesMap';
 import FacilitiesMapErrorMessage from './FacilitiesMapErrorMessage';
+import RouteNotFound from './RouteNotFound';
 
 import '../styles/css/Map.css';
 
 import withQueryStringSync from '../util/withQueryStringSync';
 
-import { facilityDetailsRoute } from '../util/constants';
+import {
+    mainRoute,
+    facilitiesRoute,
+    facilityDetailsRoute,
+} from '../util/constants';
+
+function MapAndFilterSidebar({
+    hasError,
+}) {
+    return (
+        <>
+            <Grid
+                item
+                xs={12}
+                sm={4}
+                id="panel-container"
+            >
+                <Route component={FilterSidebar} />
+            </Grid>
+            <Grid
+                item
+                xs={12}
+                sm={8}
+                style={{ position: 'relative' }}
+            >
+                <Route
+                    component={hasError ? FacilitiesMapErrorMessage : FacilitiesMap}
+                />
+            </Grid>
+        </>
+    );
+}
+
+function MapAndDetailsSidebar({
+    hasError,
+}) {
+    return (
+        <>
+            <Grid
+                item
+                xs={12}
+                sm={4}
+                id="panel-container"
+            >
+                <Route component={FacilityDetailsSidebar} />
+            </Grid>
+            <Grid
+                item
+                xs={12}
+                sm={8}
+                style={{ position: 'relative' }}
+            >
+
+                <Route
+                    component={hasError ? FacilitiesMapErrorMessage : FacilitiesMap}
+                />
+            </Grid>
+        </>
+    );
+}
 
 class MapAndSidebar extends Component {
     state = { hasError: false };
@@ -27,47 +87,29 @@ class MapAndSidebar extends Component {
     }
 
     render() {
+        const { hasError } = this.state;
+
         return (
             <Fragment>
                 <Grid container className="map-sidebar-container">
-                    <Grid
-                        item
-                        xs={12}
-                        sm={4}
-                        id="panel-container"
-                    >
-                        <Switch>
-                            <Route
-                                path={facilityDetailsRoute}
-                                component={FacilityDetailsSidebar}
-                            />
-                            <Route component={FilterSidebar} />
-                        </Switch>
-                    </Grid>
-                    <Grid
-                        item
-                        xs={12}
-                        sm={8}
-                        style={{ position: 'relative' }}
-                    >
-                        <Switch>
-                            <Route
-                                path={facilityDetailsRoute}
-                                component={
-                                    this.state.hasError
-                                        ? FacilitiesMapErrorMessage
-                                        : FacilitiesMap
-                                }
-                            />
-                            <Route
-                                component={
-                                    this.state.hasError
-                                        ? FacilitiesMapErrorMessage
-                                        : FacilitiesMap
-                                }
-                            />
-                        </Switch>
-                    </Grid>
+                    <Switch>
+                        <Route
+                            exact
+                            path={facilityDetailsRoute}
+                            render={() => <MapAndDetailsSidebar hasError={hasError} />}
+                        />
+                        <Route
+                            exact
+                            path={facilitiesRoute}
+                            render={() => <MapAndFilterSidebar hasError={hasError} />}
+                        />
+                        <Route
+                            exact
+                            path={mainRoute}
+                            render={() => <MapAndFilterSidebar hasError={hasError} />}
+                        />
+                        <Route render={() => <RouteNotFound />} />
+                    </Switch>
                 </Grid>
             </Fragment>
         );


### PR DESCRIPTION
## Overview

Make react-router setup adjustments to ensure we display RouteNotFound component on unmatched routes.

Connects #621 

## Testing Instructions

- serve branch, `./scripts/manage resetdb && ./scripts/manage processfixtures`
- turn on claim a facility
- visit the app on 6543 and navigate through routes as:
   - c1@example
   - c2@example
   - non-signed-in user

...and verify that the routing now:

- displays a component when appropriate match occurs
- displays the RouteNotFound component (which is still not very well-styled) for routes which should not match)

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
