### PR TITLE
Include match associations and dissociations in facility history response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add facility history API endpoint [#830](https://github.com/open-apparel-registry/open-apparel-registry/pull/830)
 
 ### Changed
+- Include match association records in facility history list [#841](https://github.com/open-apparel-registry/open-apparel-registry/pull/841)
 
 ### Deprecated
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -47,6 +47,8 @@ class FacilityHistoryActions:
     MERGE = 'MERGE'
     SPLIT = 'SPLIT'
     OTHER = 'OTHER'
+    ASSOCIATE = 'ASSOCIATE'
+    DISSOCIATE = 'DISSOCIATE'
 
 
 class Affiliations:

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -4,6 +4,54 @@ from api.constants import ProcessingAction, FacilityHistoryActions
 from api.models import FacilityMatch
 
 
+def create_associate_match_string(facility_str, contributor_str, list_str):
+    return 'Associate facility {} with contributor {} via list {}'.format(
+        facility_str,
+        contributor_str,
+        list_str,
+    )
+
+
+def create_associate_match_change_reason(list_item, facility):
+    return create_associate_match_string(
+        facility.id,
+        list_item.facility_list.contributor.id,
+        list_item.facility_list.id,
+    )
+
+
+def create_associate_match_entry_detail(match, facility_id):
+    return create_associate_match_string(
+        facility_id,
+        match.facility_list_item.facility_list.contributor.name,
+        match.facility_list_item.facility_list.name,
+    )
+
+
+def create_dissociate_match_string(facility_str, contributor_str, list_str):
+    return 'Dissociate facility {} from contributor {} via list {}'.format(
+        facility_str,
+        contributor_str,
+        list_str,
+    )
+
+
+def create_dissociate_match_change_reason(list_item, facility):
+    return create_dissociate_match_string(
+        facility.id,
+        list_item.facility_list.contributor.id,
+        list_item.facility_list.id,
+    )
+
+
+def create_dissociate_match_entry_detail(match, facility_id):
+    return create_dissociate_match_string(
+        facility_id,
+        match.facility_list_item.facility_list.contributor.name,
+        match.facility_list_item.facility_list.name,
+    )
+
+
 def create_geojson_diff_for_location_change(entry):
     return {
         'old': {
@@ -139,11 +187,33 @@ def create_facility_history_list(entries, facility_id):
         )
     ]
 
+    facility_match_entries = [
+        {
+            'updated_at': str(m.updated_at),
+            'action': FacilityHistoryActions.ASSOCIATE
+            if m.is_active else FacilityHistoryActions.DISSOCIATE,
+            'detail': create_associate_match_entry_detail(m, facility_id)
+            if m.is_active else create_dissociate_match_entry_detail(
+                    m,
+                    facility_id,
+            ),
+        }
+        for m
+        in FacilityMatch
+        .history
+        .filter(status__in=[
+            FacilityMatch.CONFIRMED,
+            FacilityMatch.AUTOMATIC,
+        ])
+        .filter(facility_id=facility_id)
+    ]
+
     history_entries = [
         create_facility_history_dictionary(entry)
         for entry
         in entries
     ]
 
-    return sorted(history_entries + facility_split_entries,
+    return sorted(history_entries + facility_split_entries +
+                  facility_match_entries,
                   key=lambda entry: entry['updated_at'], reverse=True)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -126,7 +126,8 @@ class FacilityListCreateTest(APITestCase):
                          previous_list_count + 1)
         self.assertEqual(FacilityListItem.objects.all().count(),
                          previous_item_count + sheet.nrows - 1)
-        items = list(FacilityListItem.objects.all())
+
+        items = list(FacilityListItem.objects.all().order_by('row_index'))
         self.assertEqual(items[0].raw_data, '"{}"'.format(
             '","'.join(sheet.row_values(1))))
 


### PR DESCRIPTION
## Overview

- add facility match associations to facility history record list
- add facility match dissociations to facility history record list

Connects #819

## Testing Instructions

- serve this branch and make sure you've run the data migration from the history endpoint PR
- turn on the facility_history feature
- run the tests to verify that they pass (and that the new tests are testing the correct thing)
- run `./scripts/resetdb` then try out the facility history endpoint for a facility to verify that you see the new association record there
- also try removing a list item and verify that you see it entered as `DISSOCIATE` in the facility's history endpoint

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
