### PR TITLE
Fix FacilityList to string and serialization with no Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Add filter option to search for contributor overlap [#925](https://github.com/op
 ### Removed
 
 ### Fixed
+- Fix FacilityList to string and serilization with no Source [#931](https://github.com/open-apparel-registry/open-apparel-registry/pull/931)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-Add filter option to search for contributor overlap [#925](https://github.com/open-apparel-registry/open-apparel-registry/pull/925)
+- Add filter option to search for contributor overlap [#925](https://github.com/open-apparel-registry/open-apparel-registry/pull/925)
 
 ### Changed
 
@@ -24,14 +24,14 @@ Add filter option to search for contributor overlap [#925](https://github.com/op
 ### Added
 
 ### Changed
-Move the facility match confirm/reject API to allow single-item match handling [#918](https://github.com/open-apparel-registry/open-apparel-registry/pull/918/)
+- Move the facility match confirm/reject API to allow single-item match handling [#918](https://github.com/open-apparel-registry/open-apparel-registry/pull/918/)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-Add a dissociate history event when list item is replaced [#919](https://github.com/open-apparel-registry/open-apparel-registry/pull/919)
+- Add a dissociate history event when list item is replaced [#919](https://github.com/open-apparel-registry/open-apparel-registry/pull/919)
 
 ### Security
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -349,11 +349,14 @@ class FacilityList(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        if self.source.contributor is None:
-            return '{0} ({1})'.format(self.name, self.id)
+        try:
+            if self.source.contributor is None:
+                return '{0} ({1})'.format(self.name, self.id)
 
-        return '{0} - {1} ({2})'.format(
-            self.source.contributor.name, self.name, self.id)
+            return '{0} - {1} ({2})'.format(
+                self.source.contributor.name, self.name, self.id)
+        except Source.DoesNotExist:
+            return '{0} [NO SOURCE] ({1})'.format(self.name, self.id)
 
 
 class FacilityListItem(models.Model):

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -244,29 +244,44 @@ class FacilityListSerializer(ModelSerializer):
                   'status_counts', 'contributor_id', 'created_at')
 
     def get_is_active(self, facility_list):
-        return facility_list.source.is_active
+        try:
+            return facility_list.source.is_active
+        except Source.DoesNotExist:
+            return False
 
     def get_is_public(self, facility_list):
-        return facility_list.source.is_public
+        try:
+            return facility_list.source.is_public
+        except Source.DoesNotExist:
+            return False
 
     def get_item_count(self, facility_list):
-        return facility_list.source.facilitylistitem_set.count()
+        try:
+            return facility_list.source.facilitylistitem_set.count()
+        except Source.DoesNotExist:
+            return 0
 
     def get_items_url(self, facility_list):
         return reverse('facility-list-items',
                        kwargs={'pk': facility_list.pk})
 
     def get_statuses(self, facility_list):
-        return (facility_list.source.facilitylistitem_set
-                .values_list('status', flat=True)
-                .distinct())
+        try:
+            return (facility_list.source.facilitylistitem_set
+                    .values_list('status', flat=True)
+                    .distinct())
+        except Source.DoesNotExist:
+            return []
 
     def get_status_counts(self, facility_list):
-        statuses = FacilityListItem \
-            .objects \
-            .filter(source=facility_list.source) \
-            .values('status') \
-            .annotate(status_count=Count('status')) \
+        try:
+            statuses = FacilityListItem \
+                .objects \
+                .filter(source=facility_list.source) \
+                .values('status') \
+                .annotate(status_count=Count('status'))
+        except Source.DoesNotExist:
+            statuses = []
 
         status_counts_dictionary = {
             status_dict.get('status'): status_dict.get('status_count')
@@ -350,8 +365,11 @@ class FacilityListSerializer(ModelSerializer):
         }
 
     def get_contributor_id(self, facility_list):
-        return facility_list.source.contributor.id \
-            if facility_list.source.contributor else None
+        try:
+            return facility_list.source.contributor.id \
+                if facility_list.source.contributor else None
+        except Source.DoesNotExist:
+            return None
 
 
 class FacilityQueryParamsSerializer(Serializer):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -34,7 +34,8 @@ from api.geocoding import (create_geocoding_params,
 from api.test_data import parsed_city_hall_data
 from api.permissions import referring_host_is_allowed, referring_host
 from api.serializers import (ApprovedFacilityClaimSerializer,
-                             FacilityCreateBodySerializer)
+                             FacilityCreateBodySerializer,
+                             FacilityListSerializer)
 
 
 class FacilityListCreateTest(APITestCase):
@@ -5334,3 +5335,16 @@ class FacilitySearchTest(FacilityAPITestCaseBase):
                 self.contributor.id,
                 self.contributor_two.id))
         self.assert_response_count(response, 0)
+
+
+class ListWithoutSourceTest(TestCase):
+    def test_str(self):
+        facility_list = FacilityList()
+        # We are checking that the __str__ method does not raise an exception.
+        str(facility_list)
+
+    def test_serializer(self):
+        facility_list = FacilityList()
+        # Checking the `data` property triggers the serialization. We are
+        # checking that it does not raise an exception.
+        FacilityListSerializer(facility_list).data


### PR DESCRIPTION
## Overview

The `__str__` method on `FacilityList` and the `FacilityList` serializer were using the `source` property without verifying this nullable relationship, which lead to crashes after deleting the `Source` record for a mistakenly uploaded list.

Connects #926

## Testing Instructions

### Reproduce the error

* Check out the `develop` branch.
* Run `./scripts/resetdb`
* Log in as `c99@example.com:password`
* Upload [empty.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/3969716/empty.csv.zip)
* Log in as `c1@example.com:password`
* Browse http://localhost:8081/admin/api/source/16/change/ and delete the source
* Browse http://localhost:8081/admin/api/facilitylist/ and verify that clicking any of the list links results in a 500 error when trying to render the edit form

### Verify the fix

* Check out this branch
* Browse http://localhost:8081/admin/api/facilitylist/ and verify that the list links work without error.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
