### PR TITLE
Add report of facility counts grouped by country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a report that groups facility counts by country [#979] (https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
+
 ### Changed
 
 - Zoom to search

--- a/src/django/api/reports/facility_counts_by_country.sql
+++ b/src/django/api/reports/facility_counts_by_country.sql
@@ -1,0 +1,6 @@
+SELECT
+    country_code,
+    COUNT(api_facility.id) AS facility_count
+FROM api_facility
+GROUP BY country_code
+ORDER BY facility_count DESC


### PR DESCRIPTION
## Overview

Adds an admin report that shows the facility counts
grouped by country, ordered by count descending.

Connects #976 

## Demo

<img width="473" alt="Screen Shot 2020-03-04 at 3 55 03 PM" src="https://user-images.githubusercontent.com/21046714/75922190-8883c680-5e30-11ea-9c11-1e040751185c.png">

## Testing Instructions

* Run `vagrant ssh` and `./scripts/server`
* Navigate to http://localhost:8081/admin/reports/facility-counts-by-country/
* Confirm that the admin report functions as required

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
