### PR TITLE
Return the contributor admin ID when serializing other locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950)
 
 ### Security
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -461,7 +461,8 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
             {
                 'lat': l.location.y,
                 'lng': l.location.x,
-                'contributor_id': l.contributor_id,
+                'contributor_id': l.contributor.admin.id if l.contributor
+                else None,
                 'contributor_name': l.contributor.name if l.contributor
                 else None,
                 'notes': l.notes,
@@ -475,7 +476,7 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
                 'lat': l.facility_list_item.geocoded_point.y,
                 'lng': l.facility_list_item.geocoded_point.x,
                 'contributor_id': l.facility_list_item.source
-                .contributor_id,
+                .contributor.admin.id,
                 'contributor_name':
                 l.facility_list_item.source.contributor.name
                 if l.facility_list_item.source.contributor else None,

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -3717,6 +3717,11 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
                     name='test contributor 2',
                     contrib_type=Contributor.OTHER_CONTRIB_TYPE)
 
+        self.assertFalse(self.other_contributor.id == self.other_user.id,
+                         'We want to verify that we serialize the proper ID '
+                         'and we can only do that if we have distinct '
+                         'Contributor and User ID values.')
+
         self.other_list = FacilityList \
             .objects \
             .create(header='header',
@@ -3780,6 +3785,14 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
             5,
         )
 
+        # The UI needs to build profile page links that use the ID of the User
+        # who is the "admin" of the Contributor, not the ID of the Contributor
+        # itself.
+        self.assertEqual(
+            data['properties']['other_locations'][0]['contributor_id'],
+            self.other_user.id
+        )
+
     def test_does_not_serialize_inactive_list_item_matches(self):
         self.other_source.is_active = False
         self.other_source.save()
@@ -3815,7 +3828,7 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
                 UpdateLocationParams.LAT: 41,
                 UpdateLocationParams.LNG: 43,
                 UpdateLocationParams.NOTES: 'A note',
-                UpdateLocationParams.CONTRIBUTOR_ID: self.contributor.id,
+                UpdateLocationParams.CONTRIBUTOR_ID: self.other_contributor.id,
             })
 
         self.client.logout()
@@ -3833,6 +3846,14 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
         self.assertEqual(
             data['properties']['other_locations'][0]['notes'],
             'A note',
+        )
+
+        # The UI needs to build profile page links that use the ID of the User
+        # who is the "admin" of the Contributor, not the ID of the Contributor
+        # itself.
+        self.assertEqual(
+            data['properties']['other_locations'][0]['contributor_id'],
+            self.other_user.id
         )
 
     def test_serializes_other_location_without_note_or_contributor(self):


### PR DESCRIPTION
## Overview

Profile page URLs are constructed using the ID of the admin user for the contributor. We update the serialization of the "Other locations" section of the facility detail page to be consistent with other places in the app where we create profile page links.

Connects #949 

## Testing Instructions

### Setup

* Checkout the `develop` branch
* Run `./scripts/resetdb` and `./scripts/server`
* Browse http://localhost:8081/admin/api/contributor/ and delete the contributor with the `(2)` suffix on the name (which should be at the bottom of the list.
* Browse http://localhost:8081/admin/api/contributor/15/change/ and change "Admin" to `c2@example.com`. Note the name of the contributor.
* Browse http://localhost:6543/?q=regina and select the facility in Shenzhen.
* Click the contributor link under "Other locations" and verify that it incorrectly links to /profile/15 and displays an empty page.
* Checkout this branch, browse http://localhost:6543/?q=regina, and select the Shenzhen facility again.
* Click the contributor link under "Other locations" and verify that it correctly links to /profile/2

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
