### PR TITLE
Show automated GPS coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Hide contributors with only errored facilities [#974] (https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
 
+- Show automated GPS coordinates after update [#978] (https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
+
 ### Security
 
 ## [2.22.0] - 2020-02-20

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -490,7 +490,6 @@ class FacilityDetailsSerializer(GeoFeatureModelSerializer):
                 FacilityMatch.AUTOMATIC,
             ])
             .filter(is_active=True)
-            if l.facility_list_item != facility.created_from
             if l.facility_list_item.geocoded_point != facility.location
             if l.facility_list_item.geocoded_point is not None
             if l.facility_list_item.source.is_active

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -3873,7 +3873,7 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
         data = json.loads(response.content)
         self.assertEqual(
             len(data['properties']['other_locations']),
-            2,
+            3,
         )
 
         self.assertEqual(
@@ -3907,9 +3907,10 @@ class SerializeOtherLocationsTest(FacilityAPITestCaseBase):
         )
 
         data = json.loads(response.content)
+
         self.assertEqual(
             len(data['properties']['other_locations']),
-            2,
+            3,
         )
 
         self.assertEqual(


### PR DESCRIPTION
## Overview

The automatically generated GPS coordinates are moved to the "other
locations" section on a facility profile when GPS coordinates
are updated.

The original, automatically generated GPS coordinates previously
disappeared from the public view when an update was made to GPS
coordinates. This could be confusing for users who had used the first
set of coordinates as their reference point for a facility.

Two tests have been updated to reflect the changed number of facilities
being returned after an update.

Connects #975 

## Demo

<img width="399" alt="Screen Shot 2020-03-04 at 10 27 58 AM" src="https://user-images.githubusercontent.com/21046714/75916720-d98ebd00-5e26-11ea-86e2-5d8ee5fe3d22.png">

## Testing Instructions

* Check out this branch
* Run `vagrant ssh` and `./scripts/test`
* All test should pass
* Run `./scripts/server`
* Look at the details view for a facility with an automated location and confirm that the location is only shown once, and not duplicated under 'other locations'
* Update the location for the facility, then return to the details view
* The facility should now have the new location under current location, and the old location under 'other locations'. Neither should be duplicated.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
