### PR TITLE
Enable signed-in users to download all facility results as a CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Adjust marker icon on selecting a new facility on the vector tiles layer [#749](https://github.com/open-apparel-registry/open-apparel-registry/pull/749)
 - Fetch next page of facilities while scrolling through sidebar list [#750](https://github.com/open-apparel-registry/open-apparel-registry/pull/750)
+- Enable signed-in users to download all facilities results as CSV [#752](https://github.com/open-apparel-registry/open-apparel-registry/pull/752)
 
 ### Changed
 

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -1,6 +1,9 @@
 import { createAction } from 'redux-act';
+import get from 'lodash/get';
 
 import apiRequest from '../util/apiRequest';
+
+import { fetchNextPageOfFacilities } from './facilities';
 
 import {
     makeLogDownloadUrl,
@@ -16,29 +19,96 @@ export const completeLogDownload =
     createAction('COMPLETE_LOG_DOWNLOAD');
 
 export function logDownload() {
-    return (dispatch, getState) => {
+    return async (dispatch, getState) => {
         dispatch(startLogDownload());
 
-        const {
-            facilities: {
+        try {
+            const {
                 facilities: {
-                    data: {
-                        features: facilities,
+                    facilities: {
+                        data: {
+                            features: facilities,
+                            count,
+                        },
+                        nextPageURL,
                     },
                 },
-            },
-        } = getState();
+                featureFlags,
+            } = getState();
 
-        const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-        const recordCount = facilities ? facilities.length : 0;
-        return apiRequest
-            .post(makeLogDownloadUrl(path, recordCount))
-            .then(() => downloadFacilitiesCSV(facilities))
-            .then(() => dispatch(completeLogDownload()))
-            .catch(err => dispatch(logErrorAndDispatchFailure(
+            const vectorTileFlagIsActive = get(featureFlags, 'flags.vector_tile', false);
+
+            const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+            if (!vectorTileFlagIsActive) {
+                const recordCount = facilities ? facilities.length : 0;
+
+                return apiRequest
+                    .post(makeLogDownloadUrl(path, recordCount))
+                    .then(() => downloadFacilitiesCSV(facilities))
+                    .then(() => dispatch(completeLogDownload()))
+                    .catch(err => dispatch(logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented the download',
+                        failLogDownload,
+                    )));
+            }
+
+            await apiRequest.post(makeLogDownloadUrl(path, count));
+
+            if (!nextPageURL) {
+                downloadFacilitiesCSV(facilities);
+            } else {
+                let nextFacilitiesSetURL = nextPageURL;
+
+                while (nextFacilitiesSetURL) {
+                    // `no-await-in-loop` is disabled because we do want the
+                    // loop to await each individual promise so it we can check
+                    // the `nextPageURL` value each time & thereby determine
+                    // whether the loop should stop or whether it should fetch
+                    // the next page of results.
+                    //
+                    // https://eslint.org/docs/rules/no-await-in-loop indicates
+                    // that the rule is meant to help developers not mistakenly
+                    // use sequential rather than parallel Promises. However,
+                    // we don't want to issue these requests in parallel since
+                    // doing so will DOS the server. See:
+                    // https://github.com/open-apparel-registry/open-apparel-registry/pull/496
+                    //
+                    // eslint-disable-next-line no-await-in-loop
+                    await dispatch(fetchNextPageOfFacilities());
+
+                    const {
+                        facilities: {
+                            facilities: {
+                                nextPageURL: newNextPageURL,
+                            },
+                        },
+                    } = getState();
+
+                    nextFacilitiesSetURL = newNextPageURL;
+                }
+
+                const {
+                    facilities: {
+                        facilities: {
+                            data: {
+                                features,
+                            },
+                        },
+                    },
+                } = getState();
+
+                downloadFacilitiesCSV(features);
+            }
+
+            return dispatch(completeLogDownload());
+        } catch (err) {
+            return dispatch(logErrorAndDispatchFailure(
                 err,
                 'An error prevented the download',
                 failLogDownload,
-            )));
+            ));
+        }
     };
 }

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -80,6 +80,10 @@ const facilitiesTabStyles = Object.freeze({
         justifyContent: 'space-between',
         alignItems: 'center',
     }),
+    listHeaderButtonStyles: Object.freeze({
+        height: '45px',
+        margin: '5px 0',
+    }),
 });
 
 function FilterSidebarFacilitiesTab({
@@ -88,6 +92,7 @@ function FilterSidebarFacilitiesTab({
     error,
     windowHeight,
     logDownloadError,
+    downloadingCSV,
     user,
     returnToSearchTab,
     handleDownload,
@@ -200,23 +205,32 @@ function FilterSidebarFacilitiesTab({
                     style={facilitiesTabStyles.titleRowStyles}
                 >
                     {headerDisplayString}
-                    <Button
-                        variant="outlined"
-                        color="primary"
-                        styles={facilitiesTabStyles.listHeaderButtonStyles}
-                        onClick={
-                            () => {
-                                if (user) {
-                                    setRequestedDownload(true);
-                                    handleDownload();
-                                } else {
-                                    setLoginRequiredDialogIsOpen(true);
-                                }
-                            }
-                        }
-                    >
-                        Download CSV
-                    </Button>
+                    {
+                        downloadingCSV
+                            ? (
+                                <div style={facilitiesTabStyles.listHeaderButtonStyles}>
+                                    <CircularProgress />
+                                </div>)
+                            : (
+                                <Button
+                                    variant="outlined"
+                                    color="primary"
+                                    style={facilitiesTabStyles.listHeaderButtonStyles}
+                                    disabled={downloadingCSV}
+                                    onClick={
+                                        () => {
+                                            if (user) {
+                                                setRequestedDownload(true);
+                                                handleDownload();
+                                            } else {
+                                                setLoginRequiredDialogIsOpen(true);
+                                            }
+                                        }
+                                    }
+                                >
+                                    Download CSV
+                                </Button>)
+                    }
                 </div>
             </Typography>
         </div>
@@ -339,6 +353,7 @@ FilterSidebarFacilitiesTab.propTypes = {
     error: arrayOf(string),
     windowHeight: number.isRequired,
     logDownloadError: arrayOf(string),
+    downloadingCSV: bool.isRequired,
     returnToSearchTab: func.isRequired,
     handleDownload: func.isRequired,
     fetchNextPage: func.isRequired,
@@ -368,6 +383,7 @@ function mapStateToProps({
         },
     },
     logDownload: {
+        fetching: downloadingCSV,
         error: logDownloadError,
     },
 }) {
@@ -378,6 +394,7 @@ function mapStateToProps({
         filterText,
         user,
         logDownloadError,
+        downloadingCSV,
         windowHeight,
         isInfiniteLoading,
     };

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -1,6 +1,6 @@
 export const OTHER = 'Other';
 
-export const FACILITIES_REQUEST_PAGE_SIZE = 25;
+export const FACILITIES_REQUEST_PAGE_SIZE = 100;
 
 // This choices must be kept in sync with the identical list
 // kept in the Django API's models.py file


### PR DESCRIPTION
## Overview

Using the machinery implemented for the infinite scroll sidebar, enable
signed-in users to download a CSV containing all of the facilities
matching any given search params, including all the OAR's facility data
when no search params are present.

Also increase the size of the facilities pages from 25 to 100. We want
to keep this value shared between the infinite scroll and the CSV
download so that we can reuse the existing machinery and so that after
downloading a CSV, the user can scroll through all the facilities in the
sidebar and can download the CSV again without undertaking new requests.

The change also adds a loading indicator to display in place of the
download CSV button while a download is underway.

Connects https://github.com/open-apparel-registry/open-apparel-registry/issues/743

## Testing Instructions

- serve this branch, then sign in and search for facilities
- click "Download CSV" and verify that it downloads all of them
- sign out, then search for facilities
- click "Download CSV" and verify that it fails but doesn't crash the app.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
