### PR TITLE
Remove Visual Artifacts from the Vector Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change "Accept" to "Confirm" in About/Processing [#815](https://github.com/open-apparel-registry/open-apparel-registry/pull/815)
 - Regularize vector tile map zoom behavior [#799](https://github.com/open-apparel-registry/open-apparel-registry/pull/799)
 - Fix a bug which caused the vector tile map to crash on login/logout [#837](https://github.com/open-apparel-registry/open-apparel-registry/pull/837)
+- Remove Visual Artifacts from the Vector Grid [#839](https://github.com/open-apparel-registry/open-apparel-registry/pull/839)
 
 ### Security
 

--- a/src/django/api/tiler.py
+++ b/src/django/api/tiler.py
@@ -36,10 +36,18 @@ def get_facility_grid_vector_tile(params, layer, z, x, y):
         .query \
         .sql_with_params()
 
+    # Exclude geoms on the edges that wrap around the world
+    wrap_filter = (
+        'abs('
+        '   ST_XMax(ST_Envelope(ST_Transform(hex_grid.geom, 4326)))'
+        ' - ST_XMin(ST_Envelope(ST_Transform(hex_grid.geom, 4326)))'
+        ') < 180')
+
     if location_query.find('WHERE') >= 0:
-        where_clause = location_query[location_query.find('WHERE'):]
+        where_clause = location_query[location_query.find('WHERE'):] \
+            + ' AND {} '.format(wrap_filter)
     else:
-        where_clause = ''
+        where_clause = ' WHERE {} '.format(wrap_filter)
 
     join_query = (
         'SELECT '


### PR DESCRIPTION
## Overview

Previously we were generating the hex grid in 4326 so we could more easily compare the location data to it. This caused visual artifacts in some zoom levels.

By creating the hex grid in its native SRID of 3857, and only converting specific instances to 4326 for comparison at the last step, we ensure that there are no visual artifacts.

Connects #801 

## Demo

Previously, we were generating the hex grid in 4326, which looked like this:

![image](https://user-images.githubusercontent.com/1430060/65895071-d32c7e80-e378-11e9-9eb2-a0c4d44a951d.png)

Now we are generating it in 3857, and converting to 4326 only for grouping the locations:

![image (2)](https://user-images.githubusercontent.com/1430060/65895100-e50e2180-e378-11e9-814d-a7a7fb5db6ad.png)

This removes visual artifacts.

![image](https://user-images.githubusercontent.com/1430060/65905582-d03c8880-e38e-11e9-9a51-f15a806b3475.png)

## Notes

~There are some edge cases (literally) of facilities being grouped at the edges, which still need work:~

![image (3)](https://user-images.githubusercontent.com/1430060/65895163-01aa5980-e379-11e9-88f8-359701710ea5.png)

Fixed in 0752dce

## Testing Instructions

* Check out this branch and `server`
* Go to the home page and ensure there are no visual artifacts on the map at different zoom levels
* Ensure the group coloring is still accurate
* Ensure clicking the grid layer still zooms in correctly
* Ensure the factory location layer still works correctly

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
