### PR TITLE
Able to click markers while polygon is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update 'parent company' label to 'parent company / supplier group' [#971](https://github.com/open-apparel-registry/open-apparel-registry/pull/971)
 - Hide contributors with only errored facilities [#974](https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
 - Show automated GPS coordinates after update [#978](https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
+- Allow click through polygon after search
 
 ### Security
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -164,7 +164,15 @@ function VectorTileFacilitiesMap({
                 zoomLevel={currentMapZoomLevel}
             />
             {drawFilterActive && <PolygonalSearchControl />}
-            {boundary != null && <GeoJSON data={boundary} />}
+            {boundary != null && (
+                <GeoJSON
+                    data={boundary}
+                    style={{
+                        renderer: L.svg({ padding: 0.5 }),
+                        interactive: false,
+                    }}
+                />
+            )}
         </ReactLeafletMap>
     );
 }


### PR DESCRIPTION
## Overview

The polygon was preventing clicks from reaching the markers on the map.
It is now rendered as a non-interactive SVG, and clicks pass through.

Connects #986 

## Testing Instructions

* Checkout this branch
* Run `vagrant ssh` and `./scripts/server`
* Draw a polygon.
* Click on the markers - the map should zoom in to the marker

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
