### PR TITLE
Open to search tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)
 - Display number of contributors per type [#981](https://github.com/open-apparel-registry/open-apparel-registry/pull/981)
+- Open to search on page load; show results count in tab bar [#985](https://github.com/open-apparel-registry/open-apparel-registry/pull/985)
 
 ### Deprecated
 

--- a/src/app/src/actions/facilities.js
+++ b/src/app/src/actions/facilities.js
@@ -16,6 +16,8 @@ import {
     createQueryStringFromSearchFilters,
 } from '../util/util';
 
+import { makeSidebarFacilitiesTabActive } from './ui';
+
 export const startFetchFacilities = createAction('START_FETCH_FACILITIES');
 export const failFetchFacilities = createAction('FAIL_FETCH_FACILITIES');
 export const completeFetchFacilities = createAction('COMPLETE_FETCH_FACILITIES');
@@ -29,6 +31,7 @@ export const resetSingleFacility = createAction('RESET_SINGLE_FACILITY');
 export function fetchFacilities({
     pageSize = FACILITIES_REQUEST_PAGE_SIZE,
     pushNewRoute = noop,
+    activateFacilitiesTab = true,
 }) {
     return (dispatch, getState) => {
         dispatch(fetchCurrentTileCacheKey());
@@ -58,10 +61,14 @@ export function fetchFacilities({
 
                     pushNewRoute(makeFacilityDetailLink(facilityID));
                 }
-
                 return data;
             })
-            .then(data => dispatch(completeFetchFacilities(data)))
+            .then((data) => {
+                dispatch(completeFetchFacilities(data));
+                if (activateFacilitiesTab) {
+                    dispatch(makeSidebarFacilitiesTabActive());
+                }
+            })
             .catch(err => dispatch(logErrorAndDispatchFailure(
                 err,
                 'An error prevented fetching facilities',

--- a/src/app/src/components/FacilitySidebarSearchTabFacilitiesCount.jsx
+++ b/src/app/src/components/FacilitySidebarSearchTabFacilitiesCount.jsx
@@ -1,64 +1,69 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { arrayOf, bool, number, string } from 'prop-types';
 import { connect } from 'react-redux';
+import get from 'lodash/get';
 
-import { fetchFacilityCount } from '../actions/facilityCount';
+import { pluralizeFacilitiesCount } from '../util/util.js';
 
-class FacilitySidebarSearchTabFacilitiesCount extends Component {
-    componentDidMount() {
-        return this.props.fetchCount();
+const FacilitySidebarSearchTabFacilitiesCount = ({
+    facilitiesCount,
+    fetching,
+    error,
+}) => {
+    if (!facilitiesCount || fetching || error) {
+        return null;
     }
 
-    render() {
-        const {
-            data,
-            fetching,
-            error,
-        } = this.props;
-
-        if (!data || fetching || error) {
-            return null;
-        }
-
-        return (
-            <div style={{ textAlign: 'right' }}>
-                {`Total facilities: ${data}`}
-            </div>
-        );
-    }
-}
+    return (
+        <div style={{
+            margin: 0,
+            verticalAlign: 'center',
+        }}
+        >
+            <p style={{
+                backgroundColor: 'rgb(199,209,250)',
+                paddingLeft: '5px',
+                paddingRight: '5px',
+                alignText: 'center',
+                color: 'rgb(9,24,143)',
+                minWidth: '100px',
+                overflow: 'none',
+                margin: '10px 0 0 0',
+            }}
+            >
+                {pluralizeFacilitiesCount(facilitiesCount)}
+            </p>
+        </div>
+    );
+};
 
 FacilitySidebarSearchTabFacilitiesCount.defaultProps = {
-    data: null,
+    facilitiesCount: null,
     error: null,
 };
 
 FacilitySidebarSearchTabFacilitiesCount.propTypes = {
-    data: number,
+    facilitiesCount: number,
     fetching: bool.isRequired,
     error: arrayOf(string),
 };
 
 function mapStateToProps({
-    facilityCount: {
-        data,
-        fetching,
-        error,
+    facilities: {
+        facilities: {
+            data,
+            error,
+            fetching,
+        },
     },
 }) {
     return {
-        data,
-        fetching,
         error,
+        fetching,
+        facilitiesCount: get(data, 'count', null),
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        fetchCount: () => dispatch(fetchFacilityCount()),
-    };
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(
+export default connect(mapStateToProps)(
     FacilitySidebarSearchTabFacilitiesCount,
 );

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -11,6 +11,7 @@ import get from 'lodash/get';
 import FilterSidebarGuideTab from './FilterSidebarGuideTab';
 import FilterSidebarSearchTab from './FilterSidebarSearchTab';
 import FilterSidebarFacilitiesTab from './FilterSidebarFacilitiesTab';
+import FacilitySidebarSearchTabFacilitiesCount from './FacilitySidebarSearchTabFacilitiesCount';
 import NonVectorTileFilterSidebarFacilitiesTab from './NonVectorTileFilterSidebarFacilitiesTab';
 import FeatureFlag from './FeatureFlag';
 
@@ -147,6 +148,7 @@ class FilterSidebar extends Component {
                                     className="tab-minwidth"
                                 />))
                     }
+                    <FacilitySidebarSearchTabFacilitiesCount />
                 </Tabs>
             </AppBar>);
 

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -113,14 +113,14 @@ class FilterSidebar extends Component {
         const handleTabChange = (_, value) => {
             const changeTabFunctionsList = vectorTileFeatureIsActive
                 ? [
-                    makeFacilitiesTabActive,
                     makeSearchTabActive,
+                    makeFacilitiesTabActive,
                     makeGuideTabActive,
                 ]
                 : [
                     makeGuideTabActive,
-                    makeSearchTabActive,
                     makeFacilitiesTabActive,
+                    makeSearchTabActive,
                 ];
 
             const changeTab = changeTabFunctionsList[value];

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -34,7 +34,6 @@ import {
 
 import {
     makeFacilityDetailLink,
-    pluralizeResultsCount,
 } from '../util/util';
 
 import COLOURS from '../util/COLOURS';
@@ -70,7 +69,6 @@ const facilitiesTabStyles = Object.freeze({
     }),
     titleRowStyles: Object.freeze({
         display: 'flex',
-        justifyContent: 'space-between',
         alignItems: 'center',
         padding: '6px 1rem',
     }),
@@ -190,8 +188,6 @@ function FilterSidebarFacilitiesTab({
 
     const facilitiesCount = get(data, 'count', null);
 
-    const headerDisplayString = pluralizeResultsCount(facilitiesCount);
-
     const LoginLink = props => <Link to={authLoginFormRoute} {...props} />;
     const RegisterLink = props => <Link to={authRegisterFormRoute} {...props} />;
 
@@ -204,7 +200,6 @@ function FilterSidebarFacilitiesTab({
                 <div
                     style={facilitiesTabStyles.titleRowStyles}
                 >
-                    {headerDisplayString}
                     {
                         downloadingCSV
                             ? (

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -13,7 +13,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import ReactSelect from 'react-select';
 import get from 'lodash/get';
 
-import FacilitySidebarSearchTabFacilitiesCount from './FacilitySidebarSearchTabFacilitiesCount';
 import ShowOnly from './ShowOnly';
 
 import {
@@ -341,7 +340,6 @@ function FilterSidebarSearchTab({
                 </div>
                 {noFacilitiesFoundMessage}
             </div>
-            <FacilitySidebarSearchTabFacilitiesCount />
         </div>
     );
 }

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -38,10 +38,10 @@ class MapAndSidebar extends Component {
         return (
             <Fragment>
                 <Grid container className="map-sidebar-container">
-                    <Grid item xs={12} sm={4} id="panel-container">
+                    <Grid item sm={12} md={4} id="panel-container">
                         <Route component={SidebarWithErrorBoundary} />
                     </Grid>
-                    <Grid item xs={12} sm={8} style={{ position: 'relative' }}>
+                    <Grid item sm={12} md={8} style={{ position: 'relative' }} className="map-container">
                         {!hasError && (
                             <Switch>
                                 <Route

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -1,7 +1,6 @@
 import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 import isObject from 'lodash/isObject';
-import get from 'lodash/get';
 
 import {
     makeSidebarGuideTabActive,
@@ -16,8 +15,6 @@ import {
 } from '../actions/ui';
 
 import { completeFetchFacilities } from '../actions/facilities';
-
-import { completeFetchFeatureFlags } from '../actions/featureFlags';
 
 import { filterSidebarTabsEnum } from '../util/constants';
 
@@ -36,17 +33,6 @@ const initialState = Object.freeze({
 });
 
 export default createReducer({
-    [completeFetchFeatureFlags]: (state, flags) => {
-        const vectorTileFeatureIsActive = get(flags, 'vector_tile', false);
-
-        return vectorTileFeatureIsActive
-            ? update(state, {
-                activeFilterSidebarTab: {
-                    $set: filterSidebarTabsEnum.facilities,
-                },
-            })
-            : state;
-    },
     [recordSearchTabResetButtonClick]: state => update(state, {
         facilitiesSidebarTabSearch: {
             resetButtonClickCount: {
@@ -75,9 +61,6 @@ export default createReducer({
         },
     }),
     [completeFetchFacilities]: state => update(state, {
-        activeFilterSidebarTab: {
-            $set: filterSidebarTabsEnum.facilities,
-        },
         facilitiesSidebarTabSearch: {
             searchTerm: {
                 $set: initialState.facilitiesSidebarTabSearch.searchTerm,

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -7,6 +7,18 @@
   flex-direction: column;
 }
 
+@media (min-width: 775px) {
+  #panel-container {
+    min-width: 450px;
+    flex: none;
+  }
+
+  .map-container {
+    flex: 1 !important;
+    max-width: initial !important;
+  }
+}
+
 .map-sidebar-container {
   height: 100%;
 }

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -277,12 +277,12 @@ export const filterSidebarTabs = Object.freeze([
         label: 'Guide',
     }),
     Object.freeze({
-        tab: filterSidebarTabsEnum.search,
-        label: 'Search',
-    }),
-    Object.freeze({
         tab: filterSidebarTabsEnum.facilities,
         label: 'Facilities',
+    }),
+    Object.freeze({
+        tab: filterSidebarTabsEnum.search,
+        label: 'Search',
     }),
 ]);
 

--- a/src/app/src/util/hooks.js
+++ b/src/app/src/util/hooks.js
@@ -65,14 +65,16 @@ export default function useUpdateLeafletMapImperatively(
         boundary,
     ]);
 
-    // Reset the map state when the reset button is clicked.
+    // Reset the map state when the reset button is clicked
+    // while zoom to search is disabled.
     const [
         currentResetButtonClickCount,
         setCurrentResetButtonClickCount,
     ] = useState(resetButtonClickCount);
 
     useEffect(() => {
-        if (resetButtonClickCount !== currentResetButtonClickCount) {
+        if (!zoomToSearch &&
+                resetButtonClickCount !== currentResetButtonClickCount) {
             const leafletMap = get(mapRef, 'current.leafletElement', null);
 
             if (leafletMap) {
@@ -88,6 +90,7 @@ export default function useUpdateLeafletMapImperatively(
         resetButtonClickCount,
         currentResetButtonClickCount,
         setCurrentResetButtonClickCount,
+        zoomToSearch,
     ]);
 
     // Set the map view centered on the facility marker, zoomed to level 15

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -634,6 +634,18 @@ export const pluralizeResultsCount = (count) => {
     return `${count} results`;
 };
 
+export const pluralizeFacilitiesCount = (count) => {
+    if (isNil(count)) {
+        return null;
+    }
+
+    if (count === 1) {
+        return '1 facility';
+    }
+
+    return `${count} facilities`;
+};
+
 export const removeDuplicatesFromOtherLocationsData = otherLocationsData => uniqWith(
     otherLocationsData,
     (location, otherLocation) => {

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -139,7 +139,7 @@ export default function withQueryStringSync(WrappedComponent) {
                 dispatch(setFiltersFromQueryString(qs));
 
                 return fetch
-                    ? dispatch(fetchFacilities(push))
+                    ? dispatch(fetchFacilities({ ...push, activateFacilitiesTab: false }))
                     : null;
             },
             clearFacilities: () => dispatch(resetFacilities()),


### PR DESCRIPTION
## Overview

The page now opens to show the search tab on initial page load. This helps users see immediately the functionality that is available in terms of searching. 

In line with this change, the tabs' order has changed to search, facilities, guide.

The search results count has also been added to the tab bar.

Connects #977 

## Demo

<img width="1356" alt="Screen Shot 2020-03-10 at 10 13 05 AM" src="https://user-images.githubusercontent.com/21046714/76320961-c2811c80-62b7-11ea-987e-bd6ad664c0f4.png">
<img width="1351" alt="Screen Shot 2020-03-10 at 10 08 13 AM" src="https://user-images.githubusercontent.com/21046714/76320969-c614a380-62b7-11ea-86b6-3c3f957ce4f4.png">

## Notes

We are no longer using the total facilities count in the UI. If we don't think we will use that API in the future, we could remove the actions and reducer related to that functionality.

The search results count still appears in the facilities tab - is this clarifying for users, or needless repetition of information?

## Testing Instructions

* Checkout this branch
* Run `vagrant ssh` and `./scripts/server`
* Open the page; it should open to the search tab. The total facilities count should show in the tab bar.
* Complete a search. The facilities tab should open and the search results count in the tab bar should update.
* Refresh the page. The search tab should open, but the search results count in the tab bar should remain the same.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
