### PR TITLE
Fetch all facilities by default on main page when vector tile feature is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fetch next page of facilities while scrolling through sidebar list [#750](https://github.com/open-apparel-registry/open-apparel-registry/pull/750)
 - Enable signed-in users to download all facilities results as CSV [#752](https://github.com/open-apparel-registry/open-apparel-registry/pull/752)
 - Add disambiguation marker to work with vector tile layer [#760](https://github.com/open-apparel-registry/open-apparel-registry/pull/760)
+- Make facilities tab primary & load all facilities by default when vector tile feature is switched on [#771](https://github.com/open-apparel-registry/open-apparel-registry/pull/771)
 
 ### Changed
 - Use PostgreSQL 10.9 in development [#751](https://github.com/open-apparel-registry/open-apparel-registry/pull/751)

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { connect } from 'react-redux';
-import { func } from 'prop-types';
+import { bool, func } from 'prop-types';
 import { Router, Route, Switch } from 'react-router-dom';
 import { ToastContainer, Slide } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css'; // eslint-disable-line import/first
 import { hot } from 'react-hot-loader/root';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 import history from './util/history';
 import Navbar from './components/Navbar';
@@ -82,6 +83,8 @@ class App extends Component {
     }
 
     render() {
+        const { fetchingFeatureFlags } = this.props;
+
         return (
             <ErrorBoundary>
                 <Router history={history}>
@@ -115,7 +118,15 @@ class App extends Component {
                                 />
                                 <Route
                                     path={facilitiesRoute}
-                                    component={MapAndSidebar}
+                                    render={
+                                        () => {
+                                            if (fetchingFeatureFlags) {
+                                                return <CircularProgress />;
+                                            }
+
+                                            return <Route component={MapAndSidebar} />;
+                                        }
+                                    }
                                 />
                                 <Route
                                     exact
@@ -179,7 +190,15 @@ class App extends Component {
                                 <Route
                                     exact
                                     path={mainRoute}
-                                    component={MapAndSidebar}
+                                    render={
+                                        () => {
+                                            if (fetchingFeatureFlags) {
+                                                return <CircularProgress />;
+                                            }
+
+                                            return <Route component={MapAndSidebar} />;
+                                        }
+                                    }
                                 />
                                 <Route render={() => <RouteNotFound />} />
                             </Switch>
@@ -199,7 +218,18 @@ class App extends Component {
 
 App.propTypes = {
     logIn: func.isRequired,
+    fetchingFeatureFlags: bool.isRequired,
 };
+
+function mapStateToProps({
+    featureFlags: {
+        fetching: fetchingFeatureFlags,
+    },
+}) {
+    return {
+        fetchingFeatureFlags,
+    };
+}
 
 function mapDispatchToProps(dispatch) {
     return {
@@ -210,4 +240,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default hot(connect(() => ({}), mapDispatchToProps)(withStyles(appStyles)(App)));
+export default hot(connect(mapStateToProps, mapDispatchToProps)(withStyles(appStyles)(App)));

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -1,6 +1,7 @@
 import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 import isObject from 'lodash/isObject';
+import get from 'lodash/get';
 
 import {
     makeSidebarGuideTabActive,
@@ -13,6 +14,8 @@ import {
 } from '../actions/ui';
 
 import { completeFetchFacilities } from '../actions/facilities';
+
+import { completeFetchFeatureFlags } from '../actions/featureFlags';
 
 import { filterSidebarTabsEnum } from '../util/constants';
 
@@ -29,6 +32,17 @@ const initialState = Object.freeze({
 });
 
 export default createReducer({
+    [completeFetchFeatureFlags]: (state, flags) => {
+        const vectorTileFeatureIsActive = get(flags, 'vector_tile', false);
+
+        return vectorTileFeatureIsActive
+            ? update(state, {
+                activeFilterSidebarTab: {
+                    $set: filterSidebarTabsEnum.facilities,
+                },
+            })
+            : state;
+    },
     [recordSearchTabResetButtonClick]: state => update(state, {
         facilitiesSidebarTabSearch: {
             resetButtonClickCount: {


### PR DESCRIPTION
## Overview

When the vector tile feature is active, fetch all facilities by default
on the main map and sidebar page. Also make the "Facilities" tab the
initially displayed tab on loading the map page if the vector tile
feature is active.

Add guards to retain prior map behavior when the vector tile feature is
not active.

Connects #765 

## Demo

![Screen Shot 2019-09-05 at 5 59 41 PM](https://user-images.githubusercontent.com/4165523/64386384-f462af00-d006-11e9-8d01-a260f3a7e4c0.png)

## Notes

Making this work while keeping the same functionality as before when the feature flag is off was a little tricky, but I think I came up with a good way to handle it which was to defer rendering any components that need to know the state of feature flags until the feature flags have returned from the API.

## Testing Instructions

Using the standard set of fixtures, serve this branch, then...

With the `vector_tile` switch turned *off*, use the app and verify that it still works as it did before.

With the `vector_tile` switch turned *on*, use the app and verify that the facilities tab populates with data as expected.

In particular: clicking the "reset" button for the vector tiles version will now undertake a new search.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
