### PR TITLE
Fix bug which prevented marker layer from loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)
+- Fix a bug which prevented the vector tile marker layer from rendering [#782](https://github.com/open-apparel-registry/open-apparel-registry/pull/782)
 
 ## [2.10.0] - 2019-08-22
 ### Added

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -348,8 +348,8 @@ function mapStateToProps({
     vectorTileLayer: { key },
 }) {
     const querystring = createQueryStringFromSearchFilters(filters);
-    const tileCacheKey = createTileCacheKeyWithEncodedFilters(querystring, key);
-    const tileURL = createTileURLWithQueryString(filters, tileCacheKey);
+    const tileCacheKey = createTileCacheKeyWithEncodedFilters(filters, key);
+    const tileURL = createTileURLWithQueryString(querystring, tileCacheKey, false);
 
     return {
         tileURL,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -277,8 +277,10 @@ export const getContributorFromQueryString = (qs) => {
     return parseInt(contributor, 10);
 };
 
-export const createTileURLWithQueryString = (qs, key) =>
-    `/tile/facilitygrid/${key}/{z}/{x}/{y}.pbf`.concat(isEmpty(qs) ? '' : `?${qs}`);
+export const createTileURLWithQueryString = (qs, key, grid = true) =>
+    `/tile/${grid ? 'facilitygrid' : 'facilities'}/${key}/{z}/{x}/{y}.pbf`.concat(
+        isEmpty(qs) ? '' : `?${qs}`,
+    );
 
 export const createTileCacheKeyWithEncodedFilters = (filters, key) =>
     `${key}-${hash(filters).slice(0, 8)}`;


### PR DESCRIPTION
## Overview

Previous work to encode the querystring into the tile cachekey mixed up
some function arguments. In turn this prevents the vector tile
facilities layer from loading. Additionally: the function extracted to
create the tileURL was unconditionally requesting the facility grid
layer, which would cause the markers layer to load as a grid, too.

This change fixes the bug so that the marker layer will render
correctly.

Connects #762 

## Testing Instructions

- load the app on this branch and verify that the grid layer and marker layer both render as expected

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
