### PR TITLE
Train persistant Dedupe model on first app request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Train persistant Dedupe model on first app request [#905](https://github.com/open-apparel-registry/open-apparel-registry/pull/905/)
 
 ### Deprecated
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -7,7 +7,8 @@ from datetime import datetime
 from functools import reduce
 
 from django.conf import settings
-from django.core.files.uploadedfile import InMemoryUploadedFile
+from django.core.files.uploadedfile import (InMemoryUploadedFile,
+                                            TemporaryUploadedFile)
 from django.db import transaction
 from django.db.models import F, Q
 from django.core import exceptions as core_exceptions
@@ -1747,7 +1748,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         if 'file' not in request.data:
             raise ValidationError('No file specified.')
         csv_file = request.data['file']
-        if type(csv_file) is not InMemoryUploadedFile:
+        if type(csv_file) not in (InMemoryUploadedFile, TemporaryUploadedFile):
             raise ValidationError('File not submitted properly.')
         if csv_file.size > MAX_UPLOADED_FILE_SIZE_IN_BYTES:
             mb = MAX_UPLOADED_FILE_SIZE_IN_BYTES / (1024*1024)

--- a/src/django/oar/startup.py
+++ b/src/django/oar/startup.py
@@ -1,0 +1,24 @@
+import logging
+import os
+import threading
+
+from api.matching import GazetteerCache
+
+logger = logging.getLogger(__name__)
+
+
+def _initialize_gazetteer_cache():
+    logger.info('Initializing the gazetteer cache...')
+    GazetteerCache.get_latest()
+    logger.info('Done initializing the gazetteer cache')
+
+
+def run():
+    # When `SERVER_SOFTWARE` is in the environment, we know that the app has
+    # been loaded from gunicorn, not a management command.
+    if os.environ.get('SERVER_SOFTWARE') is not None:
+        # This run function is called the first time a request is made to the
+        # app. In our deployments this will be the `/heath-check/` endpoint. We
+        # do our model training in a thread so that the request does not
+        # timeout.
+        threading.Thread(target=_initialize_gazetteer_cache).start()

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -25,6 +25,9 @@ from rest_framework import routers
 from rest_framework_swagger.views import get_swagger_view
 
 from oar import settings
+from oar import startup
+
+startup.run()
 
 router = routers.DefaultRouter()
 router.register('facility-lists', views.FacilityListViewSet, 'facility-list')


### PR DESCRIPTION
## Overview

To support the single-item match API we need to hold a trained and indexed Dedupe model in memory. It can take a minute or two to train an index a model. Attempting to do this in a web request resulted in a gunicorn timeout. Gunicorn responds to timeouts by killing and restarting the worker process, which puts us in a failure loop.

In this PR we address the problem by:
- Kicking off model training on the first request of any type, not just a request to the single-item match endpoint. Health check requests start right away, so this effectively starts training as soon as the app is started.
- Spawning a separate thread for model training so that the request that triggered the training can return and avoid a timeout.
- Adding our own timeout logic at the Django level do that we can return 503 Service Unavailable in response to requests that come in before the training is complete.

Connects #820

## Notes

To load test this we needed to upload a large (≅ 20,000) item list, which was raising an unhandled exception. At a certain size, Django switches to providing our view with a `TemporaryUploadedFile` instance instead of an `InMemoryUploadedFile` instance. Correctly handling this was a small change.



## Testing Instructions

* Run `./scripts/resetdb`
* Run `./scripts/manage shell_plus` and update group memberships
```
u = User.objects.get(email='c2@example.com')
u.groups.set(Group.objects.all())
u.save()
```
* Log in as `c2@example.com`
* Upload the ≅ 20,000 item [oar-facilities-contribute-2019-11-04.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/3810375/oar-facilities-contribute-2019-11-04.csv.zip)
* Fully process the list. On my machine, running the steps took between 5 and 10 minutes.
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Start/restart `./scripts/server`
* Run `./scripts/manage showmigrations` and verify that model training information messages are NOT printed.
* Browse http://localhost:6543/profile/2 and generate an API token.
* On the Vagrant VM, add the token to your shell environemnt: `[export OAR_API_TOKEN=]{token}`.
* These next steps require quick timing:
  * Browse http://localhost:8081/health-check/. Verify a quick, successful response. Verify that `Initializing the gazetteer cache...'` is printed in the server console.
  * Immediately make the POST request below and verify that after 10 seconds a 503 is returned.
  * Verify that training completes and `Done initializing the gazetteer cache` is printed to the server console.
  * Repeat the request below and verify a successful response.

```
http POST http://localhost:8081/api/facilities/?create=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, Philadelphia"
}'
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
