### PR TITLE
Fix facility claim dashboard prop types error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)
 
 ## [2.10.0] - 2019-08-22
 ### Added

--- a/src/app/src/components/Dashboard.jsx
+++ b/src/app/src/components/Dashboard.jsx
@@ -109,7 +109,7 @@ function Dashboard({
                                             flag={CLAIM_A_FACILITY}
                                             alternative={DASHBOARD_TITLE}
                                         >
-                                            {makeClickableDashboardLinkFn('Facility Claim Details')}
+                                            {makeClickableDashboardLinkFn('Facility Claim Details')()}
                                         </FeatureFlag>
                                     )
                                 }
@@ -123,7 +123,7 @@ function Dashboard({
                                             flag={CLAIM_A_FACILITY}
                                             alternative={DASHBOARD_TITLE}
                                         >
-                                            {makeClickableDashboardLinkFn('Facility Claims')}
+                                            {makeClickableDashboardLinkFn('Facility Claims')()}
                                         </FeatureFlag>
                                     )
                                 }


### PR DESCRIPTION
## Overview

The code to create headers for the dashboard facility claim routes was
accidentally passing an uncalled function to render instead of a React
component. This change fixes the proptypes error by calling the
functions and also fixes the bug whereby the headers would not display.

Brief description of what this PR does, and why it is needed.

Connects #767 

## Demo

![Screen Shot 2019-09-09 at 11 29 05 AM](https://user-images.githubusercontent.com/4165523/64544463-0d17e100-d2f5-11e9-9991-4c7365affcc1.png)

## Testing Instructions

- attempt to recreate the proptypes warning described in #767 and verify that this code dispels it
- verify that you now see a header on the dashboard facility claims list

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
