### PR TITLE
List inactive or private sources by contributor type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Train persistant Dedupe model on first app request [#905](https://github.com/open-apparel-registry/open-apparel-registry/pull/905/)
+- List inactive or private sources by contributor type [#907](https://github.com/open-apparel-registry/open-apparel-registry/pull/907)
 
 ### Deprecated
 

--- a/src/app/src/components/FacilityDetailSidebarInfo.jsx
+++ b/src/app/src/components/FacilityDetailSidebarInfo.jsx
@@ -38,12 +38,16 @@ const FacilityDetailSidebarInfo = memo(({
                         />
                     </span>
                 </ShowOnly>
-                <Link
-                    to={makeProfileRouteLink(id)}
-                    href={makeProfileRouteLink(id)}
-                >
-                    {name}
-                </Link>
+                {
+                    id ? (
+                        <Link
+                            to={makeProfileRouteLink(id)}
+                            href={makeProfileRouteLink(id)}
+                        >
+                            {name}
+                        </Link>
+                    ) : name
+                }
             </li>
         );
 

--- a/src/django/api/helpers.py
+++ b/src/django/api/helpers.py
@@ -1,0 +1,22 @@
+import re
+
+CONSONANT_SOUND = re.compile(r'''
+one(![ir])
+''', re.IGNORECASE | re.VERBOSE)
+
+VOWEL_SOUND = re.compile(r'''
+[aeio]|
+u([aeiou]|[^n][^aeiou]|ni[^dmnl]|nil[^l])|
+h(ier|onest|onou?r|ors\b|our(!i))|
+[fhlmnrsx]\b
+''', re.IGNORECASE | re.VERBOSE)
+
+
+def prefix_a_an(value):
+    """
+    Return a string prefixed with "a" or "an" as appropriate.
+    Based on https://djangosnippets.org/snippets/1519/
+    """
+    if not CONSONANT_SOUND.match(value) and VOWEL_SOUND.match(value):
+        return 'An {}'.format(value)
+    return 'A {}'.format(value)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1052,6 +1052,7 @@ class FacilityManager(models.Manager):
                 .filter(is_active=True)
                 .filter(facility_list_item__source__contributor__contrib_type__in=contributor_types) # NOQA
                 .filter(facility_list_item__source__is_active=True)
+                .filter(facility_list_item__source__is_public=True)
                 .values('facility__id')
             ]
 
@@ -1069,6 +1070,7 @@ class FacilityManager(models.Manager):
                 .filter(is_active=True)
                 .filter(facility_list_item__source__contributor__id__in=contributors) # NOQA
                 .filter(facility_list_item__source__is_active=True)
+                .filter(facility_list_item__source__is_public=True)
                 .values('facility__id')
             ]
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -492,10 +492,13 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
             return {
                 'name': source,
             }
+        request = self.context.get('request') \
+            if self.context is not None else None
+        user = request.user if request is not None else None
         return [
             format_source(source)
             for source
-            in facility.sources()
+            in facility.sources(user=user)
         ]
 
     def get_country_name(self, facility):
@@ -694,7 +697,8 @@ class ApprovedFacilityClaimSerializer(ModelSerializer):
                   'product_type_choices', 'production_type_choices')
 
     def get_facility(self, claim):
-        return FacilityDetailsSerializer(claim.facility).data
+        return FacilityDetailsSerializer(
+            claim.facility, context=self.context).data
 
     def get_countries(self, claim):
         return COUNTRY_CHOICES

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -32,7 +32,8 @@ from api.models import (FacilityList,
                         User,
                         Contributor,
                         ProductType,
-                        ProductionType)
+                        ProductionType,
+                        Source)
 from api.countries import COUNTRY_NAMES, COUNTRY_CHOICES
 from api.processing import get_country_code
 from waffle import switch_is_active
@@ -479,14 +480,20 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
         return facility_locations + facility_matches
 
     def get_contributors(self, facility):
