### PR TITLE
Return contributor details from list API and include in CSV download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Return contributor details from list API and include in CSV download [#1005](https://github.com/open-apparel-registry/open-apparel-registry/pull/1005)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.facilitiesCSV.tests.js
+++ b/src/app/src/__tests__/utils.facilitiesCSV.tests.js
@@ -15,6 +15,18 @@ it('creates a new facility row array from a feature', () => {
             country_code: 'country_code',
             country_name: 'country_name',
             oar_id: 'oar_id',
+            contributors: [
+                {
+                    id: 1,
+                    name: 'contributor_name (list_name)',
+                    verified: false,
+                },
+                {
+                    id: 2,
+                    name: 'contributor_2_name (list_2_name)',
+                    verified: true,
+                },
+            ],
         },
         geometry: {
             coordinates: [
@@ -32,6 +44,7 @@ it('creates a new facility row array from a feature', () => {
         'country_name',
         'lat',
         'lng',
+        'contributor_name (list_name)|contributor_2_name (list_2_name)',
     ];
 
     expect(isEqual(
@@ -49,6 +62,13 @@ it('creates a 2-d array including headers for exporting as a CSV', () => {
                 country_code: 'country_code',
                 country_name: 'country_name',
                 oar_id: 'oar_id',
+                contributors: [
+                    {
+                        id: 1,
+                        name: 'contributor_name',
+                        verified: false,
+                    },
+                ],
             },
             geometry: {
                 coordinates: [
@@ -69,6 +89,7 @@ it('creates a 2-d array including headers for exporting as a CSV', () => {
             'country_name',
             'lat',
             'lng',
+            'contributor_name',
         ],
     ];
 

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -3,6 +3,7 @@ import { arrayOf, bool, func, number, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -80,6 +81,9 @@ const facilitiesTabStyles = Object.freeze({
     }),
     listHeaderButtonStyles: Object.freeze({
         height: '45px',
+        margin: '5px 0',
+    }),
+    downloadLabelStyles: Object.freeze({
         margin: '5px 0',
     }),
 });
@@ -191,6 +195,10 @@ function FilterSidebarFacilitiesTab({
     const LoginLink = props => <Link to={authLoginFormRoute} {...props} />;
     const RegisterLink = props => <Link to={authRegisterFormRoute} {...props} />;
 
+    const progress = facilitiesCount
+        ? get(data, 'features', []).length * 100 / facilitiesCount
+        : 0;
+
     const listHeaderInsetComponent = (
         <div style={facilitiesTabStyles.listHeaderStyles} className="results-height-subtract">
             <Typography
@@ -204,7 +212,10 @@ function FilterSidebarFacilitiesTab({
                         downloadingCSV
                             ? (
                                 <div style={facilitiesTabStyles.listHeaderButtonStyles}>
-                                    <CircularProgress />
+                                    <div style={facilitiesTabStyles.downloadLabelStyles}>
+                                        Downloading...
+                                    </div>
+                                    <LinearProgress variant="determinate" value={progress} />
                                 </div>)
                             : (
                                 <Button

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -446,7 +446,7 @@ function mapDispatchToProps(dispatch, {
             return dispatch(resetAllFilters());
         },
         searchForFacilities: vectorTilesAreActive => dispatch(fetchFacilities({
-            pageSize: vectorTilesAreActive ? FACILITIES_REQUEST_PAGE_SIZE : 500,
+            pageSize: vectorTilesAreActive ? FACILITIES_REQUEST_PAGE_SIZE : 50,
             pushNewRoute: push,
         })),
         submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -1,6 +1,6 @@
 export const OTHER = 'Other';
 
-export const FACILITIES_REQUEST_PAGE_SIZE = 100;
+export const FACILITIES_REQUEST_PAGE_SIZE = 50;
 
 // This choices must be kept in sync with the identical list
 // kept in the Django API's models.py file

--- a/src/app/src/util/util.facilitiesCSV.js
+++ b/src/app/src/util/util.facilitiesCSV.js
@@ -11,6 +11,7 @@ export const csvHeaders = Object.freeze([
     'country_name',
     'lat',
     'lng',
+    'contributors',
 ]);
 
 export const createFacilityRowFromFeature = ({
@@ -20,6 +21,7 @@ export const createFacilityRowFromFeature = ({
         country_code,
         country_name,
         oar_id,
+        contributors,
     },
     geometry: {
         coordinates: [
@@ -35,6 +37,7 @@ export const createFacilityRowFromFeature = ({
     country_name,
     lat,
     lng,
+    contributors ? contributors.map(c => c.name).join('|') : '',
 ]);
 
 export const facilityReducer = (acc, next) =>

--- a/src/django/api/pagination.py
+++ b/src/django/api/pagination.py
@@ -11,5 +11,5 @@ class PageAndSizePagination(PageNumberPagination):
 class FacilitiesGeoJSONPagination(GeoJsonPagination):
     page_query_param = 'page'
     page_size_query_param = 'pageSize'
-    page_size = 500
-    max_page_size = 500
+    page_size = 50
+    max_page_size = 50

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -646,7 +646,14 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                             "address" "facility address_1",
                             "country_code": "US",
                             "country_name": "United States",
-                            "oar_id": "OAR_ID_1"
+                            "oar_id": "OAR_ID_1",
+                            "contributors": [
+                                {
+                                    "id": 1,
+                                    "name": "Brand A (2019 Q1 List)",
+                                    "is_verified": false
+                                }
+                            ]
                         }
                     },
                     {
@@ -662,6 +669,18 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                             "country_code": "US",
                             "country_name": "United States",
                             "oar_id": "OAR_ID_2"
+                            "contributors": [
+                                {
+                                    "id": 1,
+                                    "name": "Brand A (2019 Q1 List)",
+                                    "is_verified": false
+                                },
+                                {
+                                    "id": 2,
+                                    "name": "MSI B (2020 List)",
+                                    "is_verified": true
+                                }
+                            ]
                         }
                     }
                 ]

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -161,6 +161,9 @@ class SubmitNewUserForm(CreateAPIView):
             if name is None:
                 raise ValidationError('name cannot be blank')
 
+            if '|' in name:
+                raise ValidationError('name cannot contain the "|" character')
+
             if description is None:
                 raise ValidationError('description cannot be blank')
 
@@ -292,6 +295,9 @@ class UserProfile(RetrieveUpdateAPIView):
 
             if name is None:
                 raise ValidationError('name cannot be blank')
+
+            if '|' in name:
+                raise ValidationError('Name cannot contain the "|" character.')
 
             if description is None:
                 raise ValidationError('description cannot be blank')
@@ -1863,6 +1869,9 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             name = request.data['name']
         else:
             name = os.path.splitext(csv_file.name)[0]
+
+        if '|' in name:
+            raise ValidationError('Name cannot contain the "|" character.')
 
         if 'description' in request.data:
             description = request.data['description']


### PR DESCRIPTION
## Overview

Return contributor details from list API and include in CSV download.

Connects #997

## Demo

![2020-03-27 12 50 35](https://user-images.githubusercontent.com/17363/77796386-68f54d80-702c-11ea-9902-336f76b0f44e.gif)

## Notes

The complex permission and visibility checks required make fetching contributor details for each facility slow, so we are cutting the maximum results per page from 500 to 50.

Contributor names and list names can have commas, so we join them with a vertical bar in the CSV to make machine parsing of multiple contributors possible. We add validations that prevent contributors from including the vertical bar in their name or their list names.

We know the total number of facilities so it is possible to show percent progress. We have opted for a linear progress bar rather than a circular one because it looks better in this situation where our progress jumps rather than smoothly increases.

## Testing Instructions

* Run `./scripts/resetdb`
* Log in as c1@example.com
* Browse http://localhost:8081/admin/api/contributor/5/ and delete the contributor.
* Browse http://localhost:6543/ and open the Network tab in dev tools.
* Click the "Facilities" tab and "Download CSV." Verify that request are made with a pageSize of 50 and that the final CSV can be saved without error.
* Verify that the CSV contains records with empty, one, and multiple contributors in the new "contributors" column.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
