### PR TITLE
Restrict `/tile` Endpoint to Allowed Hosts Only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use PostgreSQL 10.9 in development [#751](https://github.com/open-apparel-registry/open-apparel-registry/pull/751)
 - Add open graph meta tags for social media sharing [#780](https://github.com/open-apparel-registry/open-apparel-registry/pull/780/files)
+- Restrict `/tile` Endpoint to Allowed Hosts Only [#791](https://github.com/open-apparel-registry/open-apparel-registry/pull/791)
 
 ### Deprecated
 

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -49,6 +49,17 @@ class IsAuthenticatedOrWebClient(permissions.BasePermission):
         return False
 
 
+class IsAllowedHost(permissions.BasePermission):
+    def has_permission(self, request, view):
+        host = referring_host(request)
+        if referring_host_is_allowed(host):
+            return True
+        else:
+            _report_warning_to_rollbar(
+                'Unallowed referring host passed with API request',
+                extra_data={'host': host})
+
+
 class IsRegisteredAndConfirmed(permissions.BasePermission):
     message = 'Insufficient permissions'
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -3378,3 +3378,24 @@ class LogDownloadTests(APITestCase):
         log = DownloadLog.objects.first()
         self.assertEqual(expected_path, log.path)
         self.assertEqual(expected_record_count, log.record_count)
+
+
+class TilePermissionsTest(APITestCase):
+    def setUp(self):
+        self.tile_path = reverse('tile', kwargs={
+            'layer': 'facilitygrid',
+            'cachekey': '1567700347-1-95f951f7',
+            'z': 6, 'x': 15, 'y': 29,
+            'ext': 'pbf',
+        })
+
+    @override_settings(ALLOWED_HOSTS=['testserver', '.allowed.org'])
+    @override_switch('vector_tile', active=True)
+    def test_allowed_hosts_can_fetch_tiles(self):
+        response = self.client.get(self.tile_path, {},
+                                   HTTP_REFERER='http://allowed.org/')
+        self.assertEqual(200, response.status_code)
+
+    def test_disallowed_hosts_cannot_fetch_tiles(self):
+        response = self.client.get(self.tile_path)
+        self.assertEqual(401, response.status_code)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -80,7 +80,7 @@ from api.serializers import (FacilityListSerializer,
                              LogDownloadQueryParamsSerializer)
 from api.countries import COUNTRY_CHOICES
 from api.aws_batch import submit_jobs
-from api.permissions import IsRegisteredAndConfirmed
+from api.permissions import IsRegisteredAndConfirmed, IsAllowedHost
 from api.pagination import FacilitiesGeoJSONPagination
 from api.mail import (send_claim_facility_confirmation_email,
                       send_claim_facility_approval_email,
@@ -2286,7 +2286,7 @@ class FacilityClaimViewSet(viewsets.ModelViewSet):
 
 
 @api_view(['GET'])
-@permission_classes([AllowAny])
+@permission_classes([IsAllowedHost])
 @renderer_classes([MvtRenderer])
 @cache_control(max_age=settings.TILE_CACHE_MAX_AGE_IN_SECONDS)
 @waffle_switch('vector_tile')


### PR DESCRIPTION
## Overview

To discourage tile hotlinking, this adds a check of the HTTP referer field to allow only those in `ALLOWED_HOSTS`.

This reuses previously created methods for checking the referer field. Leaflet VectorGrid extension doesn't support making requests with custom headers, which is why we're not also reusing the `X-OAR-Client-Key` check here.

Also adds some tests for these new permissions.

Connects #735 

## Demo

![image](https://user-images.githubusercontent.com/1430060/64564313-3d747500-d31f-11e9-9909-6a63a73136dc.png)

## Testing Instructions

* Check out this branch and visit [:6543/](http://localhost:6543/)
  - [ ] Ensure you can still see the tiles

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