-        return [
-            {
-                'id': source.contributor.admin.id
-                if source.contributor else None,
-                'name': source.display_name,
-                'is_verified': source.contributor.is_verified
-                if source.contributor else False,
+        def format_source(source):
+            if type(source) is Source:
+                return {
+                    'id': source.contributor.admin.id
+                    if source.contributor else None,
+                    'name': source.display_name,
+                    'is_verified': source.contributor.is_verified
+                    if source.contributor else False,
+                }
+            return {
+                'name': source,
             }
+        return [
+            format_source(source)
             for source
             in facility.sources()
         ]

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4856,6 +4856,13 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
     def setUp(self):
         super(FacilitySearchContributorTest, self).setUp()
         self.url = reverse('facility-list')
+        self.private_user = User.objects.create(email='shh@hush.com')
+        self.private_user_password = 'shhh'
+        self.private_user.set_password(self.private_user_password)
+        self.private_user.groups.set(
+            auth.models.Group.objects.values_list('id', flat=True))
+        self.private_user.save()
+        self.client.logout()
 
     def fetch_facility_contributors(self, facility):
         facility_url = '{}{}/'.format(self.url, facility.id)
@@ -4959,3 +4966,10 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
         contributors = self.fetch_facility_contributors(self.facility)
         self.assertEqual(1, len(contributors))
         self.assertEqual('2 Others', contributors[0].get('name'))
+
+    def test_private_user(self):
+        self.client.login(email=self.private_user.email,
+                          password=self.private_user_password)
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('One Other', contributors[0].get('name'))

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -738,7 +738,26 @@ class FacilityNamesAddressesAndContributorsTest(TestCase):
         sources = self.facility.sources()
         self.assertIn(self.source_one, sources)
         self.assertNotIn(self.source_two, sources)
-        self.assertEqual(len(sources), 1)
+        self.assertIn("One Other", sources)
+        self.assertEqual(len(sources), 2)
+
+        other_names = self.facility.other_names()
+        self.assertNotIn(self.name_two, other_names)
+        self.assertEqual(len(other_names), 0)
+
+        other_addresses = self.facility.other_addresses()
+        self.assertNotIn(self.address_two, other_addresses)
+        self.assertEqual(len(other_addresses), 0)
+
+    def test_excludes_private_matches_from_details(self):
+        self.source_two.is_public = False
+        self.source_two.save()
+
+        sources = self.facility.sources()
+        self.assertIn(self.source_one, sources)
+        self.assertNotIn(self.source_two, sources)
+        self.assertIn("One Other", sources)
+        self.assertEqual(len(sources), 2)
 
         other_names = self.facility.other_names()
         self.assertNotIn(self.name_two, other_names)
@@ -4831,3 +4850,112 @@ class FacilityCreateBodySerializerTest(TestCase):
         })
         self.assertFalse(serializer.is_valid())
         self.assertIn('country', serializer.errors)
+
+
+class FacilitySearchContributorTest(FacilityAPITestCaseBase):
+    def setUp(self):
+        super(FacilitySearchContributorTest, self).setUp()
+        self.url = reverse('facility-list')
+
+    def fetch_facility_contributors(self, facility):
+        facility_url = '{}{}/'.format(self.url, facility.id)
+        response = self.client.get(facility_url)
+        data = json.loads(response.content)
+        return data.get('properties', {}).get('contributors', [])
+
+    def test_names(self):
+        self.source.is_active = False
+        self.source.save()
+
+        self.contributor.contrib_type = 'Auditor'
+        self.contributor.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('An Auditor',
+                         contributors[0].get('name'))
+
+        self.contributor.contrib_type = 'Brand/Retailer'
+        self.contributor.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('A Brand/Retailer',
+                         contributors[0].get('name'))
+
+    def test_inactive_contributor(self):
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('test contributor 1 (First List)',
+                         contributors[0].get('name'))
+
+        self.source.is_active = False
+        self.source.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('One Other', contributors[0].get('name'))
+
+    def test_private_contributor(self):
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('test contributor 1 (First List)',
+                         contributors[0].get('name'))
+
+        self.source.is_public = False
+        self.source.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('One Other', contributors[0].get('name'))
+
+    def test_multiple(self):
+        user_two = User.objects.create(email='2@two.com')
+        user_two.set_password('shhh')
+        user_two.save()
+
+        contributor_two = Contributor \
+            .objects \
+            .create(admin=user_two,
+                    name='test contributor 2',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        source_two = Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    is_active=True,
+                    is_public=True,
+                    contributor=contributor_two)
+
+        list_item_two = FacilityListItem \
+            .objects \
+            .create(name='Item 2',
+                    address='Address',
+                    country_code='US',
+                    row_index=0,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=source_two,
+                    facility=self.facility)
+
+        FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.AUTOMATIC,
+                    facility=self.facility,
+                    facility_list_item=list_item_two,
+                    confidence=0.85,
+                    results='')
+
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(2, len(contributors))
+
+        source_two.is_active = False
+        source_two.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(2, len(contributors))
+        self.assertEqual('test contributor 1 (First List)',
+                         contributors[0].get('name'))
+        self.assertEqual('One Other',
+                         contributors[1].get('name'))
+
+        self.match.is_active = False
+        self.match.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('2 Others', contributors[0].get('name'))

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4973,3 +4973,23 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
         contributors = self.fetch_facility_contributors(self.facility)
         self.assertEqual(1, len(contributors))
         self.assertEqual('One Other', contributors[0].get('name'))
