### PR TITLE
Restore django-waffle admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Restore django-waffle admin pages [#732](https://github.com/open-apparel-registry/open-apparel-registry/pull/732)
 
 ### Security
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -6,6 +6,8 @@ from django.contrib.auth.admin import UserAdmin
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
 from simple_history.admin import SimpleHistoryAdmin
+from waffle.models import Flag, Sample, Switch
+from waffle.admin import FlagAdmin, SampleAdmin, SwitchAdmin
 
 from api import models
 
@@ -115,3 +117,6 @@ admin_site.register(models.FacilityClaim, FacilityClaimAdmin)
 admin_site.register(models.FacilityClaimReviewNote,
                     FacilityClaimReviewNoteAdmin)
 admin_site.register(models.FacilityAlias, FacilityAliasAdmin)
+admin_site.register(Flag, FlagAdmin)
+admin_site.register(Sample, SampleAdmin)
+admin_site.register(Switch, SwitchAdmin)


### PR DESCRIPTION
## Overview

django-waffle's admin pages were accidentally dropped in a recent change
to add a reports section to the Django admin site. This change restores
them.

Connects #731 

## Demo

<img width="862" alt="Screen Shot 2019-08-15 at 2 40 53 PM" src="https://user-images.githubusercontent.com/4165523/63117923-c12e8200-bf6a-11e9-894b-2f15f6544df4.png">
<img width="649" alt="Screen Shot 2019-08-15 at 2 40 44 PM" src="https://user-images.githubusercontent.com/4165523/63117924-c12e8200-bf6a-11e9-9116-846f72218d69.png">

## Testing Instructions

- serve this branch then sign in to /admin and verify you see the waffle sections and that they're still usable as before

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
