### PR TITLE
Add admin reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add admin reports [#709](https://github.com/open-apparel-registry/open-apparel-registry/pull/709)
 
 ### Changed
 - Require authentication for facility CSV downloads and log requests [#697](https://github.com/open-apparel-registry/open-apparel-registry/pull/697)

--- a/src/django/api/reports.py
+++ b/src/django/api/reports.py
@@ -1,0 +1,33 @@
+import os
+
+from glob import glob
+
+from django.db import connection
+
+
+_root = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_report_names():
+    file_paths = glob(os.path.join(_root, 'reports', '*.sql'))
+    files = [os.path.basename(f) for f in file_paths]
+    names = [os.path.splitext(f)[0].replace('_', '-') for f in files]
+    names.sort()
+    return names
+
+
+def run_report(name):
+    report_filename = os.path.join(
+        _root, 'reports', '{}.sql'.format(name.replace('-', '_')))
+    with open(report_filename, 'r') as report_file:
+        report_sql = report_file.read()
+        with connection.cursor() as cursor:
+            cursor.execute(report_sql)
+            columns = [col[0] for col in cursor.description]
+            rows = cursor.fetchall()
+            return {
+                'name': name,
+                'sql': report_sql,
+                'columns': columns,
+                'rows': rows,
+            }

--- a/src/django/api/reports/average_list_count_per_contributor.sql
+++ b/src/django/api/reports/average_list_count_per_contributor.sql
@@ -1,0 +1,17 @@
+SELECT
+  CAST (month AS int),
+  round(avg(list_count), 2)
+FROM (
+  SELECT
+    date_part('month', l.created_at) AS month,
+    c.id,
+    COUNT(*) AS list_count
+  FROM api_facilitylist l
+  JOIN api_contributor c ON c.id = l.contributor_id
+  WHERE date_part('month', l.created_at) != date_part('month', now())
+  AND l.is_public = 't'
+  AND l.is_active = 't'
+  GROUP BY date_part('month', l.created_at), c.id
+) s
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/average_matches_per_facility.sql
+++ b/src/django/api/reports/average_matches_per_facility.sql
@@ -1,0 +1,16 @@
+SELECT
+  CAST (month AS int),
+  round(avg(match_count), 2) AS average_match_count
+FROM (
+  SELECT
+    date_part('month', m.created_at) AS month,
+    f.id,
+    count(*) AS match_count
+  FROM api_facilitymatch m
+  JOIN api_facility f ON m.facility_id = f.id
+  AND status NOT IN ('REJECTED', 'PENDING')
+  AND date_part('month', m.created_at) != date_part('month', now())
+  GROUP BY date_part('month', m.created_at), f.id
+) s
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/average_matches_per_facility_by_type.sql
+++ b/src/django/api/reports/average_matches_per_facility_by_type.sql
@@ -1,0 +1,23 @@
+SELECT
+  CAST (month AS int) AS month,
+  contrib_type AS contributor_type,
+  round(avg(match_count), 2) AS average_match_count
+FROM (
+  SELECT
+    date_part('month', m.created_at) AS month,
+    f.id,
+    COUNT(*) AS match_count,
+    contrib_type
+  FROM api_facilitymatch m
+  JOIN api_facility f ON m.facility_id = f.id
+  JOIN api_facilitylistitem li ON m.facility_list_item_id = li.id
+  JOIN api_facilitylist l ON li.facility_list_id = l.id
+  JOIN api_contributor c ON c.id = l.contributor_id
+  JOIN api_user u ON u.id = c.admin_id
+  WHERE date_part('month', m.created_at) != date_part('month', now())
+  AND m.status not in ('REJECTED', 'PENDING')
+  AND not u.email like '%openapparel.org%'
+  GROUP BY date_part('month', m.created_at), f.id, contrib_type
+) s
+GROUP BY month, contrib_type
+ORDER BY month, contrib_type;

--- a/src/django/api/reports/confirmed_matches.sql
+++ b/src/django/api/reports/confirmed_matches.sql
@@ -1,0 +1,8 @@
+SELECT
+  CAST (date_part('month', li.created_at) AS int) AS month,
+  COUNT(*) AS list_item_count
+from api_facilitylistitem li
+WHERE status = 'CONFIRMED_MATCH'
+AND date_part('month', created_at) < date_part('month', now())
+GROUP BY date_part('month', li.created_at)
+ORDER BY date_part('month', li.created_at);

--- a/src/django/api/reports/contributor_first_appearance.sql
+++ b/src/django/api/reports/contributor_first_appearance.sql
@@ -1,0 +1,16 @@
+SELECT
+  CAST (month AS int),
+  name
+from (
+  SELECT DISTINCT
+    min(date_part('month', l.created_at)) AS month,
+    c.id
+  FROM api_facilitylist l
+  JOIN api_contributor c ON l.contributor_id = c.id
+  JOIN api_user u ON u.id = c.admin_id
+  WHERE date_part('month', l.created_at) != date_part('month', now())
+  AND NOT u.email LIKE '%openapparel.org%'
+  GROUP BY c.id
+) s
+JOIN api_contributor c ON c.id = s.id
+ORDER BY month, c.id, c.name;

--- a/src/django/api/reports/contributor_list_count.sql
+++ b/src/django/api/reports/contributor_list_count.sql
@@ -1,0 +1,8 @@
+SELECT
+  c.name,
+  COUNT(*) AS list_count
+FROM api_facilitylist l
+JOIN api_contributor c ON l.contributor_id = c.id
+JOIN api_user u ON u.id = c.admin_id
+GROUP BY c.name
+ORDER BY COUNT(*) DESC;

--- a/src/django/api/reports/facilities_created_not_matched.sql
+++ b/src/django/api/reports/facilities_created_not_matched.sql
@@ -1,0 +1,9 @@
+SELECT
+  CAST (date_part('month', f.created_at) AS int) AS month,
+  COUNT(*) AS match_count
+FROM api_facilitymatch m
+JOIN api_facility f ON m.facility_id = f.id
+WHERE m.facility_list_item_id = f.created_from_id
+AND date_part('month', f.created_at) < date_part('month', now())
+GROUP BY date_part('month', f.created_at)
+ORDER BY date_part('month', f.created_at);

--- a/src/django/api/reports/facilities_matched.sql
+++ b/src/django/api/reports/facilities_matched.sql
@@ -1,0 +1,10 @@
+SELECT
+  CAST (date_part('month', f.created_at) AS int) AS month,
+  COUNT(*) AS match_count
+FROM api_facilitymatch m
+JOIN api_facility f ON m.facility_id = f.id
+WHERE m.facility_list_item_id != f.created_from_id
+AND status NOT IN ('REJECTED', 'PENDING')
+AND date_part('month', f.created_at) < date_part('month', now())
+GROUP BY date_part('month', f.created_at)
+ORDER BY date_part('month', f.created_at);

--- a/src/django/api/reports/facility_lists_uploaded.sql
+++ b/src/django/api/reports/facility_lists_uploaded.sql
@@ -1,0 +1,10 @@
+SELECT
+  CAST (date_part('month', l.created_at) AS int) AS month,
+  CASE WHEN u.email LIKE '%openapparel.org%' THEN 'y' ELSE 'n' END AS is_public_list,
+  COUNT(*) AS list_count
+FROM api_facilitylist l
+JOIN api_contributor c ON l.contributor_id = c.id
+JOIN api_user u ON u.id = c.admin_id
+WHERE date_part('month', l.created_at) != date_part('month', now())
+GROUP BY date_part('month', l.created_at), is_public_list
+ORDER BY date_part('month', l.created_at), is_public_list;

--- a/src/django/api/reports/geocode_errors.sql
+++ b/src/django/api/reports/geocode_errors.sql
@@ -1,0 +1,8 @@
+SELECT
+  CAST (date_part('month', li.created_at) AS int) AS month,
+  COUNT(*) AS error_count
+FROM api_facilitylistitem li
+WHERE status = 'ERROR_GEOCODING'
+AND date_part('month', created_at) < date_part('month', now())
+GROUP BY date_part('month', li.created_at)
+ORDER BY date_part('month', li.created_at);

--- a/src/django/api/reports/geocode_no_results.sql
+++ b/src/django/api/reports/geocode_no_results.sql
@@ -1,0 +1,8 @@
+SELECT
+  CAST (date_part('month', li.created_at) AS int) AS month,
+  COUNT(*) AS list_item_count
+FROM api_facilitylistitem li
+WHERE status = 'ERROR_MATCHING'
+AND date_part('month', created_at) < date_part('month', now())
+GROUP BY date_part('month', li.created_at)
+ORDER BY date_part('month', li.created_at);

--- a/src/django/api/reports/non_public_contributors.sql
+++ b/src/django/api/reports/non_public_contributors.sql
@@ -1,0 +1,16 @@
+SELECT
+  CAST (month AS int),
+  COUNT(*) AS contributor_count
+FROM (
+  SELECT DISTINCT
+    date_part('month', l.created_at) AS month,
+    c.id
+  FROM api_facilitylist l
+  JOIN api_contributor c ON l.contributor_id = c.id
+  JOIN api_user u ON u.id = c.admin_id
+  WHERE date_part('month', l.created_at) != date_part('month', now())
+  AND NOT u.email LIKE '%openapparel.org%'
+  ORDER BY date_part('month', l.created_at), c.id
+) s
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/public_contributors.sql
+++ b/src/django/api/reports/public_contributors.sql
@@ -1,0 +1,16 @@
+SELECT
+  CAST (month AS int),
+  COUNT(*) AS contributor_count
+FROM (
+  SELECT DISTINCT
+    date_part('month', l.created_at) AS month,
+    c.id
+  FROM api_facilitylist l
+  JOIN api_contributor c ON l.contributor_id = c.id
+  JOIN api_user u ON u.id = c.admin_id
+  WHERE date_part('month', l.created_at) != date_part('month', now())
+  AND u.email LIKE '%openapparel.org%'
+  ORDER BY date_part('month', l.created_at), c.id
+) s
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/rejected_matches.sql
+++ b/src/django/api/reports/rejected_matches.sql
@@ -1,0 +1,14 @@
+SELECT
+  CAST (date_part('month', created_at) AS int) AS month,
+  COUNT(*) AS match_count
+FROM (
+  SELECT
+    facility_list_item_id,
+    max(created_at) AS created_at
+  FROM api_facilitymatch
+  WHERE status = 'REJECTED'
+  AND date_part('month', created_at) < date_part('month', now())
+  GROUP BY facility_list_item_id
+) s
+GROUP BY date_part('month', created_at)
+ORDER BY date_part('month', created_at);

--- a/src/django/api/reports/unique_contributor_count_by_type.sql
+++ b/src/django/api/reports/unique_contributor_count_by_type.sql
@@ -1,0 +1,18 @@
+SELECT
+  CAST (month AS int),
+  contrib_type AS contributor_type,
+  COUNT(*) AS contributor_count
+FROM (
+  SELECT distinct
+    min(date_part('month', l.created_at)) AS month,
+    c.id,
+    c.contrib_type
+  FROM api_facilitylist l
+  JOIN api_contributor c ON l.contributor_id = c.id
+  JOIN api_user u ON u.id = c.admin_id
+  WHERE date_part('month', l.created_at) != date_part('month', now())
+  AND NOT u.email like '%openapparel.org%'
+  GROUP BY c.id, c.contrib_type
+) s
+GROUP BY month, contrib_type
+ORDER BY month, contrib_type;

--- a/src/django/api/reports/unique_public_list_count.sql
+++ b/src/django/api/reports/unique_public_list_count.sql
@@ -1,0 +1,16 @@
+SELECT
+  CAST (month AS int),
+  COUNT(*) AS list_count
+FROM (
+  SELECT DISTINCT
+    min(date_part('month', l.created_at)) AS month,
+    c.id
+  FROM api_facilitylist l
+  JOIN api_contributor c ON L.contributor_id = c.id
+  JOIN api_user u ON u.id = c.admin_id
+  WHERE date_part('month', l.created_at) != date_part('month', now())
+  AND u.email LIKE '%openapparel.org%'
+  GROUP BY c.id
+) s
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/updated_lists.sql
+++ b/src/django/api/reports/updated_lists.sql
@@ -1,0 +1,8 @@
+SELECT
+  CAST (date_part('month', l.created_at) AS int) AS month,
+  COUNT(*) AS list_count
+FROM api_facilitylist l
+WHERE replaces_id IS NOT NULL
+AND date_part('month', l.created_at) != date_part('month', now())
+GROUP BY date_part('month', l.created_at)
+ORDER BY date_part('month', l.created_at);

--- a/src/django/api/templates/reports/report.html
+++ b/src/django/api/templates/reports/report.html
@@ -1,0 +1,54 @@
+{% load reports %}
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <title>OAR Reports | {{ name|pretty_report_name }}</title>
+        <style>
+            body {
+                padding: 1rem;
+            }
+            table {
+                border-collapse: collapse;
+            }
+
+            table, th, td {
+                border: 1px solid #aaa;
+            }
+
+            tr:nth-child(even) {
+                background-color: #eee
+            }
+
+            td {
+               padding: 4px;
+            }
+        </style>
+    </head>
+    <body>
+        <a href="{% url 'admin:reports' %}">Reports</a>
+        <h1>{{ name|pretty_report_name }}</h1>
+        <table>
+            <thead>
+                <tr>
+                    {% for val in columns %}
+                        <td>{{ val|pretty_report_name }}</td>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in rows %}
+                    <tr>
+                        {% for val in row %}
+                            <td>{{ val }}</td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <h2>Query</h2>
+        <pre>{{ sql }}</pre>
+    </body>
+</html>

--- a/src/django/api/templates/reports/reports.html
+++ b/src/django/api/templates/reports/reports.html
@@ -1,0 +1,22 @@
+{% load reports %}
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <title>OAR Reports</title>
+        <style>
+            body {
+                padding: 0 1rem;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Reports</h1>
+        <ul>
+            {% for name in names %}
+                <li><a href="{{ name }}">{{ name|pretty_report_name }}</a></li>
+            {% endfor %}
+        </ul>
+    </body>
+</html>

--- a/src/django/api/templatetags/reports.py
+++ b/src/django/api/templatetags/reports.py
@@ -1,0 +1,10 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def pretty_report_name(value):
+    return value.replace('_', ' ').replace('-', ' ').title()

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -14,13 +14,12 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf.urls.static import static
-from django.contrib import admin
 from django.urls import path, re_path, include
 from django.conf.urls import url
 
 from api import views
+from api.admin import admin_site
 from web.views import environment
-
 
 from rest_framework import routers
 from rest_framework_swagger.views import get_swagger_view
@@ -50,7 +49,7 @@ internal_apis = [
     url(r'^', include('django.contrib.auth.urls')),
     url(r'^web/environment\.js', environment, name='environment'),
     url(r'^api/docs/', views.schema_view),
-    path('admin/', admin.site.urls),
+    path('admin/', admin_site.urls),
     re_path(r'^health-check/', include('watchman.urls')),
     url(r'^api-auth/', include('rest_framework.urls')),
     url(r'^rest-auth/', include('rest_auth.urls')),


### PR DESCRIPTION
## Overview

Provides a quick, simple way to do ad-hoc reporting via raw SQL queries.

Connects #708

## Demo
<img width="498" alt="Screen Shot 2019-07-29 at 9 24 42 AM" src="https://user-images.githubusercontent.com/17363/62064905-bcd03e00-b1e2-11e9-9952-36da2188a4fb.png">


<img width="720" alt="Screen Shot 2019-07-29 at 9 13 39 AM" src="https://user-images.githubusercontent.com/17363/62064209-323b0f00-b1e1-11e9-8af2-100a7d9e429d.png">

## Notes

We add a pair of new admin views so that the reports are only accessible to superusers.

A new report can be added just by adding a `.sql` file to `/api/reports/`. The name of the report is derived from the name of the `.sql` file.

We return and display the raw SQL along with the results to make easy to debug and answer questions about how the report was generated.

We opt for raw SQL for the flexability it provides. We will never be writing data so the ORM would cause more friction than provide benefit.


## Testing Instructions

* Verify that the admin site at http://localhost:8081/admin works as before.
* Browse http://localhost:8081/admin/reports/ and verify that all the `.sql` files in `/src/django/api/reports/` appear.
* Verify that all of the reports run without error. It is expected that some of the reports will not produce results from the fixture data.
* Verify the logic of the report queries.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
