### PR TITLE
Display API docs to users who are not signed-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Use a loop and `save` rather than `update` [#666](https://github.com/open-apparel-registry/open-apparel-registry/pull/666)
+- Allow non-signed-in users to see API docs [#690](https://github.com/open-apparel-registry/open-apparel-registry/pull/690)
 
 ## [2.6.0] - 2019-06-25
 ### Added

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -48,7 +48,7 @@ schema_view = get_swagger_view(title='Open Apparel Registry API Documentation',
 internal_apis = [
     url(r'^', include('django.contrib.auth.urls')),
     url(r'^web/environment\.js', environment, name='environment'),
-    url(r'^api/docs/', schema_view),
+    url(r'^api/docs/', views.schema_view),
     path('admin/', admin.site.urls),
     re_path(r'^health-check/', include('watchman.urls')),
     url(r'^api-auth/', include('rest_framework.urls')),


### PR DESCRIPTION
## Overview

- create custom view for API docs with AllowAny permissions
- always suppress FacilityListItems documentation to prevent them from
showing up in the public docs -- or privately, since the endpoints are
mostly used internally and are not documented correctly

Connects #689

## Testing Instructions

- in `permissions.py`, adjust lines 23 and 33 to `return False` to disable the client (try this on develop first to ensure that it prevents `:8081/api/docs` from working, recreating the bug described in #689 
- `./scripts/server` this branch, ensure the permissions lines are still commented out and visit `:8081/api/docs` to verify that they load but that the interactive parts return 401s when you try to use them
- in another tab, visit the django admin and sign in as c1@example
- refresh api docs in the other tab and verify that you can now complete requests, since you are signed in
- in the django admin, generate an api token, copy it to the clipboard, and then sign out
- refresh API docs, open the Authorize dialog and enter `Token <your-api-key>` in the authorization value input
- verify that requests complete now in the interactive documentation
- verify that the FacilityListItems endpoints do not appear in the documentation

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
