### PR TITLE
Create base facility history endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add facility history API endpoint [#830](https://github.com/open-apparel-registry/open-apparel-registry/pull/830)
 
 ### Changed
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -40,6 +40,15 @@ class FacilityMergeQueryParams:
     MERGE = 'merge'
 
 
+class FacilityHistoryActions:
+    CREATE = 'CREATE'
+    UPDATE = 'UPDATE'
+    DELETE = 'DELETE'
+    MERGE = 'MERGE'
+    SPLIT = 'SPLIT'
+    OTHER = 'OTHER'
+
+
 class Affiliations:
     BENEFITS_BUSINESS_WORKERS = 'Benefits for Business and Workers (BBW)'
     BETTER_MILLS_PROGRAM = 'Better Mills Program'

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -1,0 +1,149 @@
+from django.db.models import F
+
+from api.constants import ProcessingAction, FacilityHistoryActions
+from api.models import FacilityMatch
+
+
+def create_geojson_diff_for_location_change(entry):
+    return {
+        'old': {
+            'type': 'Point',
+            'coordinates': [
+                entry.prev_record.location.x,
+                entry.prev_record.location.y,
+            ],
+        },
+        'new': {
+            'type': 'Point',
+            'coordinates': [
+                entry.location.x,
+                entry.location.y,
+            ],
+        },
+    }
+
+
+def get_change_diff_for_history_entry(entry):
+    if entry.prev_record is None:
+        return {}
+
+    delta = entry.diff_against(entry.prev_record)
+    changes = {}
+
+    for change in delta.changes:
+        if change.field not in ['created_at', 'updated_at']:
+            changes[change.field] = {
+                'old': change.old,
+                'new': change.new,
+            }
+
+    return changes
+
+
+def create_facility_history_dictionary(entry):
+    updated_at = str(entry.history_date)
+    change_reason = entry.history_change_reason or ''
+    history_type_display = entry.get_history_type_display()
+    changes = get_change_diff_for_history_entry(entry)
+
+    if 'FacilityLocation' in change_reason:
+        changes['location'] = create_geojson_diff_for_location_change(entry)
+
+        return {
+            'updated_at': updated_at,
+            'action': FacilityHistoryActions.UPDATE,
+            'detail': change_reason,
+            'changes': changes,
+        }
+    elif 'Merged with' in change_reason:
+        return {
+            'updated_at': updated_at,
+            'action': FacilityHistoryActions.MERGE,
+            'detail': change_reason,
+            'changes': changes,
+        }
+    elif 'Promoted' in change_reason:
+        changes['location'] = create_geojson_diff_for_location_change(entry)
+
+        return {
+            'updated_at': updated_at,
+            'action': FacilityHistoryActions.UPDATE,
+            'detail': change_reason,
+            'changes': changes,
+        }
+    elif 'Created' in history_type_display:
+        return {
+            'updated_at': updated_at,
+            'action': FacilityHistoryActions.CREATE,
+            'detail': history_type_display,
+            'changes': changes,
+        }
+    elif 'Deleted' in history_type_display:
+        return {
+            'updated_at': updated_at,
+            'action': FacilityHistoryActions.DELETE,
+            'detail': history_type_display,
+            'changes': changes,
+        }
+    else:
+        return {
+            'updated_at': updated_at,
+            'action': FacilityHistoryActions.OTHER,
+            'detail': history_type_display,
+            'changes': changes,
+        }
+
+
+def maybe_get_split_action_time_from_processing_results(item):
+    split_processing_times = [
+        r.get('finished_at', None)
+        for r
+        in item.processing_results
+        if r.get('action', None) == ProcessingAction.SPLIT_FACILITY
+    ]
+
+    return next(iter(split_processing_times), None)
+
+
+def processing_results_has_split_action_for_oar_id(list_item, facility_id):
+    return facility_id in [
+        r.get('previous_facility_oar_id', None)
+        for r
+        in list_item.processing_results
+        if r.get('action', None) == ProcessingAction.SPLIT_FACILITY
+    ]
+
+
+def create_facility_history_list(entries, facility_id):
+    facility_split_entries = [
+        {
+            'updated_at': maybe_get_split_action_time_from_processing_results(
+                m.facility_list_item
+            ),
+            'action': FacilityHistoryActions.SPLIT,
+            'detail': '{} was split from {}'.format(
+                m.facility.id,
+                facility_id,
+            )
+        }
+        for m
+        in FacilityMatch
+        .objects
+        .annotate(
+            processing_results=F('facility_list_item__processing_results'))
+        .extra(
+            where=['processing_results @> \'[{"action": "split_facility"}]\''])
+        if processing_results_has_split_action_for_oar_id(
+            m.facility_list_item,
+            facility_id,
+        )
+    ]
+
+    history_entries = [
+        create_facility_history_dictionary(entry)
+        for entry
+        in entries
+    ]
+
+    return sorted(history_entries + facility_split_entries,
+                  key=lambda entry: entry['updated_at'], reverse=True)

--- a/src/django/api/migrations/0035_add_facility_history_switch.py
+++ b/src/django/api/migrations/0035_add_facility_history_switch.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def create_facility_history_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.create(name='facility_history', active=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0034_facilitylocation'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_facility_history_switch)
+    ]


### PR DESCRIPTION
## Overview

Add migration to create facility_history switch

Add base facility history API endpoint to include entries for the
following actions:

- create
- delete
- merge
- promote
- split
- update location

Add function to log unforeseen errors to Rollbar & return a 404.

Connects #766 

## Demo

![Screen Shot 2019-09-26 at 4 31 21 PM](https://user-images.githubusercontent.com/4165523/65722825-189c3380-e07b-11e9-8068-9ca2351029a3.png)

## Testing Instructions

- serve this branch then run the migration and turn the `facility_history` switch on
- run the tests and verify that they pass
- read the tests and verify that they test the correct things
- try out the merge, split, promote, delete, and update location actions from the app admin dashboard, then use the facility OAR IDs in the facility history endpoint in the Swagger docs to verify that you get the correct response for the OAR IDs

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
