### PR TITLE
Add facility list items uploaded report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add facility list items uploaded report [#865](https://github.com/open-apparel-registry/open-apparel-registry/pull/865)
 
 ### Changed
 

--- a/src/django/api/reports/facility_list_items_uploaded.sql
+++ b/src/django/api/reports/facility_list_items_uploaded.sql
@@ -1,0 +1,13 @@
+-- Count the number of facility list CSV rows uploaded each month.
+
+SELECT
+  CAST (date_part('month', i.created_at) AS int) AS month,
+  CASE WHEN u.email LIKE '%openapparel.org%' THEN 'y' ELSE 'n' END AS is_public_list,
+  COUNT(*) AS item_count
+  FROM api_facilitylistitem i
+         JOIN api_facilitylist l on i.facility_list_id = l.id
+         JOIN api_contributor c ON l.contributor_id = c.id
+         JOIN api_user u ON u.id = c.admin_id
+ WHERE date_part('month', i.created_at) != date_part('month', now())
+ GROUP BY date_part('month', i.created_at), is_public_list
+ ORDER BY date_part('month', i.created_at), is_public_list;


### PR DESCRIPTION
## Overview

Add facility list items uploaded report a for monthly metrics reporting.

Connects #864

## Demo

<img width="769" alt="Screen Shot 2019-10-09 at 11 03 03 AM" src="https://user-images.githubusercontent.com/17363/66507632-66099f00-ea84-11e9-82db-dc3bb84dce38.png">

## Testing Instructions

* Browse http://localhost:8081/admin/reports/. Verify that the Facility List Items Uploaded appears.
* Run the Facility List Items Uploaded report. Verify the SQL logic and verify that the report produces results.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
