### PR TITLE
Show automated GPS coordinates

### DIFF
--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -490,7 +490,6 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
                 FacilityMatch.AUTOMATIC,
             ])
             .filter(is_active=True)
-            if l.facility_list_item != facility.created_from
             if l.facility_list_item.geocoded_point != facility.location
             if l.facility_list_item.geocoded_point is not None
             if l.facility_list_item.source.is_active


### PR DESCRIPTION
## Overview

After the GPS coordinates for a facility were updated, they were
being filtered out from the facility details view of 'other locations'.
This could be confusing for users relying on the original GPS
coordinates.

There was a filter being applied to the other locations data intended
to prevent the original location from showing up as both an other and
a current location; however, additional filters at the same point apply
specifically to filtering out the current location, so we can include
the original location only when it is not the current location by
simply removing the original-location specific filter.

Connects #929 

## Demo

<img width="399" alt="Screen Shot 2020-03-04 at 10 27 58 AM" src="https://user-images.githubusercontent.com/21046714/75900821-852a1400-5e0b-11ea-8e53-3844383e3757.png">

## Testing Instructions

* Check out this branch
* Run `vagrant ssh` and `./scripts/server`
* Check the details page of a facility whose location has not been updated.
* It should have no locations listed under 'other locations', and the current location listed correctly.
* Update the location for the facility.
* It should now have the new location listed as 'current location', and the original location listed under 'other locations'.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
