### PR TITLE
Add vector-tile/multifacility disambiguation popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adjust marker icon on selecting a new facility on the vector tiles layer [#749](https://github.com/open-apparel-registry/open-apparel-registry/pull/749)
 - Fetch next page of facilities while scrolling through sidebar list [#750](https://github.com/open-apparel-registry/open-apparel-registry/pull/750)
 - Enable signed-in users to download all facilities results as CSV [#752](https://github.com/open-apparel-registry/open-apparel-registry/pull/752)
+- Add disambiguation marker to work with vector tile layer [#760](https://github.com/open-apparel-registry/open-apparel-registry/pull/760)
 
 ### Changed
 - Use PostgreSQL 10.9 in development [#751](https://github.com/open-apparel-registry/open-apparel-registry/pull/751)

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -163,6 +163,9 @@ function VectorTileFacilitiesMap({
     match: {
         params: { oarID },
     },
+    history: {
+        push,
+    },
     facilityDetailsData,
     errorFetchingFacilityDetailsData,
     fetchingDetailsData,
@@ -217,6 +220,7 @@ function VectorTileFacilitiesMap({
             <VectorTileFacilitiesLayer
                 handleMarkerClick={handleMarkerClick}
                 oarID={oarID}
+                pushRoute={push}
             />
         </ReactLeafletMap>
     );
@@ -236,6 +240,9 @@ VectorTileFacilitiesMap.propTypes = {
         params: shape({
             oarID: string,
         }),
+    }).isRequired,
+    history: shape({
+        push: func.isRequired,
     }).isRequired,
     facilityDetailsData: facilityDetailsPropType,
     errorFetchingFacilityDetailsData: arrayOf(string),

--- a/src/django/api/tiler.py
+++ b/src/django/api/tiler.py
@@ -56,10 +56,13 @@ def get_facilities_vector_tile(params, layer, z, x, y):
                     ymin=tile_bounds.south,
                     xmax=tile_bounds.east,
                     ymax=tile_bounds.north,
-                )
+                ),
+                'x': x,
+                'y': y,
+                'z': z,
             }
         ) \
-        .values('location', 'id') \
+        .values('location', 'id', 'name', 'address', 'x', 'y', 'z') \
         .query \
         .sql_with_params()
 


### PR DESCRIPTION
## Overview

Set up the multi-facility disambiguation popup to work with the new
vector tile layer component by making the following changes:

- add the `name` and `address` fields to the features returned in the
vector tile, along with the x, y and z arguments representing the
location of the tile
- use the x y and z tile arguments to find the vector tile containing a
clicked facility marker, then check whether there are any other facilities at
the same point using a `_.isEqual` check
- if a clicked facility marker only has one facility, just continue
selecting it as before
- if a clicked facility marker represents multiple facilities, display
the existing disambiguation popup component wired up to display the
facility data
- always highlight the marker for the currently selected facility if
viewing a details page

Connects #740 

## Demo

![Screen Shot 2019-09-05 at 10 42 26 AM](https://user-images.githubusercontent.com/4165523/64352356-e3477d00-cfc9-11e9-8b14-6ed73dc070fb.png)
![Screen Shot 2019-09-05 at 10 42 33 AM](https://user-images.githubusercontent.com/4165523/64352358-e3e01380-cfc9-11e9-8ba6-be3b5833efe8.png)

## Notes

The imperative code in the useEffect handlers for this file has become a little more difficult to reason about. This was also the case for the prior imperative class-based code for the Google Map component (and for the Mapbox map component before that). I'm not sure how best to make it more legible at a glance but I'm open to suggestions.

## Testing Instructions

- serve this branch with the standard set of fixtures and vector tiles turned on
- in the terminal run `manage shell plus` and then create a set of clustered facilities at point 0,0 by running:

```
from django.contrib.gis.geos import Point
null_island = Point(0, 0)
Facility.objects.filter(country_code="IT").update(location=null_island)
```

- use the map page and verify the following states:

1. when a facility is selected, its marker has the selected marker image (and only that marker has the selected marker image, all others being unselected -- excluding, of course, when a facility at the same point is selected)

2. when the marker at 0,0 is clicked, the popup displays with the facilities listed. Clicking on any of the facilities in it should select that facility, change that marker to be selected, and change any previously selected markers to unselected

3. navigating directly to an OAR ID details page should make that marker be selected automatically

4. clicking reset should close any open popups and reset the map state

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
