### PR TITLE
Close Disambiguation Popup on Reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Close Disambiguation Popup on Reset [#812](https://github.com/open-apparel-registry/open-apparel-registry/pull/812)
 
 ### Security
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -185,6 +185,23 @@ function FacilitiesMap({
         setLoadedFacilityOARID,
     ]);
 
+    // Show the disambiguation popup menu when appropriate
+    const [facilitiesToDisambiguate, setFacilitiesToDisambiguate] = useState(
+        null,
+    );
+
+    const handleMultipleFacilitiesClusterMarkerClick = coordinates =>
+        setFacilitiesToDisambiguate(
+            data.features.reduce((acc, nextFeature) => {
+                // If the distance between points is less than the size of an
+                // individual person it is likely a precision error, not a
+                // distinct geocoded point.
+                // https://en.wikipedia.org/wiki/Decimal_degrees#Precision
+                const pointsIntersect = distance(nextFeature, coordinates) < 0.000001;
+                return pointsIntersect ? acc.concat(nextFeature) : acc;
+            }, []),
+        );
+
     // Reset the map state when the reset button is clicked
     const [
         currentResetButtonClickCount,
@@ -206,23 +223,6 @@ function FacilitiesMap({
         currentResetButtonClickCount,
         setCurrentResetButtonClickCount,
     ]);
-
-    // Show the disambiguation popup menu when appropriate
-    const [facilitiesToDisambiguate, setFacilitiesToDisambiguate] = useState(
-        null,
-    );
-
-    const handleMultipleFacilitiesClusterMarkerClick = coordinates =>
-        setFacilitiesToDisambiguate(
-            data.features.reduce((acc, nextFeature) => {
-                // If the distance between points is less than the size of an
-                // individual person it is likely a precision error, not a
-                // distinct geocoded point.
-                // https://en.wikipedia.org/wiki/Decimal_degrees#Precision
-                const pointsIntersect = distance(nextFeature, coordinates) < 0.000001;
-                return pointsIntersect ? acc.concat(nextFeature) : acc;
-            }, []),
-        );
 
     if (!clientInfoFetched) {
         return null;

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -217,11 +217,13 @@ function FacilitiesMap({
             }
 
             setCurrentResetButtonClickCount(resetButtonClickCount);
+            setFacilitiesToDisambiguate(null);
         }
     }, [
         resetButtonClickCount,
         currentResetButtonClickCount,
         setCurrentResetButtonClickCount,
+        setFacilitiesToDisambiguate,
     ]);
 
     if (!clientInfoFetched) {


### PR DESCRIPTION
## Overview

Ensures the disambiguation popup closes when the search is reset for the Cluster (non-Vector Grid) map.

Connects #796 

## Demo

![2019-09-12 13 20 40](https://user-images.githubusercontent.com/1430060/64806062-63d52300-d560-11e9-820f-6bb4a0391142.gif)

## Testing Instructions

* Check out this branch and turn off the vector tile switch `manage waffle_switch vector_tile off`
* Go to [:6543/](http://localhost:6543/) and search for `Saitex`
* Zoom in to the results on the map and click on the markers until you see a disambiguation pop-up
* Go back to the "Search" tab and click `Reset`
  - [x] Ensure the disambiguation pop-up closes

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
