### PR TITLE
Escape newline and double-quote characters when downloading CSVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix a bug which prevented the vector tile marker layer from rendering [#782](https://github.com/open-apparel-registry/open-apparel-registry/pull/782)
 - Capture infinite-scroll emitted bug in an ErrorBoundary in order not to crash the map component [#777](https://github.com/open-apparel-registry/open-apparel-registry/pull/777)
 - Correct Facility Parent Company link [#772](https://github.com/open-apparel-registry/open-apparel-registry/pull/772)
+- Escape newline and double-quote characters when downloading CSVs [#809](https://github.com/open-apparel-registry/open-apparel-registry/pull/809)
 
 ### Security
 - Fix several npm security vulnerabilities via GitHub dependabot [#792](https://github.com/open-apparel-registry/open-apparel-registry/pull/792)

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -870,11 +870,11 @@ it('joins a 2-d array into a correctly escaped CSV string', () => {
         ],
         [
             'foo, "bar", baz',
-            'hello, world',
+            'hello,\nworld',
         ],
     ];
     const expectedEscapedArrayMatch =
-        '"foo, bar, baz","hello \"world\""\n"foo, \"bar\", baz","hello, world"\n';
+        '"foo, bar, baz","hello ""world"""\n"foo, ""bar"", baz","hello, world"\n';
     expect(joinDataIntoCSVString(escapedArray)).toBe(expectedEscapedArrayMatch);
 });
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -476,6 +476,9 @@ export const makeResetPasswordConfirmURL = () =>
 
 export const makeUserProfileURL = userID => `/user-profile/${userID}/`;
 
+export const escapeCSVValue = value =>
+    replace(replace(value, /"/g, '""'), /\n/g, ' ');
+
 export const joinDataIntoCSVString = data => data
     .reduce((csvAccumulator, nextRow) => {
         const joinedColumns = nextRow
@@ -485,7 +488,7 @@ export const joinDataIntoCSVString = data => data
                 }
 
                 return rowAccumulator.concat(
-                    '' + '"' + replace(nextColumn, '"', '\"') + '"', // eslint-disable-line
+                    '' + '"' + escapeCSVValue(nextColumn) + '"', // eslint-disable-line
                     ',',
                 );
             }, '');


### PR DESCRIPTION
## Overview

When facilities had these characters in their name or address, download search
results that include them would produce invalid CSVs. We now change the escaping
of double-quotes from using \ to the more standard "" and replace newlines with
a single space to produce a valid CSV.

Connects #808

## Demo

### Before

```
"oar_id","name","address","country_code","country_name","lat","lng"
"CN2019254JV4X4T","TESTING A Newline


 Shoes Incorporated","771 Newline


 Industry, Testing Road 523940","CN","China",22.9640092,113.6989893
"CN20192544WT92D","TESTING B "Quotes" Apparel Co.","153 North "TESTING" road 12345","CN","China",35.86166,104.193397
```

### After
```
"oar_id","name","address","country_code","country_name","lat","lng"
"CN2019254JV4X4T","TESTING A Newline    Shoes Incorporated","771 Newline    Industry, Testing Road 523940","CN","China",22.9640092,113.6989893
"CN20192544WT92D","TESTING B ""Quotes"" Apparel Co.","153 North ""TESTING"" road 12345","CN","China",35.86166,104.193397
```

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

**This assumes the database has been reset with `./scripts/resetdb`**

* Log in as `c2@example.com`
* Upload  [problem-chars.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/3602479/problem-chars.csv.zip)
* Run `./scripts/dbshell` and execute this query to introduce newline characters
```sql
UPDATE api_facilitylistitem
SET raw_data = replace(raw_data, 'Newline', 'Newline' || chr(10))
WHERE facility_list_id = 16 AND row_index = 0;
```
* Fully process the uploaded list.
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Search for the uploaded facilities http://localhost:6543/?q=testing&contributors=2
* Download the CSV and verify that it has properly escaped data

```
"oar_id","name","address","country_code","country_name","lat","lng"
"CN2019254JV4X4T","TESTING A Newline    Shoes Incorporated","771 Newline    Industry, Testing Road 523940","CN","China",22.9640092,113.6989893
"CN20192544WT92D","TESTING B ""Quotes"" Apparel Co.","153 North ""TESTING"" road 12345","CN","China",35.86166,104.193397
```
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
