### PR TITLE
Properly handle null contributors in Facility.sources

### DIFF
--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4949,6 +4949,31 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
                     confidence=0.85,
                     results='')
 
+        source_three = Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    is_active=True,
+                    is_public=True)
+
+        list_item_three = FacilityListItem \
+            .objects \
+            .create(name='Item 3',
+                    address='Address',
+                    country_code='US',
+                    row_index=0,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=source_three,
+                    facility=self.facility)
+
+        FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.AUTOMATIC,
+                    facility=self.facility,
+                    facility_list_item=list_item_three,
+                    confidence=0.85,
+                    results='')
+
         contributors = self.fetch_facility_contributors(self.facility)
         self.assertEqual(2, len(contributors))
 


### PR DESCRIPTION
## Overview

This resolves an unhandled exception raised by trying to sort by a mix of integer ID and None values.

Connects #908

## Notes

This is a fix to a bug introduced in #907. See the PR description for more detail of the larger feature.

## Testing Instructions

* Verify that the unit tests pass

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- ~CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~ this is a fix to the not-yet released #907
