### PR TITLE
Add contributor and mailing list admin reports and the ability to download admin reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add vector tile ADR [#723](https://github.com/open-apparel-registry/open-apparel-registry/pull/723)
+- Add contributor and mailing list admin reports and the ability to download admin reports [#726](https://github.com/open-apparel-registry/open-apparel-registry/pull/726)
 
 ### Changed
 

--- a/src/django/api/reports/countributors.sql
+++ b/src/django/api/reports/countributors.sql
@@ -1,0 +1,12 @@
+SELECT
+  email,
+  name,
+  date(u.created_at) AS registration_date,
+  regexp_replace(description, E'[\\n\\r]+', ' ', 'g' ) AS description,
+  contrib_type,
+  website,
+  should_receive_newsletter
+FROM api_user u
+JOIN api_contributor c ON u.id = c.admin_id
+AND u.email NOT LIKE '%openapparel.org%'
+ORDER BY u.created_at, email

--- a/src/django/api/reports/mailing_list_recipients.sql
+++ b/src/django/api/reports/mailing_list_recipients.sql
@@ -1,0 +1,12 @@
+SELECT
+  email,
+  name,
+  date(u.created_at) AS registration_date,
+  regexp_replace(description, E'[\\n\\r]+', ' ', 'g' ) AS description,
+  contrib_type,
+  website
+FROM api_user u
+JOIN api_contributor c ON u.id = c.admin_id
+WHERE u.should_receive_newsletter = 't'
+AND u.email NOT LIKE '%openapparel.org%'
+ORDER BY u.created_at, email

--- a/src/django/api/templates/reports/report.html
+++ b/src/django/api/templates/reports/report.html
@@ -29,6 +29,11 @@
     <body>
         <a href="{% url 'admin:reports' %}">Reports</a>
         <h1>{{ name|pretty_report_name }}</h1>
+
+        <p>
+            <a href="data:text/csv;charset=utf-8,{{csv_data}}" download="{{name}}.csv">Download</a>
+        </p>
+
         <table>
             <thead>
                 <tr>


### PR DESCRIPTION
## Overview

We regularly need to get a list of contributors who have opted into the newsletter. Including the unfiltered list of non-public contributors is a convenience.

All the data is already available so it is easy to include a download link with a `data` url. This does create duplicate data on the page, effectively doubling the size of the report, but this system is designed to be simple, not efficient.

Connects #655

## Testing Instructions

This assumes the fixture data has been loaded.

* Use `shell_plus` or `dbshell` to update some of the "c*@example.com" contributors and change `should_receive_newsletter` to true.
* Log in as `c1@example.com`
* Browse http://localhost:8081/admin/reports/mailing-list-recipients/ and verify that the users changed in the first step appear.
* Browse http://localhost:8081/admin/reports/countributors/ and verify that all the contributors appear.
* Verify that the "Download" link on the report page works.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
