### PR TITLE
Add single facility submission endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add single facility submission endpoint [#896](https://github.com/open-apparel-registry/open-apparel-registry/pull/896)
 
 ### Changed
 - Replace facility history feature switch with feature flag [#881](https://github.com/open-apparel-registry/open-apparel-registry/pull/881)

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -40,6 +40,17 @@ class FacilityMergeQueryParams:
     MERGE = 'merge'
 
 
+class FacilityCreateQueryParams:
+    CREATE = 'create'
+    PUBLIC = 'public'
+
+
+class FeatureGroups:
+    CAN_GET_FACILITY_HISTORY = 'can_get_facility_history'
+    CAN_SUBMIT_FACILITY = 'can_submit_facility'
+    CAN_SUBMIT_PRIVATE_FACILITY = 'can_submit_private_facility'
+
+
 class FacilityHistoryActions:
     CREATE = 'CREATE'
     UPDATE = 'UPDATE'

--- a/src/django/api/management/commands/batch_process.py
+++ b/src/django/api/management/commands/batch_process.py
@@ -6,9 +6,9 @@ from django.db import transaction
 
 from api.constants import ProcessingAction
 from api.models import FacilityList, FacilityListItem
+from api.matching import match_facility_list_items
 from api.processing import (parse_facility_list_item,
                             geocode_facility_list_item,
-                            match_facility_list_items,
                             save_match_details)
 
 LINE_ITEM_ACTIONS = {

--- a/src/django/api/matching.py
+++ b/src/django/api/matching.py
@@ -1,0 +1,421 @@
+import dedupe
+import logging
+import os
+import re
+import threading
+
+from collections import defaultdict
+from datetime import datetime
+from django.conf import settings
+from django.db import transaction
+from django.db.models import Q, Max
+from unidecode import unidecode
+
+from api.models import (Facility,
+                        FacilityList,
+                        FacilityListItem,
+                        HistoricalFacility)
+
+logger = logging.getLogger(__name__)
+
+
+def clean(column):
+    """
+    Remove punctuation and excess whitespace from a value before using it to
+    find matches. This should be the same function used when developing the
+    training data read from training.json as part of train_gazetteer.
+    """
+    column = unidecode(column)
+    column = re.sub('\n', ' ', column)
+    column = re.sub('-', '', column)
+    column = re.sub('/', ' ', column)
+    column = re.sub("'", '', column)
+    column = re.sub(",", '', column)
+    column = re.sub(":", ' ', column)
+    column = re.sub(' +', ' ', column)
+    column = column.strip().strip('"').strip("'").lower().strip()
+    if not column:
+        column = None
+    return column
+
+
+def get_canonical_items():
+    """
+    Fetch all `Facility` items and create a dictionary suitable for use by a
+    Dedupe model.
+
+    Returns:
+    A dictionary. The key is the `Facility` OAR ID. The value is a dictionary
+    of clean field values keyed by field name (country, name, address). A
+    "clean" value is one which has been passed through the `clean` function.
+    """
+    facility_set = Facility.objects.all().extra(
+        select={'country': 'country_code'}).values(
+            'id', 'country', 'name', 'address')
+    return {str(i['id']): {k: clean(i[k]) for k in i if k != 'id'}
+            for i in facility_set}
+
+
+def get_messy_items_from_facility_list(facility_list):
+    """
+    Fetch all `FacilityListItem` objects that belong to the specified
+    `FacilityList` and create a dictionary suitable for use by a Dedupe model.
+
+    Arguments:
+    facility_list -- A `FacilityList`.
+
+    Returns:
+    A dictionary. The key is the `FacilityListItem` ID. The value is a
+    dictionary of clean field values keyed by field name (country, name,
+    address). A "clean" value is one which has been passed through the `clean`
+    function.
+    """
+    facility_list_item_set = facility_list.source.facilitylistitem_set.filter(
+        Q(status=FacilityListItem.GEOCODED)
+        | Q(status=FacilityListItem.GEOCODED_NO_RESULTS)).extra(
+            select={'country': 'country_code'}).values(
+                'id', 'country', 'name', 'address')
+    return {str(i['id']): {k: clean(i[k]) for k in i if k != 'id'}
+            for i in facility_list_item_set}
+
+
+def get_messy_items_for_training(mod_factor=5):
+    """
+    Fetch a subset of `FacilityListItem` objects that have been parsed and are
+    not in an error state.
+
+    Arguments:
+    mod_factor -- Used to partition a subset of `FacilityListItem` records. The
+                  larger the value, the fewer records will be contained in the
+                  subset.
+
+    Returns:
+    A dictionary. The key is the `FacilityListItem` ID. The value is a
+    dictionary of clean field values keyed by field name (country, name,
+    address). A "clean" value is one which has been passed through the `clean`
+    function.
+    """
+    facility_list_item_set = FacilityListItem.objects.exclude(
+        Q(status=FacilityListItem.UPLOADED)
+        | Q(status=FacilityListItem.ERROR)
+        | Q(status=FacilityListItem.ERROR_PARSING)
+        | Q(status=FacilityListItem.ERROR_GEOCODING)
+        | Q(status=FacilityListItem.ERROR_MATCHING)
+    ).extra(
+            select={'country': 'country_code'}).values(
+                'id', 'country', 'name', 'address')
+    records = [record for (i, record) in enumerate(facility_list_item_set)
+               if i % mod_factor == 0]
+    return {str(i['id']): {k: clean(i[k]) for k in i if k != 'id'}
+            for i in records}
+
+
+def train_gazetteer(messy, canonical, model_settings=None, should_index=False):
+    """
+    Train and return a dedupe.Gazetteer using the specified messy and canonical
+    dictionaries. The messy and canonical objects should have the same
+    structure:
+      - The key is a unique ID
+      - The value is another dictionary of field:value pairs. This dictionary
+        must contain at least 'country', 'name', and 'address' keys.
+
+    Reads a training.json file containing positive and negative matches.
+    """
+    if model_settings:
+        gazetteer = dedupe.StaticGazetteer(model_settings)
+    else:
+        fields = [
+            {'field': 'country', 'type': 'Exact'},
+            {'field': 'name', 'type': 'String'},
+            {'field': 'address', 'type': 'String'},
+        ]
+
+        gazetteer = dedupe.Gazetteer(fields)
+        gazetteer.sample(messy, canonical, 15000)
+        training_file = os.path.join(settings.BASE_DIR, 'api', 'data',
+                                     'training.json')
+        with open(training_file) as tf:
+            gazetteer.readTraining(tf)
+        gazetteer.train()
+        gazetteer.cleanupTraining()
+
+    if should_index:
+        index_start = datetime.now()
+        logger.info('Indexing started')
+        gazetteer.index(canonical)
+        index_duration = datetime.now() - index_start
+        logger.info('Indexing finished ({})'.format(index_duration))
+        logger.info('Cleanup training')
+
+    return gazetteer
+
+
+class MatchDefaults:
+    AUTOMATIC_THRESHOLD = 0.8
+    GAZETTEER_THRESHOLD = 0.5
+    RECALL_WEIGHT = 1.0
+
+
+class NoCanonicalRecordsError(Exception):
+    pass
+
+
+def match_items(messy,
+                automatic_threshold=MatchDefaults.AUTOMATIC_THRESHOLD,
+                gazetteer_threshold=MatchDefaults.GAZETTEER_THRESHOLD,
+                recall_weight=MatchDefaults.RECALL_WEIGHT):
+    """
+    Attempt to match each of the "messy" items specified with a "canonical"
+    item.
+
+    This function reads from but does not update the database.
+
+    When an argument description mentions a "clean" value it is referring to a
+    value that has been passed through the `clean` function.
+
+    Arguments:
+    messy -- A dictionary. The key is the unique identifier of each item to be
+             matched. The value is a dictionary of clean field values keyed by
+             field name (country, name, address).
+    automatic_threshold -- A number from 0.0 to 1.0. A match with a confidence
+                           score greater than this value will be assigned
+                           automatically.
+    gazetteer_threshold -- A number from 0.0 to 1.0. A match with a confidence
+                           score between this value and the
+                           `automatic_threshold` will be considers a match that
+                           requires confirmation.
+    recall_weight -- Sets the tradeoff between precision and recall. A value of
+                     1.0 give an equal weight to precision and recall.
+                     https://en.wikipedia.org/wiki/Precision_and_recall
+                     https://docs.dedupe.io/en/latest/Choosing-a-good-threshold.html
+
+    Returns:
+    An dict containing the results of the matching process and contains the
+    following keys:
+
+    processed_list_item_ids -- A list of all the keys in `messy` that were
+                               considered for matching.
+    item_matches -- A dictionary where the keys are `messy` keys and the values
+                    are lists of tuples where the first element is a key from
+                    `canonical` representing an item that is a potential match
+                    and the second element is the confidence score of the
+                    match.
+    results -- A dictionary containing additional information about the
+               matching process that pertains to all the `messy` items and
+               contains the following keys:
+        gazetteer_threshold -- The threshold computed from the trained model
+        automatic_threshold -- The value of the automatic_threshold parameter
+                               returned for convenience
+        recall_weight -- The value of the recall_weight parameter returned for
+                         convenience.
+        code_version -- The value of the GIT_COMMIT setting.
+    started -- The date and time at which the training and matching was
+               started.
+    finished -- The date and time at which the training and matching was
+                finished.
+    """
+    started = str(datetime.utcnow())
+    if len(messy.keys()) > 0:
+        no_geocoded_items = False
+        try:
+            gazetteer = GazetteerCache.get_latest()
+            gazetteer.threshold(messy, recall_weight=recall_weight)
+            results = gazetteer.match(messy, threshold=gazetteer_threshold,
+                                      n_matches=None, generator=True)
+            no_gazetteer_matches = False
+        except NoCanonicalRecordsError:
+            results = []
+            no_gazetteer_matches = True
+        except dedupe.core.BlockingError:
+            results = []
+            no_gazetteer_matches = True
+    else:
+        results = []
+        no_gazetteer_matches = Facility.objects.count() == 0
+        no_geocoded_items = len(messy.keys()) == 0
+
+    finished = str(datetime.utcnow())
+
+    item_matches = defaultdict(list)
+    for matches in results:
+        for (messy_id, canon_id), score in matches:
+            item_matches[messy_id].append((canon_id, score))
+
+    return {
+        'processed_list_item_ids': list(messy.keys()),
+        'item_matches': item_matches,
+        'results': {
+            'no_gazetteer_matches': no_gazetteer_matches,
+            'no_geocoded_items': no_geocoded_items,
+            'gazetteer_threshold': gazetteer_threshold,
+            'automatic_threshold': automatic_threshold,
+            'recall_weight': recall_weight,
+            'code_version': settings.GIT_COMMIT
+        },
+        'started': started,
+        'finished': finished
+    }
+
+
+def match_facility_list_items(
+        facility_list,
+        automatic_threshold=MatchDefaults.AUTOMATIC_THRESHOLD,
+        gazetteer_threshold=MatchDefaults.GAZETTEER_THRESHOLD,
+        recall_weight=MatchDefaults.RECALL_WEIGHT):
+    """
+    Fetch items from the specified `FacilityList` and match them to the current
+    list of facilities.
+
+    Arguments:
+    facility_list -- A FacilityList instance
+    automatic_threshold -- A number from 0.0 to 1.0. A match with a confidence
+                           score greater than this value will be assigned
+                           automatically.
+    gazetteer_threshold -- A number from 0.0 to 1.0. A match with a confidence
+                           score between this value and the
+                           `automatic_threshold` will be considers a match that
+                           requires confirmation.
+    recall_weight -- Sets the tradeoff between precision and recall. A value of
+                     1.0 give an equal weight to precision and recall.
+                     https://en.wikipedia.org/wiki/Precision_and_recall
+                     https://docs.dedupe.io/en/latest/Choosing-a-good-threshold.html
+
+    Returns:
+    See `match_items`.
+
+    """
+    if type(facility_list) != FacilityList:
+        raise ValueError('Argument must be a FacilityList')
+
+    return match_items(get_messy_items_from_facility_list(facility_list),
+                       automatic_threshold=automatic_threshold,
+                       gazetteer_threshold=gazetteer_threshold,
+                       recall_weight=recall_weight)
+
+
+def match_item(country,
+               name,
+               address,
+               id='id',
+               automatic_threshold=MatchDefaults.AUTOMATIC_THRESHOLD,
+               gazetteer_threshold=MatchDefaults.GAZETTEER_THRESHOLD,
+               recall_weight=MatchDefaults.RECALL_WEIGHT):
+    """
+    Match the details of a single facility to the list of existing facilities.
+
+    Arguments:
+    country -- A valid country name or 2-character ISO code.
+    name -- The name of the facility.
+    address -- The address of the facility.
+    id -- The key value in the returned match results.
+    automatic_threshold -- A number from 0.0 to 1.0. A match with a confidence
+                           score greater than this value will be assigned
+                           automatically.
+    gazetteer_threshold -- A number from 0.0 to 1.0. A match with a confidence
+                           score between this value and the
+                           `automatic_threshold` will be considers a match that
+                           requires confirmation.
+    recall_weight -- Sets the tradeoff between precision and recall. A value of
+                     1.0 give an equal weight to precision and recall.
+                     https://en.wikipedia.org/wiki/Precision_and_recall
+                     https://docs.dedupe.io/en/latest/Choosing-a-good-threshold.html
+
+    Returns:
+    See `match_items`.
+    """
+    return match_items(
+        {
+            str(id): {
+                "country": clean(country),
+                "name": clean(name),
+                "address": clean(address)
+            }
+        },
+        automatic_threshold=automatic_threshold,
+        gazetteer_threshold=gazetteer_threshold,
+        recall_weight=recall_weight)
+
+
+def facility_to_dedupe_record(facility):
+    """
+    Convert a `Facility` into a dictionary suitable for training and indexing a
+    Dedupe model.
+
+    Arguments:
+    facility -- A `Facility` object.
+
+    Returns:
+    A dictionary with the `Facility` id as the key and a dictionary of fields
+    as the value.
+    """
+    return {
+        str(facility.id): {
+            "country": clean(facility.country_code),
+            "name": clean(facility.name),
+            "address": clean(facility.address),
+        }
+    }
+
+
+class GazetteerCache:
+    """
+    A container for holding a single, trained and indexed Gazetteer in memory,
+    which is updated with any `Facility` rows that have been added, updated, or
+    removed since the previous call to the `get_latest` class method.
+
+    Note that the first time `get_latest` is called it will be slow, as it
+    needs to train a model and index it with all the `Facility` items.
+    """
+    _lock = threading.Lock()
+    _gazetter = None
+    _version = None
+
+    @classmethod
+    @transaction.atomic
+    def get_latest(cls):
+        with cls._lock:
+            db_version = HistoricalFacility.objects.aggregate(
+                max_id=Max('history_id')).get('max_id')
+            if cls._gazetter is None:
+                canonical = get_canonical_items()
+                if len(canonical.keys()) == 0:
+                    raise NoCanonicalRecordsError()
+                cls._gazetter = train_gazetteer(get_messy_items_for_training(),
+                                                canonical,
+                                                should_index=True)
+                cls._version = db_version
+            if db_version != cls._version:
+                if cls._version is None:
+                    last_version_id = 0
+                else:
+                    last_version_id = cls._version
+                changes = HistoricalFacility \
+                    .objects \
+                    .filter(history_id__gt=last_version_id) \
+                    .order_by('history_id') \
+                    .extra(select={'country': 'country_code'}) \
+                    .values('id', 'country', 'name', 'address',
+                            'history_type')
+                for item in changes:
+                    if item['history_type'] == '-':
+                        cls._gazetter.unindex({
+                            item['id']: {
+                                'country': clean(item['country']),
+                                'name': clean(item['name']),
+                                'address': clean(item['address']),
+                            }
+                        })
+                    else:
+                        # The history record has old field values, so we
+                        # fetch the latest version
+                        try:
+                            facility = Facility.objects.get(id=item['id'])
+                            cls._gazetter.index(
+                                facility_to_dedupe_record(facility))
+                        except Facility.DoesNotExist:
+                            # If the facility no longer exists, just skip
+                            # indexing.
+                            pass
+                cls._version = db_version
+
+        return cls._gazetter

--- a/src/django/api/migrations/0038_add_facility_history_flag.py
+++ b/src/django/api/migrations/0038_add_facility_history_flag.py
@@ -1,15 +1,19 @@
 from django.db import migrations
 
+from api.constants import FeatureGroups
+
 
 def create_can_get_facility_history(apps, schema_editor):
     Group = apps.get_model('auth', 'Group')
-    history_group = Group.objects.create(name='can_get_facility_history')
+    history_group = Group.objects.create(
+        name=FeatureGroups.CAN_GET_FACILITY_HISTORY)
 
     Flag = apps.get_model('waffle', 'Flag')
-    history_flag = Flag.objects.create(name='can_get_facility_history',
-                                       superusers=True,
-                                       staff=False,
-                                       note='Used for history API endpoint authorization')
+    history_flag = Flag.objects.create(
+        name=FeatureGroups.CAN_GET_FACILITY_HISTORY,
+        superusers=True,
+        staff=False,
+        note='Used for history API endpoint authorization')
 
     history_flag.groups.set([history_group])
 

--- a/src/django/api/migrations/0040_add_submit_facility_flag.py
+++ b/src/django/api/migrations/0040_add_submit_facility_flag.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def create_can_submit_facility(apps, schema_editor):
+    Group = apps.get_model('auth', 'Group')
+    submit_facility_group = Group.objects.create(name='can_submit_facility')
+
+    Flag = apps.get_model('waffle', 'Flag')
+    submit_facility_flag = Flag.objects.create(
+        name='can_submit_facility',
+        superusers=True,
+        staff=False,
+        note='Used for single facility submission API endpoint authorization')
+
+    submit_facility_flag.groups.set([submit_facility_group])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0039_delete_facility_history_switch'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_can_submit_facility),
+    ]

--- a/src/django/api/migrations/0041_add_private_facility_flag.py
+++ b/src/django/api/migrations/0041_add_private_facility_flag.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+from api.constants import FeatureGroups
+
+
+def create_can_submit_private_facility(apps, schema_editor):
+    Group = apps.get_model('auth', 'Group')
+    submit_private_facility_group = Group.objects.create(
+        name=FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY)
+
+    Flag = apps.get_model('waffle', 'Flag')
+    submit_private_facility_flag = Flag.objects.create(
+        name=FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY,
+        superusers=True,
+        staff=False,
+        note='Used for private facility submission API param authorization')
+
+    submit_private_facility_flag.groups.set([submit_private_facility_group])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0040_add_submit_facility_flag'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_can_submit_private_facility),
+    ]

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -270,8 +270,9 @@ def save_match_details(match_results):
         })
         item.save()
 
