### PR TITLE
Only pan map if facility not in viewport bbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Pan map on selecting a new facility only when the selected facility is off-screen [#719](https://github.com/open-apparel-registry/open-apparel-registry/pull/719)
 
 ### Security
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -158,17 +158,20 @@ function FacilitiesMap({
                         null,
                     );
 
-                    // Check whether the viewport's map bounds intersects a new bounds object
-                    // made from the facility point
-                    const mapBoundsContainsFacility = leafletMap
-                        .getBounds()
-                        .intersects([facilityLocation, facilityLocation]);
-
-                    if (!mapBoundsContainsFacility) {
-                        leafletMap.setView({
+                    if (facilityLocation) {
+                        const facilityLatLng = {
                             lat: last(facilityLocation),
                             lng: head(facilityLocation),
-                        });
+                        };
+
+                        // Check whether the viewport's map bounds contains the facility point
+                        const mapBoundsContainsFacility = leafletMap
+                            .getBounds()
+                            .contains(facilityLatLng);
+
+                        if (!mapBoundsContainsFacility) {
+                            leafletMap.setView(facilityLatLng);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Overview

- pan the map if the newly selected facility is not in the viewport bbox
- don't pan the map if the newly selected facility is already visible in
the viewport bbox

Fixes #718 

## Testing Instructions

- get this branch and verify that this fixes #718 & hasn't introduced other regressions

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
