### PR TITLE
Update reports to properly handle multiple years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Update reports to properly handle multiple years [#938](https://github.com/open-apparel-registry/open-apparel-registry/pull/938)
 
 ### Security
 

--- a/src/django/api/reports/api_request_by_user.sql
+++ b/src/django/api/reports/api_request_by_user.sql
@@ -2,13 +2,13 @@
 -- Exclude users with openapparel.org or azavea.com email addresses.
 
 SELECT
-  CAST (date_part('month', l.created_at) AS int) AS month,
+  to_char(l.created_at, 'YYYY-MM') AS month,
   email,
   COUNT(*) AS api_request_count
 FROM api_requestlog l
 JOIN api_user u ON l.user_id = u.id
-WHERE date_part('month', l.created_at) < date_part('month', now())
+WHERE to_char(l.created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
 AND NOT u.email LIKE '%openapparel.org%'
 AND NOT u.email LIKE '%azavea.com%'
-GROUP BY date_part('month', l.created_at), email
-ORDER BY date_part('month', l.created_at), email;
+GROUP BY to_char(l.created_at, 'YYYY-MM'), email
+ORDER BY to_char(l.created_at, 'YYYY-MM'), email;

--- a/src/django/api/reports/api_requests.sql
+++ b/src/django/api/reports/api_requests.sql
@@ -3,12 +3,12 @@
 -- addresses.
 
 SELECT
-  CAST (date_part('month', l.created_at) AS int) AS month,
+  to_char(l.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS api_request_count
 FROM api_requestlog l
 JOIN api_user u ON l.user_id = u.id
-WHERE date_part('month', l.created_at) < date_part('month', now())
+WHERE to_char(l.created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
 AND NOT u.email LIKE '%openapparel.org%'
 AND NOT u.email LIKE '%azavea.com%'
-GROUP BY date_part('month', l.created_at)
-ORDER BY date_part('month', l.created_at);
+GROUP BY to_char(l.created_at, 'YYYY-MM')
+ORDER BY to_char(l.created_at, 'YYYY-MM');

--- a/src/django/api/reports/api_tokens.sql
+++ b/src/django/api/reports/api_tokens.sql
@@ -3,9 +3,9 @@
 -- report will change over time.
 
 SELECT
-  CAST (date_part('month', t.created) AS int) AS month,
+  to_char(t.created, 'YYYY-MM') AS month,
   COUNT(*) AS token_count
 FROM authtoken_token t
-WHERE date_part('month', t.created) < date_part('month', now())
-GROUP BY date_part('month', t.created)
-ORDER BY date_part('month', t.created);
+WHERE to_char(t.created, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+GROUP BY to_char(t.created, 'YYYY-MM')
+ORDER BY to_char(t.created, 'YYYY-MM');

--- a/src/django/api/reports/average_list_count_per_contributor.sql
+++ b/src/django/api/reports/average_list_count_per_contributor.sql
@@ -1,18 +1,18 @@
 SELECT
-  CAST (month AS int),
+  month,
   round(avg(list_count), 2)
 FROM (
   SELECT
-    date_part('month', l.created_at) AS month,
+    to_char(l.created_at, 'YYYY-MM') AS month,
     c.id,
     COUNT(*) AS list_count
   FROM api_facilitylist l
   JOIN api_source s ON s.facility_list_id = l.id
   JOIN api_contributor c ON c.id = s.contributor_id
-  WHERE date_part('month', l.created_at) != date_part('month', now())
+  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND s.is_public = 't'
   AND s.is_active = 't'
-  GROUP BY date_part('month', l.created_at), c.id
+  GROUP BY to_char(l.created_at, 'YYYY-MM'), c.id
 ) s
 GROUP BY month
 ORDER BY month;

--- a/src/django/api/reports/average_matches_per_facility.sql
+++ b/src/django/api/reports/average_matches_per_facility.sql
@@ -1,16 +1,16 @@
 SELECT
-  CAST (month AS int),
+  month,
   round(avg(match_count), 2) AS average_match_count
 FROM (
   SELECT
-    date_part('month', m.created_at) AS month,
+    to_char(m.created_at, 'YYYY-MM') AS month,
     f.id,
     count(*) AS match_count
   FROM api_facilitymatch m
   JOIN api_facility f ON m.facility_id = f.id
   AND status NOT IN ('REJECTED', 'PENDING')
-  AND date_part('month', m.created_at) != date_part('month', now())
-  GROUP BY date_part('month', m.created_at), f.id
+  AND to_char(m.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  GROUP BY to_char(m.created_at, 'YYYY-MM'), f.id
 ) s
 GROUP BY month
 ORDER BY month;

--- a/src/django/api/reports/average_matches_per_facility_by_type.sql
+++ b/src/django/api/reports/average_matches_per_facility_by_type.sql
@@ -1,10 +1,10 @@
 SELECT
-  CAST (month AS int) AS month,
+  month,
   contrib_type AS contributor_type,
   round(avg(match_count), 2) AS average_match_count
 FROM (
   SELECT
-    date_part('month', m.created_at) AS month,
+    to_char(m.created_at, 'YYYY-MM') AS month,
     f.id,
     COUNT(*) AS match_count,
     contrib_type
@@ -15,10 +15,10 @@ FROM (
   JOIN api_facilitylist l ON s.facility_list_id = l.id
   JOIN api_contributor c ON c.id = s.contributor_id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE date_part('month', m.created_at) != date_part('month', now())
+  WHERE to_char(m.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND m.status not in ('REJECTED', 'PENDING')
   AND not u.email like '%openapparel.org%'
-  GROUP BY date_part('month', m.created_at), f.id, contrib_type
+  GROUP BY to_char(m.created_at, 'YYYY-MM'), f.id, contrib_type
 ) s
 GROUP BY month, contrib_type
 ORDER BY month, contrib_type;

--- a/src/django/api/reports/confirmed_matches.sql
+++ b/src/django/api/reports/confirmed_matches.sql
@@ -1,8 +1,8 @@
 SELECT
-  CAST (date_part('month', li.created_at) AS int) AS month,
+  to_char(li.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS list_item_count
 from api_facilitylistitem li
 WHERE status = 'CONFIRMED_MATCH'
-AND date_part('month', created_at) < date_part('month', now())
-GROUP BY date_part('month', li.created_at)
-ORDER BY date_part('month', li.created_at);
+AND to_char(created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+GROUP BY to_char(li.created_at, 'YYYY-MM')
+ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/contributor_first_appearance.sql
+++ b/src/django/api/reports/contributor_first_appearance.sql
@@ -1,15 +1,15 @@
 SELECT
-  CAST (month AS int),
+  month,
   name
 from (
   SELECT DISTINCT
-    min(date_part('month', l.created_at)) AS month,
+    min(to_char(l.created_at, 'YYYY-MM')) AS month,
     c.id
   FROM api_facilitylist l
   JOIN api_source s ON s.facility_list_id = l.id
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE date_part('month', l.created_at) != date_part('month', now())
+  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND NOT u.email LIKE '%openapparel.org%'
   GROUP BY c.id
 ) s

--- a/src/django/api/reports/facilities_created_not_matched.sql
+++ b/src/django/api/reports/facilities_created_not_matched.sql
@@ -1,9 +1,9 @@
 SELECT
-  CAST (date_part('month', f.created_at) AS int) AS month,
+  to_char(f.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS match_count
 FROM api_facilitymatch m
 JOIN api_facility f ON m.facility_id = f.id
 WHERE m.facility_list_item_id = f.created_from_id
-AND date_part('month', f.created_at) < date_part('month', now())
-GROUP BY date_part('month', f.created_at)
-ORDER BY date_part('month', f.created_at);
+AND to_char(f.created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+GROUP BY to_char(f.created_at, 'YYYY-MM')
+ORDER BY to_char(f.created_at, 'YYYY-MM');

--- a/src/django/api/reports/facilities_matched.sql
+++ b/src/django/api/reports/facilities_matched.sql
@@ -1,10 +1,10 @@
 SELECT
-  CAST (date_part('month', f.created_at) AS int) AS month,
+  to_char(f.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS match_count
-FROM api_facilitymatch m
+  FROM api_facilitymatch m
 JOIN api_facility f ON m.facility_id = f.id
 WHERE m.facility_list_item_id != f.created_from_id
 AND status NOT IN ('REJECTED', 'PENDING')
-AND date_part('month', f.created_at) < date_part('month', now())
-GROUP BY date_part('month', f.created_at)
-ORDER BY date_part('month', f.created_at);
+AND to_char(f.created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+GROUP BY to_char(f.created_at, 'YYYY-MM')
+ORDER BY to_char(f.created_at, 'YYYY-MM');

--- a/src/django/api/reports/facility_country_count.sql
+++ b/src/django/api/reports/facility_country_count.sql
@@ -1,5 +1,5 @@
 SELECT
-  CAST (date_part('month', created_at) AS int) AS month,
+  to_char(created_at, 'YYYY-MM') AS month,
   COUNT(DISTINCT country_code) AS country_count
 FROM (
   SELECT
@@ -8,5 +8,5 @@ FROM (
     FROM api_facility
     GROUP BY country_code
 ) s
-GROUP BY date_part('month', created_at)
-ORDER BY date_part('month', created_at);
+GROUP BY to_char(created_at, 'YYYY-MM')
+ORDER BY to_char(created_at, 'YYYY-MM');

--- a/src/django/api/reports/facility_list_items_uploaded.sql
+++ b/src/django/api/reports/facility_list_items_uploaded.sql
@@ -1,13 +1,13 @@
 -- Count the number of facility list CSV rows uploaded each month.
 
 SELECT
-  CAST (date_part('month', i.created_at) AS int) AS month,
+  to_char(i.created_at, 'YYYY-MM') AS month,
   CASE WHEN u.email LIKE '%openapparel.org%' THEN 'y' ELSE 'n' END AS is_public_list,
   COUNT(*) AS item_count
   FROM api_facilitylistitem i
          JOIN api_source s on i.source_id = s.id
          JOIN api_contributor c ON s.contributor_id = c.id
          JOIN api_user u ON u.id = c.admin_id
- WHERE date_part('month', i.created_at) != date_part('month', now())
- GROUP BY date_part('month', i.created_at), is_public_list
- ORDER BY date_part('month', i.created_at), is_public_list;
+ WHERE to_char(i.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+ GROUP BY to_char(i.created_at, 'YYYY-MM'), is_public_list
+ ORDER BY to_char(i.created_at, 'YYYY-MM'), is_public_list;

--- a/src/django/api/reports/facility_lists_uploaded.sql
+++ b/src/django/api/reports/facility_lists_uploaded.sql
@@ -1,11 +1,11 @@
 SELECT
-  CAST (date_part('month', l.created_at) AS int) AS month,
+  to_char(l.created_at, 'YYYY-MM') AS month,
   CASE WHEN u.email LIKE '%openapparel.org%' THEN 'y' ELSE 'n' END AS is_public_list,
   COUNT(*) AS list_count
 FROM api_facilitylist l
 JOIN api_source s ON s.facility_list_id = l.id
 JOIN api_contributor c ON s.contributor_id = c.id
 JOIN api_user u ON u.id = c.admin_id
-WHERE date_part('month', l.created_at) != date_part('month', now())
-GROUP BY date_part('month', l.created_at), is_public_list
-ORDER BY date_part('month', l.created_at), is_public_list;
+WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+GROUP BY to_char(l.created_at, 'YYYY-MM'), is_public_list
+ORDER BY to_char(l.created_at, 'YYYY-MM'), is_public_list;

--- a/src/django/api/reports/geocode_errors.sql
+++ b/src/django/api/reports/geocode_errors.sql
@@ -1,8 +1,7 @@
 SELECT
-  CAST (date_part('month', li.created_at) AS int) AS month,
+  to_char(li.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS error_count
-FROM api_facilitylistitem li
+  FROM api_facilitylistitem li
 WHERE status = 'ERROR_GEOCODING'
-AND date_part('month', created_at) < date_part('month', now())
-GROUP BY date_part('month', li.created_at)
-ORDER BY date_part('month', li.created_at);
+GROUP BY to_char(li.created_at, 'YYYY-MM')
+ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/geocode_no_results.sql
+++ b/src/django/api/reports/geocode_no_results.sql
@@ -1,8 +1,8 @@
 SELECT
-  CAST (date_part('month', li.created_at) AS int) AS month,
+  to_char(li.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS list_item_count
 FROM api_facilitylistitem li
 WHERE status = 'ERROR_MATCHING'
-AND date_part('month', created_at) < date_part('month', now())
-GROUP BY date_part('month', li.created_at)
-ORDER BY date_part('month', li.created_at);
+AND to_char(created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+GROUP BY to_char(li.created_at, 'YYYY-MM')
+ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/non_public_contributors.sql
+++ b/src/django/api/reports/non_public_contributors.sql
@@ -1,17 +1,17 @@
 SELECT
-  CAST (month AS int),
+  month,
   COUNT(*) AS contributor_count
 FROM (
   SELECT DISTINCT
-    date_part('month', l.created_at) AS month,
+    to_char(l.created_at, 'YYYY-MM') AS month,
     c.id
   FROM api_facilitylist l
   JOIN api_source s ON s.facility_list_id = l.id
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE date_part('month', l.created_at) != date_part('month', now())
+  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND NOT u.email LIKE '%openapparel.org%'
-  ORDER BY date_part('month', l.created_at), c.id
+  ORDER BY to_char(l.created_at, 'YYYY-MM'), c.id
 ) s
 GROUP BY month
 ORDER BY month;

--- a/src/django/api/reports/public_contributors.sql
+++ b/src/django/api/reports/public_contributors.sql
@@ -1,17 +1,17 @@
 SELECT
-  CAST (month AS int),
+  month,
   COUNT(*) AS contributor_count
 FROM (
   SELECT DISTINCT
-    date_part('month', l.created_at) AS month,
+    to_char(l.created_at, 'YYYY-MM') AS month,
     c.id
   FROM api_facilitylist l
   JOIN api_source s ON s.facility_list_id = l.id
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE date_part('month', l.created_at) != date_part('month', now())
+  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND u.email LIKE '%openapparel.org%'
-  ORDER BY date_part('month', l.created_at), c.id
+  ORDER BY to_char(l.created_at, 'YYYY-MM'), c.id
 ) s
 GROUP BY month
 ORDER BY month;

--- a/src/django/api/reports/rejected_matches.sql
+++ b/src/django/api/reports/rejected_matches.sql
@@ -1,5 +1,5 @@
 SELECT
-  CAST (date_part('month', created_at) AS int) AS month,
+  to_char(created_at, 'YYYY-MM') AS month,
   COUNT(*) AS match_count
 FROM (
   SELECT
@@ -7,8 +7,8 @@ FROM (
     max(created_at) AS created_at
   FROM api_facilitymatch
   WHERE status = 'REJECTED'
-  AND date_part('month', created_at) < date_part('month', now())
+  AND to_char(created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
   GROUP BY facility_list_item_id
 ) s
-GROUP BY date_part('month', created_at)
-ORDER BY date_part('month', created_at);
+GROUP BY to_char(created_at, 'YYYY-MM')
+ORDER BY to_char(created_at, 'YYYY-MM');

--- a/src/django/api/reports/unique_contributor_count_by_type.sql
+++ b/src/django/api/reports/unique_contributor_count_by_type.sql
@@ -1,17 +1,17 @@
 SELECT
-  CAST (month AS int),
+  month,
   contrib_type AS contributor_type,
   COUNT(*) AS contributor_count
 FROM (
   SELECT distinct
-    min(date_part('month', l.created_at)) AS month,
+    min(to_char(l.created_at, 'YYYY-MM')) AS month,
     c.id,
     c.contrib_type
   FROM api_facilitylist l
   JOIN api_source s ON s.facility_list_id = l.id
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE date_part('month', l.created_at) != date_part('month', now())
+  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND NOT u.email like '%openapparel.org%'
   GROUP BY c.id, c.contrib_type
 ) s

--- a/src/django/api/reports/unique_public_list_count.sql
+++ b/src/django/api/reports/unique_public_list_count.sql
@@ -1,15 +1,15 @@
 SELECT
-  CAST (month AS int),
+  month,
   COUNT(*) AS list_count
 FROM (
   SELECT DISTINCT
-    min(date_part('month', l.created_at)) AS month,
+    min(to_char(l.created_at, 'YYYY-MM')) AS month,
     c.id
   FROM api_facilitylist l
   JOIN api_source s ON s.facility_list_id = l.id
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE date_part('month', l.created_at) != date_part('month', now())
+  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND u.email LIKE '%openapparel.org%'
   GROUP BY c.id
 ) s

--- a/src/django/api/reports/updated_lists.sql
+++ b/src/django/api/reports/updated_lists.sql
@@ -1,8 +1,8 @@
 SELECT
-  CAST (date_part('month', l.created_at) AS int) AS month,
+  to_char(l.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS list_count
 FROM api_facilitylist l
 WHERE replaces_id IS NOT NULL
-AND date_part('month', l.created_at) != date_part('month', now())
-GROUP BY date_part('month', l.created_at)
-ORDER BY date_part('month', l.created_at);
+AND to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+GROUP BY to_char(l.created_at, 'YYYY-MM')
+ORDER BY to_char(l.created_at, 'YYYY-MM');


### PR DESCRIPTION

## Overview

Previously the reports were filtering and grouping by month number. Now that we have data from different years we need to use a combination of year and month.

Connects #937

## Testing Instructions

I ran all of the revised reports on production and compared their output to the existing production versions edited to remove data filtering that filters out all the rows. All counts matched. 

The following steps assumes you have users created by running `./scripts/resetdb`

* Log in as `c1@example.com`
* Browse http://localhost:8081/admin/reports/
* Verify that all reports run without error. Many will be empty because the test data does not match the filter criteria of the report.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
