### PR TITLE
Add confirmed matches to canonical facility list when matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Add a report that groups facility counts by country [#979](https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
+- Add confirmed matches to canonical facility list when matching [#964](https://github.com/open-apparel-registry/open-apparel-registry/pull/964)
 
 ### Changed
 - Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-
-- Add a report that groups facility counts by country [#979] (https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
+- Add a report that groups facility counts by country [#979](https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
 
 ### Changed
-
-- Zoom to search
+- Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-
-- Ignore case for forgot-password email [#970] [https://github.com/open-apparel-registry/open-apparel-registry/pull/970]
-
-- Update 'parent company' label to 'parent company / supplier group' [#971] (https://github.com/open-apparel-registry/open-apparel-registry/pull/971)
-
-- Hide contributors with only errored facilities [#974] (https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
-
-- Show automated GPS coordinates after update [#978] (https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
+- Ignore case for forgot-password email [#970](https://github.com/open-apparel-registry/open-apparel-registry/pull/970)
+- Update 'parent company' label to 'parent company / supplier group' [#971](https://github.com/open-apparel-registry/open-apparel-registry/pull/971)
+- Hide contributors with only errored facilities [#974](https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
+- Show automated GPS coordinates after update [#978](https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
 
 ### Security
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -27,7 +27,8 @@ from api.models import (Facility, FacilityList, FacilityListItem,
 from api.oar_id import make_oar_id, validate_oar_id
 from api.matching import match_facility_list_items
 from api.processing import (parse_facility_list_item,
-                            geocode_facility_list_item)
+                            geocode_facility_list_item,
+                            reduce_matches)
 from api.geocoding import (create_geocoding_params,
                            format_geocoded_address_data,
                            geocode_address)
@@ -1188,6 +1189,18 @@ class DedupeMatchingTests(TestCase):
                                          status=FacilityListItem.PARSED)
         result = match_facility_list_items(facility_list)
         self.assertTrue(result['results']['no_geocoded_items'])
+
+    def test_reduce_matches(self):
+        matches = [
+            ('US2020052GKF19F', 75),
+            ('US2020052GKF19F_MATCH-23', 88),
+            ('US2020052YDVKBQ', 45)
+        ]
+        expected = [
+            ('US2020052GKF19F', 88),
+            ('US2020052YDVKBQ', 45)
+        ]
+        self.assertEqual(expected, reduce_matches(matches))
 
 
 class OarIdTests(TestCase):


### PR DESCRIPTION
## Overview

Prior to this commit, when a contributor manually confirmed a facility match, then uploaded a replacement list, the same potential match would be presented for repeat confirmation because there was no mechanism to feed the confirmation back into the matching process.

Our first attempt to resolve this was by augmenting the training data loading from a static JSON file with previously confirmed matches, but this did not boost the match scores enough.

This commit resolves the problem by augmenting the canonical list of facilities with items pulled from confirmed matches. We generate temporary, "extended" IDs for these items in the format `US2020052GKF19F_MATCH-23` and normalized them back to real Facility IDs when we create model objects from the output of the Dedupe matching process.

Connects #947 

## Testing Instructions

* Run ./scripts/resetdb
* Log in as c8@example.com
* Browse http://localhost:6543/lists/8
  * Reject the match for row index 10
  * CONFIRM the match for row index 11
  * CONFIRM the match for row index 18 (if it is suggested)
  * Reject both matches for row index 25
* Browse http://localhost:6543/contribute, upload src/django/api/management/commands/facility_lists/geocoded/8.csv, and **replace the previous list.**
* Fully process the uploaded list
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Browse the results http://localhost:6543/lists/16. Verify that there are no pending matches, particularly row index 11.


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
