### PR TITLE
Update PPE fields when deactivating sources and matches or confirming/rejecting matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Update PPE fields when deactivating sources and matches or confirming/rejecting matches [#1069](https://github.com/open-apparel-registry/open-apparel-registry/pull/1069)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/FacilityDetailSidebarPPE.jsx
+++ b/src/app/src/components/FacilityDetailSidebarPPE.jsx
@@ -8,8 +8,9 @@ import { PPE_FIELD_NAMES } from '../util/constants';
 
 const FacilityDetailSidebarPPE = ({ properties }) => {
     const ppeFields = pickBy(pick(properties, PPE_FIELD_NAMES), identity);
+    const hasPPEValues = !Object.values(ppeFields).every(isEmpty);
 
-    return !isEmpty(ppeFields)
+    return hasPPEValues
         ? (
             <div className="control-panel__group">
                 <h1 className="control-panel__heading">

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1443,19 +1443,26 @@ class Facility(PPEMixin):
 
     def revert_ppe(self, item):
         """
-        If the specified item has PPE data, restore the PPE data
-        on the Facility to the values copied from the original line item
-        that created the facility. Return True if any update to the model was
-        made.
+        If the specified item has PPE data either:
+        - Restore the PPE data on the Facility to the values copied from the
+          original line item that created the facility.
+        - If the facility created the item, clear the PPE fields.
+        Return True if any update to the model was made.
         """
-        if item.has_ppe_product_types:
-            self.ppe_product_types = self.created_from.ppe_product_types
-        if item.has_ppe_contact_phone:
-            self.ppe_contact_phone = self.created_from.ppe_contact_phone
-        if item.has_ppe_contact_email:
-            self.ppe_contact_email = self.created_from.ppe_contact_email
-        if item.has_ppe_website:
-            self.ppe_website = self.created_from.ppe_website
+        if item == self.created_from:
+            self.ppe_product_types = []
+            self.ppe_contact_phone = ''
+            self.ppe_contact_email = ''
+            self.ppe_website = ''
+        else:
+            if item.has_ppe_product_types:
+                self.ppe_product_types = self.created_from.ppe_product_types
+            if item.has_ppe_contact_phone:
+                self.ppe_contact_phone = self.created_from.ppe_contact_phone
+            if item.has_ppe_contact_email:
+                self.ppe_contact_email = self.created_from.ppe_contact_email
+            if item.has_ppe_website:
+                self.ppe_website = self.created_from.ppe_website
 
         return (item.has_ppe_website
                 or item.has_ppe_contact_phone

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1408,6 +1408,39 @@ class Facility(PPEMixin):
         return self.facilityclaim_set.filter(
             status=FacilityClaim.APPROVED).count() > 0
 
+    def conditionally_set_ppe(self, item):
+        """
+        Copy PPE fields from the specified item if they are empty. `item` can
+        be either a `Facility` or a `FacilityListItem` because they both
+        inherit from `PPEMixin`. Returns True if any update to the model was
+        made.
+        """
+        should_update_ppe_product_types = \
+            item.has_ppe_product_types and not self.has_ppe_product_types
+        if (should_update_ppe_product_types):
+            self.ppe_product_types = item.ppe_product_types
+
+        should_update_ppe_contact_phone = \
+            item.has_ppe_contact_phone and not self.has_ppe_contact_phone
+        if (should_update_ppe_contact_phone):
+            self.ppe_contact_phone = item.ppe_contact_phone
+
+        should_update_ppe_contact_email = \
+            item.has_ppe_contact_email and not self.has_ppe_contact_email
+        if (should_update_ppe_contact_email):
+            self.ppe_contact_email = item.ppe_contact_email
+
+        should_update_ppe_website = \
+            item.has_ppe_website and not self.has_ppe_website
+        if (should_update_ppe_website):
+            self.ppe_website = item.ppe_website
+
+        return (
+            should_update_ppe_website
+            or should_update_ppe_contact_phone
+            or should_update_ppe_contact_email
+            or should_update_ppe_website)
+
     def revert_ppe(self, item):
         """
         If the specified item has PPE data, restore the PPE data

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -5673,6 +5673,8 @@ class PPEFieldTest(TestCase):
         self.email_two = 'two@example.com'
         self.user_one = User.objects.create(email=self.email_one)
         self.user_two = User.objects.create(email=self.email_two)
+        self.user_two.set_password('password')
+        self.user_two.save()
 
         self.contrib_one = Contributor \
             .objects \
@@ -5735,7 +5737,8 @@ class PPEFieldTest(TestCase):
                     ppe_website='http://example.com/two',
                     row_index=1,
                     status=FacilityListItem.CONFIRMED_MATCH,
-                    source=self.source_two)
+                    source=self.source_two,
+                    geocoded_point=Point(0, 0))
 
         self.facility = Facility \
             .objects \
@@ -5854,3 +5857,65 @@ class PPEFieldTest(TestCase):
                          self.facility.ppe_contact_email)
         self.assertEqual('HTTP://TEST.COM',
                          self.facility.ppe_website)
+
+    def match_url(self, match, action='detail'):
+        return reverse('facility-match-{}'.format(action),
+                       kwargs={'pk': match.pk})
+
+    def test_confirm_match_populates_ppe(self):
+        results = self.make_match_results(self.list_item_two.id,
+                                          self.facility.id, 70)
+        save_match_details(results)
+
+        pending_qs = self.facility.facilitymatch_set.filter(
+            status=FacilityMatch.PENDING)
+        self.assertEqual(1, pending_qs.count())
+        match = pending_qs[0]
+        self.assertEqual(FacilityMatch.PENDING, match.status)
+
+        self.client.login(email=self.email_two,
+                          password='password')
+        response = self.client.post(
+            self.match_url(match, action='confirm')
+        )
+        self.assertEqual(200, response.status_code)
+
+        self.facility.refresh_from_db()
+
+        self.assertEqual(self.list_item_two.ppe_product_types,
+                         self.facility.ppe_product_types)
+        self.assertEqual(self.list_item_two.ppe_contact_phone,
+                         self.facility.ppe_contact_phone)
+        self.assertEqual(self.list_item_two.ppe_contact_email,
+                         self.facility.ppe_contact_email)
+        self.assertEqual(self.list_item_two.ppe_website,
+                         self.facility.ppe_website)
+
+    def test_reject_match_creates_facility_with_ppe(self):
+        results = self.make_match_results(self.list_item_two.id,
+                                          self.facility.id, 70)
+        save_match_details(results)
+
+        pending_qs = self.facility.facilitymatch_set.filter(
+            status=FacilityMatch.PENDING)
+        self.assertEqual(1, pending_qs.count())
+        match = pending_qs[0]
+        self.assertEqual(FacilityMatch.PENDING, match.status)
+
+        self.client.login(email=self.email_two,
+                          password='password')
+        response = self.client.post(
+            self.match_url(match, action='reject')
+        )
+        self.assertEqual(200, response.status_code)
+
+        facility = Facility.objects.get(created_from=self.list_item_two)
+
+        self.assertEqual(self.list_item_two.ppe_product_types,
+                         facility.ppe_product_types)
+        self.assertEqual(self.list_item_two.ppe_contact_phone,
+                         facility.ppe_contact_phone)
+        self.assertEqual(self.list_item_two.ppe_contact_email,
+                         facility.ppe_contact_email)
+        self.assertEqual(self.list_item_two.ppe_website,
+                         facility.ppe_website)


### PR DESCRIPTION
## Overview

Ensures that PPE fields on the `Facility` are updated appropriately when the following actions are taken:

- Confirming a potential match.
- Rejecting a potential match.
- Removing (deactivating) a single item from a list.
- Replacing a list.

Connects #1058 
Connects #1065

## Notes

When a line item is not longer associated with a facility, we revert the PPE field values on the `Facility`, following the existing workflow of splitting a match.

We choose to trigger this logic in overridden `save` methods on `Source` and `FacilityMatch` so that we will apply the same reversion logic any time a block of code changes `is_active` from `True` to `False`. The `is_active` flag is sometimes changed by moderators via the Django admin so we need a solution that will work even when the change in active status is triggered by code that we do not control.

To reduce duplication we moved the set of `Q` statements that we use to filter only facilities or items that have one or more PPE fields filled in to a constant and we added a method to `Facility` handles the conditional reverting of fields.

## Testing Instructions

* Download and unzip [lists-for-testing-1069.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/5008269/lists-for-testing-1069.zip)
* Run `./scripts/resetdb`
* Log in as c2@example.com
* Browse http://localhost:6543/contribute and upload `list-8-with-ppe.csv`. 
* Fully process the list
  * ./scripts/manage batch_process --list-id 16 --action parse
  * ./scripts/manage batch_process --list-id 16 --action geocode
  * ./scripts/manage batch_process --list-id 16 --action match
* Browse http://localhost:6543/lists/16 and confirm the potential match at row index 10. Click the row and then click the facility link. Confirm that the PPE data is populated.
* Browse http://localhost:6543/lists/16 and reject the potential match at row index 11. Click the facility link and confirm that the newly created facility has populated PPE data.
* Browse http://localhost:6543/contribute and replace the previous list by uploading `list-8.csv` and choosing `list-8-with-ppe` in the "Select list to replace" dropdown. 
* Fully process the list.
  * ./scripts/manage batch_process --list-id 17 --action parse
  * ./scripts/manage batch_process --list-id 17 --action geocode
  * ./scripts/manage batch_process --list-id 17 --action match
* Browse http://localhost:6543/lists/17, click a MATCHED row and follow the link. Verify that the PPE data is no longer preset.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
