### PR TITLE
Check geocoded_point is not None when serializing other locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+Check geocoded_point is not None when serializing other locations [#861](https://github.com/open-apparel-registry/open-apparel-registry/pull/861)
 
 ### Security
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -452,6 +452,7 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
             .filter(is_active=True)
             if l.facility_list_item != facility.created_from
             if l.facility_list_item.geocoded_point != facility.location
+            if l.facility_list_item.geocoded_point is not None
             if l.facility_list_item.facility_list.is_active
             if l.facility_list_item.facility_list.is_public
         ]

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -3584,6 +3584,18 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
                     confidence=0.85,
                     results='')
 
+    def test_excludes_match_if_geocoded_point_is_none(self):
+        self.other_list_item.geocoded_point = None
+        self.other_list_item.save()
+        response = self.client.get(
+            '/api/facilities/{}/'.format(self.facility.id)
+        )
+        data = json.loads(response.content)
+        self.assertEqual(
+            len(data['properties']['other_locations']),
+            0,
+        )
+
     def test_serializes_other_match_location_in_facility_details(self):
         response = self.client.get(
             '/api/facilities/{}/'.format(self.facility.id)


### PR DESCRIPTION
## Overview

Prevents an exception from being raised in the serializer when a list item failed geocoding but was able to be matched to another facility.

Connects #850

## Testing Instructions

* Verify that the unit tests pass

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
