### PR TITLE
Encode querystring params in vector tile cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add disambiguation marker to work with vector tile layer [#760](https://github.com/open-apparel-registry/open-apparel-registry/pull/760)
 - Make facilities tab primary & load all facilities by default when vector tile feature is switched on [#771](https://github.com/open-apparel-registry/open-apparel-registry/pull/771)
 - Add facility grid layer [#755](https://github.com/open-apparel-registry/open-apparel-registry/pull/755)
+- Encode querystring params into tile cache key used by client to request vector tiles [#773](https://github.com/open-apparel-registry/open-apparel-registry/pull/773)
 
 ### Changed
 - Use PostgreSQL 10.9 in development [#751](https://github.com/open-apparel-registry/open-apparel-registry/pull/751)

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -19,6 +19,7 @@
         "leaflet.markercluster": "1.4.1",
         "lodash": "4.17.13",
         "moment": "2.24.0",
+        "object-hash": "1.3.1",
         "prop-types": "15.6.2",
         "react": "16.8.6",
         "react-app-rewire-hot-loader": "2.0.1",

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -177,7 +177,7 @@ it('creates a querystring from a set of filter selection', () => {
     };
 
     const expectedMultipleFilterSelectionsMatch =
-        'contributors=foo&contributors=bar&contributors=baz&countries=country';
+        'contributors=bar&contributors=baz&contributors=foo&countries=country';
     expect(createQueryStringFromSearchFilters(multipleFilterSelections))
         .toEqual(expectedMultipleFilterSelectionsMatch);
 

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import VectorGridDefault from 'react-leaflet-vectorgrid';
 import { withLeaflet, Popup } from 'react-leaflet';
 import L from 'leaflet';
-import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 import noop from 'lodash/noop';
 import filter from 'lodash/filter';
@@ -15,7 +14,11 @@ import sortBy from 'lodash/sortBy';
 
 import FacilitiesMapPopup from './FacilitiesMapPopup';
 
-import { createQueryStringFromSearchFilters } from '../util/util';
+import {
+    createQueryStringFromSearchFilters,
+    createTileURLWithQueryString,
+    createTileCacheKeyWithEncodedFilters,
+} from '../util/util';
 
 const VectorGrid = withLeaflet(VectorGridDefault);
 
@@ -334,11 +337,6 @@ VectorTileFacilitiesLayer.propTypes = {
     pushRoute: func.isRequired,
 };
 
-const createURLWithQueryString = (qs, key) =>
-    `/tile/facilities/${key}/{z}/{x}/{y}.pbf`.concat(
-        isEmpty(qs) ? '' : `?${qs}`,
-    );
-
 function mapStateToProps({
     filters,
     facilities: {
@@ -349,14 +347,13 @@ function mapStateToProps({
     },
     vectorTileLayer: { key },
 }) {
-    const tileURL = createURLWithQueryString(
-        createQueryStringFromSearchFilters(filters),
-        key,
-    );
+    const querystring = createQueryStringFromSearchFilters(filters);
+    const tileCacheKey = createTileCacheKeyWithEncodedFilters(querystring, key);
+    const tileURL = createTileURLWithQueryString(filters, tileCacheKey);
 
     return {
         tileURL,
-        tileCacheKey: key,
+        tileCacheKey,
         fetching,
         resetButtonClickCount,
     };

--- a/src/app/src/components/VectorTileFacilityGridLayer.jsx
+++ b/src/app/src/components/VectorTileFacilityGridLayer.jsx
@@ -4,10 +4,14 @@ import { connect } from 'react-redux';
 import VectorGridDefault from 'react-leaflet-vectorgrid';
 import { withLeaflet } from 'react-leaflet';
 import L from 'leaflet';
-import isEmpty from 'lodash/isEmpty';
 import get from 'lodash/get';
 
-import { createQueryStringFromSearchFilters } from '../util/util';
+import {
+    createQueryStringFromSearchFilters,
+    createTileURLWithQueryString,
+    createTileCacheKeyWithEncodedFilters,
+} from '../util/util';
+
 import { GRID_COLOR_RAMP } from '../util/constants';
 
 const VectorGrid = withLeaflet(VectorGridDefault);
@@ -131,9 +135,6 @@ VectorTileFacilityGridLayer.propTypes = {
     resetButtonClickCount: number.isRequired,
 };
 
-const createURLWithQueryString = (qs, key) =>
-    `/tile/facilitygrid/${key}/{z}/{x}/{y}.pbf`.concat(isEmpty(qs) ? '' : `?${qs}`);
-
 function mapStateToProps({
     filters,
     facilities: {
@@ -146,14 +147,13 @@ function mapStateToProps({
         key,
     },
 }) {
-    const tileURL = createURLWithQueryString(
-        createQueryStringFromSearchFilters(filters),
-        key,
-    );
+    const querystring = createQueryStringFromSearchFilters(filters);
+    const tileCacheKey = createTileCacheKeyWithEncodedFilters(filters, key);
+    const tileURL = createTileURLWithQueryString(querystring, tileCacheKey);
 
     return {
         tileURL,
-        tileCacheKey: key,
+        tileCacheKey,
         fetching,
         resetButtonClickCount,
     };

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -9056,7 +9056,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^1.1.4:
+object-hash@1.3.1, object-hash@^1.1.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==


### PR DESCRIPTION
## Overview

Encode qs params into vector tile cache key sent with client tile
requests. We do this client side because the client is the source of the
request and already knows what filters have been applied -- and because
the server sent cache key only encodes the version number and the
timestamp of the most recently updated facility.

The server already only checks for the presence or absence of a cache
key in the URL path, so this implementation leaves that unchanged. For future CF or S3
based caching, the path will still be set up to "just work" with
requests for specific sets of tiles.

Connects #762

## Testing Instructions

- serve the app with the vector tile feature switched on, and verify that everything still works as before but that we are now encoding the filters into the tile cache key used by the client

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
