### PR TITLE
Add a dissociate history event when list item is replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Move the facility match confirm/reject API to allow single-item match handling [
 ### Removed
 
 ### Fixed
+Add a dissociate history event when list item is replaced [#919](https://github.com/open-apparel-registry/open-apparel-registry/pull/919)
 
 ### Security
 


### PR DESCRIPTION
~**NOTE**: This is build on top of #918 and should be retargeted at `develop` when #918 is merged.~

## Overview

We were previously adding a dissociate event to the history when a match is deactivated via the "REMOVE" button in the facility list UI, but not when an item source is deactivated via uploading a replacement list.

Connects #914

## Demo

<img width="980" alt="Screen Shot 2019-11-19 at 11 44 06 AM" src="https://user-images.githubusercontent.com/17363/69175917-ed095880-0ac1-11ea-99d0-baf6330f05af.png">

## Testing Instructions

* Run `./scripts/resetdb`
* Log in as `c8@example.com:password`
* Browse http://localhost:6543/lists/8, reject the item with index 10 and confirm the item with index 11.
* Browse http://localhost:6543/contribute and submit [replace-test.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/3865495/replace-test.csv.zip) **making sure to choose the previous list to replace**.
* Fully process the updated list
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Search for an inactive facility http://localhost:6543/?q=supreme%20embellishment. Verify that the contributor is shown anonymously.
* Copy the OAR ID, browse http://localhost:8081/api/docs/#!/facilities/facilities_get_facility_history, and verify that a `DISSOCIATE` event is included.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
