### PR TITLE
Display alternate locations in facility details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add update facility location dashboard page [#814](https://github.com/open-apparel-registry/open-apparel-registry/pull/814)
+- Display other locations on facility details page [#827](https://github.com/open-apparel-registry/open-apparel-registry/pull/827)
 
 ### Changed
 - Restyle grid layer legend & show conditionally based on zoom level [#826](https://github.com/open-apparel-registry/open-apparel-registry/pull/826)

--- a/src/app/src/components/FacilityDetailsSidebarOtherLocations.jsx
+++ b/src/app/src/components/FacilityDetailsSidebarOtherLocations.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import map from 'lodash/map';
+
+import { makeProfileRouteLink } from '../util/util';
+
+const otherLocationStyles = Object.freeze({
+    listItemStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        paddingLeft: 0,
+    }),
+    spanStyles: Object.freeze({
+        margin: '0 0 5px 0',
+    }),
+});
+
+export default function FacilityDetailsSidebarOtherLocations({ data }) {
+    if (!data || !data.length) {
+        return null;
+    }
+
+    return (
+        <div className="control-panel__group">
+            <h1 className="control-panel__heading">Other locations</h1>
+            <div className="control-panel__body">
+                <ul>
+                    {map(data, location => (
+                        <li
+                            className="word-break"
+                            key={location.contributor_name}
+                        >
+                            <div style={otherLocationStyles.listItemStyles}>
+                                <span style={otherLocationStyles.spanStyles}>
+                                    {location.lng}, {location.lat}
+                                </span>
+                                {location.contributor_id && location.contributor_name && (
+                                    <span
+                                        style={
+                                            otherLocationStyles.spanStyles
+                                        }
+                                    >
+                                        Contributed by{' '}
+                                        <Link
+                                            to={makeProfileRouteLink(
+                                                location.contributor_id,
+                                            )}
+                                            href={makeProfileRouteLink(
+                                                location.contributor_id,
+                                            )}
+                                        >
+                                            {location.contributor_name}
+                                        </Link>
+                                    </span>
+                                )}
+                                {location.notes && (
+                                    <span
+                                        style={otherLocationStyles.spanStyles}
+                                    >
+                                        Notes: {location.notes}
+                                    </span>
+                                )}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Overview

Return other_locations with facility_details including both records from
the FacilityLocations table and also list items which are either
confirmed matches or automatic matches, are on public, active lists, and
have a different geocoded point.

Add tests to demo:

- serializing admin updated locations
- serializing other match locations
- hiding other match locations when the list item's list is inactive or
non-public

Display coordinates as lng, lat

Connects #823

## Demo

![Screen Shot 2019-09-23 at 7 55 07 PM](https://user-images.githubusercontent.com/4165523/65472470-9f65cc00-de41-11e9-8f80-4629c07aaaa2.png)

## Testing Instructions

- get this branch then run `./scripts/test` and verify that the new tests pass (and that they are testing the correct thing)
- sign in as an administrator and update the location for a facility, then visit its details page and verify that you see the other location listed
- sign in as c15@example and confirm the match, then visit the details page for that facility and verify that you see the location listed as depicted above

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
