### PR TITLE
Add country first appearance report

### DIFF
--- a/src/django/api/reports/country_first_appearance.sql
+++ b/src/django/api/reports/country_first_appearance.sql
@@ -1,0 +1,9 @@
+-- List the ISO country codes where facilities are located sorted by the year
+-- and month that the country first appeared.
+
+SELECT
+  country_code,
+  to_char(min(created_at), 'YYYY-MM') AS created_at
+  FROM api_facility
+GROUP BY country_code
+ORDER BY created_at DESC;


### PR DESCRIPTION
## Overview

We have an existing report that counts the number of countries added each month.
This report attempts to answer the follow up question "which countries?"

## Demo

<img width="555" alt="Screen Shot 2020-06-03 at 9 48 31 AM" src="https://user-images.githubusercontent.com/17363/83664902-817b6a00-a57f-11ea-98f4-e7feca855a3e.png">

<img width="443" alt="Screen Shot 2020-06-03 at 9 48 22 AM" src="https://user-images.githubusercontent.com/17363/83664906-82ac9700-a57f-11ea-91cd-f1cdf81bbf4e.png">

## Testing Instructions

* Browse http://localhost:8081/admin/reports/country-first-appearance/

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
