### PR TITLE
Add facility claim data to history response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add facility history API endpoint [#830](https://github.com/open-apparel-registry/open-apparel-registry/pull/830)
 
 ### Changed
+- Include match association records in facility history list [#841](https://github.com/open-apparel-registry/open-apparel-registry/pull/841)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Include match association records in facility history list [#841](https://github.com/open-apparel-registry/open-apparel-registry/pull/841)
+- Include facility claim data in facility history list [#844](https://github.com/open-apparel-registry/open-apparel-registry/pull/844)
 
 ### Deprecated
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -47,6 +47,8 @@ class FacilityHistoryActions:
     MERGE = 'MERGE'
     SPLIT = 'SPLIT'
     OTHER = 'OTHER'
+    ASSOCIATE = 'ASSOCIATE'
+    DISSOCIATE = 'DISSOCIATE'
 
 
 class Affiliations:

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -49,6 +49,9 @@ class FacilityHistoryActions:
     OTHER = 'OTHER'
     ASSOCIATE = 'ASSOCIATE'
     DISSOCIATE = 'DISSOCIATE'
+    CLAIMED = 'CLAIMED'
+    CLAIM_UPDATE = 'CLAIM_UPDATE'
+    CLAIM_REVOKE = 'CLAIM_REVOKE'
 
 
 class Affiliations:

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -1,7 +1,7 @@
 from django.db.models import F
 
 from api.constants import ProcessingAction, FacilityHistoryActions
-from api.models import FacilityMatch
+from api.models import FacilityMatch, FacilityClaim
 
 
 def create_associate_match_string(facility_str, contributor_str, list_str):
@@ -162,6 +162,60 @@ def processing_results_has_split_action_for_oar_id(list_item, facility_id):
     ]
 
 
+def create_facility_claim_entry(claim):
+    if claim.status == FacilityClaim.REVOKED:
+        return {
+            'updated_at': str(claim.updated_at),
+            'action': FacilityHistoryActions.CLAIM_REVOKE,
+            'detail': 'Claim on facility {} by {} was revoked'.format(
+                claim.facility.id,
+                claim.contributor.name,
+            ),
+        }
+
+    if claim.status == FacilityClaim.APPROVED \
+       and claim.prev_record.status == FacilityClaim.PENDING:
+        return {
+            'updated_at': str(claim.updated_at),
+            'action': FacilityHistoryActions.CLAIMED,
+            'detail': 'Facility {} was claimed by {}'.format(
+                claim.facility.id,
+                claim.contributor.name,
+            ),
+        }
+
+    if claim.status == FacilityClaim.APPROVED:
+        public_claim_data_keys = [
+            'facility_description',
+            'facility_name_english',
+            'facility_name_native_language',
+            'facility_minimum_order',
+            'facility_average_lead_time',
+            'facility_workers_count',
+            'facility_female_workers_percentage',
+            'facility_type',
+            'other_facility_type',
+            'facility_affiliations',
+            'facility_product_types',
+            'facility_production_types',
+            'facility_parent_company',
+        ]
+
+        return {
+            'updated_at': str(claim.updated_at),
+            'action': FacilityHistoryActions.CLAIM_UPDATE,
+            'detail': 'Facility {} claim public data was updated'.format(
+                claim.facility.id,
+            ),
+            'changes': {
+                k: v
+                for k, v
+                in get_change_diff_for_history_entry(claim).items()
+                if k in public_claim_data_keys
+            }
+        }
+
+
 def create_facility_history_list(entries, facility_id):
     facility_split_entries = [
         {
@@ -208,6 +262,18 @@ def create_facility_history_list(entries, facility_id):
         .filter(facility_id=facility_id)
     ]
 
+    facility_claim_entries = [
+        create_facility_claim_entry(c)
+        for c
+        in FacilityClaim
+        .history
+        .filter(status__in=[
+            FacilityClaim.APPROVED,
+            FacilityClaim.REVOKED,
+        ])
+        if c.facility.id == facility_id
+    ]
+
     history_entries = [
         create_facility_history_dictionary(entry)
         for entry
@@ -215,5 +281,5 @@ def create_facility_history_list(entries, facility_id):
     ]
 
     return sorted(history_entries + facility_split_entries +
-                  facility_match_entries,
+                  facility_match_entries + facility_claim_entries,
                   key=lambda entry: entry['updated_at'], reverse=True)

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -4,6 +4,54 @@ from api.constants import ProcessingAction, FacilityHistoryActions
 from api.models import FacilityMatch
 
 
+def create_associate_match_string(facility_str, contributor_str, list_str):
+    return 'Associate facility {} with contributor {} via list {}'.format(
+        facility_str,
+        contributor_str,
+        list_str,
+    )
+
+
+def create_associate_match_change_reason(list_item, facility):
+    return create_associate_match_string(
+        facility.id,
+        list_item.facility_list.contributor.id,
+        list_item.facility_list.id,
+    )
+
+
+def create_associate_match_entry_detail(match, facility_id):
+    return create_associate_match_string(
+        facility_id,
+        match.facility_list_item.facility_list.contributor.name,
+        match.facility_list_item.facility_list.name,
+    )
+
+
+def create_dissociate_match_string(facility_str, contributor_str, list_str):
+    return 'Dissociate facility {} from contributor {} via list {}'.format(
+        facility_str,
+        contributor_str,
+        list_str,
+    )
+
+
+def create_dissociate_match_change_reason(list_item, facility):
+    return create_dissociate_match_string(
+        facility.id,
+        list_item.facility_list.contributor.id,
+        list_item.facility_list.id,
+    )
+
+
+def create_dissociate_match_entry_detail(match, facility_id):
+    return create_dissociate_match_string(
+        facility_id,
+        match.facility_list_item.facility_list.contributor.name,
+        match.facility_list_item.facility_list.name,
+    )
+
+
 def create_geojson_diff_for_location_change(entry):
     return {
         'old': {
@@ -139,11 +187,33 @@ def create_facility_history_list(entries, facility_id):
         )
     ]
 
+    facility_match_entries = [
+        {
+            'updated_at': str(m.updated_at),
+            'action': FacilityHistoryActions.ASSOCIATE
+            if m.is_active else FacilityHistoryActions.DISSOCIATE,
+            'detail': create_associate_match_entry_detail(m, facility_id)
+            if m.is_active else create_dissociate_match_entry_detail(
+                    m,
+                    facility_id,
+            ),
+        }
+        for m
+        in FacilityMatch
+        .history
+        .filter(status__in=[
+            FacilityMatch.CONFIRMED,
+            FacilityMatch.AUTOMATIC,
+        ])
+        .filter(facility_id=facility_id)
+    ]
+
     history_entries = [
         create_facility_history_dictionary(entry)
         for entry
         in entries
     ]
 
-    return sorted(history_entries + facility_split_entries,
+    return sorted(history_entries + facility_split_entries +
+                  facility_match_entries,
                   key=lambda entry: entry['updated_at'], reverse=True)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4144,3 +4144,295 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
             len(data),
             4,
         )
+
+    @override_switch('facility_history', active=True)
+    @override_switch('claim_a_facility', active=True)
+    def test_includes_entry_for_claim_approval(self):
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        claim_facility_url = '/api/facilities/{}/claim/'.format(
+            self.facility_two.id,
+        )
+
+        claim_facility_data = {
+            'contact_person': 'contact_person',
+            'job_title': 'job_title',
+            'company_name': 'company_name',
+            'email': 'email@example.com',
+            'phone_number': 1234567,
+            'website': 'https://example.com',
+            'facility_description': 'facility_description',
+            'verification_method': 'verification_method',
+            'preferred_contact_method': 'email',
+        }
+
+        claim_response = self.client.post(
+            claim_facility_url,
+            claim_facility_data,
+        )
+
+        self.assertEqual(
+            claim_response.status_code,
+            200,
+        )
+
+        self.client.logout()
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+
+        claim = FacilityClaim.objects.first()
+
+        approve_claim_url = '/api/facility-claims/{}/approve/'.format(
+            claim.id,
+        )
+
+        approve_claim_response = self.client.post(
+            approve_claim_url,
+            {'reason': 'reason'},
+        )
+
+        self.assertEqual(
+            approve_claim_response.status_code,
+            200,
+        )
+
+        history_response = self.client.get(self.facility_two_history_url)
+
+        self.assertEqual(
+            history_response.status_code,
+            200
+        )
+
+        data = json.loads(history_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'CLAIMED',
+        )
+
+        self.assertEqual(
+            len(data),
+            3,
+        )
+
+    @override_switch('facility_history', active=True)
+    @override_switch('claim_a_facility', active=True)
+    def test_includes_entry_for_claim_revocation(self):
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        claim_facility_url = '/api/facilities/{}/claim/'.format(
+            self.facility_two.id,
+        )
+
+        claim_facility_data = {
+            'contact_person': 'contact_person',
+            'job_title': 'job_title',
+            'company_name': 'company_name',
+            'email': 'email@example.com',
+            'phone_number': 1234567,
+            'website': 'https://example.com',
+            'facility_description': 'facility_description',
+            'verification_method': 'verification_method',
+            'preferred_contact_method': 'email',
+        }
+
+        claim_response = self.client.post(
+            claim_facility_url,
+            claim_facility_data,
+        )
+
+        self.assertEqual(
+            claim_response.status_code,
+            200,
+        )
+
+        self.client.logout()
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+
+        claim = FacilityClaim.objects.first()
+
+        approve_claim_url = '/api/facility-claims/{}/approve/'.format(
+            claim.id,
+        )
+
+        approve_claim_response = self.client.post(
+            approve_claim_url,
+            {'reason': 'reason'},
+        )
+
+        self.assertEqual(
+            approve_claim_response.status_code,
+            200,
+        )
+
+        revoke_claim_url = '/api/facility-claims/{}/revoke/'.format(
+            claim.id,
+        )
+
+        revoke_claim_response = self.client.post(
+            revoke_claim_url,
+            {'reason': 'reason'},
+        )
+
+        self.assertEqual(
+            revoke_claim_response.status_code,
+            200,
+        )
+
+        history_response = self.client.get(self.facility_two_history_url)
+
+        self.assertEqual(
+            history_response.status_code,
+            200
+        )
+
+        data = json.loads(history_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'CLAIM_REVOKE',
+        )
+
+        self.assertEqual(
+            len(data),
+            4,
+        )
+
+    @override_switch('facility_history', active=True)
+    @override_switch('claim_a_facility', active=True)
+    def test_includes_entry_for_public_claimed_facility_data_changes(self):
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        claim_facility_url = '/api/facilities/{}/claim/'.format(
+            self.facility_two.id,
+        )
+
+        claim_facility_data = {
+            'contact_person': 'contact_person',
+            'job_title': 'job_title',
+            'company_name': 'company_name',
+            'email': 'email@example.com',
+            'phone_number': 1234567,
+            'website': 'https://example.com',
+            'facility_description': 'facility_description',
+            'verification_method': 'verification_method',
+            'preferred_contact_method': 'email',
+        }
+
+        claim_response = self.client.post(
+            claim_facility_url,
+            claim_facility_data,
+        )
+
+        self.assertEqual(
+            claim_response.status_code,
+            200,
+        )
+
+        self.client.logout()
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+
+        claim = FacilityClaim.objects.first()
+
+        approve_claim_url = '/api/facility-claims/{}/approve/'.format(
+            claim.id,
+        )
+
+        approve_claim_response = self.client.post(
+            approve_claim_url,
+            {'reason': 'reason'},
+        )
+
+        self.assertEqual(
+            approve_claim_response.status_code,
+            200,
+        )
+
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        update_claim_url = '/api/facility-claims/{}/claimed/'.format(
+            claim.id,
+        )
+
+        update_claim_data = {
+            'id': claim.id,
+            'facility_name_english': 'facility_name_english',
+            'facility_name_native_language': 'facility_name_native_language',
+            'facility_address': 'facility_address',
+            'facility_description': 'facility_description',
+            'facility_phone_number': 1234567,
+            'facility_phone_number_publicly_visible': True,
+            'facility_website': 'https://openapparel.org',
+            'facility_website_publicly_visible': True,
+            'facility_minimum_order_quantity': 10,
+            'facility_average_lead_time': '2 months',
+            'point_of_contact_person_name': 'point_of_contact_person_name',
+            'point_of_contact_email': 'point_of_contact_email',
+            'facility_workers_count': 20,
+            'facility_female_workers_percentage': 50,
+            'point_of_contact_publicly_visible': True,
+            'office_official_name': 'office_official_name',
+            'office_address': 'office_address',
+            'office_country_code': 'US',
+            'office_phone_number': 2345678,
+            'office_info_publicly_visible': True,
+            'facility_type': 'Cut and Sew / RMG',
+        }
+
+        update_claim_response = self.client.put(
+            update_claim_url,
+            update_claim_data,
+        )
+
+        self.assertEqual(
+            update_claim_response.status_code,
+            200,
+        )
+
+        history_response = self.client.get(self.facility_two_history_url)
+
+        self.assertEqual(
+            history_response.status_code,
+            200
+        )
+
+        data = json.loads(history_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'CLAIM_UPDATE',
+        )
+
+        self.assertEqual(
+            len(data),
+            4,
+        )
+
+        non_public_keys = [
+            'facility_website',
+            'facility_website_publicly_visible',
+            'point_of_contact_publicly_visible',
+            'point_of_contact_person_name',
+            'point_of_contact_email',
+            'office_info_publicly_visible',
+            'office_official_name',
+            'office_country_code',
+            'office_address',
+            'office_phone_number',
+        ]
+
+        for non_public_key in non_public_keys:
+            self.assertNotIn(
+                non_public_key,
+                data[0]['changes'],
+            )

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -126,7 +126,8 @@ class FacilityListCreateTest(APITestCase):
                          previous_list_count + 1)
         self.assertEqual(FacilityListItem.objects.all().count(),
                          previous_item_count + sheet.nrows - 1)
-        items = list(FacilityListItem.objects.all())
+
+        items = list(FacilityListItem.objects.all().order_by('row_index'))
         self.assertEqual(items[0].raw_data, '"{}"'.format(
             '","'.join(sheet.row_values(1))))
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -789,7 +789,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
     @transaction.atomic
     def claim(self, request, pk=None):
         if not switch_is_active('claim_a_facility'):
-            return NotFound()
+            raise NotFound()
 
         try:
             facility = Facility.objects.get(pk=pk)


### PR DESCRIPTION
## Overview

Add claim data to history response including:

- claim was approved
- claim was revoked
- claim had some public details changed (excluding non-public and
potentially non-public fields)

Connects #818 

## Notes

Per our discussion I opted to use a whitelist of public claim update field changes to ensure we don't accidentally serialize something non-public. If demand is there for including potentially non-public fields, we can reassess the approach.

## Testing Instructions

- run tests on this branch and verify that they pass
- serve this branch, turn on all the feature flag switches, then:
   - claim a facility
   - approve the claim
   - make some changes
   - revoke the claim

Then use the Swagger docs to request the facility history and verify that you see each action in the response.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
