### PR TITLE
Remove duplicate entries from other locations data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
-Check geocoded_point is not None when serializing other locations [#861](https://github.com/open-apparel-registry/open-apparel-registry/pull/861)
+- Check geocoded_point is not None when serializing other locations [#861](https://github.com/open-apparel-registry/open-apparel-registry/pull/861)
+- Remove duplicate entries from other locations data [#860](https://github.com/open-apparel-registry/open-apparel-registry/pull/860)
 
 ### Security
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -74,6 +74,7 @@ const {
     claimFacilityFacilityInfoStepIsValid,
     anyListItemMatchesAreInactive,
     pluralizeResultsCount,
+    removeDuplicatesFromOtherLocationsData,
 } = require('../util/util');
 
 const {
@@ -1279,4 +1280,95 @@ it('pluralizes a results count correclty, returning null if count is undefined o
     expect(pluralizeResultsCount(1)).toBe('1 result');
     expect(pluralizeResultsCount(0)).toBe('0 results');
     expect(pluralizeResultsCount(200)).toBe('200 results');
+});
+
+it('removes duplicate entries from other locations data', () => {
+    const entryWithNoDuplicates = [
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+        {
+            lat: 2,
+            lng: 2,
+            contributor_id: 2,
+            contributor_name: 'two',
+        },
+    ];
+
+    expect(removeDuplicatesFromOtherLocationsData(entryWithNoDuplicates)).toHaveLength(2);
+
+    const entryWithDuplicate = [
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+    ];
+
+    expect(removeDuplicatesFromOtherLocationsData(entryWithDuplicate)).toHaveLength(1);
+
+    const entryWithDuplicateLocationButDifferentContributor = [
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 2,
+            contributor_name: 'two',
+        },
+    ];
+
+    expect(
+        removeDuplicatesFromOtherLocationsData(entryWithDuplicateLocationButDifferentContributor),
+    ).toHaveLength(2);
+
+    const entryWithDuplicateLocationWithNoContributor = [
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+        {
+            lat: 1,
+            lng: 1,
+        },
+    ];
+
+    expect(
+        removeDuplicatesFromOtherLocationsData(entryWithDuplicateLocationWithNoContributor),
+    ).toHaveLength(1);
+
+    const entryWithDuplicateContributorWithDifferentLocation = [
+        {
+            lat: 1,
+            lng: 1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+        {
+            lat: 1.1,
+            lng: 1.1,
+            contributor_id: 1,
+            contributor_name: 'one',
+        },
+    ];
+
+    expect(
+        removeDuplicatesFromOtherLocationsData(entryWithDuplicateContributorWithDifferentLocation),
+    ).toHaveLength(2);
 });

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -33,6 +33,7 @@ import {
     makeDisputeClaimEmailLink,
     makeApprovedClaimDetailsLink,
     makeProfileRouteLink,
+    removeDuplicatesFromOtherLocationsData,
 } from '../util/util';
 
 import {
@@ -257,7 +258,9 @@ class FacilityDetailSidebar extends Component {
                         </div>
                         {canonicalFacilityLocation}
                         <FacilityDetailsSidebarOtherLocations
-                            data={otherLocationsData}
+                            data={
+                                removeDuplicatesFromOtherLocationsData(otherLocationsData)
+                            }
                         />
                         <FacilityDetailSidebarInfo
                             data={data.properties.other_names}

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -25,6 +25,7 @@ import toInteger from 'lodash/toInteger';
 import keys from 'lodash/keys';
 import pickBy from 'lodash/pickBy';
 import every from 'lodash/every';
+import uniqWith from 'lodash/uniqWith';
 import { isEmail, isURL } from 'validator';
 import { featureCollection, bbox } from '@turf/turf';
 import { saveAs } from 'file-saver';
@@ -633,3 +634,30 @@ export const pluralizeResultsCount = (count) => {
 
     return `${count} results`;
 };
+
+export const removeDuplicatesFromOtherLocationsData = otherLocationsData => uniqWith(
+    otherLocationsData,
+    (location, otherLocation) => {
+        const lat = get(location, 'lat', null);
+        const lng = get(location, 'lng', null);
+        const id = get(location, 'contributor_id', null);
+
+        const otherLat = get(otherLocation, 'lat', null);
+        const otherLng = get(otherLocation, 'lng', null);
+        const otherID = get(otherLocation, 'contributor_id', null);
+
+        if (lat !== otherLat || lng !== otherLng) {
+            return false;
+        }
+
+        if ((!id && otherID) || (id && !otherID)) {
+            return true;
+        }
+
+        if (id === otherID) {
+            return true;
+        }
+
+        return false;
+    },
+);


### PR DESCRIPTION
## Overview

Remove duplicate entries from other locations data using the following
logic:

- if the lat or lng are different, an entry is not a duplicate
- if the lat and lng are the same but the contributor names/ids are
present but not the same, entry is not a duplicate (because we want to
surface that more than one contributor suggested the same location)
- if the lat and lng are the same but one of the entries does not have
contributor name/id data, the entry is a duplicate
- if the lat and lng are the same otherwise, entry is a duplicate

Connects #843 

## Testing Instructions

- get branch, then run `./scripts/test` to verify that the new test passes
- read the new test and verify that it is checking the correct things
- run the app and verify that the alternate locations field now removes duplicates according to the logic described above

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
