### PR TITLE
Add associations to history response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add facility history API endpoint [#830](https://github.com/open-apparel-registry/open-apparel-registry/pull/830)
 
 ### Changed
+- Include match association records in facility history list [#851](https://github.com/open-apparel-registry/open-apparel-registry/pull/851)
 
 ### Deprecated
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -47,6 +47,8 @@ class FacilityHistoryActions:
     MERGE = 'MERGE'
     SPLIT = 'SPLIT'
     OTHER = 'OTHER'
+    ASSOCIATE = 'ASSOCIATE'
+    DISSOCIATE = 'DISSOCIATE'
 
 
 class Affiliations:

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -4,6 +4,54 @@ from api.constants import ProcessingAction, FacilityHistoryActions
 from api.models import FacilityMatch
 
 
+def create_associate_match_string(facility_str, contributor_str, list_str):
+    return 'Associate facility {} with contributor {} via list {}'.format(
+        facility_str,
+        contributor_str,
+        list_str,
+    )
+
+
+def create_associate_match_change_reason(list_item, facility):
+    return create_associate_match_string(
+        facility.id,
+        list_item.facility_list.contributor.id,
+        list_item.facility_list.id,
+    )
+
+
+def create_associate_match_entry_detail(match, facility_id):
+    return create_associate_match_string(
+        facility_id,
+        match.facility_list_item.facility_list.contributor.name,
+        match.facility_list_item.facility_list.name,
+    )
+
+
+def create_dissociate_match_string(facility_str, contributor_str, list_str):
+    return 'Dissociate facility {} from contributor {} via list {}'.format(
+        facility_str,
+        contributor_str,
+        list_str,
+    )
+
+
+def create_dissociate_match_change_reason(list_item, facility):
+    return create_dissociate_match_string(
+        facility.id,
+        list_item.facility_list.contributor.id,
+        list_item.facility_list.id,
+    )
+
+
+def create_dissociate_match_entry_detail(match, facility_id):
+    return create_dissociate_match_string(
+        facility_id,
+        match.facility_list_item.facility_list.contributor.name,
+        match.facility_list_item.facility_list.name,
+    )
+
+
 def create_geojson_diff_for_location_change(entry):
     return {
         'old': {
@@ -139,11 +187,33 @@ def create_facility_history_list(entries, facility_id):
         )
     ]
 
+    facility_match_entries = [
+        {
+            'updated_at': str(m.updated_at),
+            'action': FacilityHistoryActions.ASSOCIATE
+            if m.is_active else FacilityHistoryActions.DISSOCIATE,
+            'detail': create_associate_match_entry_detail(m, facility_id)
+            if m.is_active else create_dissociate_match_entry_detail(
+                    m,
+                    facility_id,
+            ),
+        }
+        for m
+        in FacilityMatch
+        .history
+        .filter(status__in=[
+            FacilityMatch.CONFIRMED,
+            FacilityMatch.AUTOMATIC,
+        ])
+        .filter(facility_id=facility_id)
+    ]
+
     history_entries = [
         create_facility_history_dictionary(entry)
         for entry
         in entries
     ]
 
-    return sorted(history_entries + facility_split_entries,
+    return sorted(history_entries + facility_split_entries +
+                  facility_match_entries,
                   key=lambda entry: entry['updated_at'], reverse=True)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -126,7 +126,8 @@ class FacilityListCreateTest(APITestCase):
                          previous_list_count + 1)
         self.assertEqual(FacilityListItem.objects.all().count(),
                          previous_item_count + sheet.nrows - 1)
-        items = list(FacilityListItem.objects.all())
+
+        items = list(FacilityListItem.objects.all().order_by('row_index'))
         self.assertEqual(items[0].raw_data, '"{}"'.format(
             '","'.join(sheet.row_values(1))))
 
@@ -3740,6 +3741,33 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.list_item_two.facility = self.facility_two
         self.list_item_two.save()
 
+        self.list_for_confirm_or_remove = FacilityList \
+            .objects \
+            .create(header='List for confirm or reject',
+                    file_name='list for confirm or reject',
+                    name='List for confirm or reject',
+                    is_active=True,
+                    is_public=True,
+                    contributor=self.contributor)
+
+        self.list_item_for_confirm_or_remove = FacilityListItem \
+            .objects \
+            .create(name='List item for confirmed match',
+                    address='Address for confirmed match',
+                    country_code='US',
+                    facility_list=self.list_for_confirm_or_remove,
+                    row_index=2,
+                    geocoded_point=Point(12, 34),
+                    status=FacilityListItem.POTENTIAL_MATCH)
+
+        self.match_for_confirm_or_remove = FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.PENDING,
+                    facility_list_item=self.list_item_for_confirm_or_remove,
+                    facility=self.facility_two,
+                    confidence=0.65,
+                    results='')
+
         self.facility_two_history_url = '/api/facilities/{}/history/'.format(
             self.facility_two.id
         )
@@ -3769,7 +3797,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            2,
+            4,
         )
 
     @override_switch('facility_history', active=True)