-        for m in matches:
-            m.save()
+        if item.source.create:
+            for m in matches:
+                m.save()
 
     unmatched = (FacilityListItem.objects
                  .filter(id__in=processed_list_item_ids)
@@ -288,19 +289,20 @@ def save_match_details(match_results):
                 'finished_at': finished
             })
         else:
-            facility = Facility(name=item.name,
-                                address=item.address,
-                                country_code=item.country_code,
-                                location=item.geocoded_point,
-                                created_from=item)
-            facility.save()
+            if item.source.create:
+                facility = Facility(name=item.name,
+                                    address=item.address,
+                                    country_code=item.country_code,
+                                    location=item.geocoded_point,
+                                    created_from=item)
+                facility.save()
 
-            match = make_pending_match(item.id, facility.id, 1.0)
-            match.results['match_type'] = 'no_gazetteer_match'
-            match.status = FacilityMatch.AUTOMATIC
-            match.save()
+                match = make_pending_match(item.id, facility.id, 1.0)
+                match.results['match_type'] = 'no_gazetteer_match'
+                match.status = FacilityMatch.AUTOMATIC
+                match.save()
 
-            item.facility = facility
+                item.facility = facility
             item.status = FacilityListItem.MATCHED
             item.processing_results.append({
                 'action': ProcessingAction.MATCH,

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -33,6 +33,7 @@ from api.models import (FacilityList,
                         ProductType,
                         ProductionType)
 from api.countries import COUNTRY_NAMES, COUNTRY_CHOICES
+from api.processing import get_country_code
 from waffle import switch_is_active
 
 
@@ -536,6 +537,18 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
             }
         except FacilityClaim.DoesNotExist:
             return None
+
+
+class FacilityCreateBodySerializer(Serializer):
+    country = CharField(required=True)
+    name = CharField(required=True, max_length=200)
+    address = CharField(required=True, max_length=200)
+
+    def validate_country(self, value):
+        try:
+            return get_country_code(value)
+        except ValueError as ve:
+            raise ValidationError(ve)
 
 
 class FacilityClaimSerializer(ModelSerializer):

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -12,6 +12,7 @@ from rest_framework.serializers import (CharField,
                                         EmailField,
                                         IntegerField,
                                         ListField,
+                                        BooleanField,
                                         ModelSerializer,
                                         SerializerMethodField,
                                         ValidationError,
@@ -549,6 +550,11 @@ class FacilityCreateBodySerializer(Serializer):
             return get_country_code(value)
         except ValueError as ve:
             raise ValidationError(ve)
+
+
+class FacilityCreateQueryParamsSerializer(Serializer):
+    create = BooleanField(default=True, required=False)
+    public = BooleanField(default=True, required=False)
 
 
 class FacilityClaimSerializer(ModelSerializer):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4768,9 +4768,25 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
 
     def test_valid_request_with_params(self):
         self.join_group_and_login()
-        url_with_query = '{}?create=false&public=false'.format(self.url)
+        url_with_query = '{}?create=false&public=true'.format(self.url)
         response = self.client.post(url_with_query, self.valid_facility)
 
+        # TODO: Change to 200 when implemented
+        self.assertEqual(response.status_code, 501)
+
+    def test_private_permission(self):
+        self.join_group_and_login()
+        url_with_query = '{}?public=false'.format(self.url)
+        response = self.client.post(url_with_query, self.valid_facility)
+        self.assertEqual(response.status_code, 403)
+
+        group = auth.models.Group.objects.get(
+            name=FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY,
+        )
+        self.user.groups.add(group.id)
+        self.user.save()
+
+        response = self.client.post(url_with_query, self.valid_facility)
         # TODO: Change to 200 when implemented
         self.assertEqual(response.status_code, 501)
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4762,17 +4762,13 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
     def test_valid_request(self):
         self.join_group_and_login()
         response = self.client.post(self.url, self.valid_facility)
-
-        # TODO: Change to 200 when implemented
-        self.assertEqual(response.status_code, 501)
+        self.assertEqual(response.status_code, 201)
 
     def test_valid_request_with_params(self):
         self.join_group_and_login()
         url_with_query = '{}?create=false&public=true'.format(self.url)
         response = self.client.post(url_with_query, self.valid_facility)
-
-        # TODO: Change to 200 when implemented
-        self.assertEqual(response.status_code, 501)
+        self.assertEqual(response.status_code, 200)
 
     def test_private_permission(self):
         self.join_group_and_login()
@@ -4787,8 +4783,7 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
         self.user.save()
 
         response = self.client.post(url_with_query, self.valid_facility)
-        # TODO: Change to 200 when implemented
-        self.assertEqual(response.status_code, 501)
+        self.assertEqual(response.status_code, 201)
 
 
 class FacilityCreateBodySerializerTest(TestCase):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4695,3 +4695,41 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
             history_response.status_code,
             200,
         )
+
+
+class FacilitySubmitTest(FacilityAPITestCaseBase):
+    def setUp(self):
+        super(FacilitySubmitTest, self).setUp()
+        self.url = reverse('facility-list')
+
+    def test_unauthenticated_receives_401(self):
+        self.client.logout()
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_not_in_group_receives_403(self):
+        self.client.logout()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_in_group_receives_200(self):
+        self.client.logout()
+
+        group = auth.models.Group.objects.get(
+            name='can_submit_facility',
+        )
+
+        self.user.groups.set([group.id])
+        self.user.save()
+
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+        response = self.client.post(self.url)
+
+        # TODO: Change to 200 when implemented
+        self.assertEqual(response.status_code, 501)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -17,7 +17,8 @@ from waffle.testutils import override_switch, override_flag
 
 from api.constants import (ProcessingAction,
                            LogDownloadQueryParams,
-                           UpdateLocationParams)
+                           UpdateLocationParams,
+                           FeatureGroups)
 from api.models import (Facility, FacilityList, FacilityListItem,
                         FacilityClaim, FacilityClaimReviewNote,
                         FacilityMatch, FacilityAlias, Contributor, User,
@@ -3954,7 +3955,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
             self.facility_two.id
         )
 
