### PR TITLE
Prevent list refresh on facility confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show automated GPS coordinates after update [#978](https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
 - Allow click through polygon after search
 - Fix contributor types when no contributors are found [#989](https://github.com/open-apparel-registry/open-apparel-registry/pull/989)
+- Prevent reload of facilities list on confirm [#993](https://github.com/open-apparel-registry/open-apparel-registry/pull/993)
 
 ### Security
 - Bump acorn from 5.7.3 to 5.7.4 in /src/app [#992](https://github.com/open-apparel-registry/open-apparel-registry/pull/992)

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -70,10 +70,12 @@ export function fetchFacilityList(listID = null) {
 }
 
 export function fetchFacilityListItems(
-    listID = null, page = undefined, rowsPerPage = undefined, params = null,
+    listID = null, page = undefined, rowsPerPage = undefined, params = null, preventRefresh = false,
 ) {
     return (dispatch) => {
-        dispatch(startFetchFacilityListItems());
+        if (!preventRefresh) {
+            dispatch(startFetchFacilityListItems());
+        }
 
         if (!listID) {
             return dispatch(logErrorAndDispatchFailure(

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -140,7 +140,7 @@ class FacilityListItemsTable extends Component {
                     page,
                     rowsPerPage,
                 } = createPaginationOptionsFromQueryString(search);
-                fetchListItems(listID, page, rowsPerPage, params);
+                fetchListItems(listID, page, rowsPerPage, params, true);
             }
         }
     }
@@ -732,8 +732,8 @@ function mapDispatchToProps(dispatch) {
 
             return dispatch(setSelectedFacilityListItemsRowIndex(rowIndex));
         },
-        fetchListItems: (listID, page, rowsPerPage, params) =>
-            dispatch(fetchFacilityListItems(listID, page, rowsPerPage, params)),
+        fetchListItems: (listID, page, rowsPerPage, params, preventRefresh) =>
+            dispatch(fetchFacilityListItems(listID, page, rowsPerPage, params, preventRefresh)),
         makeRemoveFacilityListItemFunction: (listID, listItemID) =>
             () => dispatch(removeFacilityListItem(listID, listItemID)),
     };


### PR DESCRIPTION
## Overview

When working through the Confirm / Reject process, the Confirm button
refreshed the entire page, which made it difficult to do a lot of
confirmations at once. This only occurred when filtering by 'Potential Matches',
as we were re-fetching the list when filtering by potential matches.

When fetching a list, we usually erase the current list and then add
the search results in to an empty field. Now, specifically when fetching
a list after confirming a facility match, we don't erase the list, only
overwriting it when the new list is returned. This allows the view to
maintain its position in the list.

Connects #982 

## Demo

Regular data:
![Mar-16-2020 14-18-49](https://user-images.githubusercontent.com/21046714/76789385-1ea1e000-6793-11ea-8e00-80e947799b6c.gif)

Data with faked multitude of matches:
![Mar-16-2020 14-11-17](https://user-images.githubusercontent.com/21046714/76789429-31b4b000-6793-11ea-8914-bd7fdaaf40ac.gif)

## Testing Instructions

* Run `vagrant ssh` and `./scripts/resetdb`
* Run `./scripts/server`
* Login as c8@example.com and navigate to an existing list
* Scroll to a match and confirm or reject
* The page should not refresh

If you would like to test with a longer list of items (although the same number of actually confirmable items):
* Run `vagrant ssh` and `./scripts/resetdb`
* Run `./scripts/manage shell_plus`
* Run:
``` 
items = FacilityListItem.objects.all()
items.update(status="POTENTIAL_MATCH")
for item in items:
	item.save()
```
* Exit the shell
* Run `./scripts/server`
* Login as c8@example.com and navigate to an existing list
* Scroll to a match and confirm or reject
* The page should not refresh

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
