### PR TITLE
Correct Facility Parent Company link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)
 - Fix a bug which prevented the vector tile marker layer from rendering [#782](https://github.com/open-apparel-registry/open-apparel-registry/pull/782)
 - Capture infinite-scroll emitted bug in an ErrorBoundary in order not to crash the map component [#777](https://github.com/open-apparel-registry/open-apparel-registry/pull/777)
+- Correct Facility Parent Company link [#772](https://github.com/open-apparel-registry/open-apparel-registry/pull/772)
 
 ### Security
 - Fix several npm security vulnerabilities via GitHub dependabot [#792](https://github.com/open-apparel-registry/open-apparel-registry/pull/792)


### PR DESCRIPTION
## Overview

There is no detail page for Facility Parent Company entities, as both Claim Contributors and Facility Parent Company links open the same page. In cases when the IDs of the two are not in sync, clicking the Facility Parent Company link would go to the wrong page.

By making the link always point to the Claim Contributor's id, we ensure that it is always correct.

Connects #729 

## Demo

![2019-09-06 11 19 54](https://user-images.githubusercontent.com/1430060/64439633-66370900-d098-11e9-84d5-5854e97a2d35.gif)

## Testing Instructions

* Follow the instructions in the issue to simulate a situation where the user id and parent company id are out of sync
* Submit a claim
* Login as `c1@example.com` and go to the dashboard to view its details
* Click the Claim Contributor link. Ensure it works.
* Click the Facility Parent Company link. Ensure it works.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
