### PR TITLE
Add & document resetdb script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Enable administrators to split facility matches into new facilities [#633](https://github.com/open-apparel-registry/open-apparel-registry/pull/633)
 - Log requests made with token authentication [#646](https://github.com/open-apparel-registry/open-apparel-registry/pull/646)
+- `./scripts/resetdb` to expedite refreshing application data during development [#672](https://github.com/open-apparel-registry/open-apparel-registry/pull/672)
 
 ### Changed
 - Require a token for all API endpoints [#644](https://github.com/open-apparel-registry/open-apparel-registry/pull/644)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Because the frontend uses [Create React App](https://github.com/facebook/create-
 
 In development, the [Django](https://www.djangoproject.com) app sits behind a [Gunicorn](https://www.gunicorn.org) worker that is passed the [`--reload` flag](https://docs.gunicorn.org/en/stable/settings.html#reload).
 
+### Development Data
+
+To destroy any existing development database and load fresh fixture data including users, facility lists, facility matches, and facilities run:
+
+```bash
+vagrant@vagrant:/vagrant$ ./scripts/resetdb
+```
+
 ### Ports
 
 | Service                    | Port                            |
@@ -103,6 +111,7 @@ In development, the [Django](https://www.djangoproject.com) app sits behind a [G
 | `bootstrap`                                            | Pull `.env` files from S3                                                                                                                                                                    |
 | `generate_fixed_dumps`                                 | Import database dumps from Sourcemap, run `create_master_account_api_key.js`, and export new database dumps                                                                                  |
 | `infra`                                                | Plan and apply remote infrastructure changes                                                                                                                                                 |
+| `resetdb`                                              | Clear development database & load fixture data including users, facility lists, matches, and facilities                                                                                      |
 | `server`                                               | Run `docker-compose.yml` services                                                                                                                                                            |
 | `setup`                                                | Provision Vagrant VM and run `update`                                                                                                                                                        |
 | `test`                                                 | Run tests                                                                                                                                                                                    |

--- a/scripts/resetdb
+++ b/scripts/resetdb
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${OAR_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Reset database and repopulate with fixture data including facilities & matches.
+"
+}
+
+function resetdb() {
+    ./scripts/manage resetdb
+}
+
+function processfixtures() {
+    ./scripts/manage processfixtures
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        resetdb
+        processfixtures
+    fi
+fi


### PR DESCRIPTION
## Overview

- add `./scripts/resetdb` to expedite reloading fixture data & processed
facilities
- document `./scripts/resetdb` in README

Connects #659 

## Testing Instructions

- get this branch
- follow the README instructions to run the resetdb script
- serve the app and verify that you can search for facilities and sign in as c2@example.com

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