-    @override_flag('can_get_facility_history', active=True)
+    @override_flag(FeatureGroups.CAN_GET_FACILITY_HISTORY, active=True)
     def test_serializes_deleted_facility_history(self):
         delete_facility_url = '/api/facilities/{}/'.format(self.facility.id)
         delete_response = self.client.delete(delete_facility_url)
@@ -4711,7 +4712,7 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
     def join_group_and_login(self):
         self.client.logout()
         group = auth.models.Group.objects.get(
-            name='can_submit_facility',
+            name=FeatureGroups.CAN_SUBMIT_FACILITY,
         )
         self.user.groups.set([group.id])
         self.user.save()

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -24,9 +24,9 @@ from api.models import (Facility, FacilityList, FacilityListItem,
                         FacilityMatch, FacilityAlias, Contributor, User,
                         RequestLog, DownloadLog, FacilityLocation, Source)
 from api.oar_id import make_oar_id, validate_oar_id
+from api.matching import match_facility_list_items
 from api.processing import (parse_facility_list_item,
-                            geocode_facility_list_item,
-                            match_facility_list_items)
+                            geocode_facility_list_item)
 from api.geocoding import (create_geocoding_params,
                            format_geocoded_address_data,
                            geocode_address)
@@ -1131,7 +1131,7 @@ def interspace(string):
 
 
 def junk_chars(string):
