### PR TITLE
Display number of contributors per type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)
+- Display number of contributors per type [#981](https://github.com/open-apparel-registry/open-apparel-registry/pull/981)
 
 ### Deprecated
 


### PR DESCRIPTION
## Overview

The endpoint to fetch all contributors now queries the number of
contributors per contributor type, the appends the count to the
display name for each contributor type. This allows the UI to
display the number of contributors for each type under the contributor
type dropdown in search.

This functionality was requested by several users, as currently this
information is only available through the admin reports.

Connects #930 

## Demo

<img width="366" alt="Screen Shot 2020-03-05 at 11 52 44 AM" src="https://user-images.githubusercontent.com/21046714/76007450-0ea91700-5edc-11ea-8ca0-2c3b80316226.png">

## Testing Instructions

* Checkout this branch
* Run `vagrant ssh` and `./scripts/server`
* Navigate to the search tab and dropdown the contributor type select
* The contributor types should each show a number of contributors.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
