### PR TITLE
Use a loop and `save` rather than `update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+Use a loop and `save` rather than `update` [#666](https://github.com/open-apparel-registry/open-apparel-registry/pull/666)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1503,11 +1503,15 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             facility_match.status = FacilityMatch.CONFIRMED
             facility_match.save()
 
-            FacilityMatch \
+            matches_to_reject = FacilityMatch \
                 .objects \
                 .filter(facility_list_item=facility_list_item) \
-                .exclude(pk=facility_match_id) \
-                .update(status=FacilityMatch.REJECTED)
+                .exclude(pk=facility_match_id)
+            # Call `save` in a loop rather than use `update` to make sure that
+            # django-simple-history can log the changes
+            for match in matches_to_reject:
+                match.status = FacilityMatch.REJECTED
+                match.save()
 
             facility_list_item.status = FacilityListItem.CONFIRMED_MATCH
             facility_list_item.facility = facility_match.facility
@@ -1742,10 +1746,14 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                 .filter(facility_list=facility_list) \
                 .get(pk=request.data.get('list_item_id'))
 
-            FacilityMatch \
+            matches_to_deactivate = FacilityMatch \
                 .objects \
-                .filter(facility_list_item=facility_list_item) \
-                .update(is_active=False)
+                .filter(facility_list_item=facility_list_item)
+            # Call `save` in a loop rather than use `update` to make sure that
+            # django-simple-history can log the changes
+            for item in matches_to_deactivate:
+                item.is_active = False
+                item.save()
 
             facility_list_item.refresh_from_db()
 


### PR DESCRIPTION
## Overview

We need to call `save` to ensure that `django-simple-history` can create historical records.

Connects #648 

## Demo

Optional. Screenshots, `curl` examples, etc.

## Notes

There is one additional usage of `update` that has been replaced in https://github.com/open-apparel-registry/open-apparel-registry/pull/649/commits/5122de97da28d10b15f36cabeff9b67c960fd96f

## Testing Instructions

* Search the Python codebase for `.update(` and verify that there are no usages left (with the possible exception of the one addressed by https://github.com/open-apparel-registry/open-apparel-registry/pull/649/commits/5122de97da28d10b15f36cabeff9b67c960fd96f)
* Reset the db
  * `./scripts/manage resetdb`
  * `./scripts/manage loadfixtures`
  * `./scripts/manage processfixtures`

* Run `./scripts/manage shell_plus` and create an additional match

```
>>> i = FacilityListItem.objects.get(facility_list_id=8, row_index=10)
>>> f = Facility.objects.get(first)
>>> FacilityMatch.objects.create(facility=f, facility_list_item=i, status='PENDING', results=[])
>>> HistoricalFacilityMatch.objects.all().count()
933
```

* Log in as `c8@example.com` and browse `http://localhost:6543/lists/8`. 
* Approve one of the matches on the line item with two possible matches.
* In `shell_plus` verify that two `HistoricalFacilityMatch` objects were created.

```
>>> HistoricalFacilityMatch.objects.all().count()
935
```

* Click "REMOVE" on one of the list items in the `MATCHED` status and confirm the removal.
* In `shell_plus` verify that the `HistoricalFacilityMatch` count increased by 1

```
>>> HistoricalFacilityMatch.objects.all().count()
936
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
