### PR TITLE
Move the facility match confirm/reject API to allow single-item…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+Move the facility match confirm/reject API to allow single-item match handling [#918](https://github.com/open-apparel-registry/open-apparel-registry/pull/918/)
 
 ### Deprecated
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -50,7 +50,6 @@ const {
     createParamsFromQueryString,
     makeReportADataIssueEmailLink,
     makeFeatureCollectionFromSingleFeature,
-    createConfirmOrRejectMatchData,
     createConfirmFacilityListItemMatchURL,
     createRejectFacilityListItemMatchURL,
     makeMyFacilitiesRoute,
@@ -740,28 +739,13 @@ it('creates a geojson FeatureCollection from a single geojson Feature', () => {
     )).toBe(true);
 });
 
-it('creates POST data for confirming or rejecting a facility list item match', () => {
-    const listItem = 'listItem';
-    const facilityMatch = 'facilityMatch';
-
-    const expectedMatch = {
-        list_item_id: listItem,
-        facility_match_id: facilityMatch,
-    };
-
-    expect(isEqual(
-        createConfirmOrRejectMatchData(listItem, facilityMatch),
-        expectedMatch,
-    )).toBe(true);
-});
-
 it('creates URLs for confirming or rejecting a facility list item match', () => {
-    const list = 'list';
-    const expectedConfirmURL = '/api/facility-lists/list/confirm/';
-    const expectedRejectURL = '/api/facility-lists/list/reject/';
+    const matchId = 'matchid';
+    const expectedConfirmURL = '/api/facility-matches/matchid/confirm/';
+    const expectedRejectURL = '/api/facility-matches/matchid/reject/';
 
-    expect(createConfirmFacilityListItemMatchURL(list)).toBe(expectedConfirmURL);
-    expect(createRejectFacilityListItemMatchURL(list)).toBe(expectedRejectURL);
+    expect(createConfirmFacilityListItemMatchURL(matchId)).toBe(expectedConfirmURL);
+    expect(createRejectFacilityListItemMatchURL(matchId)).toBe(expectedRejectURL);
 });
 
 it('creates a link to see facilities for a contributor ID', () => {

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -7,7 +7,6 @@ import {
     logErrorAndDispatchFailure,
     makeSingleFacilityListURL,
     makeSingleFacilityListItemsURL,
-    createConfirmOrRejectMatchData,
     createConfirmFacilityListItemMatchURL,
     createRejectFacilityListItemMatchURL,
     createRemoveFacilityListItemURL,
@@ -100,22 +99,21 @@ export function fetchFacilityListItems(
     };
 }
 
-export function confirmFacilityListItemMatch(facilityMatchID, listID, listItemID) {
+export function confirmFacilityListItemMatch(facilityMatchID) {
     return (dispatch) => {
         dispatch(startConfirmFacilityListItemPotentialMatch());
 
-        if (!listID || !listItemID || !facilityMatchID) {
+        if (!facilityMatchID) {
             return dispatch(logErrorAndDispatchFailure(
                 null,
-                'listID, listItemID, and facilityMatchID are required parameters',
+                'facilityMatchID is a required parameter',
                 failConfirmFacilityListItemPotentialMatch,
             ));
         }
 
         return apiRequest
             .post(
-                createConfirmFacilityListItemMatchURL(listID),
-                createConfirmOrRejectMatchData(listItemID, facilityMatchID),
+                createConfirmFacilityListItemMatchURL(facilityMatchID),
             )
             .then(({ data }) => dispatch(completeConfirmFacilityListItemPotentialMatch(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -126,22 +124,21 @@ export function confirmFacilityListItemMatch(facilityMatchID, listID, listItemID
     };
 }
 
-export function rejectFacilityListItemMatch(facilityMatchID, listID, listItemID) {
+export function rejectFacilityListItemMatch(facilityMatchID) {
     return (dispatch) => {
         dispatch(startRejectFacilityListItemPotentialMatch());
 
-        if (!listID || !listItemID || !facilityMatchID) {
+        if (!facilityMatchID) {
             return dispatch(logErrorAndDispatchFailure(
                 null,
-                'listID, listItemID, and facilityMatchID are required parameters',
+                'facilityMatchID is a required parameter',
                 failRejectFacilityListItemPotentialMatch,
             ));
         }
 
         return apiRequest
             .post(
-                createRejectFacilityListItemMatchURL(listID),
-                createConfirmOrRejectMatchData(listItemID, facilityMatchID),
+                createRejectFacilityListItemMatchURL(facilityMatchID),
             )
             .then(({ data }) => dispatch(completeRejectFacilityListItemPotentialMatch(data)))
             .catch(err => dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { bool, func, string } from 'prop-types';
+import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
@@ -21,7 +21,6 @@ function FacilityListItemsConfirmationTableRow({
     item,
     makeConfirmMatchFunction,
     makeRejectMatchFunction,
-    listID,
     fetching,
     readOnly,
 }) {
@@ -45,8 +44,8 @@ function FacilityListItemsConfirmationTableRow({
                 Object.freeze(names.concat(name)),
                 Object.freeze(addresses.concat(address)),
                 Object.freeze(confirmOrRejectFunctions.concat(Object.freeze({
-                    confirmMatch: makeConfirmMatchFunction(id, listID),
-                    rejectMatch: makeRejectMatchFunction(id, listID),
+                    confirmMatch: makeConfirmMatchFunction(id),
+                    rejectMatch: makeRejectMatchFunction(id),
                     id,
                     status,
                     matchName: name,
@@ -143,7 +142,6 @@ FacilityListItemsConfirmationTableRow.propTypes = {
     item: facilityListItemPropType.isRequired,
     makeConfirmMatchFunction: func.isRequired,
     makeRejectMatchFunction: func.isRequired,
-    listID: string.isRequired,
     fetching: bool.isRequired,
     readOnly: bool,
 };
@@ -160,16 +158,12 @@ function mapStateToProps({
     };
 }
 
-function mapDispatchToProps(dispatch, {
-    item: {
-        id: listItemID,
-    },
-}) {
+function mapDispatchToProps(dispatch) {
     return {
-        makeConfirmMatchFunction: (matchID, listID) =>
-            () => dispatch(confirmFacilityListItemMatch(matchID, listID, listItemID)),
-        makeRejectMatchFunction: (matchID, listID) =>
-            () => dispatch(rejectFacilityListItemMatch(matchID, listID, listItemID)),
+        makeConfirmMatchFunction: matchID =>
+            () => dispatch(confirmFacilityListItemMatch(matchID)),
+        makeRejectMatchFunction: matchID =>
+            () => dispatch(rejectFacilityListItemMatch(matchID)),
     };
 }
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -450,16 +450,11 @@ export const makeFeatureCollectionFromSingleFeature = feature => Object.freeze({
     ]),
 });
 
-export const createConfirmOrRejectMatchData = (listItemID, facilityMatchID) => Object.freeze({
-    list_item_id: listItemID,
-    facility_match_id: facilityMatchID,
-});
+export const createConfirmFacilityListItemMatchURL = matchID =>
+    `/api/facility-matches/${matchID}/confirm/`;
 
-export const createConfirmFacilityListItemMatchURL = listID =>
-    `/api/facility-lists/${listID}/confirm/`;
-
-export const createRejectFacilityListItemMatchURL = listID =>
-    `/api/facility-lists/${listID}/reject/`;
+export const createRejectFacilityListItemMatchURL = matchID =>
+    `/api/facility-matches/${matchID}/reject/`;
 
 export const createRemoveFacilityListItemURL = listID =>
     `/api/facility-lists/${listID}/remove/`;

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -223,6 +223,9 @@ def save_match_details(match_results):
     Arguments:
     match_results -- The dict return value from a call to
                      match_facility_list_items.
+
+    Returns:
+    The list of `FacilityMatch` objects created
     """
     processed_list_item_ids = match_results['processed_list_item_ids']
     item_matches = match_results['item_matches']
@@ -240,6 +243,7 @@ def save_match_details(match_results):
             status=FacilityMatch.PENDING,
             results=results)
 
+    all_matches = []
     for item_id, matches in item_matches.items():
         item = FacilityListItem.objects.get(id=item_id)
         item.status = FacilityListItem.POTENTIAL_MATCH
@@ -273,6 +277,8 @@ def save_match_details(match_results):
         if item.source.create:
             for m in matches:
                 m.save()
+
+        all_matches.extend(matches)
 
     unmatched = (FacilityListItem.objects
                  .filter(id__in=processed_list_item_ids)
@@ -311,3 +317,5 @@ def save_match_details(match_results):
                 'finished_at': finished
             })
         item.save()
+
+    return all_matches

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -918,11 +918,13 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
         self.remove_url = '/api/facility-lists/{}/remove/' \
             .format(self.current_list.id)
 
+    def match_url(self, match, action='detail'):
+        return reverse('facility-match-{}'.format(action),
+                       kwargs={'pk': match.pk})
+
     def test_confirming_match_rejects_other_potential_matches(self):
         confirm_response = self.client.post(
-            self.confirm_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='confirm')
         )
 
         confirmed_match = FacilityMatch \
@@ -939,9 +941,7 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_confirming_match_changes_list_item_status(self):
         confirm_response = self.client.post(
-            self.confirm_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='confirm')
         )
 
         updated_list_item = FacilityListItem \
@@ -954,9 +954,7 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_confirming_match_doesnt_create_new_facility(self):
         confirm_response = self.client.post(
-            self.confirm_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='confirm')
         )
 
         facilities = Facility.objects.all()
@@ -966,15 +964,11 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_rejecting_last_potential_match_changes_list_item_status(self):
         reject_response_one = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='reject')
         )
 
         reject_response_two = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_two.id},
+            self.match_url(self.potential_facility_match_two, action='reject')
         )
 
         self.assertEqual(reject_response_one.status_code, 200)
@@ -989,9 +983,7 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_rejecting_one_of_several_matches_changes_match_to_rejected(self):
         reject_response_one = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='reject')
         )
 
         self.assertEqual(reject_response_one.status_code, 200)
@@ -1012,9 +1004,7 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_rejecting_one_of_several_matches_doesnt_change_item_status(self):
         reject_response_one = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='reject')
         )
 
         self.assertEqual(reject_response_one.status_code, 200)
@@ -1028,15 +1018,11 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_rejecting_last_potential_match_creates_new_facility(self):
         reject_response_one = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='reject')
         )
 
         reject_response_two = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_two.id},
+            self.match_url(self.potential_facility_match_two, action='reject')
         )
 
         self.assertEqual(reject_response_one.status_code, 200)
@@ -1049,15 +1035,11 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
         initial_facility_matches_count = FacilityMatch.objects.all().count()
 
         reject_response_one = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='reject')
         )
 
         reject_response_two = self.client.post(
-            self.reject_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_two.id},
+            self.match_url(self.potential_facility_match_two, action='reject')
         )
 
         self.assertEqual(reject_response_one.status_code, 200)
@@ -1074,9 +1056,7 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_removing_a_list_item_sets_its_matches_to_inactive(self):
         confirm_response = self.client.post(
-            self.confirm_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='confirm')
         )
 
         confirmed_match = FacilityMatch \
@@ -1113,9 +1093,7 @@ class ConfirmRejectAndRemoveFacilityMatchTest(TestCase):
 
     def test_only_list_contribtutor_can_remove_a_list_item(self):
         confirm_response = self.client.post(
-            self.confirm_url,
-            {"list_item_id": self.current_list_item.id,
-             "facility_match_id": self.potential_facility_match_one.id},
+            self.match_url(self.potential_facility_match_one, action='confirm')
         )
 
         confirmed_match = FacilityMatch \
@@ -4281,19 +4259,11 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.client.login(email=self.user_email,
                           password=self.user_password)
 
-        confirm_url = '/api/facility-lists/{}/confirm/'.format(
-            self.list_for_confirm_or_remove.id,
+        confirm_url = '/api/facility-matches/{}/confirm/'.format(
+            self.match_for_confirm_or_remove.id,
         )
 
-        confirm_data = {
-            'list_item_id': self.list_item_for_confirm_or_remove.id,
-            'facility_match_id': self.match_for_confirm_or_remove.id,
-        }
-
-        confirm_response = self.client.post(
-            confirm_url,
-            confirm_data,
-        )
+        confirm_response = self.client.post(confirm_url)
 
         self.assertEqual(
             confirm_response.status_code,
@@ -4348,19 +4318,11 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         self.client.login(email=self.user_email,
                           password=self.user_password)
 
-        confirm_url = '/api/facility-lists/{}/confirm/'.format(
-            self.list_for_confirm_or_remove.id,
+        confirm_url = '/api/facility-matches/{}/confirm/'.format(
+            self.match_for_confirm_or_remove.id,
         )
 
-        confirm_data = {
-            'list_item_id': self.list_item_for_confirm_or_remove.id,
-            'facility_match_id': self.match_for_confirm_or_remove.id,
-        }
-
-        confirm_response = self.client.post(
-            confirm_url,
-            confirm_data,
-        )
+        confirm_response = self.client.post(confirm_url)
 
         self.assertEqual(
             confirm_response.status_code,
@@ -5089,9 +5051,9 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
         self.assertEqual(0, get_facility_count())
 
 
-class FacilityMatchTest(FacilityAPITestCaseBase):
+class SingleItemFacilityMatchTest(FacilityAPITestCaseBase):
     def setUp(self):
-        super(FacilityMatchTest, self).setUp()
+        super(SingleItemFacilityMatchTest, self).setUp()
         self.contributor_two = Contributor \
             .objects \
             .create(admin=self.superuser,
@@ -5126,19 +5088,18 @@ class FacilityMatchTest(FacilityAPITestCaseBase):
         self.list_item_two.facility = self.facility
         self.list_item_two.save()
 
-        self.client.login(email=self.user_email,
-                          password=self.user_password)
-
     def match_url(self, match, action='detail'):
         return reverse('facility-match-{}'.format(action),
                        kwargs={'pk': match.pk})
 
     def test_get_match_detail(self):
-        response = self.client.get(self.match_url(self.match))
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+
+        response = self.client.get(self.match_url(self.match_two))
         self.assertEqual(200, response.status_code)
 
     def test_only_contributor_can_get_match_detail(self):
-        self.client.logout()
         self.client.login(email=self.superuser_email,
                           password=self.superuser_password)
 
@@ -5146,14 +5107,14 @@ class FacilityMatchTest(FacilityAPITestCaseBase):
         self.assertEqual(404, response.status_code)
 
     def test_confirm(self):
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+
         response = self.client.post(
-            self.match_url(self.match, action='confirm'))
-        # TODO: Change after implementation
-        # data = json.loads(response.content)
-        self.assertEqual(501, response.status_code)
+            self.match_url(self.match_two, action='confirm'))
+        self.assertEqual(200, response.status_code)
 
     def test_only_contributor_can_confirm(self):
-        self.client.logout()
         self.client.login(email=self.superuser_email,
                           password=self.superuser_password)
 
@@ -5162,14 +5123,13 @@ class FacilityMatchTest(FacilityAPITestCaseBase):
         self.assertEqual(404, response.status_code)
 
     def test_reject(self):
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
         response = self.client.post(
-            self.match_url(self.match, action='reject'))
-        # TODO: Change after implementation
-        # data = json.loads(response.content)
-        self.assertEqual(501, response.status_code)
+            self.match_url(self.match_two, action='reject'))
+        self.assertEqual(200, response.status_code)
 
     def test_only_contributor_can_reject(self):
-        self.client.logout()
         self.client.login(email=self.superuser_email,
                           password=self.superuser_password)
         response = self.client.post(

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2032,378 +2032,6 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     @transaction.atomic
-    @action(detail=True,
-            methods=['post'],
-            url_path='confirm')
-    def confirm_match(self, request, pk=None):
-        """
-        Confirm a potential match between an existing Facility and a Facility
-        List Item from an authenticated Contributor's Facility List.
-
-        Returns an updated Facility List Item with the confirmed match's status
-        changed to `CONFIRMED` and the Facility List Item's status changed to
-        `CONFIRMED_MATCH`. On confirming a potential match, all other
-        potential matches will have their status changed to `REJECTED`.
-
-        ## Request Body
-
-        **Required**
-
-        `list_item_id` (`number`): ID for the Facility List Item rejecting a
-                       match with an existing Facility.
-
-        `facility_match_id` (`number`): ID for the potential Facility Match
-                            rejected as a match for the Facility List Item.
-
-        **Example**
-
-            {
-                "list_item_id": 1,
-                "facility_match_id": 1
-            }
-
-        ## Sample Response
-
-            {
-                "id": 1,
-                "matches": [
-                    {
-                        "id": 1,
-                        "status": "CONFIRMED",
-                        "confidence": 0.6,
-                        "results": {
-                            "match_type": "single_gazetteer_match",
-                            "code_version": "12asdf",
-                            "recall_weight": 1,
-                            "automatic_threshold": 0.8,
-                            "gazetteer_threshold": 0.5,
-                            "no_gazetteer_matches": false
-                        }
-                        "oar_id": "oar_id_1",
-                        "name": "facility match name 1",
-                        "address": "facility match address 1",
-                        "location": {
-                            "lat": 1,
-                            "lng": 1
-                        },
-                        "is_active": true
-                    },
-                    {
-                        "id": 2,
-                        "status": "REJECTED",
-                        "confidence": 0.7,
-                        "results": {
-                            "match_type": "single_gazetteer_match",
-                            "code_version": "34asdf",
-                            "recall_weight": 1,
-                            "automatic_threshold": 0.8,
-                            "gazetteer_threshold": 0.5,
-                            "no_gazetteer_matches": false
-                        }
-                        "oar_id": "oar_id_2",
-                        "name": "facility match name 2",
-                        "address": "facility match address 2",
-                        "location": {
-                            "lat": 2,
-                            "lng": 2
-                        },
-                        "is_active": true
-                    }
-                ],
-                "row_index": 1,
-                "address": "facility list item address",
-                "name": "facility list item name",
-                "raw_data": "facility liste item name, facility list item address", # noqa
-                "status": "CONFIRMED_MATCH",
-                "processing_started_at": null,
-                "processing_completed_at": null,
-                "country_code": "US",
-                "facility_list": 1,
-                "country_name": "United States",
-                "processing_errors": null,
-                "list_statuses": ["CONFIRMED_MATCH"],
-                "matched_facility": {
-                    "oar_id": "oar_id_1",
-                    "name": "facility match name 1",
-                    "address": "facility match address 1",
-                    "location": {
-                        "lat": 1,
-                        "lng": 1
-                    },
-                    "created_from_id": 12345
-                }
-            }
-        """
-        try:
-            list_item_id = request.data.get('list_item_id')
-            facility_match_id = request.data.get('facility_match_id')
-
-            if list_item_id is None:
-                raise ValidationError('missing required list_item_id')
-
-            if facility_match_id is None:
-                raise ValidationError('missing required facility_match_id')
-
-            user_contributor = request.user.contributor
-            facility_list = FacilityList \
-                .objects \
-                .filter(source__contributor=user_contributor) \
-                .get(pk=pk)
-            facility_list_item = FacilityListItem \
-                .objects \
-                .filter(source=facility_list.source) \
-                .get(pk=list_item_id)
-            facility_match = FacilityMatch \
-                .objects \
-                .filter(facility_list_item=facility_list_item) \
-                .get(pk=facility_match_id)
-
-            if facility_list_item.status != FacilityListItem.POTENTIAL_MATCH:
-                raise ValidationError(
-                    'facility list item status must be POTENTIAL_MATCH')
-
-            if facility_match.status != FacilityMatch.PENDING:
-                raise ValidationError('facility match status must be PENDING')
-
-            facility_match.status = FacilityMatch.CONFIRMED
-            facility_match.changeReason = create_associate_match_change_reason(
-                facility_list_item,
-                facility_match.facility,
-            )
-
-            facility_match.save()
-
-            matches_to_reject = FacilityMatch \
-                .objects \
-                .filter(facility_list_item=facility_list_item) \
-                .exclude(pk=facility_match_id)
-            # Call `save` in a loop rather than use `update` to make sure that
-            # django-simple-history can log the changes
-            for match in matches_to_reject:
-                match.status = FacilityMatch.REJECTED
-                match.save()
-
-            facility_list_item.status = FacilityListItem.CONFIRMED_MATCH
-            facility_list_item.facility = facility_match.facility
-            facility_list_item.save()
-
-            response_data = FacilityListItemSerializer(facility_list_item).data
-
-            response_data['list_statuses'] = (facility_list
-                                              .source
-                                              .facilitylistitem_set
-                                              .values_list('status', flat=True)
-                                              .distinct())
-
-            return Response(response_data)
-        except FacilityList.DoesNotExist:
-            raise NotFound()
-        except FacilityListItem.DoesNotExist:
-            raise NotFound()
-        except FacilityMatch.DoesNotExist:
-            raise NotFound()
-
-    @transaction.atomic
-    @action(detail=True,
-            methods=['post'],
-            url_path='reject')
-    def reject_match(self, request, pk=None):
-        """
-        Reject a potential match between an existing Facility and a Facility
-        List Item from an authenticated Contributor's Facility List.
-
-        Returns an updated Facility List Item with the potential match's status
-        changed to `REJECTED`.
-
-        If all potential matches have been rejected and the Facility List Item
-        has been successfully geocoded, creates a new Facility from the
-        Facility List Item.
-
-        ## Request Body
-
-        **Required**
-
-        `list_item_id` (`number`): ID for the Facility List Item rejecting a
-                       match with an existing Facility.
-
-        `facility_match_id` (`number`): ID for the potential Facility Match
-                            rejected as a match for the Facility List Item.
-
-        **Example**
-
-            {
-                "list_item_id": 1,
-                "facility_match_id": 2
-            }
-
-        ## Sample Response
-
-            {
-                "id": 1,
-                "matches": [
-                    {
-                        "id": 1,
-                        "status": "PENDING",
-                        "confidence": 0.6,
-                        "results": {
-                            "match_type": "single_gazetteer_match",
-                            "code_version": "12asdf",
-                            "recall_weight": 1,
-                            "automatic_threshold": 0.8,
-                            "gazetteer_threshold": 0.5,
-                            "no_gazetteer_matches": false
-                        }
-                        "oar_id": "oar_id_1",
-                        "name": "facility match name 1",
-                        "address": "facility match address 1",
-                        "location": {
-                            "lat": 1,
-                            "lng": 1
-                        },
-                        "is_active": true
-                    },
-                    {
-                        "id": 2,
-                        "status": "REJECTED",
-                        "confidence": 0.7,
-                        "results": {
-                            "match_type": "single_gazetteer_match",
-                            "code_version": "34asdf",
-                            "recall_weight": 1,
-                            "automatic_threshold": 0.8,
-                            "gazetteer_threshold": 0.5,
-                            "no_gazetteer_matches": false
-                        }
-                        "oar_id": "oar_id_2",
-                        "name": "facility match name 2",
-                        "address": "facility match address 2",
-                        "location": {
-                            "lat": 2,
-                            "lng": 2
-                        },
-                        "is_active": true
-                    }
-                ]
-                "row_index": 1,
-                "address": "facility list item address",
-                "name": "facility list item name",
-                "raw_data": "facility liste item name, facility list item address", # noqa
-                "status": "POTENTIAL_MATCH",
-                "processing_started_at": null,
-                "processing_completed_at": null,
-                "country_code": "US",
-                "country_name": "United States",
-                "matched_facility": null,
-                "processing_errors": null,
-                "facility_list": 1,
-                "list_statuses": ["POTENTIAL_MATCH"],
-            }
-        """
-        try:
-            list_item_id = request.data.get('list_item_id')
-            facility_match_id = request.data.get('facility_match_id')
-
-            if list_item_id is None:
-                raise ValidationError('missing required list_item_id')
-
-            if facility_match_id is None:
-                raise ValidationError('missing required facility_match_id')
-
-            user_contributor = request.user.contributor
-            facility_list = FacilityList \
-                .objects \
-                .filter(source__contributor=user_contributor) \
-                .get(pk=pk)
-            facility_list_item = FacilityListItem \
-                .objects \
-                .filter(source=facility_list.source) \
-                .get(pk=list_item_id)
-            facility_match = FacilityMatch \
-                .objects \
-                .filter(facility_list_item=facility_list_item) \
-                .get(pk=facility_match_id)
-
-            if facility_list_item.status != FacilityListItem.POTENTIAL_MATCH:
-                raise ValidationError(
-                    'facility list item status must be POTENTIAL_MATCH')
-
-            if facility_match.status != FacilityMatch.PENDING:
-                raise ValidationError('facility match status must be PENDING')
-
-            facility_match.status = FacilityMatch.REJECTED
-            facility_match.save()
-
-            remaining_potential_matches = FacilityMatch \
-                .objects \
-                .filter(facility_list_item=facility_list_item) \
-                .filter(status=FacilityMatch.PENDING)
-
-            # If no potential matches remain:
-            #
-            # - create a new facility for a list item with a geocoded point
-            # - set status to `ERROR_MATCHING` for list item with no point
-            if remaining_potential_matches.count() == 0:
-                no_location = facility_list_item.geocoded_point is None
-                no_geocoding_results = facility_list_item.status == \
-                    FacilityListItem.GEOCODED_NO_RESULTS
-
-                if (no_location or no_geocoding_results):
-                    facility_list_item.status = FacilityListItem.ERROR_MATCHING
-                    timestamp = str(datetime.utcnow())
-                    facility_list_item.processing_results.append({
-                        'action': ProcessingAction.CONFIRM,
-                        'started_at': timestamp,
-                        'error': True,
-                        'message': ('Unable to create a new facility from an '
-                                    'item with no geocoded location'),
-                        'finished_at': timestamp,
-                    })
-                else:
-                    new_facility = Facility \
-                        .objects \
-                        .create(name=facility_list_item.name,
-                                address=facility_list_item.address,
-                                country_code=facility_list_item.country_code,
-                                location=facility_list_item.geocoded_point,
-                                created_from=facility_list_item)
-
-                    # also create a new facility match
-                    match_results = {
-                        "match_type": "all_potential_matches_rejected",
-                    }
-
-                    FacilityMatch \
-                        .objects \
-                        .create(facility_list_item=facility_list_item,
-                                facility=new_facility,
-                                confidence=1.0,
-                                status=FacilityMatch.CONFIRMED,
-                                results=match_results)
-
-                    facility_list_item.facility = new_facility
-
-                    facility_list_item.status = FacilityListItem \
-                        .CONFIRMED_MATCH
-
-                facility_list_item.save()
-
-            response_data = FacilityListItemSerializer(facility_list_item).data
-
-            response_data['list_statuses'] = (facility_list
-                                              .source
-                                              .facilitylistitem_set
-                                              .values_list('status', flat=True)
-                                              .distinct())
-
-            return Response(response_data)
-        except FacilityList.DoesNotExist:
-            raise NotFound()
-        except FacilityListItem.DoesNotExist:
-            raise NotFound()
-        except FacilityMatch.DoesNotExist:
-            raise NotFound()
-
-    @transaction.atomic
     @action(detail=True, methods=['post'],
             url_path='remove')
     def remove_item(self, request, pk=None):
@@ -2854,11 +2482,24 @@ class FacilityMatchViewSet(mixins.RetrieveModelMixin,
     def validate_request(self, request, pk):
         # We only allow retrieving matches to items that the logged in user has
         # submitted
-        if not self.queryset.filter(
+        filter = self.queryset.filter(
             pk=pk,
             facility_list_item__source__contributor=request.user.contributor
-        ).exists():
+        )
+        if not filter.exists():
             raise Http404
+
+        facility_match = filter.first()
+        facility_list_item = facility_match.facility_list_item
+
+        if facility_list_item.status != FacilityListItem.POTENTIAL_MATCH:
+            raise ValidationError(
+                'facility list item status must be POTENTIAL_MATCH')
+
+        if facility_match.status != FacilityMatch.PENDING:
+            raise ValidationError('facility match status must be PENDING')
+
+        return facility_match
 
     def retrieve(self, request, pk=None):
         self.validate_request(request, pk)
@@ -2875,9 +2516,116 @@ class FacilityMatchViewSet(mixins.RetrieveModelMixin,
         changed to `CONFIRMED` and the Facility List Item's status changed to
         `CONFIRMED_MATCH`. On confirming a potential match, all other
         potential matches will have their status changed to `REJECTED`.
+
+        ## Sample Response
+
+            {
+                "id": 1,
+                "matches": [
+                    {
+                        "id": 1,
+                        "status": "CONFIRMED",
+                        "confidence": 0.6,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "12asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_1",
+                        "name": "facility match name 1",
+                        "address": "facility match address 1",
+                        "location": {
+                            "lat": 1,
+                            "lng": 1
+                        },
+                        "is_active": true
+                    },
+                    {
+                        "id": 2,
+                        "status": "REJECTED",
+                        "confidence": 0.7,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "34asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_2",
+                        "name": "facility match name 2",
+                        "address": "facility match address 2",
+                        "location": {
+                            "lat": 2,
+                            "lng": 2
+                        },
+                        "is_active": true
+                    }
+                ],
+                "row_index": 1,
+                "address": "facility list item address",
+                "name": "facility list item name",
+                "raw_data": "facility liste item name, facility list item address", # noqa
+                "status": "CONFIRMED_MATCH",
+                "processing_started_at": null,
+                "processing_completed_at": null,
+                "country_code": "US",
+                "facility_list": 1,
+                "country_name": "United States",
+                "processing_errors": null,
+                "list_statuses": ["CONFIRMED_MATCH"],
+                "matched_facility": {
+                    "oar_id": "oar_id_1",
+                    "name": "facility match name 1",
+                    "address": "facility match address 1",
+                    "location": {
+                        "lat": 1,
+                        "lng": 1
+                    },
+                    "created_from_id": 12345
+                }
+            }
+
         """
-        self.validate_request(request, pk)
-        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+        facility_match = self.validate_request(request, pk)
+        facility_list_item = facility_match.facility_list_item
+
+        facility_match.status = FacilityMatch.CONFIRMED
+        facility_match.changeReason = create_associate_match_change_reason(
+            facility_match.facility_list_item,
+            facility_match.facility,
+        )
+
+        facility_match.save()
+
+        matches_to_reject = FacilityMatch \
+            .objects \
+            .filter(facility_list_item=facility_list_item) \
+            .exclude(pk=facility_match.pk)
+        # Call `save` in a loop rather than use `update` to make sure that
+        # django-simple-history can log the changes
+        for match in matches_to_reject:
+            match.status = FacilityMatch.REJECTED
+            match.save()
+
+        facility_list_item.status = FacilityListItem.CONFIRMED_MATCH
+        facility_list_item.facility = facility_match.facility
+        facility_list_item.save()
+
+        response_data = FacilityListItemSerializer(facility_list_item).data
+
+        if facility_list_item.source.source_type == Source.LIST:
+            response_data['list_statuses'] = (
+                facility_list_item
+                .source
+                .facilitylistitem_set
+                .values_list('status', flat=True)
+                .distinct())
+
+        return Response(response_data)
 
     @transaction.atomic
     @action(detail=True, methods=['POST'])
@@ -2892,9 +2640,141 @@ class FacilityMatchViewSet(mixins.RetrieveModelMixin,
         If all potential matches have been rejected and the Facility List Item
         has been successfully geocoded, creates a new Facility from the
         Facility List Item.
+
+        ## Sample Response
+
+            {
+                "id": 1,
+                "matches": [
+                    {
+                        "id": 1,
+                        "status": "PENDING",
+                        "confidence": 0.6,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "12asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_1",
+                        "name": "facility match name 1",
+                        "address": "facility match address 1",
+                        "location": {
+                            "lat": 1,
+                            "lng": 1
+                        },
+                        "is_active": true
+                    },
+                    {
+                        "id": 2,
+                        "status": "REJECTED",
+                        "confidence": 0.7,
+                        "results": {
+                            "match_type": "single_gazetteer_match",
+                            "code_version": "34asdf",
+                            "recall_weight": 1,
+                            "automatic_threshold": 0.8,
+                            "gazetteer_threshold": 0.5,
+                            "no_gazetteer_matches": false
+                        }
+                        "oar_id": "oar_id_2",
+                        "name": "facility match name 2",
+                        "address": "facility match address 2",
+                        "location": {
+                            "lat": 2,
+                            "lng": 2
+                        },
+                        "is_active": true
+                    }
+                ]
+                "row_index": 1,
+                "address": "facility list item address",
+                "name": "facility list item name",
+                "raw_data": "facility liste item name, facility list item address", # noqa
+                "status": "POTENTIAL_MATCH",
+                "processing_started_at": null,
+                "processing_completed_at": null,
+                "country_code": "US",
+                "country_name": "United States",
+                "matched_facility": null,
+                "processing_errors": null,
+                "facility_list": 1,
+                "list_statuses": ["POTENTIAL_MATCH"],
+            }
         """
-        self.validate_request(request, pk)
-        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+        facility_match = self.validate_request(request, pk)
+        facility_list_item = facility_match.facility_list_item
+
+        facility_match.status = FacilityMatch.REJECTED
+        facility_match.save()
+
+        remaining_potential_matches = FacilityMatch \
+            .objects \
+            .filter(facility_list_item=facility_list_item) \
+            .filter(status=FacilityMatch.PENDING)
+
+        # If no potential matches remain:
+        #
+        # - create a new facility for a list item with a geocoded point
+        # - set status to `ERROR_MATCHING` for list item with no point
+        if remaining_potential_matches.count() == 0:
+            no_location = facility_list_item.geocoded_point is None
+            no_geocoding_results = facility_list_item.status == \
+                FacilityListItem.GEOCODED_NO_RESULTS
+
+            if (no_location or no_geocoding_results):
+                facility_list_item.status = FacilityListItem.ERROR_MATCHING
+                timestamp = str(datetime.utcnow())
+                facility_list_item.processing_results.append({
+                    'action': ProcessingAction.CONFIRM,
+                    'started_at': timestamp,
+                    'error': True,
+                    'message': ('Unable to create a new facility from an '
+                                'item with no geocoded location'),
+                    'finished_at': timestamp,
+                })
+            else:
+                new_facility = Facility \
+                    .objects \
+                    .create(name=facility_list_item.name,
+                            address=facility_list_item.address,
+                            country_code=facility_list_item.country_code,
+                            location=facility_list_item.geocoded_point,
+                            created_from=facility_list_item)
+
+                # also create a new facility match
+                match_results = {
+                    "match_type": "all_potential_matches_rejected",
+                }
+
+                FacilityMatch \
+                    .objects \
+                    .create(facility_list_item=facility_list_item,
+                            facility=new_facility,
+                            confidence=1.0,
+                            status=FacilityMatch.CONFIRMED,
+                            results=match_results)
+
+                facility_list_item.facility = new_facility
+
+                facility_list_item.status = FacilityListItem \
+                    .CONFIRMED_MATCH
+
+            facility_list_item.save()
+
+        response_data = FacilityListItemSerializer(facility_list_item).data
+
+        if facility_list_item.source.source_type == Source.LIST:
+            response_data['list_statuses'] = (
+                facility_list_item
+                .source
+                .facilitylistitem_set
+                .values_list('status', flat=True)
+                .distinct())
+
+        return Response(response_data)
 
 
 @api_view(['GET'])

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -34,6 +34,8 @@ router.register('facility-lists', views.FacilityListViewSet, 'facility-list')
 router.register('facilities', views.FacilitiesViewSet, 'facility')
 router.register('facility-claims', views.FacilityClaimViewSet,
                 'facility-claim')
+router.register('facility-matches', views.FacilityMatchViewSet,
+                'facility-match')
 
 public_apis = [
     url(r'^api/', include(router.urls)),


### PR DESCRIPTION
## Overview

To support confirming and rejecting matches for single-item submissions, we need to move the confirm/reject API out from under the facility list API. 

To keep the number of UI changes to a minimum we are returning the same list item details when a request is successful.

We attempt to make it easy for API consumers to complete a partial match by constructing the full paths that can be POSTed to to confirm or reject the match.

Connects #916

## Testing Instructions

* Run `./scripts/resetdb`
* Run `./scripts/manage user_groups -e c8@example.com -a add -g can_submit_facility`
* Log in as `c8@example.com:password`.
* Browse http://localhost:6543/profile/8. Generate an API token and export it into the environment
```
export OAR_API_TOKEN={token}
```
* Submit a facility. Verify that the request is successful and that a `POTENTIAL_MATCH` is returned with with `confirm_match_url` and `reject_match_url` keys. 
```
http POST http://localhost:8081/api/facilities/ \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "China",
  "name": "Huai An Yuan Tong Headwear Mfg. Co. Ltd.",
  "address": "No.1 Yan Huang Avenue Lian Shui New Industrial Zone,Huai An,Jiangsu 223400. China"
}'
```
* Take the OAR from the response and browse http://localhost:6543/facilities/{oar_id}. Verify that the currently logged in contributor is NOT yet listed as a facility contributor.
* Copy the `confirm_match_url` and POST to it. Verify a successful response with a `CONFIRMED_MATCH` status and verify that the currently logged in contributor is now listed on the facility details page http://localhost:6543/facilities/{oar_id}
```
http POST http://localhost:8081/api/facility-matches/934/confirm/ \
"Authorization: Token $OAR_API_TOKEN"
```
* Submit the same details again. Confirm that another `POTENTIAL_MATCH` is created.
```
http POST http://localhost:8081/api/facilities/ \
"Authorization: Token $OAR_API_TOKEN" \
<<< '{
  "country": "China",
  "name": "Huai An Yuan Tong Headwear Mfg. Co. Ltd.",
  "address": "No.1 Yan Huang Avenue Lian Shui New Industrial Zone,Huai An,Jiangsu 223400. China"
}'
```
* POST to the rejection URL. Verify that the successful response contains 2 match records, one `REJECTED` and one `CONFIRMED` with a confidence of `1.0` representing the newly created facility. 
```
http POST http://localhost:8081/api/facility-matches/935/reject/ \
"Authorization: Token $OAR_API_TOKEN"
```
* Browse http://localhost:6543/lists/8
  * Reject the match for row index 10. Verify that a new facility is created.
  * Confirm the match for row index 11. Verify that the currently logged in contributor is listed on the details page for the facility.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
