### PR TITLE
Handle EmptyResultSet error raised by tile requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Handle EmptyResultSet error raised by tile requests [#911](https://github.com/open-apparel-registry/open-apparel-registry/pull/911)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2851,9 +2851,13 @@ def get_tile(request, layer, cachekey, z, x, y, ext):
     if not params.is_valid():
         raise ValidationError(params.errors)
 
-    if layer == 'facilities':
-        tile = get_facilities_vector_tile(request.query_params, layer, z, x, y)
-    elif layer == 'facilitygrid':
-        tile = get_facility_grid_vector_tile(
-            request.query_params, layer, z, x, y)
-    return Response(tile.tobytes())
+    try:
+        if layer == 'facilities':
+            tile = get_facilities_vector_tile(
+                request.query_params, layer, z, x, y)
+        elif layer == 'facilitygrid':
+            tile = get_facility_grid_vector_tile(
+                request.query_params, layer, z, x, y)
+        return Response(tile.tobytes())
+    except core_exceptions.EmptyResultSet:
+        return Response(None, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Overview

In difficult to recreate situations an `EmptyResultSet` exception is being raised by Django while generating the where clause for a grid vector tile. In this context it is logically correct to simply return 204 No Content with an empty body, which the Leaflet grid layer handles without any issues.

Connects #845

## Notes

I could not reliably recreate the error condition so there is an additional commit that should be dropped before merging the PR which deterministically raises the problematic exception for every tile request with an even numbered X and Y. 

## Testing Instructions

* (Re)start `./scripts/server`.
* Run `./scripts/manage incrementtileversion` to invalidate any in-browser cached tiles.
* Open the developer tools "Network" tab, browse http://localhost:6543/, and zoom in a few times. Verify that:
  * All the requests to `/tile/*` return 200 or 204.
  * No errors are logged to the server console.

## Checklist

- [x] DROP test commit
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
