### PR TITLE
Prevent map crash by not using strict equality when comparing point coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Restore django-waffle admin pages [#732](https://github.com/open-apparel-registry/open-apparel-registry/pull/732)
+- Prevent map crash by not using strict equality when comparing point coordinates [#737](https://github.com/open-apparel-registry/open-apparel-registry/pull/737)
 
 ### Security
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -214,7 +214,11 @@ function FacilitiesMap({
     const handleMultipleFacilitiesClusterMarkerClick = coordinates =>
         setFacilitiesToDisambiguate(
             data.features.reduce((acc, nextFeature) => {
-                const pointsIntersect = !distance(nextFeature, coordinates);
+                // If the distance between points is less than the size of an
+                // individual person it is likely a precision error, not a
+                // distinct geocoded point.
+                // https://en.wikipedia.org/wiki/Decimal_degrees#Precision
+                const pointsIntersect = distance(nextFeature, coordinates) < 0.000001;
                 return pointsIntersect ? acc.concat(nextFeature) : acc;
             }, []),
         );


### PR DESCRIPTION
## Overview

Points were not being combined into a disambiguation popup and throwing an exception when a precision or rounding error prevented the points from being strictly equal.

Connects #734

## Testing Instructions

* Run `./scripts/resetdb`
* Run `./scripts/manage dbshell` and set the same location for all facilities in VN.
```
UPDATE api_facility 
SET location = st_geomfromtext('POINT(106.8909948 10.9393085)', 4326) 
WHERE id IN (
  SELECT id 
  FROM api_facility 
  WHERE country_code = 'VN'
);
```
* Browse http://localhost:6543/?countries=VN
* Click the `97` cluster. Verify that the map component does not crash and a disambiguation popup is displayed.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
