### PR TITLE
Make dashboard link clickable as a breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Require a token for all API endpoints [#644](https://github.com/open-apparel-registry/open-apparel-registry/pull/644)
 - Validate claimed facility website field and show as hyperlink [#647](https://github.com/open-apparel-registry/open-apparel-registry/pull/647)
 - Update app text in claim a facility workflow [#642](https://github.com/open-apparel-registry/open-apparel-registry/pull/642)
+- Make "Dashboard" text on dashboard screens a clickable link [#667](https://github.com/open-apparel-registry/open-apparel-registry/pull/667)
 
 ### Deprecated
 

--- a/src/app/src/components/Dashboard.jsx
+++ b/src/app/src/components/Dashboard.jsx
@@ -17,6 +17,7 @@ import { checkWhetherUserHasDashboardAccess } from '../util/util';
 
 import {
     CLAIM_A_FACILITY,
+    dashboardRoute,
     dashboardListsRoute,
     dashboardClaimsRoute,
     dashboardClaimsDetailsRoute,
@@ -78,6 +79,15 @@ function Dashboard({
         </div>
     );
 
+    const makeClickableDashboardLinkFn = screenTitle => () => (
+        <span>
+            <Link to={dashboardRoute} href={dashboardRoute}>
+                Dashboard
+            </Link>
+            {` / ${screenTitle}`}
+        </span>
+    );
+
     return (
         <AppOverflow>
             <AppGrid
@@ -87,7 +97,7 @@ function Dashboard({
                         <Switch>
                             <Route
                                 path={dashboardListsRoute}
-                                render={() => 'Dashboard / Contributor Lists'}
+                                render={makeClickableDashboardLinkFn('Contributor Lists')}
                             />
                             <Route
                                 path={dashboardClaimsDetailsRoute}
@@ -97,7 +107,7 @@ function Dashboard({
                                             flag={CLAIM_A_FACILITY}
                                             alternative={DASHBOARD_TITLE}
                                         >
-                                            Dashboard / Facility Claim Details
+                                            {makeClickableDashboardLinkFn('Facility Claim Details')}
                                         </FeatureFlag>
                                     )
                                 }
@@ -110,22 +120,22 @@ function Dashboard({
                                             flag={CLAIM_A_FACILITY}
                                             alternative={DASHBOARD_TITLE}
                                         >
-                                            Dashboard / Facility Claims
+                                            {makeClickableDashboardLinkFn('Facility Claims')}
                                         </FeatureFlag>
                                     )
                                 }
                             />
                             <Route
                                 path={dashboardDeleteFacilityRoute}
-                                render={() => 'Dashboard / Delete Facility'}
+                                render={makeClickableDashboardLinkFn('Delete Facility')}
                             />
                             <Route
                                 path={dashboardMergeFacilitiesRoute}
-                                render={() => 'Dashboard / Merge Facilities'}
+                                render={makeClickableDashboardLinkFn('Merge Facilities')}
                             />
                             <Route
                                 path={dashboardSplitFacilityMatchesRoute}
-                                render={() => 'Dashboard / Split Facility Matches'}
+                                render={makeClickableDashboardLinkFn('Split Facility Matches')}
                             />
                             <Route render={() => DASHBOARD_TITLE} />
                         </Switch>


### PR DESCRIPTION
## Overview

Make the dashboard text on any specific dashboard page into a clickable link.

Connects #665

## Demo

![Screen Shot 2019-07-10 at 10 25 12 AM](https://user-images.githubusercontent.com/4165523/60977192-05d85500-a2fd-11e9-99c5-888784a1ca1c.png)

## Testing Instructions

- serve this branch with the default data and sign in as c1@example.com
- visit the dashboard page and verify that each of the specific dashboard pages now has a clickable link in the dashboard that goes back to the main dashboard page.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
