### PR TITLE
Hides contributors with only errored facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update 'parent company' label to 'parent company / supplier group' [#971] (https://github.com/open-apparel-registry/open-apparel-registry/pull/971)
 
+- Hide contributors with only errored facilities [#974] (https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
+
 ### Security
 
 ## [2.22.0] - 2020-02-20

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -1223,22 +1223,26 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.email_two = 'two@example.com'
         self.email_three = 'three@example.com'
         self.email_four = 'four@example.com'
+        self.email_five = 'five@example.com'
 
         self.contrib_one_name = 'contributor that should be included'
         self.contrib_two_name = 'contributor with no lists'
         self.contrib_three_name = 'contributor with an inactive list'
         self.contrib_four_name = 'contributor with a non public list'
+        self.contrib_five_name = 'contributor with only error items'
 
         self.country_code = 'US'
         self.list_one_name = 'one'
         self.list_one_b_name = 'one-b'
         self.list_three_name = 'three'
         self.list_four_name = 'four'
+        self.list_five_name = 'five'
 
         self.user_one = User.objects.create(email=self.email_one)
         self.user_two = User.objects.create(email=self.email_two)
         self.user_three = User.objects.create(email=self.email_three)
         self.user_four = User.objects.create(email=self.email_four)
+        self.user_five = User.objects.create(email=self.email_five)
 
         self.contrib_one = Contributor \
             .objects \
@@ -1262,6 +1266,12 @@ class ContributorsListAPIEndpointTests(TestCase):
             .objects \
             .create(admin=self.user_four,
                     name=self.contrib_four_name,
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.contrib_five = Contributor \
+            .objects \
+            .create(admin=self.user_five,
+                    name=self.contrib_five_name,
                     contrib_type=Contributor.OTHER_CONTRIB_TYPE)
 
         self.list_one = FacilityList \
@@ -1318,6 +1328,24 @@ class ContributorsListAPIEndpointTests(TestCase):
                     is_active=True,
                     contributor=self.contrib_four)
 
+        self.list_five = FacilityList \
+            .objects \
+            .create(header="header",
+                    file_name="one",
+                    name=self.list_five_name)
+
+        self.source_five = Source \
+            .objects \
+            .create(source_type=Source.LIST,
+                    facility_list=self.list_five,
+                    contributor=self.contrib_five)
+
+        self.list_item_five = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_five,
+                    status=FacilityListItem.ERROR_PARSING)
+
     def test_contributors_list_has_only_contributors_with_active_lists(self):
         response = self.client.get('/api/contributors/')
         response_data = response.json()
@@ -1340,6 +1368,11 @@ class ContributorsListAPIEndpointTests(TestCase):
 
         self.assertNotIn(
             self.contrib_four_name,
+            contributor_names,
+        )
+
+        self.assertNotIn(
+            self.contrib_five_name,
             contributor_names,
         )
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -380,12 +380,14 @@ def all_contributors(request):
             [2, "Contributor Two"]
         ]
     """
+    valid_sources = Source.objects.filter(
+        is_active=True, is_public=True).exclude(
+        facilitylistitem__status__in=FacilityListItem.ERROR_STATUSES)
     response_data = [
         (contributor.id, contributor.name)
         for contributor
         in Contributor.objects.filter(
-            source__is_active=True,
-            source__is_public=True).distinct().order_by('name')
+            source__in=valid_sources).distinct().order_by('name')
     ]
 
     return Response(response_data)


### PR DESCRIPTION
## Overview

Filters the contributors list to only return contributors who
have sources which are active, public, and linked to at least one
facility with a non-errored status.

This prevents contributors who only have facilities in an errored state from 
appearing in the dropdown.

Connects #965 

## Testing Instructions

 * Run `./scripts/resetdb`
 * Register and confirm a new account with the name "BAD LIST."
 * Upload [bad.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4263292/bad.csv.zip)
 * Process the file through the "parse" step `./scripts/manage batch_process --list-id 16 --action parse`
 * Browse http://localhost:6543/lists/16 and verify that there is one item in the `ERROR_PARSING` status
 * Browse http://localhost:6543/. "BAD LIST" will NOT appear in the Contributor search dropdown.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
