### PR TITLE
Fix Swagger docs header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Set Swagger API docs header [#694](https://github.com/open-apparel-registry/open-apparel-registry/pull/694)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -102,7 +102,7 @@ def _report_facility_claim_email_error_to_rollbar(claim):
 @permission_classes([AllowAny])
 @renderer_classes([SwaggerUIRenderer, OpenAPIRenderer])
 def schema_view(request):
-    generator = schemas.SchemaGenerator(title='API Docs',
+    generator = schemas.SchemaGenerator(title='Open Apparel Registry API',
                                         patterns=urls.public_apis)
     return Response(generator.get_schema())
 


### PR DESCRIPTION
## Overview

Fixes a bug introduced in #690 whereby I had accidentally changed the API docs header.

Connects #693 

## Demo

![Screen Shot 2019-07-18 at 10 23 54 AM](https://user-images.githubusercontent.com/4165523/61465616-65121700-a946-11e9-94d4-34b2482327b2.png)

## Testing Instructions

- serve app
- open Swagger docs
- verify new header reads "Open Apparel Registry API"

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
