### PR TITLE
Only count contributors with active public items for type count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Only count contributors with active public items for type count [#1002](https://github.com/open-apparel-registry/open-apparel-registry/pull/1002)
 
 ### Security
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -5467,3 +5467,34 @@ class ListWithoutSourceTest(TestCase):
         # Checking the `data` property triggers the serialization. We are
         # checking that it does not raise an exception.
         FacilityListSerializer(facility_list).data
+
+
+class ContributorTypesTest(FacilityAPITestCaseBase):
+    def get_contributor_types(self):
+        return self.client.get(reverse('all_contributor_types'))
+
+    def fetch_and_assert_all_counts_are_zero(self):
+        response = self.get_contributor_types()
+        data = json.loads(response.content)
+        for (id, label) in data:
+            self.assertEqual(f'{id} [0]', label)
+
+    def test_all_types_are_returned(self):
+        response = self.get_contributor_types()
+        data = json.loads(response.content)
+        self.assertEqual(len(Contributor.CONTRIB_TYPE_CHOICES), len(data))
+
+    def test_only_public_sources_are_counted(self):
+        self.source.is_public = False
+        self.source.save()
+        self.fetch_and_assert_all_counts_are_zero()
+
+    def test_only_active_sources_are_counted(self):
+        self.source.is_active = False
+        self.source.save()
+        self.fetch_and_assert_all_counts_are_zero()
+
+    def test_only_confirmed_items_are_counted(self):
+        self.list_item.status = FacilityListItem.GEOCODED
+        self.list_item.save()
+        self.fetch_and_assert_all_counts_are_zero()

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -416,7 +416,11 @@ def all_contributor_types(request):
             ["Factory / Facility", "Factory / Facility [1]"]
         ]
     """
-    counts = Contributor.objects.values(
+    active_contrib_ids = Source.objects.filter(
+        is_active=True, is_public=True,
+        facilitylistitem__status__in=FacilityListItem.COMPLETE_STATUSES
+    ).values('contributor_id')
+    counts = Contributor.objects.filter(id__in=active_contrib_ids).values(
         'contrib_type').annotate(num_type=Count('contrib_type'))
 
     types = [


### PR DESCRIPTION
## Overview

We recently updated the contributors filter dropdown to only contain
contributors that have active, public list items. In this commit we fix the
contributor type counts by applying the same filter criteria before counting.

Connects #1001

## Testing Instructions

* Run `./scripts/resetdb`
* Browse http://localhost:6543/, open the contributor types dropdown and verify that "Auditor" has a count of "[1]"
* Register a new account with type "Auditor," confirm it, and log in.
* Browse http://localhost:6543/, open the contributor types dropdown and verify that "Auditor" still has a count of "[1]"
* Browse http://localhost:6543/contribute and upload [one-bad-one-good.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4371180/one-bad-one-good.csv.zip)
* Process the list through the first 2 steps
  * ./scripts/manage batch_process --list-id 16 --action parse
  * ./scripts/manage batch_process --list-id 16 --action geocode
* Browse http://localhost:6543/, open the contributor types dropdown and verify that "Auditor" still has a count of "[1]"
* Process the list through the final step
  * ./scripts/manage batch_process --list-id 16 --action match
* Browse http://localhost:6543/, open the contributor types dropdown and verify that "Auditor" now has a count of "[2]"


## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
