### PR TITLE
If there are multiple high quality matches choose exact string match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- If there are multiple high quality matches choose exact string match [#1016](https://github.com/open-apparel-registry/open-apparel-registry/pull/1016)
 
 ### Deprecated
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -28,7 +28,7 @@ from api.oar_id import make_oar_id, validate_oar_id
 from api.matching import match_facility_list_items
 from api.processing import (parse_facility_list_item,
                             geocode_facility_list_item,
-                            reduce_matches)
+                            reduce_matches, is_string_match)
 from api.geocoding import (create_geocoding_params,
                            format_geocoded_address_data,
                            geocode_address)
@@ -1201,6 +1201,29 @@ class DedupeMatchingTests(TestCase):
             ('US2020052YDVKBQ', 45)
         ]
         self.assertEqual(expected, reduce_matches(matches))
+
+    def test_is_string_match(self):
+        # The clean function will remove stray characters
+        item = FacilityListItem(
+            country_code='US',
+            name='Pants Ahoy',
+            address='123 Main St')
+        facility = Facility(
+            country_code='US',
+            name='"PANTS AHOY"',
+            address='123     MAIN     ST')
+        self.assertTrue(is_string_match(item, facility))
+
+        # Needs to be an exact character match
+        item = FacilityListItem(
+            country_code='US',
+            name='Pants Ahoy',
+            address='123 Main St')
+        facility = Facility(
+            country_code='US',
+            name='Pants Ahoy',
+            address='123 Main Street')
+        self.assertFalse(is_string_match(item, facility))
 
 
 class OarIdTests(TestCase):


### PR DESCRIPTION
## Overview

It is possible for a submitted item to match multiple facilities with greater than 80% confidence, which we have previously presented to the contributor as potential matches, requiring an decision. This PR attempts to reduce the number of potential matches by considering an exact string match (after removing extraneous characters) to be a better match than other high-confidence matches.

Connects #1014 

## Testing Instructions

### Check the current behavior

* Checkout `develop`
* Run `./scripts/resetdb`
* Log in as `c2@example.com`
* Submit [large-list-with-duplicates.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4601851/large-list-with-duplicates.csv.zip)
* Fully process the list
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Browse http://localhost:6543/lists/16?status=POTENTIAL_MATCH and confirm or reject all the potential matches.
* Submit [large-list-with-duplicates.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4601851/large-list-with-duplicates.csv.zip) again making sure to select the previous list as the list to replace
* Fully process the list
  * `./scripts/manage batch_process --list-id 17 --action parse`
  * `./scripts/manage batch_process --list-id 17 --action geocode`
  * `./scripts/manage batch_process --list-id 17 --action match`
* Browse http://localhost:6543/lists/17?status=POTENTIAL_MATCH and note the number of items with potential matches. In my test it was 443 but the randomness in the matching process may result in a slightly different count

### Check this branch

* Checkout this PR
* Run `./scripts/resetdb`
* Log in as `c2@example.com`
* Submit [large-list-with-duplicates.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4601851/large-list-with-duplicates.csv.zip)
* Fully process the list
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Browse http://localhost:6543/lists/16?status=POTENTIAL_MATCH and confirm or reject all the potential matches.
* Submit [large-list-with-duplicates.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4601851/large-list-with-duplicates.csv.zip) again making sure to select the previous list as the list to replace
* Fully process the list
  * `./scripts/manage batch_process --list-id 17 --action parse`
  * `./scripts/manage batch_process --list-id 17 --action geocode`
  * `./scripts/manage batch_process --list-id 17 --action match`
* Browse http://localhost:6543/lists/17?status=POTENTIAL_MATCH and note the number of items with potential matches. Verify that there are significantly fewer potential matches. In my test it was 306 but the randomness in the matching process may result in a slightly different count


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
