### PR TITLE
Use a nested query when filtering by contributor type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Use a nested query when filtering by contributor type [#954](https://github.com/open-apparel-registry/open-apparel-registry/pull/954)
+
 ### Deprecated
 
 ### Removed
@@ -21,7 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.21.1] - 2020-02-11
 
 ### Fixed
-Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950) [#952](https://github.com/open-apparel-registry/open-apparel-registry/pull/952)
+
+- Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950) [#952](https://github.com/open-apparel-registry/open-apparel-registry/pull/952)
 
 ## [2.21.0] - 2020-01-08
 ### Added

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1043,22 +1043,17 @@ class FacilityManager(models.Manager):
                 .filter(country_code__in=countries)
 
         if len(contributor_types):
-            type_match_facility_ids = [
-                match['facility__id']
-                for match
-                in FacilityMatch
-                .objects
-                .filter(status__in=[FacilityMatch.AUTOMATIC,
-                                    FacilityMatch.CONFIRMED])
-                .filter(is_active=True)
-                .filter(facility_list_item__source__contributor__contrib_type__in=contributor_types) # NOQA
-                .filter(facility_list_item__source__is_active=True)
-                .filter(facility_list_item__source__is_public=True)
-                .values('facility__id')
-            ]
-
             facilities_qs = facilities_qs \
-                .filter(id__in=type_match_facility_ids)
+                .filter(id__in=FacilityMatch
+                        .objects
+                        .filter(status__in=[FacilityMatch.AUTOMATIC,
+                                            FacilityMatch.CONFIRMED])
+                        .filter(is_active=True)
+                        .filter(facility_list_item__source__contributor__contrib_type__in=contributor_types) # NOQA
+                        .filter(facility_list_item__source__is_active=True)
+                        .filter(facility_list_item__source__is_public=True)
+                        .values('facility__id')
+                )
 
         if len(contributors):
             if combine_contributors.upper() == 'AND':


### PR DESCRIPTION

## Overview

Previously we were calculating a list of facility IDs in a separate query and passing that literal list as an "in" parameter. When there are thousands of matching facilities this creates queries that so large, in terms of raw text size, that they break query analysis tools.

In development, the latency of tile requests is unaffected by this change.

Connects #894

## Demo

The staging database is configured to log queries over 500ms

<img width="1300" alt="Screen Shot 2020-02-19 at 2 48 51 PM" src="https://user-images.githubusercontent.com/17363/74880074-b4c71f80-5327-11ea-9f5f-932e60770179.png">

I used this request on staging for testing, which "filters" by all possible contributor types (because we deleted many contributor accounts on staging, this returns ~6000 facilities) 

https://staging.openapparel.org/facilities?contributor_types=Auditor&contributor_types=Brand%2FRetailer&contributor_types=Civil%20Society%20Organization&contributor_types=Factory%20%2F%20Facility&contributor_types=Manufacturing%20Group%20%2F%20Supplier%20%2F%20Vendor&contributor_types=Multi%20Stakeholder%20Initiative&contributor_types=Other&contributor_types=Researcher%20%2F%20Academic&contributor_types=Service%20Provider&contributor_types=Union

To exercise the existing develop branch, I ran `incrementtileversion` to first break the tile cache.

```
vagrant@vagrant:/vagrant$ ./scripts/manage ecsmanage incrementtileversion
```

I then refreshed the URL above and double-click zoomed into China several times, zooming in before the tiles had loaded.

After deploying this branch to staging, I repeated the entire process.

No tile queries were logged. The log file created when loading tiles is so large (1.8MB) because the query on the develop branch includes a literal array of thousands of OAR IDs in the query.

<img width="1364" alt="Screen Shot 2020-02-19 at 2 47 52 PM" src="https://user-images.githubusercontent.com/17363/74880115-c6a8c280-5327-11ea-8aef-60ca2788dc12.png">

## Notes

This change is not guaranteed to resolve the timeout/downtime issues #894 but:
* There is evidence that it is improving query performance.
* It prevents creating slow query logs of unwieldy size that break tools like pgbadger. 

## Testing Instructions

* Verify that the unit tests pass.
* Compare the result count when searching by a contributor type on the `develop` branch vs. this PR branch and verify that they are equal.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
