### PR TITLE
Include PPE product types in free text query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add PPE-related model fields and API support [#1037](https://github.com/open-apparel-registry/open-apparel-registry/pull/1037)
 - Show PPE fields on facility detail and include in CSV downloads [#1041](https://github.com/open-apparel-registry/open-apparel-registry/pull/1041)
 - Add PPE filter checkbox to the facility search page [#1044](https://github.com/open-apparel-registry/open-apparel-registry/pull/1044)
+- Include PPE product types in free text query [#1045](https://github.com/open-apparel-registry/open-apparel-registry/pull/1045)
 
 ### Changed
 

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -202,7 +202,12 @@ function FilterSidebarSearchTab({
                         htmlFor={FACILITIES}
                         className="form__label"
                     >
-                        Search a Facility Name or OAR ID
+                        <FeatureFlag
+                            flag="ppe"
+                            alternative="Search a Facility Name or OAR ID"
+                        >
+                              Search a Facility Name, OAR ID, or PPE Product Type
+                        </FeatureFlag>
                     </InputLabel>
                     <TextField
                         id={FACILITIES}

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -12,6 +12,7 @@ from django.contrib.gis.geos import GEOSGeometry
 from django.utils.dateformat import format
 from allauth.account.models import EmailAddress
 from simple_history.models import HistoricalRecords
+from waffle import switch_is_active
 
 from api.constants import FeatureGroups
 from api.countries import COUNTRY_CHOICES
@@ -1090,9 +1091,15 @@ class FacilityManager(models.Manager):
         facilities_qs = Facility.objects.all()
 
         if free_text_query is not None:
-            facilities_qs = facilities_qs \
-                .filter(Q(name__icontains=free_text_query) |
-                        Q(id__icontains=free_text_query))
+            if switch_is_active('ppe'):
+                facilities_qs = facilities_qs \
+                    .filter(Q(name__icontains=free_text_query) |
+                            Q(id__icontains=free_text_query) |
+                            Q(ppe_product_types__icontains=free_text_query))
+            else:
+                facilities_qs = facilities_qs \
+                    .filter(Q(name__icontains=free_text_query) |
+                            Q(id__icontains=free_text_query))
 
         # `name` is deprecated in favor of `q`. We keep `name` available for
         # backward compatibility.


### PR DESCRIPTION
## Overview

Allows searching for a specific type of PPE product using the simplest possible implementation. Can be combined with the `ppe` filter for more precision searching.

Connects #1031

## Demo

<img width="284" alt="Screen Shot 2020-07-09 at 10 00 31 AM" src="https://user-images.githubusercontent.com/17363/87068851-0d119780-c1cb-11ea-96f9-23bf37747b0a.png">

## Testing Instructions

These instructions assume `resetdb` has been run.

- Download and unzip [ppe.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4893793/ppe.csv.zip)
- Log in as `c7@example.com`, browse http://localhost:6543/contribute and submit `ppe.csv`
- Fully process the file by running commands on the vagrant VM
  - `./scripts/manage batch_process --list-id 16 --action parse`
  - `./scripts/manage batch_process --list-id 16 --action geocode`
  - `./scripts/manage batch_process --list-id 16 --action match`
- Free-text search for "gloves" and verify that 3 facilities are returned, 2 that match "gloves" in the name and 1 that matches "gloves" in the PPE product types.
- In a separate browser session log in as c1@example.com, browse http://localhost:8081/admin/waffle/switch/4/change/, uncheck the "Active" box on the PPE switch and click "Save an continue editing." 
- In the original browser session browse http://localhost:6543/ and verify that the label on the free text search field has changed. Search for "gloves" and verify that only the 2 name matches are returned.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
