### PR TITLE
Fix facility history entry order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Check geocoded_point is not None when serializing other locations [#861](https://github.com/open-apparel-registry/open-apparel-registry/pull/861)
 - Remove duplicate entries from other locations data [#860](https://github.com/open-apparel-registry/open-apparel-registry/pull/860)
+- Fix facility history entry order [#862](https://github.com/open-apparel-registry/open-apparel-registry/pull/862)
 
 ### Security
 

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -165,7 +165,7 @@ def processing_results_has_split_action_for_oar_id(list_item, facility_id):
 def create_facility_claim_entry(claim):
     if claim.status == FacilityClaim.REVOKED:
         return {
-            'updated_at': str(claim.updated_at),
+            'updated_at': str(claim.history_date),
             'action': FacilityHistoryActions.CLAIM_REVOKE,
             'detail': 'Claim on facility {} by {} was revoked'.format(
                 claim.facility.id,
@@ -176,7 +176,7 @@ def create_facility_claim_entry(claim):
     if claim.status == FacilityClaim.APPROVED \
        and claim.prev_record.status == FacilityClaim.PENDING:
         return {
-            'updated_at': str(claim.updated_at),
+            'updated_at': str(claim.history_date),
             'action': FacilityHistoryActions.CLAIM,
             'detail': 'Facility {} was claimed by {}'.format(
                 claim.facility.id,
@@ -210,7 +210,7 @@ def create_facility_claim_entry(claim):
 
         if any(public_changes):
             return {
-                'updated_at': str(claim.updated_at),
+                'updated_at': str(claim.history_date),
                 'action': FacilityHistoryActions.CLAIM_UPDATE,
                 'detail': 'Facility {} claim public data was updated'.format(
                     claim.facility.id,
@@ -248,7 +248,7 @@ def create_facility_history_list(entries, facility_id):
 
     facility_match_entries = [
         {
-            'updated_at': str(m.updated_at),
+            'updated_at': str(m.history_date),
             'action': FacilityHistoryActions.ASSOCIATE
             if m.is_active else FacilityHistoryActions.DISSOCIATE,
             'detail': create_associate_match_entry_detail(m, facility_id)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4040,6 +4040,34 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         )
 
     @override_switch('facility_history', active=True)
+    def test_associate_appears_after_create_in_history_data(self):
+        history_response = self.client.get(
+            self.history_url,
+        )
+
+        self.assertEqual(
+            history_response.status_code,
+            200,
+        )
+
+        data = json.loads(history_response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'ASSOCIATE',
+        )
+
+        self.assertEqual(
+            data[1]['action'],
+            'CREATE',
+        )
+
+        self.assertEqual(
+            len(data),
+            2,
+        )
+
+    @override_switch('facility_history', active=True)
     def test_includes_association_for_confirmed_match(self):
         self.client.logout()
         self.client.login(email=self.user_email,


### PR DESCRIPTION

## Overview

Use `entry.history_date` value for all facility history entry sort
comparisons to regularize the sort order.

Connects #853 

## Demo

<img width="995" alt="Screen Shot 2019-10-07 at 12 22 23 PM" src="https://user-images.githubusercontent.com/4165523/66329908-5ad83700-e8fd-11e9-8749-3f5336fa28f7.png">

## Testing Instructions

- serve this branch with the facility_history switch on & verify that the CREATE event appears first in the sequence, prior to ASSOCIATE events
- verify that the tests pass

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
