### PR TITLE
Add can view full contributor detail flag/group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Train persistant Dedupe model on first app request [#905](https://github.com/open-apparel-registry/open-apparel-registry/pull/905/)
 - List inactive or private sources by contributor type [#907](https://github.com/open-apparel-registry/open-apparel-registry/pull/907)
+- Add can view full contributor detail flag/group [#910](https://github.com/open-apparel-registry/open-apparel-registry/pull/910)
 
 ### Deprecated
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -49,6 +49,7 @@ class FeatureGroups:
     CAN_GET_FACILITY_HISTORY = 'can_get_facility_history'
     CAN_SUBMIT_FACILITY = 'can_submit_facility'
     CAN_SUBMIT_PRIVATE_FACILITY = 'can_submit_private_facility'
+    CAN_VIEW_FULL_CONTRIB_DETAIL = 'can_view_full_contrib_detail'
 
 
 class FacilityHistoryActions:

--- a/src/django/api/management/commands/user_groups.py
+++ b/src/django/api/management/commands/user_groups.py
@@ -1,0 +1,53 @@
+import sys
+
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+
+from api.models import User
+
+
+class Command(BaseCommand):
+    help = ('Given a User email address and a command, add or remove a '
+            'group membership for that user  ')
+
+    def add_arguments(self, parser):
+        group = parser.add_argument_group('required arguments')
+        group.add_argument('-e', '--email',
+                           required=True,
+                           help='The user\'s email address')
+        group.add_argument('-a', '--action',
+                           required=True,
+                           help='The action (add or remove)')
+        group.add_argument('-g', '--group',
+                           required=True,
+                           help='The name of a group')
+
+    def handle(self, *args, **options):
+        email = options['email']
+        action = options['action']
+        group_name = options['group']
+
+        try:
+            user = User.objects.get(email=email)
+            group_name = group_name.lower()
+            group = Group.objects.get(name=group_name)
+            action = action.lower()
+            if action not in ('add', 'remove'):
+                self.stderr.write('Action must be "add" or "remove"')
+                sys.exit(1)
+
+            if action == 'add':
+                user.groups.add(group)
+            if action == 'remove':
+                user.groups.remove(group)
+            user.save()
+
+        except User.DoesNotExist:
+            self.stderr.write('No User found for {}'.format(email))
+            sys.exit(1)
+        except Group.DoesNotExist:
+            self.stderr.write('No group found for {}'.format(group_name))
+            group_names = ', '.join(Group.objects.values_list('name',
+                                                              flat=True))
+            self.stderr.write('Choices are: {}'.format(group_names))
+            sys.exit(1)

--- a/src/django/api/migrations/0042_add_can_view_full_contrib_detail_flag.py
+++ b/src/django/api/migrations/0042_add_can_view_full_contrib_detail_flag.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+from api.constants import FeatureGroups
+
+
+def create_can_view_full_contrib_detail(apps, schema_editor):
+    Group = apps.get_model('auth', 'Group')
+    view_full_contrib_detial_group = Group.objects.create(
+        name=FeatureGroups.CAN_VIEW_FULL_CONTRIB_DETAIL)
+
+    Flag = apps.get_model('waffle', 'Flag')
+    view_full_contrib_detail_flag = Flag.objects.create(
+        name=FeatureGroups.CAN_VIEW_FULL_CONTRIB_DETAIL,
+        superusers=True,
+        staff=False,
+        note='Used for full contributor detail authorization')
+
+    view_full_contrib_detail_flag.groups.set([view_full_contrib_detial_group])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0041_add_private_facility_flag'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_can_view_full_contrib_detail),
+    ]

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib import auth
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.contrib.gis.geos import Point
 
 from rest_framework import status
@@ -4217,7 +4218,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             data[0]['detail'],
-            'Associate facility {} with contributor {} via list {}'.format(
+            'Associate facility {} with {} via list {}'.format(
                 self.facility_two.id,
                 self.contributor.name,
                 self.list_two.name,
@@ -4227,6 +4228,23 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.assertEqual(
             len(data),
             2,
+        )
+
+        self.superuser.groups.add(
+            Group.objects.get(name=FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY))
+        self.superuser.save()
+
+        automatic_match_response = self.client.get(
+            self.facility_two_history_url,
+        )
+
+        data = json.loads(automatic_match_response.content)
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Associate facility {} with an Other'.format(
+                self.facility_two.id,
+            ),
         )
 
     @override_flag('can_get_facility_history', active=True)
@@ -4295,7 +4313,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             data[0]['detail'],
-            'Associate facility {} with contributor {} via list {}'.format(
+            'Associate facility {} with {} via list {}'.format(
                 self.facility_two.id,
                 self.contributor.name,
                 self.list_for_confirm_or_remove.name,
@@ -4305,6 +4323,23 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.assertEqual(
             len(data),
             3,
+        )
+
+        self.user.groups.add(
+            Group.objects.get(name=FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY))
+        self.user.save()
+
+        confirmed_match_response = self.client.get(
+            self.facility_two_history_url,
+        )
+
+        data = json.loads(confirmed_match_response.content)
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Associate facility {} with an Other'.format(
+                self.facility_two.id,
+            ),
         )
 
     @override_flag('can_get_facility_history', active=True)
@@ -4363,7 +4398,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             data[0]['detail'],
-            'Dissociate facility {} from contributor {} via list {}'.format(
+            'Dissociate facility {} from {} via list {}'.format(
                 self.facility_two.id,
                 self.contributor.name,
                 self.list_for_confirm_or_remove.name,
@@ -4373,6 +4408,23 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.assertEqual(
             len(data),
             4,
+        )
+
+        self.user.groups.add(
+            Group.objects.get(name=FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY))
+        self.user.save()
+
+        confirmed_match_response = self.client.get(
+            self.facility_two_history_url,
+        )
+
+        data = json.loads(confirmed_match_response.content)
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Dissociate facility {} from an Other'.format(
+                self.facility_two.id,
+            ),
         )
 
     @override_flag('can_get_facility_history', active=True)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4860,7 +4860,11 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
         self.private_user_password = 'shhh'
         self.private_user.set_password(self.private_user_password)
         self.private_user.groups.set(
-            auth.models.Group.objects.values_list('id', flat=True))
+            auth.models.Group.objects.filter(
+                name__in=[
+                    FeatureGroups.CAN_SUBMIT_FACILITY,
+                    FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY
+                ]).values_list('id', flat=True))
         self.private_user.save()
         self.client.logout()
 
@@ -4998,6 +5002,19 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
         contributors = self.fetch_facility_contributors(self.facility)
         self.assertEqual(1, len(contributors))
         self.assertEqual('One Other', contributors[0].get('name'))
+
+        self.private_user.groups.set(
+            auth.models.Group.objects.filter(
+                name__in=[
+                    FeatureGroups.CAN_SUBMIT_FACILITY,
+                    FeatureGroups.CAN_SUBMIT_PRIVATE_FACILITY,
+                    FeatureGroups.CAN_VIEW_FULL_CONTRIB_DETAIL
+                ]).values_list('id', flat=True))
+        self.private_user.save()
+        contributors = self.fetch_facility_contributors(self.facility)
+        self.assertEqual(1, len(contributors))
+        self.assertEqual('test contributor 1 (First List)',
+                         contributors[0].get('name'))
 
     def test_inactive_or_private_contributor_omitted(self):
         def get_facility_count():

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1673,6 +1673,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         facility_history = create_facility_history_list(
             historical_facility_queryset,
             pk,
+            user=request.user
         )
 
         return Response(facility_history)


### PR DESCRIPTION
## Overview

This permission acts as an override to allow members of the "can submit private facilities" group to still see contributor details.

It replaces checking if the user has contributed any public data, allowing us to have more control over the visibility of contributors and to avoid a situation where a contributor submits thousands of private facilities and a single public one to get access to the full contributor details.

We also updated the history endpoint to follow the design of the recent changes to the facility details serializer where we conditionally show the contributor type instead of the full name unless the user making the request has the appropriate permissions.




Connects #874

## Demo

<img width="954" alt="Screen Shot 2019-11-08 at 1 25 25 PM" src="https://user-images.githubusercontent.com/17363/68510981-1ad4de80-0232-11ea-9a08-80c9aa5801c0.png">


## Notes

Also fixes a bug where items submitted individually would appear in the history as being from "list [Unknown]." We now exclude the list description if there is no list associated with the `Source.`

Also includes a new `user_groups` management command. The Django Admin does not have a default UI for managing group memberships. This command allows us to use `ecsmanage` to update group memberships in ECS deployments where do not have access to an interactive `shell_plus` session.

## Testing Instructions

* Run `./scripts/resetdb`
* Log in a `c2@example.com:password`
* Browse http://localhost:6543/?q=regina and select the facility in Shenzhen. Copy the OAR ID.
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_get_facility_history. Submit the test form with the OAR ID. Verify that a 403 error is returned.
* Run management command to allow history access
```
./scripts/manage user_groups -e c2@example.com -a add -g can_get_facility_history
```
* Submit the API test form again and verify that history is returned and that the "detail" values contain full contributor details.
* Run management command to allow private submission access
```
./scripts/manage user_groups -e c2@example.com -a add -g can_submit_private_facility
```
* Submit the API test form again and verify that history is returned but that the contributor details are now anonymous.
* Browse http://localhost:6543/facilities/{the-oar-id} and verify that the contributor details are anonymous.
* Run management command to allow full contributor details
```
./scripts/manage user_groups -e c2@example.com -a add -g can_view_full_contrib_detail
```
* Submit the API test form again and verify that history is returned and that the "detail" values once again contain full contributor details.
* Browse http://localhost:6543/facilities/{the-oar-id} and verify that the full contributor details are displayed.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
