### PR TITLE
Add a contributors with active lists report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a report that groups facility counts by country [#979](https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
 - Add confirmed matches to canonical facility list when matching [#964](https://github.com/open-apparel-registry/open-apparel-registry/pull/964)
 - Add polygonal search [#969](https://github.com/open-apparel-registry/open-apparel-registry/pull/969)
+- Add report that lists contributors with active lists [#990](https://github.com/open-apparel-registry/open-apparel-registry/pull/990)
 
 ### Changed
 - Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)

--- a/src/django/api/reports/contributors_with_active_facilities.sql
+++ b/src/django/api/reports/contributors_with_active_facilities.sql
@@ -1,0 +1,18 @@
+SELECT
+    u.email,
+    c.name,
+    date(u.created_at) AS registration_date,
+    regexp_replace(c.description, E'[\\n\\r]+', ' ', 'g' ) AS description,
+    c.contrib_type,
+    c.website,
+    u.should_receive_newsletter
+FROM api_contributor c
+JOIN api_user u ON u.id = c.admin_id
+INNER JOIN api_source s ON (c.id = s.contributor_id)
+WHERE s.id IN (
+    SELECT V0.id
+      FROM api_source V0
+     WHERE (V0.is_active = true AND V0.is_public = true AND NOT (V0.id IN (SELECT U1.source_id FROM api_facilitylistitem U1 WHERE U1.status IN ('ERROR', 'ERROR_PARSING', 'ERROR_GEOCODING', 'ERROR_MATCHING'))))
+ )
+AND u.email NOT LIKE '%openapparel.org%'
+ORDER BY u.created_at, email


### PR DESCRIPTION
## Overview

The exiting /admin/reports/countributors/ report shows all registered
accounts. We need a version that only lists those contributor accounts
that have submitted facilities.

This adds a contributors-with-active-facilities report.
It has the same output schema as the contributors report and
uses the same filter criteria as the /api/contributors endpoint.

Connects #988 

## Demo

<img width="1240" alt="Screen Shot 2020-03-13 at 1 51 30 PM" src="https://user-images.githubusercontent.com/21046714/76646684-c61fd800-6531-11ea-9c62-3b8ea6cea7ae.png">

## Testing Instructions

* Checkout this branch
* Run `vagrant ssh` and `./scripts/server`
* Open http://localhost:8081/admin/reports/contributors-with-active-facilities/
* You should see a report which contains the same contributors as the api/contributors endpoint, and takes the same format as the contributors report.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
