### PR TITLE
Regularize map zoom and pan behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Close Disambiguation Popup on Reset [#812](https://github.com/open-apparel-registry/open-apparel-registry/pull/812)
 - Change "Accept" to "Confirm" in About/Processing [#815](https://github.com/open-apparel-registry/open-apparel-registry/pull/815)
+- Regularize vector tile map zoom behavior [#799](https://github.com/open-apparel-registry/open-apparel-registry/pull/799)
 
 ### Security
 

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -280,7 +280,12 @@ function FilterSidebarFacilitiesTab({
                                             style={facilitiesTabStyles.listItemStyles}
                                         >
                                             <Link
-                                                to={makeFacilityDetailLink(oarID)}
+                                                to={{
+                                                    pathname: makeFacilityDetailLink(oarID),
+                                                    state: {
+                                                        panMapToFacilityDetails: true,
+                                                    },
+                                                }}
                                                 href={makeFacilityDetailLink(oarID)}
                                                 style={facilitiesTabStyles.linkStyles}
                                             >

--- a/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -316,7 +316,12 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                                             style={facilitiesTabStyles.listItemStyles}
                                         >
                                             <Link
-                                                to={makeFacilityDetailLink(oarID)}
+                                                to={{
+                                                    pathname: makeFacilityDetailLink(oarID),
+                                                    state: {
+                                                        panMapToFacilityDetails: true,
+                                                    },
+                                                }}
                                                 href={makeFacilityDetailLink(oarID)}
                                                 style={facilitiesTabStyles.linkStyles}
                                             >

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { array, arrayOf, bool, func, number, shape, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { Map as ReactLeafletMap, ZoomControl } from 'react-leaflet';
@@ -9,9 +9,6 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { toast } from 'react-toastify';
 import noop from 'lodash/noop';
 import get from 'lodash/get';
-import head from 'lodash/head';
-import last from 'lodash/last';
-import delay from 'lodash/delay';
 
 import Button from './Button';
 import VectorTileFacilitiesLayer from './VectorTileFacilitiesLayer';
@@ -29,9 +26,11 @@ import {
     initialCenter,
     initialZoom,
     minimumZoom,
-    detailsZoomLevel,
+    maxVectorTileFacilitiesGridZoom,
     GOOGLE_CLIENT_SIDE_API_KEY,
 } from '../util/constants.facilitiesMap';
+
+import useUpdateLeafletMapImperatively from '../util/hooks';
 
 const mapComponentStyles = Object.freeze({
     mapContainerStyles: Object.freeze({
@@ -63,120 +62,6 @@ const mapComponentStyles = Object.freeze({
     }),
 });
 
-function useUpdateLeafletMapImperatively(
-    resetButtonClickCount,
-    { oarID, data, error, fetching },
-) {
-    const mapRef = useRef(null);
-
-    // Set the map view on a facility location if the user has arrived
-    // directly from a URL containing a valid OAR ID
-    const [
-        shouldSetViewOnReceivingData,
-        setShouldSetViewOnReceivingData,
-    ] = useState(!!oarID);
-
-    useEffect(() => {
-        if (shouldSetViewOnReceivingData) {
-            if (data) {
-                const leafletMap = get(mapRef, 'current.leafletElement', null);
-
-                const facilityLocation = get(
-                    data,
-                    'geometry.coordinates',
-                    null,
-                );
-
-                if (leafletMap && facilityLocation) {
-                    leafletMap.setView(
-                        {
-                            lng: head(facilityLocation),
-                            lat: last(facilityLocation),
-                        },
-                        detailsZoomLevel,
-                    );
-                }
-
-                setShouldSetViewOnReceivingData(false);
-            } else if (error) {
-                setShouldSetViewOnReceivingData(false);
-            }
-        }
-    }, [
-        shouldSetViewOnReceivingData,
-        setShouldSetViewOnReceivingData,
-        data,
-        error,
-    ]);
-
-    // Set the map view on the facility location if it is not within the
-    // current viewport bbox
-    const [appIsGettingFacilityData, setAppIsGettingFacilityData] = useState(fetching);
-
-    useEffect(() => {
-        if (shouldSetViewOnReceivingData) {
-            noop();
-        } else if (fetching && !appIsGettingFacilityData) {
-            setAppIsGettingFacilityData(true);
-        } else if (!fetching && appIsGettingFacilityData && data) {
-            const leafletMap = get(mapRef, 'current.leafletElement', null);
-            const facilityLocation = get(data, 'geometry.coordinates', null);
-
-            delay(
-                () => {
-                    if (leafletMap && facilityLocation) {
-                        const facilityLatLng = {
-                            lng: head(facilityLocation),
-                            lat: last(facilityLocation),
-                        };
-
-                        const mapBoundsContainsFacility = leafletMap
-                            .getBounds()
-                            .contains(facilityLatLng);
-
-                        if (!mapBoundsContainsFacility) {
-                            leafletMap.setView(facilityLatLng);
-                        }
-                    }
-
-                    setAppIsGettingFacilityData(false);
-                },
-                0,
-            );
-        }
-    }, [
-        fetching,
-        appIsGettingFacilityData,
-        setAppIsGettingFacilityData,
-        data,
-        shouldSetViewOnReceivingData,
-    ]);
-
-    // Reset the map state when the reset button is clicked
-    const [
-        currentResetButtonClickCount,
-        setCurrentResetButtonClickCount,
-    ] = useState(resetButtonClickCount);
-
-    useEffect(() => {
-        if (resetButtonClickCount !== currentResetButtonClickCount) {
-            const leafletMap = get(mapRef, 'current.leafletElement', null);
-
-            if (leafletMap) {
-                leafletMap.setView(initialCenter, initialZoom);
-            }
-
-            setCurrentResetButtonClickCount(resetButtonClickCount);
-        }
-    }, [
-        resetButtonClickCount,
-        currentResetButtonClickCount,
-        setCurrentResetButtonClickCount,
-    ]);
-
-    return mapRef;
-}
-
 function VectorTileFacilitiesMap({
     resetButtonClickCount,
     clientInfoFetched,
@@ -188,16 +73,19 @@ function VectorTileFacilitiesMap({
     history: {
         push,
     },
+    location,
     facilityDetailsData,
-    errorFetchingFacilityDetailsData,
-    fetchingDetailsData,
     gridColorRamp,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
         data: facilityDetailsData,
-        fetching: fetchingDetailsData,
-        error: errorFetchingFacilityDetailsData,
+        shouldPanMapToFacilityDetails: get(
+            location,
+            'state.panMapToFacilityDetails',
+            false,
+        ),
+        isVectorTileMap: true,
     });
 
     if (!clientInfoFetched) {
@@ -279,13 +167,13 @@ function VectorTileFacilitiesMap({
                 handleMarkerClick={handleMarkerClick}
                 oarID={oarID}
                 pushRoute={push}
-                minZoom={12}
+                minZoom={maxVectorTileFacilitiesGridZoom + 1}
                 maxZoom={22}
             />
             <VectorTileFacilityGridLayer
                 handleCellClick={handleCellClick}
                 minZoom={1}
-                maxZoom={11}
+                maxZoom={maxVectorTileFacilitiesGridZoom}
             />
         </ReactLeafletMap>
     );
@@ -293,7 +181,6 @@ function VectorTileFacilitiesMap({
 
 VectorTileFacilitiesMap.defaultProps = {
     facilityDetailsData: null,
-    errorFetchingFacilityDetailsData: null,
 };
 
 VectorTileFacilitiesMap.propTypes = {
@@ -309,9 +196,12 @@ VectorTileFacilitiesMap.propTypes = {
     history: shape({
         push: func.isRequired,
     }).isRequired,
+    location: shape({
+        state: shape({
+            panMapToFacilityDetails: bool,
+        }),
+    }).isRequired,
     facilityDetailsData: facilityDetailsPropType,
-    errorFetchingFacilityDetailsData: arrayOf(string),
-    fetchingDetailsData: bool.isRequired,
     gridColorRamp: arrayOf(array).isRequired,
 };
 
@@ -321,7 +211,7 @@ function mapStateToProps({
     },
     clientInfo: { fetched, countryCode },
     facilities: {
-        singleFacility: { data, error, fetching },
+        singleFacility: { data },
     },
     vectorTileLayer: {
         gridColorRamp,
@@ -332,8 +222,6 @@ function mapStateToProps({
         clientInfoFetched: fetched,
         countryCode: countryCode || COUNTRY_CODES.default,
         facilityDetailsData: data,
-        errorFetchingFacilityDetailsData: error,
-        fetchingDetailsData: fetching,
         gridColorRamp,
     };
 }

--- a/src/app/src/util/constants.facilitiesMap.js
+++ b/src/app/src/util/constants.facilitiesMap.js
@@ -9,5 +9,6 @@ export const initialCenter = Object.freeze({
 
 export const initialZoom = 2;
 export const minimumZoom = 2;
+export const maxVectorTileFacilitiesGridZoom = 11;
 
 export const detailsZoomLevel = 15;

--- a/src/app/src/util/hooks.js
+++ b/src/app/src/util/hooks.js
@@ -1,0 +1,144 @@
+import { useRef, useEffect, useState } from 'react';
+import get from 'lodash/get';
+import head from 'lodash/head';
+import last from 'lodash/last';
+import delay from 'lodash/delay';
+
+import {
+    detailsZoomLevel,
+    initialZoom,
+    initialCenter,
+    maxVectorTileFacilitiesGridZoom,
+} from './constants.facilitiesMap';
+
+export default function useUpdateLeafletMapImperatively(
+    resetButtonClickCount,
+    {
+        oarID,
+        data,
+        shouldPanMapToFacilityDetails,
+        isVectorTileMap = false,
+    } = {},
+) {
+    const mapRef = useRef(null);
+
+    // Reset the map state when the reset button is clicked.
+    const [
+        currentResetButtonClickCount,
+        setCurrentResetButtonClickCount,
+    ] = useState(resetButtonClickCount);
+
+    useEffect(() => {
+        if (resetButtonClickCount !== currentResetButtonClickCount) {
+            const leafletMap = get(mapRef, 'current.leafletElement', null);
+
+            if (leafletMap) {
+                leafletMap.setView(
+                    initialCenter,
+                    initialZoom,
+                );
+            }
+
+            setCurrentResetButtonClickCount(resetButtonClickCount);
+        }
+    }, [
+        resetButtonClickCount,
+        currentResetButtonClickCount,
+        setCurrentResetButtonClickCount,
+    ]);
+
+    // Set the map view centered on the facility marker, zoomed to level 15
+    // if the user has arrived at the page with a URL including an OAR ID.
+    const [
+        shouldSetViewOnReceivingData,
+        setShouldSetViewOnReceivingData,
+    ] = useState(!!oarID);
+
+    useEffect(() => {
+        if (data && shouldSetViewOnReceivingData) {
+            const leafletMap = get(mapRef, 'current.leafletElement', null);
+            const facilityLocation = get(
+                data,
+                'geometry.coordinates',
+                null,
+            );
+
+            delay(() => {
+                if (leafletMap && facilityLocation) {
+                    const facilityLatLng = {
+                        lng: head(facilityLocation),
+                        lat: last(facilityLocation),
+                    };
+
+                    leafletMap.setView(
+                        facilityLatLng,
+                        detailsZoomLevel,
+                    );
+                }
+            }, 0);
+
+            setShouldSetViewOnReceivingData(false);
+        }
+    }, [
+        data,
+        shouldSetViewOnReceivingData,
+        setShouldSetViewOnReceivingData,
+    ]);
+
+    // Set the map view to center on the facility at zoom level 15 if
+    // the user has clicked on a facility list item in the sidebar for a
+    // facility that is currently off-screen or when the vector tile map
+    // is zoomed out a level low enough to show the grid layer.
+    const [
+        panMapOnGettingFacilityData,
+        setPanMapOnGettingFacilityData,
+    ] = useState(shouldPanMapToFacilityDetails);
+
+    useEffect(() => {
+        if (shouldPanMapToFacilityDetails && !panMapOnGettingFacilityData) {
+            setPanMapOnGettingFacilityData(true);
+        } else if (data && panMapOnGettingFacilityData) {
+            const leafletMap = get(mapRef, 'current.leafletElement', null);
+
+            const facilityLocation = get(
+                data,
+                'geometry.coordinates',
+                null,
+            );
+
+            if (leafletMap && facilityLocation) {
+                const facilityLatLng = {
+                    lng: head(facilityLocation),
+                    lat: last(facilityLocation),
+                };
+
+                const mapBoundsContainsFacility = leafletMap
+                    .getBounds()
+                    .contains(facilityLatLng);
+
+                const currentMapZoomLevel = leafletMap.getZoom();
+
+                const shouldSetMapView = (isVectorTileMap
+                    && (currentMapZoomLevel < maxVectorTileFacilitiesGridZoom + 1))
+                    || !mapBoundsContainsFacility;
+
+                if (shouldSetMapView) {
+                    leafletMap.setView(
+                        facilityLatLng,
+                        detailsZoomLevel,
+                    );
+                }
+            }
+
+            setPanMapOnGettingFacilityData(false);
+        }
+    }, [
+        data,
+        shouldPanMapToFacilityDetails,
+        panMapOnGettingFacilityData,
+        setPanMapOnGettingFacilityData,
+        isVectorTileMap,
+    ]);
+
+    return mapRef;
+}


### PR DESCRIPTION
## Overview

Extract a useUpdateLeafletMapImperatively hook, then use it to adjust
the map components to have the following behavior on selecting a new
facility:

For the non-vector-tile FacilitiesMap:

- [x] if the user clicks on a facility marker, do not pan & zoom to the
facility
- [x] if the user arrives at the map directly from a URL containing an OAR
ID, set the map view on the facility location, zoomed to level 15
- [ ] if the user clicks on a facility in the sidebar, do not pan & zoom to
the facility unless the selected facility is outside of the current map
viewport bbox when the details data returns

For the vector tile map:

- [x] if the user clicks on a facility marker, do not pan & zoom to the
facility
- [x] if the user arrives at the map directly from a URL containing an OAR
ID, set the map view on the facility location, zoomed to level 15
- [x] if the user clicks on a facility in the sidebar and the selected
facility is outside of the bbox OR the zoom level is
within the range in which the facilities grid layer is shown, pan to the
facility and set the zoom level at 15. This ensures that the facility
details marker will be visible even if the map was at grid-layer zoom
levels before

Connects #757 

## Testing Instructions

- serve this branch and use the app both in vector tile and non-vector tile modes to verify that it works according to the cases described above and that it addresses the spirit of #757 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
