### PR TITLE
Handle cases when Source contributor or facility_list are None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove legacy API [#888](https://github.com/open-apparel-registry/open-apparel-registry/pull/888)
 
 ### Fixed
+- Handle cases when Source contributor or facility_list are None [#903](https://github.com/open-apparel-registry/open-apparel-registry/pull/903)
 
 ### Security
 

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -15,16 +15,19 @@ def create_associate_match_string(facility_str, contributor_str, list_str):
 def create_associate_match_change_reason(list_item, facility):
     return create_associate_match_string(
         facility.id,
-        list_item.source.contributor.id,
-        list_item.source.facility_list.id,
+        list_item.source.contributor.id
+        if list_item.source.contributor else '[Unknown]',
+        list_item.source.facility_list.id
+        if list_item.source.facility_list else '[Unknown]',
     )
 
 
 def create_associate_match_entry_detail(match, facility_id):
+    source = match.facility_list_item.source
     return create_associate_match_string(
         facility_id,
-        match.facility_list_item.source.contributor.name,
-        match.facility_list_item.source.facility_list.name,
+        source.contributor.name if source.contributor else '[Unknown]',
+        source.facility_list.name if source.facility_list else '[Unknown]',
     )
 
 
@@ -39,16 +42,19 @@ def create_dissociate_match_string(facility_str, contributor_str, list_str):
 def create_dissociate_match_change_reason(list_item, facility):
     return create_dissociate_match_string(
         facility.id,
-        list_item.source.contributor.id,
-        list_item.source.facility_list.id,
+        list_item.source.contributor.id
+        if list_item.source.contributor else '[Unknown]',
+        list_item.source.facility_list.id
+        if list_item.source.facility_list else '[Unknown]',
     )
 
 
 def create_dissociate_match_entry_detail(match, facility_id):
+    source = match.facility_list_item.source
     return create_dissociate_match_string(
         facility_id,
-        match.facility_list_item.source.contributor.name,
-        match.facility_list_item.source.facility_list.name,
+        source.contributor.name if source.contributor else '[Unknown]',
+        source.facility_list.name if source.facility_list else '[Unknown]',
     )
 
 

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -162,6 +162,7 @@ def send_approved_claim_notice_to_list_contributors(request, facility_claim):
         source.contributor
         for source in
         facility_claim.facility.sources()
+        if source.contributor is not None
     ]
 
     for contributor in list_contributors:
@@ -211,6 +212,7 @@ def send_claim_update_notice_to_list_contributors(request, facility_claim):
         source.contributor
         for source in
         facility_claim.facility.sources()
+        if source.contributor is not None
     ]
 
     for contributor in list_contributors:

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -259,11 +259,11 @@ class Source(models.Model):
 
     @property
     def display_name(self):
+        name = self.contributor.name \
+            if self.contributor else '[Unknown Contributor]'
         if self.facility_list:
-            return '{} ({})'.format(
-                self.contributor.name,
-                self.facility_list.name)
-        return self.contributor.name
+            return '{} ({})'.format(name, self.facility_list.name)
+        return name
 
     def __str__(self):
         return '{0} ({1})'.format(
@@ -306,6 +306,9 @@ class FacilityList(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
+        if self.source.contributor is None:
+            return '{0} ({1})'.format(self.name, self.id)
+
         return '{0} - {1} ({2})'.format(
             self.source.contributor.name, self.name, self.id)
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -349,7 +349,8 @@ class FacilityListSerializer(ModelSerializer):
         }
 
     def get_contributor_id(self, facility_list):
-        return facility_list.source.contributor.id
+        return facility_list.source.contributor.id \
+            if facility_list.source.contributor else None
 
 
 class FacilityQueryParamsSerializer(Serializer):
@@ -456,8 +457,9 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
                 'lng': l.facility_list_item.geocoded_point.x,
                 'contributor_id': l.facility_list_item.source
                 .contributor_id,
-                'contributor_name': l.facility_list_item.source
-                .contributor.name,
+                'contributor_name':
+                l.facility_list_item.source.contributor.name
+                if l.facility_list_item.source.contributor else None,
                 'notes': None,
             }
             for l
@@ -479,9 +481,11 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
     def get_contributors(self, facility):
         return [
             {
-                'id': source.contributor.admin.id,
+                'id': source.contributor.admin.id
+                if source.contributor else None,
                 'name': source.display_name,
-                'is_verified': source.contributor.is_verified,
+                'is_verified': source.contributor.is_verified
+                if source.contributor else False,
             }
             for source
             in facility.sources()

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1380,9 +1380,11 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                         'list_description':
                         m.facility_list_item.source.facility_list.description,
                         'list_contributor_name':
-                        m.facility_list_item.source.contributor.name,
+                        m.facility_list_item.source.contributor.name
+                        if m.facility_list_item.source.contributor else None,
                         'list_contributor_id':
-                        m.facility_list_item.source.contributor.id,
+                        m.facility_list_item.source.contributor.id
+                        if m.facility_list_item.source.contributor else None,
                         'match_id': m.id,
                     }
                     for m
@@ -1525,11 +1527,14 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     'list_name':
                     m.facility_list_item.source.facility_list.name,
                     'list_description':
-                    m.facility_list_item.source.facility_list.description,
+                    m.facility_list_item.source.facility_list.description
+                    if m.facility_list_item.source.facility_list else None,
                     'list_contributor_name':
-                    m.facility_list_item.source.contributor.name,
+                    m.facility_list_item.source.contributor.name
+                    if m.facility_list_item.source.contributor else None,
                     'list_contributor_id':
-                    m.facility_list_item.source.contributor.id,
+                    m.facility_list_item.source.contributor.id
+                    if m.facility_list_item.source.contributor else None,
                     'match_id': m.id,
                 }
                 for m


### PR DESCRIPTION
## Overview

Both of these are nullable fields, so code that references them needs to properly cope with null values to avoid unhandled exceptions.

Connects #885

## Demo

<img width="1093" alt="Screen Shot 2019-11-05 at 7 40 48 AM" src="https://user-images.githubusercontent.com/17363/68218704-0084d180-ffa2-11e9-91e7-6688d4775480.png">

<img width="325" alt="Screen Shot 2019-11-05 at 7 42 44 AM" src="https://user-images.githubusercontent.com/17363/68218705-0084d180-ffa2-11e9-909e-92ba419f440a.png">


## Notes

Testing the new feature adding in `release/2.17.0` was blocked by the fact that we have some null fields in the staging database. The models support null fields, and this has caused problems testing other features, so we are opting to fix the issue as part of the release.

## Testing Instructions

I have made a `test/handle-null-source-and-list` branch based on this branch and deployed it to staging, where there are a lot of deleted contributors.

- Verify that tests pass.
- Visually verify the code for correctness.
- Browse https://staging.openapparel.org/facilities/CN2019283B3FZJR (a facility with a deleted contributor). Verify that it loads without error.
- Browse https://staging.openapparel.org/api/docs/#!/facilities/facilities_get_facility_history. Use the form to get the history for CN2019283B3FZJR and verify that it returns without error.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
