### PR TITLE
Zoom to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Zoom to search
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/actions/ui.js
+++ b/src/app/src/actions/ui.js
@@ -14,3 +14,6 @@ export const updateSidebarFacilitiesTabTextFilter =
     createAction('UPDATE_SIDEBAR_FACILITIES_TAB_TEXT_FILTER');
 export const resetSidebarFacilitiesTabTextFilter =
     createAction('RESET_SIDEBAR_FACILITIES_TAB_TEXT_FILTER');
+
+export const toggleZoomToSearch =
+    createAction('TOGGLE_ZOOM_TO_SEARCH');

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -58,6 +58,7 @@ function VectorTileFacilitiesMap({
     location,
     facilityDetailsData,
     gridColorRamp,
+    extent,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
@@ -68,6 +69,7 @@ function VectorTileFacilitiesMap({
             false,
         ),
         isVectorTileMap: true,
+        extent,
     });
 
     const [currentMapZoomLevel, setCurrentMapZoomLevel] = useState(
@@ -188,6 +190,7 @@ function mapStateToProps({
     clientInfo: { fetched, countryCode },
     facilities: {
         singleFacility: { data },
+        facilities: { data: facilitiesData },
     },
     vectorTileLayer: {
         gridColorRamp,
@@ -199,6 +202,7 @@ function mapStateToProps({
         countryCode: countryCode || COUNTRY_CODES.default,
         facilityDetailsData: data,
         gridColorRamp,
+        extent: facilitiesData ? facilitiesData.extent : null,
     };
 }
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -14,6 +14,7 @@ import Button from './Button';
 import VectorTileFacilitiesLayer from './VectorTileFacilitiesLayer';
 import VectorTileFacilityGridLayer from './VectorTileFacilityGridLayer';
 import VectorTileGridLegend from './VectorTileGridLegend';
+import ZoomToSearchControl from './ZoomToSearchControl';
 
 import { COUNTRY_CODES } from '../util/constants';
 
@@ -59,6 +60,7 @@ function VectorTileFacilitiesMap({
     facilityDetailsData,
     gridColorRamp,
     extent,
+    zoomToSearch,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
@@ -70,6 +72,7 @@ function VectorTileFacilitiesMap({
         ),
         isVectorTileMap: true,
         extent,
+        zoomToSearch,
     });
 
     const [currentMapZoomLevel, setCurrentMapZoomLevel] = useState(
@@ -121,6 +124,9 @@ function VectorTileFacilitiesMap({
                 minZoom={1}
                 zIndex={1}
             />
+            <Control position="topleft">
+                <ZoomToSearchControl />
+            </Control>
             <Control position="bottomleft">
                 <VectorTileGridLegend
                     currentZoomLevel={currentMapZoomLevel}
@@ -186,6 +192,7 @@ VectorTileFacilitiesMap.propTypes = {
 function mapStateToProps({
     ui: {
         facilitiesSidebarTabSearch: { resetButtonClickCount },
+        zoomToSearch,
     },
     clientInfo: { fetched, countryCode },
     facilities: {
@@ -203,6 +210,7 @@ function mapStateToProps({
         facilityDetailsData: data,
         gridColorRamp,
         extent: facilitiesData ? facilitiesData.extent : null,
+        zoomToSearch,
     };
 }
 

--- a/src/app/src/components/ZoomToSearchControl.jsx
+++ b/src/app/src/components/ZoomToSearchControl.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import COLOURS from '../util/COLOURS';
+
+import { toggleZoomToSearch } from '../actions/ui';
+
+const zoomStyles = Object.freeze({
+    zoomStyle: Object.freeze({
+        background: 'white',
+        border: `1px solid ${COLOURS.NAVY_BLUE}`,
+        fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+        fontSize: '13px',
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '10px',
+    }),
+    zoomLabelStyle: Object.freeze({
+        padding: '5px',
+        textTransform: 'uppercase',
+    }),
+});
+
+function ZoomToSearchControl({
+    zoomToSearch,
+    toggleZoom,
+}) {
+    return (
+        <div id="zoom-search" style={zoomStyles.zoomStyle}>
+            <input
+                type="checkbox"
+                name="zoom-checkbox"
+                checked={zoomToSearch}
+                onChange={e => toggleZoom(e.target.checked)}
+            />
+            <label
+                htmlFor="zoom-checkbox"
+                style={zoomStyles.zoomLabelStyle}
+            >
+                    Zoom to Search
+            </label>
+        </div>
+    );
+}
+
+function mapStateToProps({ ui: { zoomToSearch } }) {
+    return { zoomToSearch };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        toggleZoom: checked => dispatch(toggleZoomToSearch(checked)),
+    };
+}
+
+ZoomToSearchControl.defaultProps = {
+    zoomToSearch: true,
+};
+
+ZoomToSearchControl.propTypes = {
+    toggleZoom: PropTypes.func.isRequired,
+    zoomToSearch: PropTypes.bool,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ZoomToSearchControl);

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -11,6 +11,7 @@ import {
     resetSidebarFacilitiesTabTextFilter,
     recordSearchTabResetButtonClick,
     reportWindowResize,
+    toggleZoomToSearch,
 } from '../actions/ui';
 
 import { completeFetchFacilities } from '../actions/facilities';
@@ -29,6 +30,7 @@ const initialState = Object.freeze({
         innerHeight: isObject(window) ? window.innerHeight : null,
         innerWidth: isObject(window) ? window.innerWidth : null,
     }),
+    zoomToSearch: true,
 });
 
 export default createReducer({
@@ -96,5 +98,8 @@ export default createReducer({
     }),
     [reportWindowResize]: (state, payload) => update(state, {
         window: { $merge: payload },
+    }),
+    [toggleZoomToSearch]: (state, payload) => update(state, {
+        zoomToSearch: { $set: payload },
     }),
 }, initialState);

--- a/src/app/src/util/hooks.js
+++ b/src/app/src/util/hooks.js
@@ -18,9 +18,33 @@ export default function useUpdateLeafletMapImperatively(
         data,
         shouldPanMapToFacilityDetails,
         isVectorTileMap = false,
+        extent,
     } = {},
 ) {
     const mapRef = useRef(null);
+
+    const [
+        currentExtent,
+        setCurrentExtent,
+    ] = useState(extent);
+    useEffect(() => {
+        if (zoomToSearch && extent != null && currentExtent !== extent) {
+            const leafletMap = get(mapRef, 'current.leafletElement', null);
+
+            if (leafletMap) {
+                leafletMap.fitBounds([
+                    [extent[3], extent[2]],
+                    [extent[1], extent[0]],
+                ], { maxZoom: detailsZoomLevel, padding: [20, 20] });
+            }
+
+            setCurrentExtent(extent);
+        }
+    }, [
+        extent,
+        currentExtent,
+        zoomToSearch,
+    ]);
 
     // Reset the map state when the reset button is clicked.
     const [

--- a/src/app/src/util/hooks.js
+++ b/src/app/src/util/hooks.js
@@ -19,6 +19,7 @@ export default function useUpdateLeafletMapImperatively(
         shouldPanMapToFacilityDetails,
         isVectorTileMap = false,
         extent,
+        zoomToSearch,
     } = {},
 ) {
     const mapRef = useRef(null);


### PR DESCRIPTION
## Overview

The features search API includes the extent (outer boundaries) of the
search results in the form [y1, x1, y2, x2], representing the lower left
and upper right corners of the boundaries of the results.

We want to zoom to the extent of the search results, so we have added
this to allow that functionality. If the data from a search includes an extent field
(an array of [y1, x1, y2, x2]) then the map will zoom to fit the boundaries of the extent. The
map will zoom again if the extent changes. 

The zoom to search functionality is turned on and off by a checkbox on
the map, which is selected by default. Users are able to disable zoom to
search by unchecking the checkbox.

The state of the checkbox is held in the UI reducer. This seemed like
a logical location as it primarily controls the way information is
presented, not the information itself.

Connects #406 

## Demo

<img width="1373" alt="Screen Shot 2020-02-28 at 11 28 50 AM" src="https://user-images.githubusercontent.com/21046714/75566350-87f8c380-5a1d-11ea-81d1-87532f493a89.png">

## Notes

- The checkbox to disable the filter is currently located on the map and mimics the style of the legend that already exists. This should be reviewed by a designer.

- Because there is no hook in the pagination classes to allow additional
data fields to the response, we added the extent directly to the
response data. We attempted an extension of the pagination class to
allow for the addition of the extent data directly, but the current
setup of the classes involved didn't allow for this extension.

## Testing Instructions

* Run `./scripts/update` in Vagrant ssh
* Search for facilities - searching with a specific region name will give the most noticeable results
* The map should zoom to the search results
* Search for a specific facility by name
* The map should zoom to the facility
* Disable 'zoom to search' with the checkbox on the map
* Search for facilities, then a specific facility
* The map should not zoom in response to the searches

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
