### PR TITLE
Use a decimal value for opacity in App.css rather than percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Implement Source model step 3 [#858](https://github.com/open-apparel-registry/open-apparel-registry/pull/858)
 
+### Fixed
+- Use a decimal value for opacity in App.css rather than percent [#891](https://github.com/open-apparel-registry/open-apparel-registry/pull/891)
+
 ## [2.15.0] - 2019-10-14
 ### Added
 - Implement Source model step 2 [#857](https://github.com/open-apparel-registry/open-apparel-registry/pull/857)

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -126,7 +126,7 @@ li.dropdown-list-item button {
   margin-bottom: 16px;
 }
 .form__label {
-  opacity: 100%;
+  opacity: 1;
   color: #000 !important;
   font-weight: 500;
   font-size: 16px;


### PR DESCRIPTION

## Overview

In both staging and production multiple Firefox 70 users were seeing missing labels on the user registration form. The opacity value should be a decimal value between 0 and 1, not a percent. It appears that older versions of Firefox were more lenient.

Connects #890

## Testing Instructions

* Run `./scripts/cibuild`
* Run `./scripts/server`
* Browse https://openapparel.org/auth/register in Firefox 70 and verify that the labels appear.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
