### PR TITLE
Fix vector tile map crashes on login/logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Close Disambiguation Popup on New Search [#825](https://github.com/open-apparel-registry/open-apparel-registry/pull/825)
 - Change "Accept" to "Confirm" in About/Processing [#815](https://github.com/open-apparel-registry/open-apparel-registry/pull/815)
 - Regularize vector tile map zoom behavior [#799](https://github.com/open-apparel-registry/open-apparel-registry/pull/799)
+- Fix a bug which caused the vector tile map to crash on login/logout [#837](https://github.com/open-apparel-registry/open-apparel-registry/pull/837)
 
 ### Security
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -149,6 +149,7 @@ function VectorTileFacilitiesMap({
                 handleCellClick={handleCellClick}
                 minZoom={1}
                 maxZoom={maxVectorTileFacilitiesGridZoom}
+                zoomLevel={currentMapZoomLevel}
             />
         </ReactLeafletMap>
     );

--- a/src/app/src/components/VectorTileFacilityGridLayer.jsx
+++ b/src/app/src/components/VectorTileFacilityGridLayer.jsx
@@ -59,6 +59,7 @@ const VectorTileFacilityGridLayer = ({
     handleCellClick,
     minZoom,
     maxZoom,
+    zoomLevel,
     gridColorRamp,
 }) => {
     const vectorTileURL = useUpdateTileURL(
@@ -89,12 +90,6 @@ const VectorTileFacilityGridLayer = ({
             maxZoom={maxZoom}
             vectorTileLayerStyles={{
                 facilitygrid(properties) {
-                    const layer = get(
-                        vectorTileLayerRef,
-                        'current.leafletElement',
-                    );
-                    // eslint-disable-next-line no-underscore-dangle
-                    const zoomLevel = layer._map.getZoom();
                     const factor = 2 * Math.max(0, zoomLevel - 4);
                     const count = get(properties, 'count', 0);
                     if (count === 0) {
@@ -137,6 +132,7 @@ VectorTileFacilityGridLayer.propTypes = {
     fetching: bool.isRequired,
     resetButtonClickCount: number.isRequired,
     gridColorRamp: arrayOf(array).isRequired,
+    zoomLevel: number.isRequired,
 };
 
 function mapStateToProps({


### PR DESCRIPTION
## Overview

Fix a bug whereby the vector tile map would crash on logging in or
logging out caused by a missing check to ensure that the map object
existed before calling getZoom. Adjust it to use the stored zoom state
instead.

Connects #822 

## Notes

Fixing this uncovered another quirk whereby we are clearing the existing facilities data on logout, along with the filter settings. This is how the existing map setup also works, so I did not try to address it here and will make another card for fixing it.

## Testing Instructions

- get this branch then sign in and turn on the vector tile map
- try to re-create the bug described in #822 and verify that it has been fixed

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
