### PR TITLE
Make small Createable/Multiselect UI refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add affiliations and certifications fields to claimed facility profile [#671](https://github.com/open-apparel-registry/open-apparel-registry/pull/671)
 - Add product and production type to claimed facility profile [#680](https://github.com/open-apparel-registry/open-apparel-registry/pull/680)
 - Make facility description required on claim a facility form [#679](https://github.com/open-apparel-registry/open-apparel-registry/pull/679)
+- Adjust how product and production type options are set for claimed details profile form [#684](https://github.com/open-apparel-registry/open-apparel-registry/pull/684)
 
 ### Deprecated
 

--- a/src/app/src/components/ClaimedFacilitiesDetails.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetails.jsx
@@ -19,8 +19,6 @@ import map from 'lodash/map';
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
 import isNull from 'lodash/isNull';
-import partition from 'lodash/partition';
-import concat from 'lodash/concat';
 import Select, { Creatable } from 'react-select';
 import { isEmail, isInt } from 'validator';
 import { toast } from 'react-toastify';
@@ -191,26 +189,17 @@ const InputSection = ({
             }
 
             if (isCreatable && isMultiSelect) {
-                const [
-                    optionsInExistingSet,
-                    newlyCreatedOptionsPrime,
-                ] = partition(
-                    value,
-                    v => includes(map(selectOptions, 'value'), v),
-                );
-
-                const mapStringToOption = s => ({ value: s, label: s });
-
-                return concat(
-                    map(optionsInExistingSet, mapStringToOption),
-                    map(newlyCreatedOptionsPrime, mapStringToOption),
-                );
+                return map(value, s => ({ value: s, label: s }));
             }
 
-            window.console.warn('isCreatable && !isMultiSelect case is not yet implemented');
-
-            return [];
+            // isCreatable && !isMultiSelect creates an option object from the value
+            return {
+                value,
+                label: value,
+            };
         })();
+
+        const SelectComponent = isCreatable ? Creatable : Select;
 
         return (
             <div style={claimedFacilitiesDetailsStyles.inputSectionStyles}>
@@ -222,25 +211,14 @@ const InputSection = ({
                     {label}
                 </InputLabel>
                 {asideNode}
-                { isCreatable ? (
-                    <Creatable
-                        onChange={onChange}
-                        value={selectValue}
-                        options={selectOptions}
-                        disabled={disabled}
-                        styles={selectStyles}
-                        isMulti={isMultiSelect}
-                    />
-                ) : (
-                    <Select
-                        onChange={onChange}
-                        value={selectValue}
-                        options={selectOptions}
-                        disabled={disabled}
-                        styles={selectStyles}
-                        isMulti={isMultiSelect}
-                    />
-                )}
+                <SelectComponent
+                    onChange={onChange}
+                    value={selectValue}
+                    options={selectOptions}
+                    disabled={disabled}
+                    styles={selectStyles}
+                    isMulti={isMultiSelect}
+                />
             </div>
         );
     }

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -283,6 +283,6 @@ export const approvedFacilityClaimPropType = shape({
     facility_types: arrayOf(arrayOf(string)).isRequired,
     affiliation_choices: arrayOf(arrayOf(string)).isRequired,
     certification_choices: arrayOf(arrayOf(string)).isRequired,
-    product_type_choices: arrayOf(string).isRequired,
-    production_type_choices: arrayOf(string).isRequired,
+    product_type_choices: arrayOf(arrayOf(string)).isRequired,
+    production_type_choices: arrayOf(arrayOf(string)).isRequired,
 });


### PR DESCRIPTION
## Overview

I had some very tiny epiphanies about simpler ways to do the multiselect/creatable dropdowns for product types & production types, so I'm making this PR to update the code before we forget about it.

- drop partition/concat/map code to set up selected creatable
multiselect options: it's effectively useless because the createables
don't care whether the selected values are within the list of choices
sent from the API
- adjust conditional setup for Creatable/Select components
- update product_types and production_types propTypes

Connects #652 

## Testing Instructions

- serve this branch and verify that the claimed details form works the same as it does on develop

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
