### PR TITLE
Prevent crashing the parse job if ppe_product_types value too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Prevent crashing the parse job if ppe_product_types value too long [#1062](https://github.com/open-apparel-registry/open-apparel-registry/pull/1062)
+
 ### Security
 
 - Bump lodash from 4.17.13 to 4.17.19 in /src/app [#1051](https://github.com/open-apparel-registry/open-apparel-registry/pull/1051)

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -160,6 +160,16 @@ def parse_facility_list_item(item):
                     'There is a problem with the {0}: {1}'.format(name,
                                                                   error_str)
                 )
+
+            # If there is a validation error on the `ppe_product_types` array
+            # field, `full_clean` appears to set it to an empty string which
+            # then causes `save` to raise an exception.
+            ppe_product_types_is_valid = (
+                item.ppe_product_types is None
+                or isinstance(item.ppe_product_types, list))
+            if not ppe_product_types_is_valid:
+                item.ppe_product_types = []
+
             item.status = FacilityListItem.ERROR_PARSING
             item.processing_results.append({
                 'action': ProcessingAction.PARSE,


### PR DESCRIPTION

## Overview

If there is a validation error on the `ppe_product_types` array field, `full_clean` appears to set it to an empty string which then causes `save` to raise an exception. We work around this by setting the field to an empty list if it is not None and not a list.

Connects #1061 

## Demo

<img width="1458" alt="Screen Shot 2020-07-29 at 2 39 13 PM" src="https://user-images.githubusercontent.com/17363/88856423-4e351000-d1a9-11ea-831c-be8e748c20dd.png">


## Testing Instructions

These steps assume `./scripts/resetdb` has been run.

* Log in as c2@example.com
* Upload [single-item-ppe-product-type-too-long.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/4997568/single-item-ppe-product-type-too-long.csv.zip)
* Run the parse job
  * ./scripts/manage batch_process --list-id 16 --action parse
* Verify the job reports a failed line but exits successfuly.
* Browse http://localhost:6543/lists/16, click the row, and verify that an informative validation error is shown.



## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
