### PR TITLE
Add facility grid layer

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -5,6 +5,7 @@
     "private": true,
     "dependencies": {
         "@hot-loader/react-dom": "16.8.6",
+        "@mapbox/sphericalmercator": "1.1.0",
         "@material-ui/core": "3.1.0",
         "@material-ui/icons": "3.0.1",
         "@turf/distance": "6.0.1",

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -205,6 +205,8 @@ const VectorTileFacilitiesLayer = ({
     tileCacheKey,
     oarID,
     pushRoute,
+    minZoom,
+    maxZoom,
 }) => {
     const [multipleFacilitiesAtPoint, setMultipleFacilitiesAtPoint] = useState(
         null,
@@ -272,6 +274,8 @@ const VectorTileFacilitiesLayer = ({
                 url={vectorTileURL}
                 type="protobuf"
                 rendererFactory={L.canvas.tile}
+                minZoom={minZoom}
+                maxZoom={maxZoom}
                 vectorTileLayerStyles={{
                     facilities(properties) {
                         const facilityID = get(properties, 'id', null);

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -15,6 +15,7 @@ import delay from 'lodash/delay';
 
 import Button from './Button';
 import VectorTileFacilitiesLayer from './VectorTileFacilitiesLayer';
+import VectorTileFacilityGridLayer from './VectorTileFacilityGridLayer';
 
 import { COUNTRY_CODES } from '../util/constants';
 
@@ -221,6 +222,12 @@ function VectorTileFacilitiesMap({
                 handleMarkerClick={handleMarkerClick}
                 oarID={oarID}
                 pushRoute={push}
+                minZoom={12}
+                maxZoom={22}
+            />
+            <VectorTileFacilityGridLayer
+                minZoom={1}
+                maxZoom={11}
             />
         </ReactLeafletMap>
     );

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -12,6 +12,7 @@ import get from 'lodash/get';
 import head from 'lodash/head';
 import last from 'lodash/last';
 import delay from 'lodash/delay';
+import SphericalMercator from '@mapbox/sphericalmercator';
 
 import Button from './Button';
 import VectorTileFacilitiesLayer from './VectorTileFacilitiesLayer';
@@ -29,6 +30,8 @@ import {
     detailsZoomLevel,
     GOOGLE_CLIENT_SIDE_API_KEY,
 } from '../util/constants.facilitiesMap';
+
+const sm = new SphericalMercator();
 
 const mapComponentStyles = Object.freeze({
     mapContainerStyles: Object.freeze({
@@ -182,6 +185,15 @@ function VectorTileFacilitiesMap({
         return null;
     }
 
+    const handleCellClick = (event) => {
+        const { x, y, z, count } = get(event, 'layer.properties', {});
+        const leafletMap = get(mapRef, 'current.leafletElement', null);
+        if (count && leafletMap) {
+            const [w, s, e, n] = sm.bbox(x, y, z);
+            leafletMap.fitBounds([[s, w], [n, e]]);
+        }
+    };
+
     return (
         <ReactLeafletMap
             id="oar-leaflet-map"
@@ -226,6 +238,7 @@ function VectorTileFacilitiesMap({
                 maxZoom={22}
             />
             <VectorTileFacilityGridLayer
+                handleCellClick={handleCellClick}
                 minZoom={1}
                 maxZoom={11}
             />

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -18,11 +18,13 @@ import Button from './Button';
 import VectorTileFacilitiesLayer from './VectorTileFacilitiesLayer';
 import VectorTileFacilityGridLayer from './VectorTileFacilityGridLayer';
 
-import { COUNTRY_CODES } from '../util/constants';
+import { COUNTRY_CODES, GRID_COLOR_RAMP } from '../util/constants';
 
 import { makeFacilityDetailLink } from '../util/util';
 
 import { facilityDetailsPropType } from '../util/propTypes';
+
+import COLOURS from '../util/COLOURS';
 
 import {
     initialCenter,
@@ -42,6 +44,24 @@ const mapComponentStyles = Object.freeze({
         right: '24px',
         top: '20px',
         fontSize: '12px',
+    }),
+    legendStyle: Object.freeze({
+        background: 'white',
+        border: `1px solid ${COLOURS.NAVY_BLUE}`,
+        padding: '6px',
+        margin: '20px',
+        height: '22px',
+        fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+    }),
+    legendLabelStyle: Object.freeze({
+        width: '6.5rem',
+        padding: '0.08rem',
+        textAlign: 'center',
+    }),
+    legendCellStyle: Object.freeze({
+        width: '20px',
+        opacity: '0.8',
+        background: 'red',
     }),
 });
 
@@ -194,6 +214,15 @@ function VectorTileFacilitiesMap({
         }
     };
 
+    const legendCell = (background) => {
+        const style = Object.assign({}, mapComponentStyles.legendCellStyle, {
+            background,
+        });
+        return (
+            <td key={background} style={style}>&nbsp;</td>
+        );
+    };
+
     return (
         <ReactLeafletMap
             id="oar-leaflet-map"
@@ -217,6 +246,23 @@ function VectorTileFacilitiesMap({
                 minZoom={1}
                 zIndex={1}
             />
+            <Control position="bottomleft">
+                <div id="map-legend" style={mapComponentStyles.legendStyle}>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td style={mapComponentStyles.legendLabelStyle}>
+                                    FEWER FACILITIES
+                                </td>
+                                {GRID_COLOR_RAMP.map(colorDef => legendCell(colorDef[1]))}
+                                <td style={mapComponentStyles.legendLabelStyle}>
+                                    MORE FACILITIES
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </Control>
             <Control position="topright">
                 <CopyToClipboard
                     text={window.location.href}

--- a/src/app/src/components/VectorTileFacilityGridLayer.jsx
+++ b/src/app/src/components/VectorTileFacilityGridLayer.jsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { bool, number, string } from 'prop-types';
+import { connect } from 'react-redux';
+import VectorGridDefault from 'react-leaflet-vectorgrid';
+import { withLeaflet } from 'react-leaflet';
+import L from 'leaflet';
+import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
+
+import { createQueryStringFromSearchFilters } from '../util/util';
+
+const VectorGrid = withLeaflet(VectorGridDefault);
+
+function useUpdateTileURL(tileURL, performingNewSearch, resetButtonClickCount) {
+    const [
+        vectorTileURLWithQueryParams,
+        setVectorTileURLWithQueryParams,
+    ] = useState(tileURL);
+
+    const [isFetching, setIsFetching] = useState(performingNewSearch);
+    const [storedResetCount, setStoredResetCount] = useState(
+        resetButtonClickCount,
+    );
+
+    useEffect(() => {
+        if (performingNewSearch && !isFetching) {
+            setIsFetching(true);
+        } else if (!performingNewSearch && isFetching) {
+            setIsFetching(false);
+            setVectorTileURLWithQueryParams(tileURL);
+        } else if (resetButtonClickCount !== storedResetCount) {
+            setIsFetching(false);
+            setStoredResetCount(resetButtonClickCount);
+            setVectorTileURLWithQueryParams(tileURL);
+        }
+    }, [
+        tileURL,
+        setVectorTileURLWithQueryParams,
+        isFetching,
+        setIsFetching,
+        performingNewSearch,
+        storedResetCount,
+        setStoredResetCount,
+        resetButtonClickCount,
+    ]);
+
+    return vectorTileURLWithQueryParams;
+}
+
+const VectorTileFacilityGridLayer = ({
+    tileURL,
+    fetching,
+    resetButtonClickCount,
+    tileCacheKey,
+    getNewCacheKey,
+    minZoom,
+    maxZoom,
+}) => {
+    const vectorTileURL = useUpdateTileURL(
+        tileURL,
+        fetching,
+        resetButtonClickCount,
+        getNewCacheKey,
+    );
+
+    const vectorTileLayerRef = useRef(null);
+
+    if (!tileCacheKey) {
+        // We throw an error here if the tile cache key is missing.
+        // This crashes the map, intentionally, but an ErrorBoundary
+        // handles the crash so that the application continues to run.
+        throw new Error('Missing tile cache key');
+    }
+
+    return (
+        <VectorGrid
+            ref={vectorTileLayerRef}
+            key={vectorTileURL}
+            url={vectorTileURL}
+            type="protobuf"
+            rendererFactory={L.canvas.tile}
+            updateWhenZooming={false}
+            minZoom={minZoom}
+            maxZoom={maxZoom}
+            vectorTileLayerStyles={{
+                facilitygrid(properties) {
+                    const layer = get(
+                        vectorTileLayerRef,
+                        'current.leafletElement',
+                    );
+                    // eslint-disable-next-line no-underscore-dangle
+                    const zoomLevel = layer._map.getZoom();
+                    const factor = 2 * Math.max(0, zoomLevel - 4);
+                    const count = get(properties, 'count', 0);
+                    if (count === 0) {
+                        return {
+                            fill: false,
+                            stroke: false,
+                        };
+                    }
+                    const colors = [
+                        [0, '#009EE6'],
+                        [10, '#0086D8'],
+                        [20, '#016ECB'],
+                        [40, '#0256BE'],
+                        [80, '#033EB1'],
+                        [160, '#0427A4'],
+                    ];
+                    const fillColor = colors.reduce(
+                        // eslint-disable-next-line no-confusing-arrow
+                        (color, [val, c]) => count + factor > val ? c : color, colors[0],
+                    );
+
+                    return {
+                        fill: true,
+                        fillColor,
+                        fillOpacity: 0.8,
+                        stroke: true,
+                        weight: 0.5,
+                        color: '#0427A4',
+                    };
+                },
+            }}
+            subdomains=""
+            zIndex={100}
+            interactive
+            /* onClick={handleCellClick} */
+        />
+    );
+};
+
+VectorTileFacilityGridLayer.propTypes = {
+    // handleCellClick: func.isRequired,
+    tileURL: string.isRequired,
+    tileCacheKey: string.isRequired,
+    fetching: bool.isRequired,
+    resetButtonClickCount: number.isRequired,
+};
+
+const createURLWithQueryString = (qs, key) =>
+    `/tile/facilitygrid/${key}/{z}/{x}/{y}.pbf`.concat(isEmpty(qs) ? '' : `?${qs}`);
+
+function mapStateToProps({
+    filters,
+    facilities: {
+        facilities: { fetching },
+    },
+    ui: {
+        facilitiesSidebarTabSearch: { resetButtonClickCount },
+    },
+    vectorTileLayer: {
+        key,
+    },
+}) {
+    const tileURL = createURLWithQueryString(
+        createQueryStringFromSearchFilters(filters),
+        key,
+    );
+
+    return {
+        tileURL,
+        tileCacheKey: key,
+        fetching,
+        resetButtonClickCount,
+    };
+}
+
+export default connect(
+    mapStateToProps,
+)(VectorTileFacilityGridLayer);

--- a/src/app/src/components/VectorTileFacilityGridLayer.jsx
+++ b/src/app/src/components/VectorTileFacilityGridLayer.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { bool, number, string } from 'prop-types';
+import { bool, func, number, string } from 'prop-types';
 import { connect } from 'react-redux';
 import VectorGridDefault from 'react-leaflet-vectorgrid';
 import { withLeaflet } from 'react-leaflet';
@@ -53,6 +53,7 @@ const VectorTileFacilityGridLayer = ({
     resetButtonClickCount,
     tileCacheKey,
     getNewCacheKey,
+    handleCellClick,
     minZoom,
     maxZoom,
 }) => {
@@ -124,13 +125,13 @@ const VectorTileFacilityGridLayer = ({
             subdomains=""
             zIndex={100}
             interactive
-            /* onClick={handleCellClick} */
+            onClick={handleCellClick}
         />
     );
 };
 
 VectorTileFacilityGridLayer.propTypes = {
-    // handleCellClick: func.isRequired,
+    handleCellClick: func.isRequired,
     tileURL: string.isRequired,
     tileCacheKey: string.isRequired,
     fetching: bool.isRequired,

--- a/src/app/src/components/VectorTileFacilityGridLayer.jsx
+++ b/src/app/src/components/VectorTileFacilityGridLayer.jsx
@@ -8,6 +8,7 @@ import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 
 import { createQueryStringFromSearchFilters } from '../util/util';
+import { GRID_COLOR_RAMP } from '../util/constants';
 
 const VectorGrid = withLeaflet(VectorGridDefault);
 
@@ -99,17 +100,9 @@ const VectorTileFacilityGridLayer = ({
                             stroke: false,
                         };
                     }
-                    const colors = [
-                        [0, '#009EE6'],
-                        [10, '#0086D8'],
-                        [20, '#016ECB'],
-                        [40, '#0256BE'],
-                        [80, '#033EB1'],
-                        [160, '#0427A4'],
-                    ];
-                    const fillColor = colors.reduce(
+                    const fillColor = GRID_COLOR_RAMP.reduce(
                         // eslint-disable-next-line no-confusing-arrow
-                        (color, [val, c]) => count + factor > val ? c : color, colors[0],
+                        (color, [val, c]) => count + factor > val ? c : color, GRID_COLOR_RAMP[0],
                     );
 
                     return {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -489,3 +489,12 @@ export const claimAFacilityPreferredContactOptions = Object.freeze([
         label: 'Phone',
     }),
 ]);
+
+export const GRID_COLOR_RAMP = Object.freeze([
+    [0, '#009EE6'],
+    [10, '#0086D8'],
+    [20, '#016ECB'],
+    [40, '#0256BE'],
+    [80, '#033EB1'],
+    [160, '#0427A4'],
+]);

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -1535,6 +1535,11 @@
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
+"@mapbox/sphericalmercator@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz#f3b1af042620716a1289fc41e1e97f610823aefe"
+  integrity sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==
+
 "@material-ui/core@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.1.0.tgz#40c70e0764ef27dca5e149551577eba10c2e79ce"

--- a/src/django/api/tiler.py
+++ b/src/django/api/tiler.py
@@ -21,7 +21,7 @@ def latlng_bounds_to_grid_table_values(llb, tile_bounds):
     return '({geom}, {mvt_geom})'.format(geom=geom, mvt_geom=mvt_geom)
 
 
-def get_facilities_grid_vector_tile(params, layer, z, x, y):
+def get_facility_grid_vector_tile(params, layer, z, x, y):
     tile_bounds = mercantile.bounds(x, y, z)
     grid_tiles = mercantile.children((x, y, z), zoom=z+GRID_ZOOM_FACTOR)
     tile_values = [

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -88,7 +88,8 @@ from api.mail import (send_claim_facility_confirmation_email,
                       send_approved_claim_notice_to_list_contributors,
                       send_claim_update_notice_to_list_contributors)
 from api.exceptions import BadRequestException
-from api.tiler import get_facilities_vector_tile
+from api.tiler import (get_facilities_vector_tile,
+                       get_facility_grid_vector_tile)
 from api.renderers import MvtRenderer
 
 
@@ -2291,7 +2292,7 @@ def get_tile(request, layer, cachekey, z, x, y, ext):
     if cachekey is None:
         raise BadRequestException('missing cache key')
 
-    if layer != 'facilities':
+    if layer not in ['facilities', 'facilitygrid']:
         raise BadRequestException('invalid layer name: {}'.format(layer))
 
     if ext != 'pbf':
@@ -2302,5 +2303,9 @@ def get_tile(request, layer, cachekey, z, x, y, ext):
     if not params.is_valid():
         raise ValidationError(params.errors)
 
-    tile = get_facilities_vector_tile(request.query_params, layer, z, x, y)
+    if layer == 'facilities':
+        tile = get_facilities_vector_tile(request.query_params, layer, z, x, y)
+    elif layer == 'facilitygrid':
+        tile = get_facility_grid_vector_tile(
+            request.query_params, layer, z, x, y)
     return Response(tile.tobytes())


### PR DESCRIPTION
## Overview

Add a layer to show facilities aggregated by a fishnet grid at low zoom levels.

Connects #741

## Demo

![2019-09-04 18 28 26](https://user-images.githubusercontent.com/17363/64304736-e0a14500-cf41-11e9-8355-f3d78c8b9bb7.gif)

## Notes

The first iteration of this used a generic "wrapping" approach where the exact query produced by the ORM was joined to a synthesized table of grid polygons. This is the safest option, but each tile query took multiple seconds on staging dues to the query planner falling back to full sequential table scans.

`JOIN`ing the `api_facility` table directly in the tile query provided a 5x-10x boost in query performance at the cost of making the tile query construction more brittle.

## Testing Instructions

* Verify that the grid tiles load quickly.
* Verify that clicking a grid cell zooms the map to the extent of that cell.
* Verify that the map switches to showing the marker layer at zoom levels greater than 11.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
