### PR TITLE
Properly handle deleted contributor when serializing other locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.21.1] - 2020-02-11
 
 ### Fixed
-Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950)
+Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950) [#952](https://github.com/open-apparel-registry/open-apparel-registry/pull/952)
 
 ## [2.21.0] - 2020-01-08
 ### Added

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -475,8 +475,9 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
             {
                 'lat': l.facility_list_item.geocoded_point.y,
                 'lng': l.facility_list_item.geocoded_point.x,
-                'contributor_id': l.facility_list_item.source
-                .contributor.admin.id,
+                'contributor_id':
+                l.facility_list_item.source.contributor.admin.id
+                if l.facility_list_item.source.contributor else None,
                 'contributor_name':
                 l.facility_list_item.source.contributor.name
                 if l.facility_list_item.source.contributor else None,


### PR DESCRIPTION
**NOTE**: This is targeted at the `release/2.21.1` branch

## Overview

This change avoids a crash in the FacilityDetailsSerializer when the contributor
of a match with an alternate location has been deleted.

Connects #949

## Notes

This should have been part of #950

## Testing Instructions

* Checkout the `release/2.21.1` branch
* Run `./scripts/resetdb` and `./scripts/server`
* Browse http://localhost:8081/admin/api/contributor/15/change/ and delete the contributor.
* Browse http://localhost:6543/?q=regina and select the facility in Shenzhen. Verify that an error prevents the details page from loading.
* Checkout this branch, browse http://localhost:6543/?q=regina, and select the Shenzhen facility again. Verify that the facility details load correctly.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
