### PR TITLE
Add OAR survey dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Implement Source model step 2 [#857](https://github.com/open-apparel-registry/open-apparel-registry/pull/857)
+- Add OAR survey dialog [#869](https://github.com/open-apparel-registry/open-apparel-registry/pull/869)
 
 ### Changed
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -30,6 +30,7 @@ import FeatureFlag from './components/FeatureFlag';
 import ClaimFacility from './components/ClaimFacility';
 import ClaimedFacilities from './components/ClaimedFacilities';
 import AboutClaimedFacilities from './components/AboutClaimedFacilities';
+import SurveyDialogNotification from './components/SurveyDialogNotification';
 
 import './App.css';
 
@@ -213,6 +214,7 @@ class App extends Component {
                             transition={Slide}
                         />
                         <GDPRNotification />
+                        <SurveyDialogNotification />
                     </div>
                 </Router>
             </ErrorBoundary>

--- a/src/app/src/components/SurveyDialogNotification.jsx
+++ b/src/app/src/components/SurveyDialogNotification.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Typography from '@material-ui/core/Typography';
+import constant from 'lodash/constant';
+import attempt from 'lodash/attempt';
+import isError from 'lodash/isError';
+import moment from 'moment';
+
+const surveyURL = 'http://bit.ly/OARSurvey';
+
+const surveyDialogStyles = Object.freeze({
+    containerStyles: Object.freeze({
+        padding: '10px',
+    }),
+    titleStyles: Object.freeze({
+        marginLeft: '10px',
+    }),
+    contentStyles: Object.freeze({
+        fontSize: '20px',
+        margin: '5px 10px 10px 10px',
+    }),
+});
+
+const InvisibleDiv = constant(<div style={{ display: 'none ' }} />);
+
+const surveyEndDate = moment('2019-11-10');
+const currentDate = moment();
+const SURVEY_DIALOG_HAS_BEEN_DISPLAYED = 'SURVEY_DIALOG_HAS_BEEN_DISPLAYED';
+
+const trySetDialogHasBeenDisplayedToLocalStorage = () => attempt(
+    () => window.localStorage.setItem(
+        SURVEY_DIALOG_HAS_BEEN_DISPLAYED,
+        SURVEY_DIALOG_HAS_BEEN_DISPLAYED,
+    ),
+);
+
+const dialogEntryIsNotSavedInLocalStorage = () => {
+    const result = attempt(
+        () => window.localStorage.getItem(SURVEY_DIALOG_HAS_BEEN_DISPLAYED),
+    );
+
+    return isError(result) ? true : !result;
+};
+
+export default function SurveyDialogNotification() {
+    const [dialogIsOpen, setDialogIsOpen] = useState(
+        currentDate.isBefore(surveyEndDate) &&
+            dialogEntryIsNotSavedInLocalStorage(),
+    );
+
+    const closeDialog = () => {
+        trySetDialogHasBeenDisplayedToLocalStorage();
+
+        return setDialogIsOpen(false);
+    };
+
+    return (
+        <Dialog open={dialogIsOpen}>
+            {dialogIsOpen ? (
+                <div style={surveyDialogStyles.containerStyles}>
+                    <DialogTitle style={surveyDialogStyles.titleStyles}>
+                        Help us help you
+                    </DialogTitle>
+                    <DialogContent>
+                        <Typography style={surveyDialogStyles.contentStyles}>
+                            We prioritize developments & new features on the OAR
+                            based on user feedback.
+                        </Typography>
+                        <Typography style={surveyDialogStyles.contentStyles}>
+                            Got something you&#39;d like to see on the tool? Share
+                            your feedback through our survey:{' '}
+                            <a
+                                href={surveyURL}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={closeDialog}
+                            >
+                                {surveyURL}
+                            </a>
+                        </Typography>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={closeDialog}
+                        >
+                            Close
+                        </Button>
+                    </DialogActions>
+                </div>
+            ) : (
+                <InvisibleDiv />
+            )}
+        </Dialog>
+    );
+}


### PR DESCRIPTION
## Overview

Add OAR survey dialog to display if

- the current date is before November 10, 2019
- the user has not already clicked either the close button or the survey
link and that action has been recorded to localStorage

Connects #855 

## Demo

![Screen Shot 2019-10-12 at 9 54 14 AM](https://user-images.githubusercontent.com/4165523/66702504-66997400-ecd6-11e9-89f0-9949da070491.png)

![Screen Shot 2019-10-12 at 9 54 58 AM](https://user-images.githubusercontent.com/4165523/66702508-6a2cfb00-ecd6-11e9-99f0-75e9bb29d2f0.png)

## Testing Instructions

- get this branch, then visit the page and verify that you see the dialog
- verify that clicking either the close button or the link button will:
   - dismiss the dialog
   - set a value to `localstorage` which will prevent the dialog from being seen on subsequent visits
- clear `localStorage`, then update the `surveyEndDate` time to be yesterday
- refresh the page and verify that you do not see the dialog

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
