### PR TITLE
Include contributors if they have any active facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Include contributors if they have any active facilities [#999](https://github.com/open-apparel-registry/open-apparel-registry/pull/999)
 
 ### Security
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -405,6 +405,7 @@ class FacilityListItem(models.Model):
     )
 
     ERROR_STATUSES = [ERROR, ERROR_PARSING, ERROR_GEOCODING, ERROR_MATCHING]
+    COMPLETE_STATUSES = [MATCHED, CONFIRMED_MATCH]
 
     class Meta:
         indexes = [

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -1237,12 +1237,14 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.email_three = 'three@example.com'
         self.email_four = 'four@example.com'
         self.email_five = 'five@example.com'
+        self.email_six = 'six@example.com'
 
         self.contrib_one_name = 'contributor that should be included'
         self.contrib_two_name = 'contributor with no lists'
         self.contrib_three_name = 'contributor with an inactive list'
         self.contrib_four_name = 'contributor with a non public list'
         self.contrib_five_name = 'contributor with only error items'
+        self.contrib_six_name = 'contributor with one good and one error item'
 
         self.country_code = 'US'
         self.list_one_name = 'one'
@@ -1250,12 +1252,14 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.list_three_name = 'three'
         self.list_four_name = 'four'
         self.list_five_name = 'five'
+        self.list_six_name = 'six'
 
         self.user_one = User.objects.create(email=self.email_one)
         self.user_two = User.objects.create(email=self.email_two)
         self.user_three = User.objects.create(email=self.email_three)
         self.user_four = User.objects.create(email=self.email_four)
         self.user_five = User.objects.create(email=self.email_five)
+        self.user_six = User.objects.create(email=self.email_six)
 
         self.contrib_one = Contributor \
             .objects \
@@ -1287,6 +1291,12 @@ class ContributorsListAPIEndpointTests(TestCase):
                     name=self.contrib_five_name,
                     contrib_type=Contributor.OTHER_CONTRIB_TYPE)
 
+        self.contrib_six = Contributor \
+            .objects \
+            .create(admin=self.user_six,
+                    name=self.contrib_six_name,
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
         self.list_one = FacilityList \
             .objects \
             .create(header="header",
@@ -1299,6 +1309,12 @@ class ContributorsListAPIEndpointTests(TestCase):
                     facility_list=self.list_one,
                     contributor=self.contrib_one)
 
+        self.list_item_one = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_one,
+                    status=FacilityListItem.MATCHED)
+
         self.list_one_b = FacilityList \
             .objects \
             .create(header="header",
@@ -1310,6 +1326,12 @@ class ContributorsListAPIEndpointTests(TestCase):
             .create(source_type=Source.LIST,
                     facility_list=self.list_one_b,
                     contributor=self.contrib_one)
+
+        self.list_item_one_b = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_one_b,
+                    status=FacilityListItem.MATCHED)
 
         # Contributor two has no lists
 
@@ -1344,7 +1366,7 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.list_five = FacilityList \
             .objects \
             .create(header="header",
-                    file_name="one",
+                    file_name="five",
                     name=self.list_five_name)
 
         self.source_five = Source \
@@ -1358,6 +1380,30 @@ class ContributorsListAPIEndpointTests(TestCase):
             .create(row_index=0,
                     source=self.source_five,
                     status=FacilityListItem.ERROR_PARSING)
+
+        self.list_six = FacilityList \
+            .objects \
+            .create(header="header",
+                    file_name="six",
+                    name=self.list_six_name)
+
+        self.source_six = Source \
+            .objects \
+            .create(source_type=Source.LIST,
+                    facility_list=self.list_six,
+                    contributor=self.contrib_six)
+
+        self.list_item_six_a = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_six,
+                    status=FacilityListItem.ERROR_PARSING)
+
+        self.list_item_six_b = FacilityListItem \
+            .objects \
+            .create(row_index=1,
+                    source=self.source_six,
+                    status=FacilityListItem.MATCHED)
 
     def test_contributors_list_has_only_contributors_with_active_lists(self):
         response = self.client.get('/api/contributors/')
@@ -1389,8 +1435,13 @@ class ContributorsListAPIEndpointTests(TestCase):
             contributor_names,
         )
 
+        self.assertIn(
+            self.contrib_six_name,
+            contributor_names,
+        )
+
         self.assertEqual(
-            1,
+            2,
             len(contributor_names),
         )
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -381,8 +381,8 @@ def all_contributors(request):
         ]
     """
     valid_sources = Source.objects.filter(
-        is_active=True, is_public=True).exclude(
-        facilitylistitem__status__in=FacilityListItem.ERROR_STATUSES)
+        is_active=True, is_public=True,
+        facilitylistitem__status__in=FacilityListItem.COMPLETE_STATUSES)
     response_data = [
         (contributor.id, contributor.name)
         for contributor


### PR DESCRIPTION

## Overview

We were previously excluding contributors from the filter list if any of their items were in an error state. This meant that if a contributor submitted a list with one successfully processed item and one error item, the contributor would be filtered out.

To address this we are now checking for any item in a `MATCHED` or `CONFIRMED_MATCH` status. This has an additional benefit of excluding contributors from the list while their list is still processing.

Connects #998

## Testing Instructions

* Check out the `develop` branch
* Follow the instructions in #998 to reproduce the failure
* Check out this branch
* Refresh localhost:6543 and verify that the newly registered contributor appears in the contributors dropdown. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
