### PR TITLE
added tooltips if table cells exceed certain lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Added tooltips if table cells exceed certain lengths [#1054](https://github.com/open-apparel-registry/open-apparel-registry/pull/1054)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -715,3 +715,8 @@ hr {
 .mobile-navigation-drawer .navButton {
   padding: 15px;
 }
+
+.cell-tooltip {
+  font-size: 12px !important;
+  margin: 0 !important;
+}

--- a/src/app/src/components/CellElement.jsx
+++ b/src/app/src/components/CellElement.jsx
@@ -6,6 +6,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import Tooltip from '@material-ui/core/Tooltip';
 import isObject from 'lodash/isObject';
 
 import { facilityMatchStatusChoicesEnum } from '../util/constants';
@@ -73,6 +74,25 @@ export default class CellElement extends Component {
         } = this.props;
 
         if (!hasActions) {
+            const OverflowTooltip = ({ children }) => {
+                if (item.length > 50) {
+                    return (
+                        <Tooltip
+                            title={item}
+                            placement="top-start"
+                            classes={{ tooltip: 'cell-tooltip' }}
+                            enterDelay={100}
+                        >
+                            <span style={confirmRejectMatchRowStyles.cellOverflowStyles}>
+                                {children}
+                            </span>
+                        </Tooltip>
+                    );
+                }
+
+                return children;
+            };
+
             const insetComponent = (() => {
                 if (stringIsHidden) {
                     return ' ';
@@ -83,6 +103,7 @@ export default class CellElement extends Component {
                         <Link
                             to={linkURL}
                             href={linkURL}
+                            style={confirmRejectMatchRowStyles.cellOverflowStyles}
                         >
                             {item}
                         </Link>
@@ -101,7 +122,9 @@ export default class CellElement extends Component {
                             : confirmRejectMatchRowStyles.cellRowStyles
                     }
                 >
-                    {insetComponent}
+                    <OverflowTooltip>
+                        {insetComponent}
+                    </OverflowTooltip>
                 </div>
             );
         }

--- a/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
+++ b/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { arrayOf, bool, func, number, oneOf, oneOfType, shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
 import get from 'lodash/get';
 import isFunction from 'lodash/isFunction';
 
@@ -33,6 +34,20 @@ export default function FacilityListItemsDetailedTableRowCell({
         }
 
         if (!isFunction(handleRemoveItem)) {
+            if (title.length > 50) {
+                return (
+                    <Tooltip
+                        title={title}
+                        placement="top-start"
+                        classes={{ tooltip: 'cell-tooltip' }}
+                        enterDelay={200}
+                    >
+                        <span style={confirmRejectMatchRowStyles.cellOverflowStyles}>
+                            {title}
+                        </span>
+                    </Tooltip>
+                );
+            }
             return title;
         }
 

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -47,12 +47,18 @@ export const confirmRejectMatchRowStyles = Object.freeze({
         display: 'flex',
         flexDirection: 'column',
     }),
+    cellOverflowStyles: Object.freeze({
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+    }),
     cellRowStyles: Object.freeze({
-        height: '55px',
         minHeight: '55px',
         display: 'flex',
         alignItems: 'top',
         maxWidth: '400px',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'hidden',
     }),
     cellSubtitleStyles: Object.freeze({
         display: 'flex',
@@ -65,6 +71,9 @@ export const confirmRejectMatchRowStyles = Object.freeze({
         display: 'flex',
         alignItems: 'top',
         maxWidth: '400px',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'hidden',
     }),
     errorCellRowStyles: Object.freeze({
         height: '75px',


### PR DESCRIPTION
## Overview

This PR addresses the overlapping content in the facility list. Due to the complexity of the tables, the simplest fix was to truncate longer strings, and show the full string in a tooltip on hover. The tooltips will only show once a string exceeds 50 characters.

Connects #389

## Demo

![image](https://user-images.githubusercontent.com/1928955/87714171-618fb680-c779-11ea-8bf9-598e267eea03.png)

## Testing Instructions

* Upload the two attached lists and process them.
* Begin the process of matching
* Ensure the cells don't overlap, but instead truncate. If they truncate make sure you can hover and see a tooltip

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
