### PR TITLE
Fix AWS Batch submission to use Source ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Use a decimal value for opacity in App.css rather than percent [#891](https://github.com/open-apparel-registry/open-apparel-registry/pull/891)
+- Fix AWS Batch submission to use Source ID [#893](https://github.com/open-apparel-registry/open-apparel-registry/pull/893)
 
 ## [2.15.0] - 2019-10-14
 ### Added

--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -59,7 +59,7 @@ def submit_jobs(environment, facility_list, skip_parse=False):
 
     item_table = FacilityListItem.objects.model._meta.db_table
     results_column = 'processing_results'
-    list_id_column = 'facility_list_id'
+    source_id_column = 'source_id'
 
     def submit_job(action, is_array=False, depends_on=None):
         if depends_on is None:
@@ -91,13 +91,13 @@ def submit_jobs(environment, facility_list, skip_parse=False):
     def append_processing_result(result_dict):
         query = ("UPDATE {item_table} "
                  "SET {results_column} = {results_column} || '{dict_json}' "
-                 "WHERE {list_id_column} = {list_id}")
+                 "WHERE {source_id_column} = {source_id}")
         query = query.format(
             item_table=item_table,
             results_column=results_column,
             dict_json=json.dumps(result_dict),
-            list_id_column=list_id_column,
-            list_id=facility_list.id
+            source_id_column=source_id_column,
+            source_id=facility_list.source.id
         )
         with connection.cursor() as cursor:
             cursor.execute(query)


### PR DESCRIPTION
## Overview

This change was mistakenly omitted from the refactoring commits where we changed all references to `FacilityListItem.facility_list_id` over to `FacilityListItem.source_id`. This was missed in our interactive testing because this code path is only executed when running on AWS.

Connects #892

## Testing Instructions

* Run this branch on staging
* Log in
* Submit a facility list. Verify that it is completely processed.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
