### PR TITLE
Update PPE filter checkbox label / allow viewing RequestLog in the Django admin / log matching traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Update PPE filter checkbox label / allow viewing RequestLog in the Django admin / log matching traceback [#1049](https://github.com/open-apparel-registry/open-apparel-registry/pull/1049)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -224,7 +224,7 @@ function FilterSidebarSearchTab({
                             htmlFor={PPE}
                             className="form__label"
                         >
-                            Only include PPE facilities
+                            Only show PPE facilities
                         </InputLabel>
                         <Checkbox
                             checked={!!ppe}

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -112,6 +112,26 @@ class SourceAdmin(admin.ModelAdmin):
     readonly_fields = ('source_type', 'facility_list', 'create')
 
 
+class RequestLogAdmin(admin.ModelAdmin):
+    readonly_fields = ('user', 'token', 'method', 'path', 'response_code',
+                       'created_at')
+    actions = None
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def changeform_view(self, request, object_id=None, form_url='',
+                        extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['show_save_and_continue'] = False
+        extra_context['show_save'] = False
+        return super(RequestLogAdmin, self).changeform_view(
+            request, object_id, extra_context=extra_context)
+
+
 admin_site.register(models.Version)
 admin_site.register(models.User, OarUserAdmin)
 admin_site.register(models.Contributor, ContributorAdmin)
@@ -128,3 +148,4 @@ admin_site.register(Flag, FlagAdmin)
 admin_site.register(Sample, SampleAdmin)
 admin_site.register(Switch, SwitchAdmin)
 admin_site.register(Group)
+admin_site.register(models.RequestLog, RequestLogAdmin)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1543,6 +1543,15 @@ class RequestLog(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def __str__(self):
+        return '{} - {} - {} {} {} ({})'.format(
+            self.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            self.user.email,
+            self.method,
+            self.path,
+            self.response_code,
+            self.id)
+
 
 class ProductType(models.Model):
     value = models.CharField(

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1113,6 +1113,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                 'started_at': match_started,
                 'error': True,
                 'message': str(e),
+                'trace': traceback.format_exc(),
                 'finished_at': str(datetime.utcnow())
             })
             item.save()


### PR DESCRIPTION
## Overview

Makes 2 small changes discussed and implemented during a weekly status call and a third change to help future debugging of matching failures.

## Demo

<img width="562" alt="Screen Shot 2020-07-15 at 1 02 51 PM" src="https://user-images.githubusercontent.com/17363/87590392-8e6d9c00-c69b-11ea-9a4f-b6a4fb0bab37.png">

<img width="680" alt="Screen Shot 2020-07-15 at 1 02 16 PM" src="https://user-images.githubusercontent.com/17363/87590402-92012300-c69b-11ea-8b1a-8659901aec3b.png">

<img width="420" alt="Screen Shot 2020-07-15 at 1 02 26 PM" src="https://user-images.githubusercontent.com/17363/87590412-962d4080-c69b-11ea-8fd2-ef73dac50ee6.png">

<img width="1265" alt="Screen Shot 2020-07-16 at 9 34 16 AM" src="https://user-images.githubusercontent.com/17363/87697928-a13daa80-c747-11ea-9457-dbf843374416.png">

## Testing Instructions

* Apply [1049.patch.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/4932825/1049.patch.txt) and restart `./scripts/server

```diff
diff --git a/src/django/api/views.py b/src/django/api/views.py
index 38ff127..8d164bf 100644
--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1064,6 +1064,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
 
         match_started = str(datetime.utcnow())
         try:
+            raise Exception('boom')
             match_results = match_item(country_code, name, address, item.id)
             match_objects = save_match_details(match_results)
 
```
* Browse http://localhost:6543/ and confirm the PPE checkbox text
* Log in as c2@example.com, browse http://localhost:6543/profile/2, and create an API token.
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_list and use the "Authorize" button to set the header value to `Token {{token_value}}`
* Enter "gloves" in the `q` field and click "Try it out!" Verify a successful response.
* In a separate  browser session log in as c1@example.com
* Browse http://localhost:8081/admin/api/requestlog/ and verify that the API request appears. Click the row to view the detail page and verify that no edit options are available.
* Browse http://localhost:8081/admin/api/user/2/change/, add the user to all groups, and save
* In the c2@example.com browser session browse https://openapparel.org/api/docs/#!/facilities/facilities_create, set `create` to "false" and submit the following facility data.
```js
{
"country": "US",
"name": "ABC Textiles",
"address": "1 Main St New York 13662"
}
```
* Verify that ERROR_MATCHING is returned
* In the admin browser session browse https://openapparel.org/admin/api/facilitylistitem/, select the most recent item (which should have an error status), and verify that the traceback is included at the end of the "Processing resuslts" JSON array.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
