### PR TITLE
Remove `promote` endpoint from Swagger docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 
 ### Removed
+- Drop undocumented endpoint from Swagger docs [#803](https://github.com/open-apparel-registry/open-apparel-registry/pull/803)
 
 ### Fixed
 - Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -494,6 +494,9 @@ class FacilitiesAutoSchema(AutoSchema):
         if 'split' in path:
             return None
 
+        if 'promote' in path:
+            return None
+
         return super(FacilitiesAutoSchema, self).get_link(
             path, method, base_url)
 


### PR DESCRIPTION
## Overview

Remove `promote` endpoint from Swagger docs.

Connects #748 

## Demo

![Screen Shot 2019-09-10 at 3 55 34 PM](https://user-images.githubusercontent.com/4165523/64645707-75dd8700-d3e3-11e9-8ae8-d44ca73e2bf6.png)

## Testing Instructions

- serve this branch and verify that the promote endpoint no longer appears in the Swagger docs

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