-    return string + 'YY'
+    return 'AA' + string + 'YY'
 
 
 class DedupeMatchingTests(TestCase):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4765,6 +4765,14 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
         # TODO: Change to 200 when implemented
         self.assertEqual(response.status_code, 501)
 
+    def test_valid_request_with_params(self):
+        self.join_group_and_login()
+        url_with_query = '{}?create=false&public=false'.format(self.url)
+        response = self.client.post(url_with_query, self.valid_facility)
+
+        # TODO: Change to 200 when implemented
+        self.assertEqual(response.status_code, 501)
+
 
 class FacilityCreateBodySerializerTest(TestCase):
     def test_valid_data(self):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -51,9 +51,11 @@ from api.constants import (CsvHeaderField,
                            FacilityListQueryParams,
                            FacilityListItemsQueryParams,
                            FacilityMergeQueryParams,
+                           FacilityCreateQueryParams,
                            ProcessingAction,
                            LogDownloadQueryParams,
-                           UpdateLocationParams)
+                           UpdateLocationParams,
+                           FeatureGroups)
 from api.models import (FacilityList,
                         FacilityListItem,
                         FacilityClaim,
@@ -632,7 +634,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         # explicitly invoke our custom permission class.
         if not IsRegisteredAndConfirmed().has_permission(request, self):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
-        if not flag_is_active(request._request, 'can_submit_facility'):
+        if not flag_is_active(request._request,
+                              FeatureGroups.CAN_SUBMIT_FACILITY):
             raise PermissionDenied()
 
         body_serializer = FacilityCreateBodySerializer(data=request.data)
@@ -1275,7 +1278,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                 }
             ]
         """
-        if not flag_is_active(request._request, 'can_get_facility_history'):
+        if not flag_is_active(request._request,
+                              FeatureGroups.CAN_GET_FACILITY_HISTORY):
             raise PermissionDenied()
 
         historical_facility_queryset = Facility.history.filter(id=pk)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -76,6 +76,7 @@ from api.serializers import (FacilityListSerializer,
                              FacilitySerializer,
                              FacilityDetailsSerializer,
                              FacilityCreateBodySerializer,
+                             FacilityCreateQueryParamsSerializer,
                              UserSerializer,
                              UserProfileSerializer,
                              FacilityClaimSerializer,
@@ -636,6 +637,10 @@ class FacilitiesViewSet(mixins.ListModelMixin,
 
         body_serializer = FacilityCreateBodySerializer(data=request.data)
         body_serializer.is_valid(raise_exception=True)
+
+        params_serializer = FacilityCreateQueryParamsSerializer(
+            data=request.query_params)
+        params_serializer.is_valid(raise_exception=True)
 
         return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -75,6 +75,7 @@ from api.serializers import (FacilityListSerializer,
                              FacilityListQueryParamsSerializer,
                              FacilitySerializer,
                              FacilityDetailsSerializer,
+                             FacilityCreateBodySerializer,
                              UserSerializer,
                              UserProfileSerializer,
                              FacilityClaimSerializer,
@@ -632,6 +633,10 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         if not flag_is_active(request._request, 'can_submit_facility'):
             raise PermissionDenied()
+
+        body_serializer = FacilityCreateBodySerializer(data=request.data)
+        body_serializer.is_valid(raise_exception=True)
+
         return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 
     @transaction.atomic

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -644,6 +644,12 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         params_serializer = FacilityCreateQueryParamsSerializer(
             data=request.query_params)
         params_serializer.is_valid(raise_exception=True)
+        public_submission = params_serializer.validated_data[
+            FacilityCreateQueryParams.PUBLIC]
+        private_allowed = flag_is_active(
+            request._request, FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY)
+        if not public_submission and not private_allowed:
+            raise PermissionDenied('Cannot submit a private facility')
 
         return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
 


### PR DESCRIPTION
## Overview

Add single facility submission endpoint.

Connects #820
Connects #872 
Connects #873 

## Demo

### Match response

```js
{
  "matches": [
    {
      "id": "CN2019303BQ3FZP",
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          120.596047,
          32.172013
        ]
      },
      "properties": {
        "name": "Nantong Jackbeanie Headwear Garment Co. Ltd.",
        "address": "No. 808, The Third Industry Park, Guoyuan Town, Rugao City Nantong",
        "country_code": "CN",
        "oar_id": "CN2019303BQ3FZP",
        "other_names": [],
        "other_addresses": [],
        "contributors": [
          {
            "id": 4,
            "name": "Researcher A (Summer 2019 Affiliate List)",
            "is_verified": false
          }
        ],
        "country_name": "China",
        "claim_info": null,
        "other_locations": []
      },
      "confidence": 0.8153
    }
  ],
  "item_id": 964,
  "geocoded_geometry": {
    "type": "Point",
    "coordinates": [
      120.596047,
      32.172013
    ]
  },
  "geocoded_address": "Guoyuanzhen, Rugao, Nantong, Jiangsu, China",
  "status": "MATCHED",
  "oar_id": "CN2019303BQ3FZP"
}
```

### Potential match response

```js
{
  "matches": [
    {
      "id": "CN2019303BQ3FZP",
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          120.596047,
          32.172013
        ]
      },
      "properties": {
        "name": "Nantong Jackbeanie Headwear Garment Co. Ltd.",
        "address": "No. 808, The Third Industry Park, Guoyuan Town, Rugao City Nantong",
        "country_code": "CN",
        "oar_id": "CN2019303BQ3FZP",
        "other_names": [],
        "other_addresses": [],
        "contributors": [
          {
            "id": 4,
            "name": "Researcher A (Summer 2019 Affiliate List)",
            "is_verified": false
          }
        ],
        "country_name": "China",
        "claim_info": null,
        "other_locations": []
      },
      "confidence": 0.7686
    }
  ],
  "item_id": 959,
  "geocoded_geometry": {
    "type": "Point",
    "coordinates": [
      120.596047,
      32.172013
    ]
  },
  "geocoded_address": "Guoyuanzhen, Rugao, Nantong, Jiangsu, China",
  "status": "POTENTIAL_MATCH"
}
```

### New facility response

```js
{
  "matches": [],
  "item_id": 954,
  "geocoded_geometry": {
    "type": "Point",
    "coordinates": [
      119.2221539,
      33.79772
    ]
  },
  "geocoded_address": "30, 32 Yanhuang Ave, Lianshui Xian, Huaian Shi, Jiangsu Sheng, China, 223402",
  "status": "NEW_FACILITY"
}
```

### No match and geocode returned no results response

```js
{
  "matches": [],
  "item_id": 965,
  "geocoded_geometry": null,
  "geocoded_address": null,
  "status": "ERROR_MATCHING"
}
```

## Notes

We are introducing 2 new groups/waffle flags

- `can_submit_facility` controls access to the single-item submission endpoint.
- `can_submit_private_facility` allows passing a `public=false` query string argument.

Implementing the previously unused `create` action on the facilities resource is a natural fit for submitting a single facility record.

The endpoint requires POSTing a JSON body with `name`, `address`, and `country` fields. We reuse the existing validation function from list processing to ensure that the submitted `country` can be converted to acountry code.

In order to support quickly matching individual list items we needed a way of holding a trained and indexed model in memory and keeping it updated as the facility data changed. The new `GazetteerCache` class implements this by holding a trained model in a class variable and reading from the `HistoricalFacility` table to determine whether items need to be added or removed from the index.

The `GazetteerCache` includes a threading lock to ensure that only one thread can ever be updating the cached gazetteer.

Although the management command-based matching uses the new `GazetteerCache` the actual behavior has not changed, since starting a process from scratch will result in training a new model, as we have always done.

As part of this refactor we have also addressed a problem with single item CSV uploads causing the match process run out of memory. We address this by changing the way models are trained. Instead of using the input file, we use 20% of the submitted list items as our "messy" data.

The flow of the `create` view is based on the batch processing pipeline, but all three steps are completed at once. Each stage is wrapped in an individual try block so we can report unexpected failures similar to the batch process.

The "parse" step is combined with the saving of the initial `Source` and `FacilityListItem` records, since the data fields are submitted "pre-parsed." We create `Source` and `FacilityListItem` objects even when the user passes the `create=false` option because we still want to track the submission of the data in the `Source` table and the performance of the matching in the `FacilityListItem.processing_results` field.

We were able to reuse the `save_match_details` function used by the batch processing. The only change we needed to make was to wrap the model save code with a check of the `Source.create` property.

We needed to adjust the facility delete method because submitting high-confidence matches with `create=false` was creating `FacilityListItem` rows with foreign key references to the `Facility`, but not a corresponding `FacilityMatch` row.


## Testing Instructions

### Setup / Regression test batch processing

- Run `./scripts/manage migrate` and `./scripts/resetdb`. Verify that `resetdb` matches models without error and that the dev data is matched correctly.
- Log in as `c8@example.com`, browse http://localhost:6543/lists, and verify that there are some pending matches.
- Submit and process [other-location-test.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/3789808/other-location-test.csv.zip). Verify that the steps complete without error
  - `./scripts/manage batch_process --list-id 16 --action parse`
  - `./scripts/manage batch_process --list-id 16 --action geocode`
  - `./scripts/manage batch_process --list-id 16 --action match`
- Browse http://localhost:6543/lists/16 and verify that there are matches

### Test single item submission

- Still logged in as c8@example.com, browse "My Profile" and create an API token"
- On the Vagrant VM, add the token to your shell environemnt: `export OAR_API_TOKEN={token}`
- Post to the endpoint and verify that it returns 401 / requires auth.
```
http POST http://localhost:8081/api/facilities/?create=false 
```
- Post to the endpoint with auth and verify that it returns 403
```
http POST http://localhost:8081/api/facilities/?create=false \
"Authorization: Token $OAR_API_TOKEN"
```
- Run `./scripts/manage shell_plus` and add the user to the group that allows single-item submission
```
from django.contrib import auth
g = auth.models.Group.objects.get(name='can_submit_facility')
u = User.objects.get(email='c8@example.com')
u.groups.add(g)
u.save()
```
- Post to the endpoint and verify that it returns 400 because a JSON body was not included
```
http POST http://localhost:8081/api/facilities/?create=false \
"Authorization: Token $OAR_API_TOKEN" 
```
- POST with a body and verify a successful response with a status of `NEW_FACILITY`.
```
http POST http://localhost:8081/api/facilities/?create=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, Philadelphia"
}'
```
- POST a near match and verify a successful response with a status of `POTENTIAL_MATCH`
```
http POST http://localhost:8081/api/facilities/?create=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
	"country": "China",
	"name": "Nantong Jackbeanie Headwear & Garment Co. Ltd.",
	"address": "No.808,the third industry park,Guoyuan Town,Nantong 226500."
}'
```
- POST an exact match and verify a successful response with a status of `MATCHED`
```
http POST http://localhost:8081/api/facilities/?create=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
	"country": "China",
	"name": "Nantong Jackbeanie Headwear Garment Co. Ltd.",
	"address": "No. 808, The Third Industry Park, Guoyuan Town, Rugao City Nantong"
}'
```
- POST without the `create=false` argument, verify a successful response, and verify that the "Azavea" facility is now searchable http://localhost:6543/facilities?q=azavea
```
http POST http://localhost:8081/api/facilities/ \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, Philadelphia"
}'
```
- POST a match without `create=false`, verify a successful response, and verify that the contributor with `"id": 8` is listed in the `contributors` array.
```
http POST http://localhost:8081/api/facilities/ \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "Bangladesh",
  "name": "AKH Shirts Ltd.",
  "address": "Savar Dhaka 1340 Bangladesh"
}'
````
- Attempt to POST a facility with `public=false` and verify that a 403 is returned
```
http POST http://localhost:8081/api/facilities/?public=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "Vietnam",
  "name": "28 Hung Phu",
  "address": "No. 168 Quang Trung Street Ward 10 Go Vap District, Hochi Minh"
}'
```
- Run `./scripts/manage shell_plus` and add the user to the group that allows private submission
```
from django.contrib import auth
g = auth.models.Group.objects.get(name='can_submit_private_facility')
u = User.objects.get(email='c8@example.com')
u.groups.add(g)
u.save()
```
- Repeat the POST with `public=false` and verify a successful response with a status of `NEW_FACILITY`
```
http POST http://localhost:8081/api/facilities/?public=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "Vietnam",
  "name": "28 Hung Phu",
  "address": "No. 168 Quang Trung Street Ward 10 Go Vap District, Hochi Minh"
}'
```
- Verify that the facility is searchable http://localhost:6543/facilities?q=hung%20phu and that the details page for the facility does not mention the contributor.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
