### PR TITLE
Allow groups memberships to be changed in the Django admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Allow groups memberships to be changed in the Django admin [#934](https://github.com/open-apparel-registry/open-apparel-registry/pull/934)
 
 ### Changed
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -43,11 +43,12 @@ admin_site = ApiAdminSite()
 
 
 class OarUserAdmin(UserAdmin):
-    exclude = ('last_name', 'date_joined', 'first_name')
+    exclude = ('last_name', 'date_joined', 'first_name', 'username')
     fieldsets = (
-        (None, {'fields': ('email', 'username', 'is_staff', 'is_active',
+        (None, {'fields': ('email', 'is_staff', 'is_active',
                            'should_receive_newsletter',
-                           'has_agreed_to_terms_of_service')}),
+                           'has_agreed_to_terms_of_service',
+                           'groups')}),
     )
 
 


### PR DESCRIPTION


## Overview

When we implemented a custom admin configuration for the users page we mistakenly omitted groups. This may have been because there was an error trying to save the page with an empty `username` field. Excluding `username` (we only use `email` in OAR) resolves the save error.

Connects #933

## Demo

<img width="1044" alt="Screen Shot 2019-12-30 at 9 13 08 AM" src="https://user-images.githubusercontent.com/17363/71590151-a0636500-2ae4-11ea-9710-db905a3351e3.png">

## Testing Instructions

These notes assume `./scripts/resetdb` has been run.

* Log in as `c2@example.com`
* Browse http://localhost:6543/profile/2 and generate an API token.
* Browse http://localhost:8081/api/docs/ and click the 'Authorize" button. Submit `Token {your token}`
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_create (you will likely need to refresh)
  * Copy the "Sample Request Body" JSON and paste it into the "data" form field.
  * Set "create" to false.
  * Submit. Verify that a 403 error is returned.
* In a separate browser or private window, log in as `c1@example.com`
* Browse http://localhost:8081/admin/api/user/2/change/
* Move `can_submit_facility` from "Available groups" to "Chosen groups" and click "Save." Verify that the save is successful
* Return to the Swaggar API page and submit the request again. Verify that there is now a 200 response rather than a 403. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
