### PR TITLE
DO NOT MERGE: Test/disable email sending

### DIFF
--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -118,6 +118,7 @@ admin_site.register(models.FacilityList)
 admin_site.register(models.Source, SourceAdmin)
 admin_site.register(models.FacilityListItem, FacilityListItemAdmin)
 admin_site.register(models.Facility, FacilityHistoryAdmin)
+admin_site.register(models.FacilityLocation)
 admin_site.register(models.FacilityMatch, FacilityMatchAdmin)
 admin_site.register(models.FacilityClaim, FacilityClaimAdmin)
 admin_site.register(models.FacilityClaimReviewNote,

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -270,10 +270,11 @@ USE_TZ = True
 
 AWS_DEFAULT_REGION = os.getenv('AWS_DEFAULT_REGION', 'eu-west-1')
 
-if DEBUG:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-else:
-    EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+# if DEBUG:
+#     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# else:
+#     EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
 
 DEFAULT_FROM_EMAIL = os.getenv(
     'DEFAULT_FROM_EMAIL', 'noreply@staging.openapparel.org')


### PR DESCRIPTION
## Overview

Temporarily disable email sending on the staging site by replacing the deployed SES backend with https://docs.djangoproject.com/en/2.2/topics/email/#dummy-backend