### PR TITLE
Fix map marker anchor location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Restore django-waffle admin pages [#732](https://github.com/open-apparel-registry/open-apparel-registry/pull/732)
 - Prevent map crash by not using strict equality when comparing point coordinates [#737](https://github.com/open-apparel-registry/open-apparel-registry/pull/737)
+- Fix map marker anchor location [#745](https://github.com/open-apparel-registry/open-apparel-registry/pull/745)
 
 ### Security
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -61,7 +61,7 @@ const createIcon = iconUrl =>
     L.icon({
         iconUrl,
         iconSize: [30, 40],
-        iconAnchor: [30, 40],
+        iconAnchor: [15, 40],
         popupAnchor: null,
         shadowUrl: null,
         shadowSize: null,


### PR DESCRIPTION
## Overview

Prevent points from "drifting" when the map zooms by correctly anchoring the
marker to the center of the image.

Connects #744

## Demo

![2019-08-21 14 40 26](https://user-images.githubusercontent.com/17363/63470985-e4ea4000-c422-11e9-9508-704e46810036.gif)


## Testing Instructions

* Zoom the map on a point and verify that the point stays anchored.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
