### PR TITLE
Close Disambiguation Popup on New Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Close Disambiguation Popup on Reset [#812](https://github.com/open-apparel-registry/open-apparel-registry/pull/812)
+- Close Disambiguation Popup on New Search [#825](https://github.com/open-apparel-registry/open-apparel-registry/pull/825)
 - Change "Accept" to "Confirm" in About/Processing [#815](https://github.com/open-apparel-registry/open-apparel-registry/pull/815)
 - Regularize vector tile map zoom behavior [#799](https://github.com/open-apparel-registry/open-apparel-registry/pull/799)
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -73,6 +73,7 @@ const unselectedMarkerIcon = createIcon(unselectedMarkerURL);
 const selectedMarkerIcon = createIcon(selectedMarkerURL);
 
 function FacilitiesMap({
+    fetching,
     data,
     navigateToFacilityDetails,
     facilityDetailsData,
@@ -226,6 +227,13 @@ function FacilitiesMap({
         setFacilitiesToDisambiguate,
     ]);
 
+    useEffect(() => {
+        // Close multiple facilities popup on fresh searches
+        if (fetching) {
+            setFacilitiesToDisambiguate(null);
+        }
+    }, [fetching]);
+
     if (!clientInfoFetched) {
         return null;
     }
@@ -358,6 +366,7 @@ FacilitiesMap.defaultProps = {
 };
 
 FacilitiesMap.propTypes = {
+    fetching: bool.isRequired,
     data: facilityCollectionPropType,
     navigateToFacilityDetails: func.isRequired,
     facilityDetailsData: facilityPropType,
@@ -373,7 +382,7 @@ FacilitiesMap.propTypes = {
 
 function mapStateToProps({
     facilities: {
-        facilities: { data },
+        facilities: { fetching, data },
         singleFacility: { data: facilityDetailsData },
     },
     ui: {
@@ -382,6 +391,7 @@ function mapStateToProps({
     clientInfo: { fetched, countryCode },
 }) {
     return {
+        fetching,
         data,
         facilityDetailsData,
         resetButtonClickCount,

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -269,6 +269,13 @@ const VectorTileFacilitiesLayer = ({
         }
     };
 
+    useEffect(() => {
+        // Close multiple facilities popup on fresh searches
+        if (fetching) {
+            closeMultipleFacilitiesPopup();
+        }
+    }, [fetching]);
+
     return (
         <>
             <VectorGrid


### PR DESCRIPTION
## Overview

Similar to 02bd8f3 and #812, this closes the disambiguation popup when a new search is performed. We use `facilities.fetching` as a proxy for telling when a new search has been fired.

Connects #796 

## Demo

In the old map:

![2019-09-20 16 40 50](https://user-images.githubusercontent.com/1430060/65357975-74237880-dbc6-11e9-9a8e-f5bb681952ae.gif)

In the new map:

![2019-09-20 16 44 08](https://user-images.githubusercontent.com/1430060/65357985-784f9600-dbc6-11e9-8548-a32e78843e17.gif)

## Testing Instructions

* Note if `vector_tile` waffle switch is on or off
* Check out this branch and `server`
* Go to the home page and search for "saitex"
* Click through to the markers until you see a disambiguation popup
* Switch the sidebar to search, and search for something else, _without clicking Reset_
  - [x] Ensure the disambiguation popup closes
* Toggle `vector_tile` and run the above test again
  - [x] Ensure the disambiguation popup closes

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
