### PR TITLE
fixes mobile overflow, mobile tooltip

### DIFF
--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -702,6 +702,21 @@ hr {
   .facility-detail_map {
     width: auto;
   }
+
+  #panel-container {
+    width: auto;
+    max-width: 100%;
+    min-width: auto;
+  }
+
+  .sharedFacilityTooltip {
+    z-index: 99999999 !important;
+  }
+
+  .sharedFacilityTooltip-inner {
+    max-height: 80vh;
+    overflow: auto;
+  }
 }
 
 @media (max-width: 410px) {

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -239,7 +239,17 @@ function FilterSidebarSearchTab({
                             }
                             label="Show only shared facilities"
                         />
-                        <Tooltip title={tooltipTitle} placement="right">
+                        <Tooltip
+                            title={tooltipTitle}
+                            placement="right"
+                            enterDelay={50}
+                            interactive
+                            disableTouchListener
+                            classes={{
+                                popper: 'sharedFacilityTooltip',
+                                tooltip: 'sharedFacilityTooltip-inner',
+                            }}
+                        >
                             <IconButton>
                                 <InfoIcon />
                             </IconButton>

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -5,14 +5,12 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-width: 450px;
+  width: 450px;
+  flex: none;
 }
 
 @media (min-width: 775px) {
-  #panel-container {
-    min-width: 450px;
-    flex: none;
-  }
-
   .map-container {
     flex: 1 !important;
     max-width: initial !important;


### PR DESCRIPTION
## Overview

- Fixed an issue where the "Show only shared facilities" wasnt showing on mobile
    - Added max-height and overflow scrolling within the tooltip for mobile
- Fixed an issue when filtering by Contributors with long names caused the app to overflow on mobile.

Connects #1033

## Demo

**Tooltip fix**
<img width="427" alt="Screen Shot 2020-06-30 at 1 06 33 PM" src="https://user-images.githubusercontent.com/1928955/86156304-ba055980-bad3-11ea-93c6-3e4eb5b8b63f.png">

**Overflow issue before**
<img width="418" alt="Screen Shot 2020-06-30 at 1 12 10 PM" src="https://user-images.githubusercontent.com/1928955/86156310-bbcf1d00-bad3-11ea-8d15-532495dffdca.png">

**Overflow issue after**
<img width="415" alt="Screen Shot 2020-06-30 at 1 11 52 PM" src="https://user-images.githubusercontent.com/1928955/86156309-bb368680-bad3-11ea-9cdd-db66bd80b738.png">

## Testing Instructions

* interact with the tooltip on mobile
* Filter by a contributor with a long name. The input should either truncate or go to a new line.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
