### PR TITLE
Fix the contributors with active facilities report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a report that groups facility counts by country [#979](https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
 - Add confirmed matches to canonical facility list when matching [#964](https://github.com/open-apparel-registry/open-apparel-registry/pull/964)
 - Add polygonal search [#969](https://github.com/open-apparel-registry/open-apparel-registry/pull/969)
-- Add report that lists contributors with active lists [#990](https://github.com/open-apparel-registry/open-apparel-registry/pull/990)
+- Add report that lists contributors with active lists
+  [#990](https://github.com/open-apparel-registry/open-apparel-registry/pull/990) [#991](https://github.com/open-apparel-registry/open-apparel-registry/pull/991)
 
 ### Changed
 - Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)

--- a/src/django/api/reports/contributors_with_active_facilities.sql
+++ b/src/django/api/reports/contributors_with_active_facilities.sql
@@ -1,18 +1,23 @@
 SELECT
-    u.email,
-    c.name,
-    date(u.created_at) AS registration_date,
-    regexp_replace(c.description, E'[\\n\\r]+', ' ', 'g' ) AS description,
-    c.contrib_type,
-    c.website,
-    u.should_receive_newsletter
+  u.email,
+  c.name,
+  date(u.created_at) AS registration_date,
+  regexp_replace(c.description, E'[\\n\\r]+', ' ', 'g' ) AS description,
+  c.contrib_type,
+  c.website,
+  u.should_receive_newsletter
 FROM api_contributor c
 JOIN api_user u ON u.id = c.admin_id
-INNER JOIN api_source s ON (c.id = s.contributor_id)
-WHERE s.id IN (
-    SELECT V0.id
-      FROM api_source V0
-     WHERE (V0.is_active = true AND V0.is_public = true AND NOT (V0.id IN (SELECT U1.source_id FROM api_facilitylistitem U1 WHERE U1.status IN ('ERROR', 'ERROR_PARSING', 'ERROR_GEOCODING', 'ERROR_MATCHING'))))
- )
+WHERE c.id IN (
+  SELECT contributor_id
+  FROM api_source
+  WHERE is_active = true
+  AND is_public = true
+  AND id IN (
+    SELECT source_id
+    FROM api_facilitylistitem
+    WHERE status NOT IN ('ERROR', 'ERROR_PARSING', 'ERROR_GEOCODING', 'ERROR_MATCHING')
+  )
+)
 AND u.email NOT LIKE '%openapparel.org%'
 ORDER BY u.created_at, email


### PR DESCRIPTION
## Overview

The first draft of the report had two issues that we only realized after running
the report with production data:

- Lines were duplicated for contributor with multiple lists.
- If any of the items on a contributor's list were in an error state, the
  contributor did not appear.

This commit attempts to address those issues by:

- Using an `IN` clause with a subquery rather than joining the contributor table
  to the source table.
- Inverting the error status filter condition to allow a contributor if any
  sources are in a non-error status.

Connects #988 

## Testing Instructions

**NOTE** I was was unable to reproduce the problem with contributors not appearing using development data at the time of opening this PR but, in the interest of getting a report out ASAP I have not waited until I could come up with a test situation.

* Check out the `develop` branch
* Log in as `c2@example.com`
* Browse http://localhost:6543/contribute and submit
[good.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/4331413/good.csv.zip)
* Fully process the uploaded csv
  * ./scripts/manage batch_process --list-id 16 --action parse
  * ./scripts/manage batch_process --list-id 16 --action geocode
  * ./scripts/manage batch_process --list-id 16 --action match
* Log in as `c1@example.com`
* Browse http://localhost:8081/admin/reports/contributors-with-active-facilities/ The c2@example.com contributor will appear twice.
* Checkout this branch
* Verify the testing instructions from #990
* Log in as `c1@example.com`
* Browse http://localhost:8081/admin/reports/contributors-with-active-facilities/  and verify that `c2@example.com` only appears once.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
