### PR TITLE
Add reports to count API requests and API token creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add update facility location dashboard page [#814](https://github.com/open-apparel-registry/open-apparel-registry/pull/814)
 - Display other locations on facility details page [#827](https://github.com/open-apparel-registry/open-apparel-registry/pull/827)
+- Add reports to count API requests and API token creation [#833](https://github.com/open-apparel-registry/open-apparel-registry/pull/833)
 
 ### Changed
 - Restyle grid layer legend & show conditionally based on zoom level [#826](https://github.com/open-apparel-registry/open-apparel-registry/pull/826)

--- a/src/django/api/reports/api_request_by_user.sql
+++ b/src/django/api/reports/api_request_by_user.sql
@@ -1,0 +1,14 @@
+-- Count the number of API requests made by each user in each month.
+-- Exclude users with openapparel.org or azavea.com email addresses.
+
+SELECT
+  CAST (date_part('month', l.created_at) AS int) AS month,
+  email,
+  COUNT(*) AS api_request_count
+FROM api_requestlog l
+JOIN api_user u ON l.user_id = u.id
+WHERE date_part('month', l.created_at) < date_part('month', now())
+AND NOT u.email LIKE '%openapparel.org%'
+AND NOT u.email LIKE '%azavea.com%'
+GROUP BY date_part('month', l.created_at), email
+ORDER BY date_part('month', l.created_at), email;

--- a/src/django/api/reports/api_requests.sql
+++ b/src/django/api/reports/api_requests.sql
@@ -1,0 +1,14 @@
+-- Count the number of API requests made each month.
+-- Exclude requests made by users with openapparel.org or azavea.com email
+-- addresses.
+
+SELECT
+  CAST (date_part('month', l.created_at) AS int) AS month,
+  COUNT(*) AS api_request_count
+FROM api_requestlog l
+JOIN api_user u ON l.user_id = u.id
+WHERE date_part('month', l.created_at) < date_part('month', now())
+AND NOT u.email LIKE '%openapparel.org%'
+AND NOT u.email LIKE '%azavea.com%'
+GROUP BY date_part('month', l.created_at)
+ORDER BY date_part('month', l.created_at);

--- a/src/django/api/reports/api_tokens.sql
+++ b/src/django/api/reports/api_tokens.sql
@@ -1,0 +1,11 @@
+-- Count the number of API tokens created each month.
+-- NOTE: API tokens can be deleted by users, so the counts returned by this
+-- report will change over time.
+
+SELECT
+  CAST (date_part('month', t.created) AS int) AS month,
+  COUNT(*) AS token_count
+FROM authtoken_token t
+WHERE date_part('month', t.created) < date_part('month', now())
+GROUP BY date_part('month', t.created)
+ORDER BY date_part('month', t.created);


### PR DESCRIPTION


## Overview

Add reports to count API requests and API token creation for quarterly metrics reporting.

Connects  #832

## Testing Instructions

These instructions assume that you have run `./scripts/resetdb`

* Log in as c2@example.com
* Browse http://localhost:6543/profile/2 and create an API token. Copy and save it for later.
* Run `./scripts/manage dbshell` and execute the following query to "backdate" the token
```sql
UPDATE authtoken_token SET created = created - interval '2 months';
```
* Browse http://localhost:8081/admin/reports/api-tokens/ and verify that a token count of `1` appears
* Make an API request
```
curl -H 'Authorization: Token YOUR_TOKEN_HERE' "http://localhost:8081//api/facilities/?pageSize=1
```
* Run `./scripts/manage dbshell` and execute the following query to "backdate" the request
```sql
UPDATE api_requestlog SET created_at = created_at - interval '2 months';
```
* Browse http://localhost:8081/admin/reports/api-requests/ and verify that a request count of `1` appears.
* Browse http://localhost:8081/admin/reports/api-request-by-user/ and verify that that a request count of `1` appears for `c2@example.com`

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
