### PR TITLE
Enable Waffle switches when running resetdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Include match association records in facility history list [#851](https://github.com/open-apparel-registry/open-apparel-registry/pull/851)
 - Include facility claim data in facility history list [#852](https://github.com/open-apparel-registry/open-apparel-registry/pull/852)
+- Enable Waffle switches when running resetdb [#859](https://github.com/open-apparel-registry/open-apparel-registry/pull/859)
 
 ### Deprecated
 

--- a/scripts/resetdb
+++ b/scripts/resetdb
@@ -21,11 +21,18 @@ function processfixtures() {
     ./scripts/manage processfixtures
 }
 
+function enableswitches() {
+    ./scripts/manage waffle_switch facility_history on
+    ./scripts/manage waffle_switch vector_tile on
+    ./scripts/manage waffle_switch claim_a_facility on
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
         resetdb
+        enableswitches
         processfixtures
     fi
 fi


### PR DESCRIPTION
## Overview

We want all of these features to be on by default when testing because we are
most often going to want to exercises all the available features.

## Testing Instructions

* Run `./scripts/resetdb`
* Browse http://localhost:8081/admin/waffle/switch/ and verify that all the switches are enabled.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
