### PR TITLE
Add PPE filter checkbox to the facility search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add PPE-related model fields and API support [#1037](https://github.com/open-apparel-registry/open-apparel-registry/pull/1037)
 - Show PPE fields on facility detail and include in CSV downloads [#1041](https://github.com/open-apparel-registry/open-apparel-registry/pull/1041)
+- Add PPE filter checkbox to the facility search page [#1044](https://github.com/open-apparel-registry/open-apparel-registry/pull/1044)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -246,12 +246,12 @@ it('creates a set of filters from a querystring', () => {
         countries: [],
         combineContributors: '',
         boundary: null,
+        ppe: '',
     };
 
-    expect(isEqual(
+    expect(
         createFiltersFromQueryString(contributorsString),
-        expectedContributorsMatch,
-    )).toBe(true);
+    ).toEqual(expectedContributorsMatch);
 
     const combinedContributorsString = '?contributors=1&contributors=2&combine_contributors=AND';
     const expectedCombinedContributorsMatch = {
@@ -270,12 +270,12 @@ it('creates a set of filters from a querystring', () => {
         countries: [],
         combineContributors: 'AND',
         boundary: null,
+        ppe: '',
     };
 
-    expect(isEqual(
+    expect(
         createFiltersFromQueryString(combinedContributorsString),
-        expectedCombinedContributorsMatch,
-    )).toBe(true);
+    ).toEqual(expectedCombinedContributorsMatch);
 
 
     const typesString = '?contributor_types=Union&contributor_types=Service Provider';
@@ -295,12 +295,12 @@ it('creates a set of filters from a querystring', () => {
         countries: [],
         combineContributors: '',
         boundary: null,
+        ppe: '',
     };
 
-    expect(isEqual(
+    expect(
         createFiltersFromQueryString(typesString),
-        expectedTypesMatch,
-    )).toBe(true);
+    ).toEqual(expectedTypesMatch);
 
     const countriesString = '?countries=US&countries=CN';
     const expectedCountriesMatch = {
@@ -319,12 +319,12 @@ it('creates a set of filters from a querystring', () => {
         ],
         combineContributors: '',
         boundary: null,
+        ppe: '',
     };
 
-    expect(isEqual(
+    expect(
         createFiltersFromQueryString(countriesString),
-        expectedCountriesMatch,
-    )).toBe(true);
+    ).toEqual(expectedCountriesMatch);
 
     const stringWithCountriesMissing = '?contributor_types=Union&countries=';
     const expectedMissingCountriesMatch = {
@@ -339,12 +339,27 @@ it('creates a set of filters from a querystring', () => {
         countries: [],
         combineContributors: '',
         boundary: null,
+        ppe: '',
     };
 
-    expect(isEqual(
+    expect(
         createFiltersFromQueryString(stringWithCountriesMissing),
-        expectedMissingCountriesMatch,
-    )).toBe(true);
+    ).toEqual(expectedMissingCountriesMatch);
+
+    const ppeString = '?ppe=true';
+    const expectedPPEMatch = {
+        facilityFreeTextQuery: '',
+        contributors: [],
+        contributorTypes: [],
+        countries: [],
+        combineContributors: '',
+        boundary: null,
+        ppe: 'true',
+    };
+
+    expect(
+        createFiltersFromQueryString(ppeString),
+    ).toEqual(expectedPPEMatch);
 });
 
 it('creates a facility detail link', () => {

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -13,6 +13,7 @@ export const updateContributorTypeFilter = createAction('UPDATE_CONTRIBUTOR_TYPE
 export const updateCountryFilter = createAction('UPDATE_COUNTRY_FILTER');
 export const updateCombineContributorsFilterOption = createAction('UPDATE_COMBINE_CONTRIBUTORS_FILTER_OPTION');
 export const updateBoundaryFilter = createAction('UPDATE_BOUNDARY_FILTER');
+export const updatePPEFilter = createAction('UPDATE_PPE_FILTER');
 export const resetAllFilters = createAction('RESET_ALL_FILTERS');
 export const updateAllFilters = createAction('UPDATE_ALL_FILTERS');
 

--- a/src/app/src/components/FacilityDetailSidebarPPE.jsx
+++ b/src/app/src/components/FacilityDetailSidebarPPE.jsx
@@ -18,7 +18,11 @@ const FacilityDetailSidebarPPE = ({ properties }) => {
                         <div style={{ marginBottom: '5px' }}>
                             Product Types
                             <ul>
-                                {ppeFields.ppe_product_types.map(t => <li>{t}</li>)}
+                                {
+                                    ppeFields.ppe_product_types.map(
+                                        t => <li key={t}>{t}</li>,
+                                    )
+                                }
                             </ul>
                         </div>
                     ) : null}

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -14,6 +14,7 @@ import ReactSelect from 'react-select';
 import get from 'lodash/get';
 
 import ShowOnly from './ShowOnly';
+import FeatureFlag from './FeatureFlag';
 
 import {
     updateFacilityFreeTextQueryFilter,
@@ -22,6 +23,7 @@ import {
     updateCountryFilter,
     updateCombineContributorsFilterOption,
     updateBoundaryFilter,
+    updatePPEFilter,
     resetAllFilters,
 } from '../actions/filters';
 
@@ -66,6 +68,7 @@ const FACILITIES = 'FACILITIES';
 const CONTRIBUTORS = 'CONTRIBUTORS';
 const CONTRIBUTOR_TYPES = 'CONTRIBUTOR_TYPES';
 const COUNTRIES = 'COUNTRIES';
+const PPE = 'PPE';
 
 function FilterSidebarSearchTab({
     contributorOptions,
@@ -91,6 +94,8 @@ function FilterSidebarSearchTab({
     activateDrawFilter,
     clearDrawFilter,
     boundary,
+    ppe,
+    updatePPE,
 }) {
     if (fetchingOptions) {
         return (
@@ -192,7 +197,7 @@ function FilterSidebarSearchTab({
             style={filterSidebarStyles.controlPanelContentStyles}
         >
             <div>
-                <div className="form__field">
+                <div className="form__field" style={{ marginBottom: '10px' }}>
                     <InputLabel
                         htmlFor={FACILITIES}
                         className="form__label"
@@ -208,6 +213,22 @@ function FilterSidebarSearchTab({
                         onKeyPress={submitFormOnEnterKeyPress}
                     />
                 </div>
+                <FeatureFlag flag="ppe">
+                    <div className="form__field" style={{ marginBottom: '16px' }}>
+                        <InputLabel
+                            htmlFor={PPE}
+                            className="form__label"
+                        >
+                            Only include PPE facilities
+                        </InputLabel>
+                        <Checkbox
+                            checked={!!ppe}
+                            onChange={updatePPE}
+                            color="primary"
+                            value={ppe}
+                        />
+                    </div>
+                </FeatureFlag>
                 <div className="form__field">
                     <InputLabel
                         shrink={false}
@@ -357,12 +378,14 @@ FilterSidebarSearchTab.propTypes = {
     updateContributor: func.isRequired,
     updateContributorType: func.isRequired,
     updateCountry: func.isRequired,
+    updatePPE: func.isRequired,
     updateCombineContributors: func.isRequired,
     facilityFreeTextQuery: string.isRequired,
     contributors: contributorOptionsPropType.isRequired,
     contributorTypes: contributorTypeOptionsPropType.isRequired,
     countries: countryOptionsPropType.isRequired,
     combineContributors: string.isRequired,
+    ppe: string.isRequired,
     fetchingFacilities: bool.isRequired,
     searchForFacilities: func.isRequired,
     facilities: facilityCollectionPropType,
@@ -392,6 +415,7 @@ function mapStateToProps({
         countries,
         combineContributors,
         boundary,
+        ppe,
     },
     facilities: {
         facilities: {
@@ -416,6 +440,7 @@ function mapStateToProps({
         fetchingFacilities,
         facilities,
         boundary,
+        ppe,
         fetchingOptions: fetchingContributors
             || fetchingContributorTypes
             || fetchingCountries,
@@ -438,6 +463,9 @@ function mapDispatchToProps(dispatch, {
         },
         updateContributorType: v => dispatch(updateContributorTypeFilter(v)),
         updateCountry: v => dispatch(updateCountryFilter(v)),
+        updatePPE: e => dispatch(updatePPEFilter(
+            e.target.checked ? 'true' : '',
+        )),
         updateCombineContributors: e => dispatch(
             updateCombineContributorsFilterOption(e.target.checked ? 'AND' : ''),
         ),

--- a/src/app/src/reducers/FacilitiesReducer.js
+++ b/src/app/src/reducers/FacilitiesReducer.js
@@ -23,6 +23,7 @@ import {
     updateContributorFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
+    updatePPEFilter,
     resetAllFilters,
     updateAllFilters,
 } from '../actions/filters';
@@ -155,6 +156,7 @@ export default createReducer({
     [updateContributorFilter]: clearFacilitiesDataOnFilterChange,
     [updateContributorTypeFilter]: clearFacilitiesDataOnFilterChange,
     [updateCountryFilter]: clearFacilitiesDataOnFilterChange,
+    [updatePPEFilter]: clearFacilitiesDataOnFilterChange,
     [resetAllFilters]: clearFacilitiesDataOnFilterChange,
     [updateAllFilters]: clearFacilitiesDataOnFilterChange,
     [completeSubmitLogOut]: clearFacilitiesDataOnFilterChange,

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -6,6 +6,7 @@ import {
     updateContributorFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
+    updatePPEFilter,
     updateCombineContributorsFilterOption,
     updateBoundaryFilter,
     resetAllFilters,
@@ -31,6 +32,7 @@ const initialState = Object.freeze({
     countries: Object.freeze([]),
     combineContributors: '',
     boundary: null,
+    ppe: '',
 });
 
 export const maybeSetFromQueryString = field => (state, payload) => {
@@ -65,6 +67,9 @@ export default createReducer({
     }),
     [updateBoundaryFilter]: (state, payload) => update(state, {
         boundary: { $set: payload },
+    }),
+    [updatePPEFilter]: (state, payload) => update(state, {
+        ppe: { $set: payload },
     }),
     [resetAllFilters]: () => initialState,
     [updateAllFilters]: (_state, payload) => payload,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -140,6 +140,7 @@ export const createQueryStringFromSearchFilters = ({
     countries = [],
     combineContributors = '',
     boundary = {},
+    ppe = '',
 }) => {
     const inputForQueryString = Object.freeze({
         q: facilityFreeTextQuery,
@@ -148,6 +149,7 @@ export const createQueryStringFromSearchFilters = ({
         countries: createCompactSortedQuerystringInputObject(countries),
         combine_contributors: combineContributors,
         boundary: isEmpty(boundary) ? '' : JSON.stringify(boundary),
+        ppe,
     });
 
     return querystring.stringify(omitBy(inputForQueryString, isEmpty));
@@ -192,6 +194,7 @@ export const createFiltersFromQueryString = (qs) => {
         countries = [],
         combine_contributors: combineContributors = '',
         boundary = '',
+        ppe = '',
     } = querystring.parse(qsToParse);
 
     return Object.freeze({
@@ -201,6 +204,7 @@ export const createFiltersFromQueryString = (qs) => {
         countries: createSelectOptionsFromParams(countries),
         combineContributors,
         boundary: isEmpty(boundary) ? null : JSON.parse(boundary),
+        ppe,
     });
 };
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -30,6 +30,7 @@ class FacilitiesQueryParams:
     COUNTRIES = 'countries'
     COMBINE_CONTRIBUTORS = 'combine_contributors'
     BOUNDARY = 'boundary'
+    PPE = 'ppe'
 
 
 class FacilityListQueryParams:

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -390,6 +390,7 @@ class FacilityQueryParamsSerializer(Serializer):
     page = IntegerField(required=False)
     pageSize = IntegerField(required=False)
     boundary = CharField(required=False)
+    ppe = BooleanField(default=False, required=False)
 
 
 class FacilityListQueryParamsSerializer(Serializer):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -494,7 +494,7 @@ def log_download(request):
 class FacilitiesAPIFilterBackend(BaseFilterBackend):
     def get_schema_fields(self, view):
         if view.action == 'list':
-            return [
+            fields = [
                 coreapi.Field(
                     name='q',
                     location='query',
@@ -549,18 +549,24 @@ class FacilitiesAPIFilterBackend(BaseFilterBackend):
                         'Pass a GeoJSON geometry to filter by '
                         'facilities within the boundaries of that geometry.')
                 ),
-                coreapi.Field(
-                    name='ppe',
-                    location='query',
-                    type='boolean',
-                    required=False,
-                    description=(
-                        'If "true" only facilities with PPE '
-                        'production details or PPE-specific contact '
-                        'information will be returned. Any other value will '
-                        'return all facilities.'),
-                ),
             ]
+
+            if switch_is_active('ppe'):
+                fields.append(
+                    coreapi.Field(
+                        name='ppe',
+                        location='query',
+                        type='boolean',
+                        required=False,
+                        description=(
+                            'If "true" only facilities with PPE '
+                            'production details or PPE-specific contact '
+                            'information will be returned. Any other value '
+                            'will return all facilities.'),
+                    )
+                )
+
+            return fields
 
         if view.action == 'create':
             return [

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -549,6 +549,17 @@ class FacilitiesAPIFilterBackend(BaseFilterBackend):
                         'Pass a GeoJSON geometry to filter by '
                         'facilities within the boundaries of that geometry.')
                 ),
+                coreapi.Field(
+                    name='ppe',
+                    location='query',
+                    type='boolean',
+                    required=False,
+                    description=(
+                        'If "true" only facilities with PPE '
+                        'production details or PPE-specific contact '
+                        'information will be returned. Any other value will '
+                        'return all facilities.'),
+                ),
             ]
 
         if view.action == 'create':


### PR DESCRIPTION
## Overview

Adds a PPE checkbox to the facility search page and connects it to the search API.

Connects #1043

## Demo

<img width="730" alt="Screen Shot 2020-07-08 at 4 26 03 PM" src="https://user-images.githubusercontent.com/17363/86980102-d6d70800-c137-11ea-9712-9b3925b7775e.png">


## Testing Instructions

These instructions assume `resetdb` has been run.

- Download and unzip [ppe.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4893793/ppe.csv.zip)
- Log in as `c7@example.com`, browse http://localhost:6543/contribute and submit `ppe.csv`
- Fully process the file by running commands on the vagrant VM
  - `./scripts/manage batch_process --list-id 16 --action parse`
  - `./scripts/manage batch_process --list-id 16 --action geocode`
  - `./scripts/manage batch_process --list-id 16 --action match`
- Browse http://localhost:6543/facilities?ppe=true and verify that all 5 facilities from the CSV are returned.
- Clear the search and run a text search for "all" and verify that there are 11 results. Then check the PPE checkbox and search again. Verify that there is a single result.
- Browse http://localhost:8081/api/docs/#!/facilities/facilities_list and verify that the "ppe" field is documented.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
