### PR TITLE
Forgot password not case-sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Ignore case for forgot-password email [#970] [https://github.com/open-apparel-registry/open-apparel-registry/pull/970]
+
 ### Security
 
 ## [2.22.0] - 2020-02-20

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -896,7 +896,7 @@ class UserPasswordResetSerializer(PasswordResetSerializer):
         if not self.reset_form.is_valid():
             raise ValidationError("Error")
 
-        if not User.objects.filter(email=user_email).exists():
+        if not User.objects.filter(email__iexact=user_email).exists():
             raise ValidationError("Error")
 
         return user_email


### PR DESCRIPTION
## Overview

When users enter their email to retrieve a forgotten password,
the search to confirm their email is not case-sensitive.

Connects #968 

## Demo

![email_case](https://user-images.githubusercontent.com/21046714/75705148-cc3bcc00-5c88-11ea-9e44-9478c46d6b59.gif)

## Testing Instructions

* Checkout this branch
* Run `vagrant ssh` and `./scripts/server`
* Go to 'login' and select 'forgot password'
* Enter your email with capitalization that doesn't match how you originally capitalized it when you signed up
* The forgot password email should 'send' successfully (check the console to see it printed there)

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
