### PR TITLE
Fix infinite scroll map bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)
 - Fix a bug which prevented the vector tile marker layer from rendering [#782](https://github.com/open-apparel-registry/open-apparel-registry/pull/782)
+- Capture infinite-scroll emitted bug in an ErrorBoundary in order not to crash the map component [#777](https://github.com/open-apparel-registry/open-apparel-registry/pull/777)
 
 ### Security
 - Fix several npm security vulnerabilities via GitHub dependabot [#792](https://github.com/open-apparel-registry/open-apparel-registry/pull/792)

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -2,8 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 
-import FilterSidebar from './FilterSidebar';
-import FacilityDetailsSidebar from './FacilityDetailSidebar';
+import SidebarWithErrorBoundary from './SidebarWithErrorBoundary';
 import FacilitiesMap from './FacilitiesMap';
 import FacilitiesMapErrorMessage from './FacilitiesMapErrorMessage';
 import FeatureFlag from './FeatureFlag';
@@ -40,23 +39,7 @@ class MapAndSidebar extends Component {
             <Fragment>
                 <Grid container className="map-sidebar-container">
                     <Grid item xs={12} sm={4} id="panel-container">
-                        <Switch>
-                            <Route
-                                exact
-                                path={facilityDetailsRoute}
-                                component={FacilityDetailsSidebar}
-                            />
-                            <Route
-                                exact
-                                path={facilitiesRoute}
-                                component={FilterSidebar}
-                            />
-                            <Route
-                                exact
-                                path={mainRoute}
-                                component={FilterSidebar}
-                            />
-                        </Switch>
+                        <Route component={SidebarWithErrorBoundary} />
                     </Grid>
                     <Grid item xs={12} sm={8} style={{ position: 'relative' }}>
                         {!hasError && (

--- a/src/app/src/components/SidebarWithErrorBoundary.jsx
+++ b/src/app/src/components/SidebarWithErrorBoundary.jsx
@@ -1,0 +1,50 @@
+import React, { Component } from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+import {
+    facilityDetailsRoute,
+    facilitiesRoute,
+    mainRoute,
+} from '../util/constants';
+
+import FacilityDetailsSidebar from './FacilityDetailSidebar';
+import FilterSidebar from './FilterSidebar';
+
+export default class SidebarWithErrorBoundary extends Component {
+    state = { hasError: false };
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error) {
+        if (window.Rollbar) {
+            window.Rollbar.error(error);
+        }
+    }
+
+    render() {
+        return (
+            <Switch>
+                <Route
+                    key={JSON.stringify(this.state.hasError)}
+                    exact
+                    path={facilityDetailsRoute}
+                    component={FacilityDetailsSidebar}
+                />
+                <Route
+                    key={JSON.stringify(this.state.hasError)}
+                    exact
+                    path={facilitiesRoute}
+                    component={FilterSidebar}
+                />
+                <Route
+                    key={JSON.stringify(this.state.hasError)}
+                    exact
+                    path={mainRoute}
+                    component={FilterSidebar}
+                />
+            </Switch>
+        );
+    }
+}

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bool, func, shape, string } from 'prop-types';
+import { bool, func, number, shape, string } from 'prop-types';
 import get from 'lodash/get';
 
 import { setFiltersFromQueryString } from '../actions/filters';
@@ -104,7 +104,7 @@ export default function withQueryStringSync(WrappedComponent) {
                 search: string.isRequired,
             }),
         }).isRequired,
-        resetButtonClickCount: func.isRequired,
+        resetButtonClickCount: number.isRequired,
         vectorTileFeatureIsActive: bool.isRequired,
         fetchingFeatureFlags: bool.isRequired,
     };


### PR DESCRIPTION
## Overview

The map and the sidebar components shared a common error boundary, which had special rules for rendering the fallback "Map can't be displayed!" component whenever any error got emitted within that tree. As a consequence, errors emitted from the sidebar -- including those from the infinite list component -- would cause the map component to get into a failure state, even if the error was not fatal to the sidebar.

To split those errors, we now wrap the sidebar in its own separate error boundary which will catch errors before they get propagated to the entire `MapAndSidebar` component. In some cases these may still be fatal to the filter sidebar -- and the app in general -- but they won't immediately crash the map. If these errors are fatal to the whole app, we can spend some time later figuring out how to recover from them.

Connects #758 

## Demo

![Screen Shot 2019-09-06 at 5 15 53 PM](https://user-images.githubusercontent.com/4165523/64461172-6d770a80-d0ca-11e9-89d5-2c4f5e34b90d.png)

## Notes

I was able to reproduce the error locally by loading all local facilities, then just scrolling back and forth through the list rapidly. This can/will eventually cause the following error, which is not fatal the first time it is encountered, at least:

![Screen Shot 2019-09-09 at 1 06 09 PM](https://user-images.githubusercontent.com/4165523/64551279-b0232780-d302-11e9-8dd5-1f26400034e6.png)

Setting the `key` attribute for the relevant routes to be `this.state.hasError` will force rerender on the error happening the first time, since the value will change. If we want it to catch errors subsequent to the first time, we could also set this value to be an incrementing counter.

Rationale for just having it re-render once is that we probably do want to know if it's a repeated error.

## Testing Instructions

- make sure you've got the latest version of React devtools installed
- serve this branch with the vector tile feature on
- open the React devtools and click the `hasError` prop for the new `MapAndSidebarFilterErrorBoundary` to set it true. Note that the app still continues to work
- refresh page, then try scrolling rapidly back and forth through the facilities list until you see the error happen. Verify that the map no longer crashes

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
