### PR TITLE
Add filter option to search for contributor overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+Add filter option to search for contributor overlap [#925](https://github.com/open-apparel-registry/open-apparel-registry/pull/925)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -244,12 +244,37 @@ it('creates a set of filters from a querystring', () => {
         ],
         contributorTypes: [],
         countries: [],
+        combineContributors: '',
     };
 
     expect(isEqual(
         createFiltersFromQueryString(contributorsString),
         expectedContributorsMatch,
     )).toBe(true);
+
+    const combinedContributorsString = '?contributors=1&contributors=2&combine_contributors=AND';
+    const expectedCombinedContributorsMatch = {
+        facilityFreeTextQuery: '',
+        contributors: [
+            {
+                value: 1,
+                label: '1',
+            },
+            {
+                value: 2,
+                label: '2',
+            },
+        ],
+        contributorTypes: [],
+        countries: [],
+        combineContributors: 'AND',
+    };
+
+    expect(isEqual(
+        createFiltersFromQueryString(combinedContributorsString),
+        expectedCombinedContributorsMatch,
+    )).toBe(true);
+
 
     const typesString = '?contributor_types=Union&contributor_types=Service Provider';
     const expectedTypesMatch = {
@@ -266,6 +291,7 @@ it('creates a set of filters from a querystring', () => {
             },
         ],
         countries: [],
+        combineContributors: '',
     };
 
     expect(isEqual(
@@ -288,6 +314,7 @@ it('creates a set of filters from a querystring', () => {
                 label: 'CN',
             },
         ],
+        combineContributors: '',
     };
 
     expect(isEqual(
@@ -306,6 +333,7 @@ it('creates a set of filters from a querystring', () => {
             },
         ],
         countries: [],
+        combineContributors: '',
     };
 
     expect(isEqual(

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -11,6 +11,7 @@ export const updateFacilityFreeTextQueryFilter =
 export const updateContributorFilter = createAction('UPDATE_CONTRIBUTOR_FILTER');
 export const updateContributorTypeFilter = createAction('UPDATE_CONTRIBUTOR_TYPE_FILTER');
 export const updateCountryFilter = createAction('UPDATE_COUNTRY_FILTER');
+export const updateCombineContributorsFilterOption = createAction('UPDATE_COMBINE_CONTRIBUTORS_FILTER_OPTION');
 export const resetAllFilters = createAction('RESET_ALL_FILTERS');
 export const updateAllFilters = createAction('UPDATE_ALL_FILTERS');
 

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -6,6 +6,7 @@ import {
     updateContributorFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
+    updateCombineContributorsFilterOption,
     resetAllFilters,
     updateAllFilters,
 } from '../actions/filters';
@@ -27,6 +28,7 @@ const initialState = Object.freeze({
     contributors: Object.freeze([]),
     contributorTypes: Object.freeze([]),
     countries: Object.freeze([]),
+    combineContributors: '',
 });
 
 export const maybeSetFromQueryString = field => (state, payload) => {
@@ -55,6 +57,9 @@ export default createReducer({
     }),
     [updateCountryFilter]: (state, payload) => update(state, {
         countries: { $set: payload },
+    }),
+    [updateCombineContributorsFilterOption]: (state, payload) => update(state, {
+        combineContributors: { $set: payload },
     }),
     [resetAllFilters]: () => initialState,
     [updateAllFilters]: (_state, payload) => payload,

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -208,6 +208,7 @@ export const filtersPropType = shape({
     contributors: arrayOf(reactSelectOptionPropType).isRequired,
     contributorTypes: arrayOf(reactSelectOptionPropType).isRequired,
     countries: arrayOf(reactSelectOptionPropType).isRequired,
+    combineContributors: string.isRequired,
 });
 
 export const facilityListItemStatusPropType =

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -138,12 +138,14 @@ export const createQueryStringFromSearchFilters = ({
     contributors = [],
     contributorTypes = [],
     countries = [],
+    combineContributors = '',
 }) => {
     const inputForQueryString = Object.freeze({
         q: facilityFreeTextQuery,
         contributors: createCompactSortedQuerystringInputObject(contributors),
         contributor_types: createCompactSortedQuerystringInputObject(contributorTypes),
         countries: createCompactSortedQuerystringInputObject(countries),
+        combine_contributors: combineContributors,
     });
 
     return querystring.stringify(omitBy(inputForQueryString, isEmpty));
@@ -186,6 +188,7 @@ export const createFiltersFromQueryString = (qs) => {
         contributors = [],
         contributor_types: contributorTypes = [],
         countries = [],
+        combine_contributors: combineContributors = '',
     } = querystring.parse(qsToParse);
 
     return Object.freeze({
@@ -193,6 +196,7 @@ export const createFiltersFromQueryString = (qs) => {
         contributors: createSelectOptionsFromParams(contributors),
         contributorTypes: createSelectOptionsFromParams(contributorTypes),
         countries: createSelectOptionsFromParams(countries),
+        combineContributors,
     });
 };
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -24,6 +24,7 @@ class FacilitiesQueryParams:
     CONTRIBUTORS = 'contributors'
     CONTRIBUTOR_TYPES = 'contributor_types'
     COUNTRIES = 'countries'
+    COMBINE_CONTRIBUTORS = 'combine_contributors'
 
 
 class FacilityListQueryParams:

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -5183,3 +5183,154 @@ class SingleItemFacilityMatchTest(FacilityAPITestCaseBase):
         response = self.client.post(
             self.match_url(self.match, action='reject'))
         self.assertEqual(404, response.status_code)
+
+
+class FacilitySearchTest(FacilityAPITestCaseBase):
+    def setUp(self):
+        super(FacilitySearchTest, self).setUp()
+
+        self.user_two_email = 'two@example.com'
+        self.user_two_password = 'example123'
+        self.user_two = User.objects.create(email=self.user_two_email)
+        self.user_two.set_password(self.user_two_password)
+        self.user_two.save()
+
+        self.contributor_two = Contributor \
+            .objects \
+            .create(admin=self.user_two,
+                    name='test contributor 2',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.list_two = FacilityList \
+            .objects \
+            .create(header='header',
+                    file_name='two',
+                    name='Second List')
+
+        self.source_two = Source \
+            .objects \
+            .create(facility_list=self.list_two,
+                    source_type=Source.LIST,
+                    contributor=self.contributor_two)
+
+        self.list_item_two = FacilityListItem \
+            .objects \
+            .create(name='Item',
+                    address='Address',
+                    country_code='US',
+                    row_index=1,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=self.source_two)
+
+        self.facility_two = Facility \
+            .objects \
+            .create(name='Name Two',
+                    address='Address Two',
+                    country_code='US',
+                    location=Point(5, 5),
+                    created_from=self.list_item_two)
+
+        self.match_two = FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.AUTOMATIC,
+                    facility=self.facility_two,
+                    facility_list_item=self.list_item_two,
+                    confidence=0.85,
+                    results='')
+
+        self.list_item_two.facility = self.facility_two
+        self.list_item_two.save()
+
+        self.source_two_b = Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    contributor=self.contributor)
+
+        self.list_item_two_b = FacilityListItem \
+            .objects \
+            .create(name='Item 2b',
+                    address='Address',
+                    country_code='US',
+                    row_index=1,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=self.source_two_b)
+
+        self.match_two_b = FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.AUTOMATIC,
+                    facility=self.facility_two,
+                    facility_list_item=self.list_item_two_b,
+                    confidence=0.85,
+                    results='')
+
+        self.list_item_two_b.facility = self.facility_two
+        self.list_item_two_b.save()
+
+        self.base_url = reverse('facility-list')
+        self.contributor_or_url = self.base_url + \
+            '?contributors={}&contributors={}'
+        self.contributor_and_url = self.base_url + \
+            '?contributors={}&contributors={}&combine_contributors=AND'
+
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
+    def assert_response_count(self, response, count):
+        data = json.loads(response.content)
+        self.assertEqual(count, int(data['count']))
+
+    def test_contributor_or_search(self):
+        response = self.client.get(
+            self.contributor_or_url.format(
+                self.contributor.id,
+                self.contributor_two.id))
+        self.assert_response_count(response, 2)
+
+    def test_contributor_and_search(self):
+        response = self.client.get(
+            self.contributor_and_url.format(
+                self.contributor.id,
+                self.contributor_two.id))
+        self.assert_response_count(response, 1)
+
+    def test_contributor_and_inactive_match(self):
+        self.match_two_b.is_active = False
+        self.match_two_b.save()
+
+        response = self.client.get(
+            self.contributor_and_url.format(
+                self.contributor.id,
+                self.contributor_two.id))
+        self.assert_response_count(response, 0)
+
+    def test_contributor_and_inactive_source(self):
+        self.source_two_b.is_active = False
+        self.source_two_b.save()
+
+        response = self.client.get(
+            self.contributor_and_url.format(
+                self.contributor.id,
+                self.contributor_two.id))
+        self.assert_response_count(response, 0)
+
+    def test_contributor_and_private_source(self):
+        self.source_two_b.is_public = False
+        self.source_two_b.save()
+
+        response = self.client.get(
+            self.contributor_and_url.format(
+                self.contributor.id,
+                self.contributor_two.id))
+        self.assert_response_count(response, 0)
+
+    def test_contributor_and_pending_match(self):
+        self.match_two_b.status = FacilityMatch.PENDING
+        self.match_two_b.save()
+
+        response = self.client.get(
+            self.contributor_and_url.format(
+                self.contributor.id,
+                self.contributor_two.id))
+        self.assert_response_count(response, 0)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -499,6 +499,16 @@ class FacilitiesAPIFilterBackend(BaseFilterBackend):
                     required=False,
                     description='Country Code',
                 ),
+                coreapi.Field(
+                    name='combine_contributors',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description=(
+                        'Set this to "AND" if the results should contain '
+                        'facilities associated with ALL the specified '
+                        'contributors.')
+                ),
             ]
 
         if view.action == 'create':


### PR DESCRIPTION
## Overview

Adds a new option to the facility search API and and associated UI that allows optionally filtering facilities by contributor using an "AND" search rather than an "OR" search.

Connects #921

## Demo

NOTE [the help text was revised](https://github.com/open-apparel-registry/open-apparel-registry/pull/925#issuecomment-564654520) after this initial screencast was recorded.

![2019-12-10 18 19 44](https://user-images.githubusercontent.com/17363/70583050-bf23ab00-1b79-11ea-99cd-60cfae6610cb.gif)


## Notes

While adding support for this to the `filter_by_query_params` method we also replaced the previous filter by contributor code with a statement that computes the "IN" query on the server side. The large SQL statements generated by passing thousands of IDs in a literal "IN" statement were so large that they made analyzing query performance from SQL slow query logs difficult to impossible.

The tooltip text is a placeholder and will be replaced with a submission from Katie.

## Testing Instructions

* Run `./scripts/resetdb` and `./scripts/server`
* Search for "regina" and select the facility in China. Remember 2 of the three listed contributors.
* Reset the search, return to the "Search" tab, and enter the 2 contributors from the previous step in the "Filter by Contributor" box. Verify that the new checkbox only appears after the second item is added to the list.
* Run the search and verify that there are multiple facility matches.
* Return to the "Search" tab and check the checkbox. Run the search again and verify that only a single facility is now returned.
* Refresh the page, verify that the search is restored, return to the "Search" tab and verify that the checkbox is checked.
* Remove one of the facilities from the  "Filter by Contributor" box and verify that the checkbox is hidden and the `combine_contributors` querystring argument is no longer present in the URL.
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_list and verify that the `combine_contributors` argument is documented.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
