### PR TITLE
Show PPE fields on facility detail and include in CSV downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Add PPE-related model fields and API support [#1037](https://github.com/open-apparel-registry/open-apparel-registry/pull/1037)
+- Add PPE-related model fields and API support [#1037](https://github.com/open-apparel-registry/open-apparel-registry/pull/1037)
+- Show PPE fields on facility detail and include in CSV downloads [#1041](https://github.com/open-apparel-registry/open-apparel-registry/pull/1041)
 
 ### Changed
 

--- a/scripts/resetdb
+++ b/scripts/resetdb
@@ -24,6 +24,7 @@ function processfixtures() {
 function enableswitches() {
     ./scripts/manage waffle_switch vector_tile on
     ./scripts/manage waffle_switch claim_a_facility on
+    ./scripts/manage waffle_switch ppe on
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/src/app/src/__tests__/utils.facilitiesCSV.tests.js
+++ b/src/app/src/__tests__/utils.facilitiesCSV.tests.js
@@ -7,6 +7,8 @@ import {
     formatDataForCSV,
 } from '../util/util.facilitiesCSV';
 
+import { PPE_FIELD_NAMES } from '../util/constants';
+
 it('creates a new facility row array from a feature', () => {
     const feature = {
         properties: {
@@ -97,4 +99,111 @@ it('creates a 2-d array including headers for exporting as a CSV', () => {
         formatDataForCSV(facilities),
         expected2DArray,
     )).toBe(true);
+});
+
+it('creates a 2-d array including PPE headers', () => {
+    const facilities = [
+        {
+            properties: {
+                name: 'name',
+                address: 'address',
+                country_code: 'country_code',
+                country_name: 'country_name',
+                oar_id: 'oar_id',
+                contributors: [
+                    {
+                        id: 1,
+                        name: 'contributor_name',
+                        verified: false,
+                    },
+                ],
+            },
+            geometry: {
+                coordinates: [
+                    'lng',
+                    'lat',
+                ],
+            },
+        },
+    ];
+
+    const expectedHeader = csvHeaders.concat(PPE_FIELD_NAMES);
+    const expectedRow = [
+        'oar_id',
+        'name',
+        'address',
+        'country_code',
+        'country_name',
+        'lat',
+        'lng',
+        'contributor_name',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+    ];
+
+    const expected2DArray = [expectedHeader, expectedRow];
+
+    expect(
+        formatDataForCSV(facilities, { includePPEFields: true }),
+    ).toEqual(expected2DArray);
+});
+
+it('creates a 2-d array including PPE headers and values', () => {
+    const facilities = [
+        {
+            properties: {
+                name: 'name',
+                address: 'address',
+                country_code: 'country_code',
+                country_name: 'country_name',
+                oar_id: 'oar_id',
+                contributors: [
+                    {
+                        id: 1,
+                        name: 'contributor_name',
+                        verified: false,
+                    },
+                ],
+                ppe_product_types: ['ppe_product_type_1', 'ppe_product_type_2'],
+                ppe_contact_phone: 'ppe_contact_phone',
+                ppe_contact_email: 'ppe_contact_email',
+                ppe_website: 'ppe_website',
+            },
+            geometry: {
+                coordinates: [
+                    'lng',
+                    'lat',
+                ],
+            },
+        },
+    ];
+
+    const expected2DArray = [
+        csvHeaders.concat([
+            'ppe_product_types',
+            'ppe_contact_phone',
+            'ppe_contact_email',
+            'ppe_website',
+        ]),
+        [
+            'oar_id',
+            'name',
+            'address',
+            'country_code',
+            'country_name',
+            'lat',
+            'lng',
+            'contributor_name',
+            'ppe_product_type_1|ppe_product_type_2',
+            'ppe_contact_phone',
+            'ppe_contact_email',
+            'ppe_website',
+        ],
+    ];
+
+    expect(
+        formatDataForCSV(facilities, { includePPEFields: true }),
+    ).toEqual(expected2DArray);
 });

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -37,6 +37,7 @@ export function logDownload() {
             } = getState();
 
             const vectorTileFlagIsActive = get(featureFlags, 'flags.vector_tile', false);
+            const ppeIsActive = get(featureFlags, 'flags.ppe', false);
 
             const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 
@@ -45,7 +46,10 @@ export function logDownload() {
 
                 return apiRequest
                     .post(makeLogDownloadUrl(path, recordCount))
-                    .then(() => downloadFacilitiesCSV(facilities))
+                    .then(() => downloadFacilitiesCSV(
+                        facilities,
+                        { includePPEFields: ppeIsActive },
+                    ))
                     .then(() => dispatch(completeLogDownload()))
                     .catch(err => dispatch(logErrorAndDispatchFailure(
                         err,
@@ -57,7 +61,7 @@ export function logDownload() {
             await apiRequest.post(makeLogDownloadUrl(path, count));
 
             if (!nextPageURL) {
-                downloadFacilitiesCSV(facilities);
+                downloadFacilitiesCSV(facilities, { includePPEFields: ppeIsActive });
             } else {
                 let nextFacilitiesSetURL = nextPageURL;
 
@@ -99,7 +103,7 @@ export function logDownload() {
                     },
                 } = getState();
 
-                downloadFacilitiesCSV(features);
+                downloadFacilitiesCSV(features, { includePPEFields: ppeIsActive });
             }
 
             return dispatch(completeLogDownload());

--- a/src/app/src/components/ContributeHeader.jsx
+++ b/src/app/src/components/ContributeHeader.jsx
@@ -1,6 +1,9 @@
 import React, { Fragment, memo } from 'react';
 import MaterialButton from '@material-ui/core/Button';
 
+import FeatureFlag from './FeatureFlag';
+import { PPE } from '../util/constants';
+
 const ContributeHeader = memo(() => (
     <Fragment>
         <div className="control-panel__group">
@@ -60,26 +63,28 @@ const ContributeHeader = memo(() => (
                         Download CSV Template
                     </MaterialButton>
                 </div>
-                <div style={{ margin: '20px 0' }}>
-                    <MaterialButton
-                        disableRipple
-                        variant="outlined"
-                        color="primary"
-                        className="outlined-button outlined-button--inline"
-                        href="/contributor-templates/OAR_Contributor_Template_With_PPE.xlsx"
-                    >
-                        Download Excel (XLSX) Template With PPE Columns
-                    </MaterialButton>
-                    <MaterialButton
-                        disableRipple
-                        variant="outlined"
-                        color="primary"
-                        className="outlined-button"
-                        href="/contributor-templates/OAR_Contributor_Template_With_PPE.csv"
-                    >
-                        Download CSV Template With PPE Columns
-                    </MaterialButton>
-                </div>
+                <FeatureFlag flag={PPE}>
+                    <div style={{ margin: '20px 0' }}>
+                        <MaterialButton
+                            disableRipple
+                            variant="outlined"
+                            color="primary"
+                            className="outlined-button outlined-button--inline"
+                            href="/contributor-templates/OAR_Contributor_Template_With_PPE.xlsx"
+                        >
+                            Download Excel (XLSX) Template With PPE Columns
+                        </MaterialButton>
+                        <MaterialButton
+                            disableRipple
+                            variant="outlined"
+                            color="primary"
+                            className="outlined-button"
+                            href="/contributor-templates/OAR_Contributor_Template_With_PPE.csv"
+                        >
+                            Download CSV Template With PPE Columns
+                        </MaterialButton>
+                    </div>
+                </FeatureFlag>
             </div>
         </div>
     </Fragment>

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -15,6 +15,7 @@ import FacilityDetailsStaticMap from './FacilityDetailsStaticMap';
 import FacilityDetailSidebarInfo from './FacilityDetailSidebarInfo';
 import FacilityDetailsSidebarOtherLocations from './FacilityDetailsSidebarOtherLocations';
 import FacilityDetailSidebarClaimedInfo from './FacilityDetailSidebarClaimedInfo';
+import FacilityDetailSidebarPPE from './FacilityDetailSidebarPPE';
 import FeatureFlag from './FeatureFlag';
 import BadgeUnclaimed from './BadgeUnclaimed';
 import BadgeVerified from './BadgeVerified';
@@ -38,6 +39,7 @@ import {
 
 import {
     CLAIM_A_FACILITY,
+    PPE,
     facilitiesRoute,
 } from '../util/constants';
 
@@ -282,6 +284,9 @@ class FacilityDetailSidebar extends Component {
                             label="Contributors:"
                             isContributorsList
                         />
+                        <FeatureFlag flag={PPE}>
+                            <FacilityDetailSidebarPPE properties={data.properties} />
+                        </FeatureFlag>
                         <FeatureFlag flag={CLAIM_A_FACILITY}>
                             <ShowOnly when={!!data.properties.claim_info}>
                                 <FacilityDetailSidebarClaimedInfo

--- a/src/app/src/components/FacilityDetailSidebarPPE.jsx
+++ b/src/app/src/components/FacilityDetailSidebarPPE.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import pick from 'lodash/pick';
+import isEmpty from 'lodash/isEmpty';
+
+import { PPE_FIELD_NAMES } from '../util/constants';
+
+const FacilityDetailSidebarPPE = ({ properties }) => {
+    const ppeFields = pick(properties, PPE_FIELD_NAMES);
+
+    return !isEmpty(ppeFields)
+        ? (
+            <div className="control-panel__group">
+                <h1 className="control-panel__heading">
+                    PPE Details:
+                </h1>
+                <div className="control-panel__body">
+                    {!isEmpty(ppeFields.ppe_product_types) ? (
+                        <div style={{ marginBottom: '5px' }}>
+                            Product Types
+                            <ul>
+                                {ppeFields.ppe_product_types.map(t => <li>{t}</li>)}
+                            </ul>
+                        </div>
+                    ) : null}
+
+                    {ppeFields.ppe_contact_phone ? (
+                        <div style={{ marginBottom: '5px' }}>
+                            Contact Phone: {ppeFields.ppe_contact_phone}
+                        </div>
+                    ) : null}
+
+                    {ppeFields.ppe_contact_email ? (
+                        <div style={{ marginBottom: '5px' }}>
+                            Contact Email:{' '}
+                            <a
+                                href={
+                                    `mailto:${
+                                        ppeFields.ppe_contact_email
+                                    }?subject=PPE Information`}
+                            >
+                                {ppeFields.ppe_contact_email}
+                            </a>
+                        </div>
+                    ) : null}
+
+                    {ppeFields.ppe_website ? (
+                        <div style={{ marginBottom: '5px' }}>
+                            <a
+                                href={ppeFields.ppe_website}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Website
+                            </a>
+                        </div>
+                    ) : null}
+                </div>
+            </div>
+        ) : null;
+};
+
+export default FacilityDetailSidebarPPE;

--- a/src/app/src/components/FacilityDetailsSidebarOtherLocations.jsx
+++ b/src/app/src/components/FacilityDetailsSidebarOtherLocations.jsx
@@ -23,7 +23,7 @@ export default function FacilityDetailsSidebarOtherLocations({ data }) {
 
     return (
         <div className="control-panel__group">
-            <h1 className="control-panel__heading">Other locations</h1>
+            <h1 className="control-panel__heading">Other locations:</h1>
             <div className="control-panel__body">
                 <ul>
                     {map(data, location => (

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -422,6 +422,7 @@ export const facilitiesListTableTooltipTitles = Object.freeze({
 
 export const CLAIM_A_FACILITY = 'claim_a_facility';
 export const VECTOR_TILE = 'vector_tile';
+export const PPE = 'ppe';
 
 export const COUNTRY_CODES = Object.freeze({
     default: 'IE',
@@ -494,4 +495,11 @@ export const GRID_COLOR_RAMP = Object.freeze([
     [10, '#0086D8'],
     [40, '#0256BE'],
     [160, '#0427A4'],
+]);
+
+export const PPE_FIELD_NAMES = Object.freeze([
+    'ppe_product_types',
+    'ppe_contact_phone',
+    'ppe_contact_email',
+    'ppe_website',
 ]);

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -14,6 +14,7 @@ import {
     facilityMatchStatusChoicesEnum,
     CLAIM_A_FACILITY,
     VECTOR_TILE,
+    PPE,
     facilityClaimStatusChoicesEnum,
 } from './constants';
 
@@ -214,7 +215,7 @@ export const filtersPropType = shape({
 export const facilityListItemStatusPropType =
     oneOf(Object.values(facilityListItemStatusChoicesEnum).concat('Status'));
 
-export const featureFlagPropType = oneOf([CLAIM_A_FACILITY, VECTOR_TILE]);
+export const featureFlagPropType = oneOf([CLAIM_A_FACILITY, VECTOR_TILE, PPE]);
 
 export const facilityClaimsListPropType = arrayOf(shape({
     created_at: string.isRequired,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -68,8 +68,8 @@ export const downloadListItemCSV = (list, items) =>
         `${list.id}_${list.name}_${(new Date()).toLocaleDateString()}.csv`,
     );
 
-export const downloadFacilitiesCSV = facilities =>
-    DownloadCSV(createFacilitiesCSV(facilities), 'facilities.csv');
+export const downloadFacilitiesCSV = (facilities, options) =>
+    DownloadCSV(createFacilitiesCSV(facilities, options), 'facilities.csv');
 
 export const makeUserLoginURL = () => '/user-login/';
 export const makeUserLogoutURL = () => '/user-logout/';

--- a/src/django/api/migrations/0045_add_ppe_switch.py
+++ b/src/django/api/migrations/0045_add_ppe_switch.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def create_ppe_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.create(name='ppe', active=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0044_add_ppe_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_ppe_switch)
+    ]

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -422,7 +422,9 @@ class FacilitySerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Facility
         fields = ('id', 'name', 'address', 'country_code', 'location',
-                  'oar_id', 'country_name', 'contributors')
+                  'oar_id', 'country_name', 'contributors',
+                  'ppe_product_types', 'ppe_contact_phone',
+                  'ppe_contact_email', 'ppe_website')
         geo_field = 'location'
 
     # Added to ensure including the OAR ID in the geojson properties map

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -47,6 +47,7 @@ from allauth.account.utils import complete_signup
 import coreapi
 from waffle import switch_is_active, flag_is_active
 from waffle.decorators import waffle_switch
+from waffle.models import Switch
 
 
 from oar import urls
@@ -2216,10 +2217,8 @@ class FacilityListViewSet(viewsets.ModelViewSet):
 @permission_classes((AllowAny,))
 def api_feature_flags(request):
     response_data = {
-        'claim_a_facility': switch_is_active('claim_a_facility'),
-        'vector_tile': switch_is_active('vector_tile'),
+        s.name: switch_is_active(s.name) for s in Switch.objects.all()
     }
-
     return Response(response_data)
 
 


### PR DESCRIPTION
## Overview

Show PPE fields on facility detail and include in CSV downloads.

Connects #1032

## Demo

<img width="899" alt="Screen Shot 2020-07-08 at 9 07 12 AM" src="https://user-images.githubusercontent.com/17363/86944833-277d3f80-c0fd-11ea-8213-cd398220d1c3.png">

<img width="1223" alt="Screen Shot 2020-07-08 at 9 32 43 AM" src="https://user-images.githubusercontent.com/17363/86945547-02d59780-c0fe-11ea-815d-15311c9d68f1.png">

## Notes

Tracking PPE production may not be a long term feature of the OAR so we add put the display of PPE data behind a feature flag. This also gives us the ability to release other features to production before the PPE feature set is finalized. We refactored the feature flag API so that we no longer have to enumerate the flags by name, reducing the boilerplate required to create a new feature flag.

Adding the PPE fields to the CSV required adding the fields to the facility serializer.

We incorporate the existing feature flag into the front end so that PPE fields are not returned in the CSV if the feature is disabled. Conditionally changing the fields returned from a serializer is challenging, so we have opted to not alter the API responses based on the feature flag.

We use the newly-added PPE feature flag to hide the additional template download buttons unless the feature is enabled.

## Testing Instructions

These instructions assume `resetdb` has been run.

- Run migrations.
- Browse any facility detail page and verify that a PPE section is not shown. 
- Download and unzip  [ppe.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4886643/ppe.csv.zip)
- Log in as `c7@example.com`, browse http://localhost:6543/contribute and submit `ppe.csv`
- Fully process the file by running commands on the vagrant VM
  - `./scripts/manage batch_process --list-id 16 --action parse`
  - `./scripts/manage batch_process --list-id 16 --action geocode`
  - `./scripts/manage batch_process --list-id 16 --action match`
- Browse http://localhost:6543/lists/16 and open the links to the new facilities. Verify that the appropriate PPE data is displayed. 
  - The Azavea facility has all PPE fields
  - The Some Other Company facility only has PPE product types and an email
- Browse http://localhost:6543/facilities?countries=US, choose the "Facilities" tab and click "Download CSV." Verify that PPE data is included in the CSV 
- In a separate browser session log in as c1@example.com, browse http://localhost:8081/admin/waffle/switch/4/change/, uncheck the "Active" box on the PPE switch and click "Save an continue editing." 
- In the original browser session, browse http://localhost:6543/lists/16 and open the links to the new facilities. Verify that the PPE data is hidden. 
- Browse http://localhost:6543/facilities?countries=US, choose the "Facilities" tab and click "Download CSV." Verify that PPE data is no longer included in the CSV 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
