### PR TITLE
Restyle grid layer legend & display conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add update facility location dashboard page [#814](https://github.com/open-apparel-registry/open-apparel-registry/pull/814)
 
 ### Changed
+- Restyle grid layer legend & show conditionally based on zoom level [#826](https://github.com/open-apparel-registry/open-apparel-registry/pull/826)
 
 ### Deprecated
 

--- a/src/app/src/components/VectorTileGridLegend.jsx
+++ b/src/app/src/components/VectorTileGridLegend.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import COLOURS from '../util/COLOURS';
+
+import { maxVectorTileFacilitiesGridZoom } from '../util/constants.facilitiesMap';
+
+const legendStyles = Object.freeze({
+    legendStyle: Object.freeze({
+        background: 'white',
+        border: `1px solid ${COLOURS.NAVY_BLUE}`,
+        fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+        fontSize: '13px',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '10px',
+    }),
+    legendLabelStyle: Object.freeze({
+        padding: '5px',
+        textTransform: 'uppercase',
+    }),
+    legendCellStyle: Object.freeze({
+        width: '20px',
+        height: '20px',
+        borderRadius: '50%',
+        opacity: '0.8',
+        background: 'red',
+        padding: '5px',
+        margin: '3px',
+    }),
+});
+
+export default function VectorTileGridLegend({
+    currentZoomLevel,
+    gridColorRamp,
+}) {
+    if (
+        !currentZoomLevel ||
+        currentZoomLevel > maxVectorTileFacilitiesGridZoom
+    ) {
+        return null;
+    }
+
+    const legendCell = (background, size) => {
+        const style = Object.assign({}, legendStyles.legendCellStyle, {
+            background,
+            width: `${size}px`,
+            height: `${size}px`,
+        });
+
+        return <div key={background} style={style} />;
+    };
+
+    return (
+        <div id="map-legend" style={legendStyles.legendStyle}>
+            <span style={legendStyles.legendLabelStyle}>Fewer facilities</span>
+            {gridColorRamp.map((colorDef, i, a) =>
+                legendCell(colorDef[1], 20 - 2 * (a.length - 1 - i)))}
+            <span style={legendStyles.legendLabelStyle}>More facilities</span>
+        </div>
+    );
+}


### PR DESCRIPTION
## Overview

- restyle grid layer legend to use circles rather than boxes for the
legend items
- display the grid layer legend only for zoom levels at which the grid
layer is shown

Connects #798 

## Demo

<img width="851" alt="Screen Shot 2019-09-23 at 12 34 16 PM" src="https://user-images.githubusercontent.com/4165523/65444670-87b92400-ddfe-11e9-96a3-052f0b8ed278.png">

## Testing Instructions

- serve this branch with vector tiles switched on and the default facilities data loaded
- verify that the legend now displays only at zoom levels for which the grid layer is also shown and that it disappears when the marker layer is displayed

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
