### PR TITLE
Allow superusers to change the Contributor of a Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Replace facility history feature switch with feature flag [#881](https://github.com/open-apparel-registry/open-apparel-registry/pull/881)
 - Better accommodate outside contributors [#895](https://github.com/open-apparel-registry/open-apparel-registry/pull/895)
+- Allow superusers to change the Contributor of a Source [#901](https://github.com/open-apparel-registry/open-apparel-registry/pull/901)
 
 ### Deprecated
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -108,7 +108,7 @@ class FacilityAliasAdmin(SimpleHistoryAdmin):
 
 
 class SourceAdmin(admin.ModelAdmin):
-    readonly_fields = ('contributor', 'source_type', 'facility_list', 'create')
+    readonly_fields = ('source_type', 'facility_list', 'create')
 
 
 admin_site.register(models.Version)


### PR DESCRIPTION
## Overview

The ability to transfer the ownership of a "public list" to a contributor after they sign up was lost when we transitioned to using the `Source` model and made the `contributor` field read-only on the admin.

Connects #900

## Demo

<img width="303" alt="Screen Shot 2019-11-04 at 11 59 27 AM" src="https://user-images.githubusercontent.com/17363/68149151-96fdb800-fefa-11e9-868a-d0199682dac9.png">

## Testing Instructions

This assumes you have run `./scripts/resetdb`

* Register a new account.
* Log in as `c1@example.com`
* Browse http://localhost:8081/admin/api/source/2/change/. Verify that the `Contributor` field is a dropdown list.
* Make note of the old contributor, select a different contributor, and save the `Source`. Make note of the new contributor.
* Browse http://localhost:8081/?contributors=2 and verify that there are no results.
* Search for the newly registered contributor account and verify that there are results.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