@@ -3809,7 +3837,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            2,
+            3,
         )
 
     @override_switch('facility_history', active=True)
@@ -3838,7 +3866,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            2,
+            3,
         )
 
     @override_switch('facility_history', active=True)
@@ -3913,7 +3941,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            2,
+            3,
         )
 
     @override_switch('facility_history', active=True)
@@ -3963,7 +3991,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            2,
+            3,
         )
 
     @override_switch('facility_history', active=True)
@@ -3971,3 +3999,148 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         invalid_history_url = '/api/facilities/hello/history/'
         invalid_history_response = self.client.get(invalid_history_url)
         self.assertEqual(invalid_history_response.status_code, 404)
+
+    @override_switch('facility_history', active=True)
+    def test_includes_association_for_automatic_match(self):
+        automatic_match_response = self.client.get(
+            self.facility_two_history_url,
+        )
+
+        data = json.loads(automatic_match_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'ASSOCIATE',
+        )
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Associate facility {} with contributor {} via list {}'.format(
+                self.facility_two.id,
+                self.contributor.name,
+                self.list_two.name,
+            ),
+        )
+
+        self.assertEqual(
+            len(data),
+            2,
+        )
+
+    @override_switch('facility_history', active=True)
+    def test_includes_association_for_confirmed_match(self):
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        confirm_url = '/api/facility-lists/{}/confirm/'.format(
+            self.list_for_confirm_or_remove.id,
+        )
+
+        confirm_data = {
+            'list_item_id': self.list_item_for_confirm_or_remove.id,
+            'facility_match_id': self.match_for_confirm_or_remove.id,
+        }
+
+        confirm_response = self.client.post(
+            confirm_url,
+            confirm_data,
+        )
+
+        self.assertEqual(
+            confirm_response.status_code,
+            200,
+        )
+
+        confirmed_match_response = self.client.get(
+            self.facility_two_history_url,
+        )
+
+        data = json.loads(confirmed_match_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'ASSOCIATE',
+        )
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Associate facility {} with contributor {} via list {}'.format(
+                self.facility_two.id,
+                self.contributor.name,
+                self.list_for_confirm_or_remove.name,
+            ),
+        )
+
+        self.assertEqual(
+            len(data),
+            3,
+        )
+
+    @override_switch('facility_history', active=True)
+    def test_includes_dissociation_record_when_match_is_severed(self):
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        confirm_url = '/api/facility-lists/{}/confirm/'.format(
+            self.list_for_confirm_or_remove.id,
+        )
+
+        confirm_data = {
+            'list_item_id': self.list_item_for_confirm_or_remove.id,
+            'facility_match_id': self.match_for_confirm_or_remove.id,
+        }
+
+        confirm_response = self.client.post(
+            confirm_url,
+            confirm_data,
+        )
+
+        self.assertEqual(
+            confirm_response.status_code,
+            200,
+        )
+
+        remove_item_url = '/api/facility-lists/{}/remove/'.format(
+            self.list_for_confirm_or_remove.id,
+        )
+
+        remove_item_data = {
+            'list_item_id': self.list_item_for_confirm_or_remove.id,
+        }
+
+        remove_item_response = self.client.post(
+            remove_item_url,
+            remove_item_data,
+        )
+
+        self.assertEqual(
+            remove_item_response.status_code,
+            200,
+        )
+
+        removed_match_response = self.client.get(
+            self.facility_two_history_url,
+        )
+
+        data = json.loads(removed_match_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'DISSOCIATE',
+        )
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Dissociate facility {} from contributor {} via list {}'.format(
+                self.facility_two.id,
+                self.contributor.name,
+                self.list_for_confirm_or_remove.name,
+            ),
+        )
+
+        self.assertEqual(
+            len(data),
+            4,
+        )


### PR DESCRIPTION
## Overview

- add facility match associations to facility history record list
- add facility match dissociations to facility history record list

Connects #819

## Testing Instructions

- serve this branch and make sure you've run the data migration from the history endpoint PR
- turn on the facility_history feature
- run the tests to verify that they pass (and that the new tests are testing the correct thing)
- run `./scripts/resetdb` then try out the facility history endpoint for a facility to verify that you see the new association record there
- also try removing a list item and verify that you see it entered as `DISSOCIATE` in the facility's history endpoint

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