+
+    def test_inactive_or_private_contributor_omitted(self):
+        def get_facility_count():
+            url = '{}?contributors={}'.format(
+                self.url, self.contributor.id)
+            response = self.client.get(url)
+            data = json.loads(response.content)
+            return int(data.get('count'))
+
+        self.assertEqual(1, get_facility_count())
+
+        self.source.is_public = False
+        self.source.is_active = True
+        self.source.save()
+        self.assertEqual(0, get_facility_count())
+
+        self.source.is_public = True
+        self.source.is_active = False
+        self.source.save()
+        self.assertEqual(0, get_facility_count())

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -672,7 +672,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         """
         try:
             queryset = Facility.objects.get(pk=pk)
-            response_data = FacilityDetailsSerializer(queryset).data
+            context = {'request': request}
+            response_data = FacilityDetailsSerializer(
+                queryset, context=context).data
             return Response(response_data)
         except Facility.DoesNotExist:
             raise NotFound()
@@ -950,7 +952,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                 result['status'] = item.status
                 for facility_id, score in matches:
                     facility = Facility.objects.get(id=facility_id)
-                    facility_dict = FacilityDetailsSerializer(facility).data
+                    context = {'request': request}
+                    facility_dict = FacilityDetailsSerializer(
+                        facility, context=context).data
                     # calling `round` alone was not trimming digits
                     facility_dict['confidence'] = float(str(round(score, 4)))
                     if score < automatic_threshold:
@@ -1369,7 +1373,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         merge.delete()
 
         target.refresh_from_db()
-        response_data = FacilityDetailsSerializer(target).data
+        context = {'request': request}
+        response_data = FacilityDetailsSerializer(target, context=context).data
         return Response(response_data)
 
     @action(detail=True, methods=['GET', 'POST'],
@@ -1382,8 +1387,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         try:
             if request.method == 'GET':
                 facility = Facility.objects.get(pk=pk)
-
-                facility_data = FacilityDetailsSerializer(facility).data
+                context = {'request': request}
+                facility_data = FacilityDetailsSerializer(
+                    facility, context=context).data
 
                 facility_data['properties']['matches'] = [
                     {
@@ -1532,8 +1538,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             match.facility_list_item.save()
 
             facility.refresh_from_db()
-
-            facility_data = FacilityDetailsSerializer(facility).data
+            context = {'request': request}
+            facility_data = FacilityDetailsSerializer(
+                facility, context=context).data
 
             facility_data['properties']['matches'] = [
                 {
@@ -1605,7 +1612,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                 facility_location.id)
         facility.save()
 
-        facility_data = FacilityDetailsSerializer(facility).data
+        context = {'request': request}
+        facility_data = FacilityDetailsSerializer(
+            facility, context=context).data
         return Response(facility_data)
 
     @action(detail=True, methods=['GET'],


### PR DESCRIPTION
## Overview

We now list inactive or private sources in facility details but only reveal the contributor type for these sources. Knowing what types of contributors are associated with a facility is meaningful metadata.

As part of our plans for paid API access we are only allowing those who have paid for the ability to submit private data to see full contributor details if they have also submitted some facility data publicly.

Anonymous visitors to the site and free API users will continue to see full contributor details.

We have been filtering by `is_active` to prevent leaking association details when searching by contributor. Now that we are allowing private submissions, we must filter in the same way.

Connects #871

## Demo

<img width="413" alt="Screen Shot 2019-11-07 at 8 04 24 AM" src="https://user-images.githubusercontent.com/17363/68435388-6b880100-0178-11ea-9f00-f898f9801dac.png">


<img width="415" alt="Screen Shot 2019-11-07 at 8 04 40 AM" src="https://user-images.githubusercontent.com/17363/68435384-6925a700-0178-11ea-972f-91691da401d6.png">

## Testing Instructions

* Run `./scripts/resetdb`
* Browse http://localhost:6543/?q=regina and select the facility in Shenzhen. Copy the OAR ID.
* Follow one on the links under "Contributors:" and copy the profile ID from the URL
* Log in with the account corresponding to the profile ID: `c{profile-id}@example.com`
* Browse http://localhost:6543/lists and select the single list.
* Search the list for "regina" and click "REMOVE" on the matching item.
* Click the linked facility name on to return to the facility details page. Confirm that under "Contributors:" the contributor is now displayed as just the contributor type and is not a link.
* Copy this contributor type
* Restart `./scripts/server/` (to get around a problem with console output not appearing) 
* Register and confirm a new account with the same contributor type. The confirmation email link should appear in the server console.
* Create an API key for the new account. On the vagrant VM, export the token into the environment `export OAR_API_TOKEN={token}`
* Add the newly created account to all the permission groups
```
u = User.objects.get(id=101)
u.groups.set(Group.objects.values_list('id', flat=True))
u.save()
```
* Browse the details page for the "regina" facility. Verify that all the contributors are now shown as just their contributor types.
* POST a new private facility match. Verify a successful response
```
http POST http://localhost:8081/api/facilities/?public=false \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
    "country": "China",
    "name": "Regina Miracle Intimate Apparel (Shenzhen) Ltd.",
    "address": "No. 5 Cengyao Industrial Estate, Yulu, Gongming, BaoAn, Shenzhen, Guangdong 518106"
}'
```
* Refresh the facility details page and verify that there is now an item under "Contributors:" that reads "2 {plural contributor type}"
* Submit a public facility. Verify a successful response.
```
http POST http://localhost:8081/api/facilities/ \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, Philadelphia"
}'
```
* Refresh the "regina" facility detail page. Verify that the full details of 2 contributors are now visible.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
