### PR TITLE
Update PPE fields when matching, splitting, and merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show PPE fields on facility detail and include in CSV downloads [#1041](https://github.com/open-apparel-registry/open-apparel-registry/pull/1041)
 - Add PPE filter checkbox to the facility search page [#1044](https://github.com/open-apparel-registry/open-apparel-registry/pull/1044)
 - Include PPE product types in free text query [#1045](https://github.com/open-apparel-registry/open-apparel-registry/pull/1045)
+- Update PPE filter checkbox label / allow viewing RequestLog in the Django admin / log matching traceback [#1049](https://github.com/open-apparel-registry/open-apparel-registry/pull/1049)
+- Update PPE fields when matching, splitting, and merging [#1055](https://github.com/open-apparel-registry/open-apparel-registry/pull/1055)
 
 ### Changed
-
-- Update PPE filter checkbox label / allow viewing RequestLog in the Django admin / log matching traceback [#1049](https://github.com/open-apparel-registry/open-apparel-registry/pull/1049)
 
 ### Deprecated
 

--- a/src/app/src/components/FacilityDetailSidebarPPE.jsx
+++ b/src/app/src/components/FacilityDetailSidebarPPE.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
+import identity from 'lodash/identity';
 import isEmpty from 'lodash/isEmpty';
 
 import { PPE_FIELD_NAMES } from '../util/constants';
 
 const FacilityDetailSidebarPPE = ({ properties }) => {
-    const ppeFields = pick(properties, PPE_FIELD_NAMES);
+    const ppeFields = pickBy(pick(properties, PPE_FIELD_NAMES), identity);
 
     return !isEmpty(ppeFields)
         ? (

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -405,6 +405,25 @@ class PPEMixin(models.Model):
         verbose_name='ppe website',
         help_text='The website for PPE information')
 
+    @property
+    def has_ppe_product_types(self):
+        return (self.ppe_product_types is not None
+                and self.ppe_product_types != [])
+
+    @property
+    def has_ppe_contact_phone(self):
+        return (self.ppe_contact_phone is not None
+                and self.ppe_contact_phone != '')
+
+    @property
+    def has_ppe_contact_email(self):
+        return (self.ppe_contact_email is not None
+                and self.ppe_contact_email != '')
+
+    @property
+    def has_ppe_website(self):
+        return (self.ppe_website is not None and self.ppe_website != '')
+
 
 class FacilityListItem(PPEMixin):
     """

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -361,6 +361,38 @@ def save_match_details(match_results):
         if item.source.create:
             for m in matches:
                 m.save()
+                if m.status == FacilityMatch.AUTOMATIC:
+                    should_update_ppe_product_types = (
+                        item.has_ppe_product_types
+                        and not m.facility.has_ppe_product_types)
+                    if should_update_ppe_product_types:
+                        m.facility.ppe_product_types = item.ppe_product_types
+
+                    should_update_ppe_contact_phone = (
+                        item.has_ppe_contact_phone
+                        and not m.facility.has_ppe_contact_phone)
+                    if should_update_ppe_contact_phone:
+                        m.facility.ppe_contact_phone = item.ppe_contact_phone
+
+                    should_update_ppe_contact_email = (
+                        item.has_ppe_contact_email
+                        and not m.facility.has_ppe_contact_email)
+                    if should_update_ppe_contact_email:
+                        m.facility.ppe_contact_email = item.ppe_contact_email
+
+                    should_update_ppe_website = (
+                        item.has_ppe_website
+                        and not m.facility.has_ppe_website)
+                    if should_update_ppe_website:
+                        m.facility.ppe_website = item.ppe_website
+
+                    should_save_facility = (
+                        should_update_ppe_product_types
+                        or should_update_ppe_contact_phone
+                        or should_update_ppe_contact_email
+                        or should_update_ppe_website)
+                    if should_save_facility:
+                        m.facility.save()
 
         all_matches.extend(matches)
 


### PR DESCRIPTION
## Overview

When creating matches to existing facilities, splitting a match, or merging two facilities, update the PPE fields as needed

~Connects #1048~
Connects #1050

## Notes

After discussing how PPE fields should be handled in the case of multiple matches we decided that it is OK to break with the previous behavior of all the properties of `Facility` being copied from a single `FacilityListItem`. We want to be able to add PPE information to facilities by uploading a list and matching items to existing facilities, but we don't want to require promoting matches since it will:
  1. Require extra work
  2. May overwrite a better name or address in the process

When this PR is merged, matching a list item to a facility wither by automatic match or a manual merge, will copy PPE fields from the item if they have not already been set on the `Facility`. Implementing this behavior required us to also modify the split action to restore/clear PPE field values by copying them back from the list item that originally created the `Facility`. This isn't a 100% correct solution in all cases since the PPE field values could be from multiple matches, but we are not expecting that to be a situation that occurs in practice.

## Testing Instructions

* Run ./scripts/resetdb
* Open two browser sessions, and admin session logged in as c1@example.com and a normal session logged in as c2@example.com
* In the c2@example.com session browse http://localhost:6543/contribute and upload 
[clarksville-hosiery-ppe.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4940223/clarksville-hosiery-ppe.csv.zip)
* Process the list
  * ./scripts/manage batch_process --list-id 16 --action parse
  * ./scripts/manage batch_process --list-id 16 --action geocode
  * ./scripts/manage batch_process --list-id 16 --action match
* Browse http://localhost:6543/lists/16, verify that the row `MATCHED`, and click the link to navigate to the detail page. Verify that the PPE fields are populated. Copy the OAR ID.
* In the c1@example.com session browse http://localhost:6543/dashboard/adjustfacilitymatches and submit the copied OAR ID.
* Split the match and verify that it succeeds. Browse the new facility detail page and verify that the PPE data is listed. Browse the old facility detail page and verify that the PPE data has been removed. Copy the new OAR ID.
* Browse http://localhost:6543/dashboard/mergefacilities, enter the old OAR ID first, then the new OAR ID created when the match was split (The "clarksville-hosiery-ppe" item should be on the right)
* Merge the facilities then browse the detail page of the old OAR ID. Verify that the PPE details have returned.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
