### PR TITLE
Rework GazetteerCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Rework GazetteerCache [#1076](https://github.com/open-apparel-registry/open-apparel-registry/pull/1076)
+
 ### Security
 
 ## [2.29.0] - 2020-08-06

--- a/scripts/resetdb
+++ b/scripts/resetdb
@@ -27,6 +27,17 @@ function enableswitches() {
     ./scripts/manage waffle_switch ppe on
 }
 
+function assigngroups() {
+    ./scripts/manage user_groups -e c2@example.com -a add -g can_submit_facility
+    ./scripts/manage user_groups -e c2@example.com -a add -g can_submit_private_facility
+    ./scripts/manage user_groups -e c2@example.com -a add -g can_get_facility_history
+    ./scripts/manage user_groups -e c2@example.com -a add -g can_view_full_contrib_detail
+}
+
+function maketoken() {
+    ./scripts/manage shell -c "from rest_framework.authtoken.models import Token; from api.models import User; token = Token.objects.create(user=User.objects.get(id=2),key='1d18b962d6f976b0b7e8fcf9fcc39b56cf278051'); print('Token for c2@example.com'); print(token)"
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
@@ -34,5 +45,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         resetdb
         enableswitches
         processfixtures
+        assigngroups
+        maketoken
     fi
 fi

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -81,7 +81,8 @@ from api.processing import (parse_csv_line,
                             parse_csv,
                             parse_excel,
                             get_country_code,
-                            save_match_details)
+                            save_match_details,
+                            reduce_matches)
 from api.serializers import (FacilityListSerializer,
                              FacilityListItemSerializer,
                              FacilityListItemsQueryParamsSerializer,
@@ -1074,7 +1075,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             for item_id, matches in item_matches.items():
                 result['item_id'] = item_id
                 result['status'] = item.status
-                for (facility_id, score), match in zip(matches, match_objects):
+                for (facility_id, score), match in zip(reduce_matches(matches),
+                                                       match_objects):
                     facility = Facility.objects.get(id=facility_id)
                     context = {'request': request}
                     facility_dict = FacilityDetailsSerializer(


### PR DESCRIPTION
## Overview

Rework the `GazetteerCache` to fix errors, process `FacilityMatch` history, and be more resilient to failure.

Connects #1071 

## Notes

### `resetdb` now creates an API key and assigns permissions

We updated `./scripts/resetdb` to assign groups to a user and generate an API key This makes the process of testing APIs after running `resetdb` easier by removing the need to make these changes manually. We make these changes to c2@example.com because c1@example.com is an admin user without an associated contributor record. Users without contributor records can't make API calls. We use a fixed token so that test requests saved in scripts or REST client tools don't have to be edited.

### Fixed a bug when matching via the API when facilities have manually confirmed matches

In a previous commit we added confirmed matches to our canonical list of facilities using a "synthetic" ID that does not match a record in the Facility table and added a `reduce_matches` helper function that can be used to process the dedupe results to replace these synthetic IDs with real IDs.

Creating a facility match through the API has a different code path than the batch processing and was not properly handling these synthetic IDs, resulting in unhandled exceptions.

### Shorten the amount of time spent in database transactions

Prior to this PR the training of the dedupe model happened inside of a database transaction. With a large list of facilities this training can take significant amount of time. We don't need to update the database after training is complete, so we have refactored the code to fetch all the required data and then close the transaction before starting the training. Prior to this change we were already running our QuerySets through list comprehensions, so we are not increasing the memory footprint beyond what was already in use.

We also move the updating of the `_version` property to occur inside the loop where we process each history record individually. Previously, if we exited the loop early, records that had already been processed would be reprocessed the next time we updated the model. We also lost the ability to log the last good record for debugging.

### Attempt to recover from incremental model update failures by rebuilding the model

To avoid getting "stuck" attempting to incrementally update the model, failing with an error, and then hitting the same incremental update error the next time through the loop we add an exception handler that attempts to post the exception to Rollbar for debugging and then rebuilds the model from scratch. This will likely create more timeout errors in exchange for not failing with the same errors over and over.

### Include `FacilityMatch` records when incrementally updating the model

The incrementally updated GazetteerCache was not complete because we were ignoring confirmed matches, which we add to the canonical list of facilities indexed by a synthetic ID. To address this we add code to the `GazetteerCache` to process `HistoricalFacilityMatch` records using a method similar to the one used for processing `HistoricalFacilty` records.

We added `logger.debug` statements to make it easier to see the processing actions at runtime.

## Testing Instructions

### Verify the existing bug

* Check out `develop-with-resetdb-update` which includes the automatic permissions and API generation (082ab1f)
* Run `./scripts/resetdb`
* Log in as c8@example.com
* Browse http://localhost:6543/lists/8 and:
  * Reject match index 10 (Huai An Yuan Tong Headwear Mfg. Co. Ltd.)
  * Approve match index 11 (Nantong Jackbeanie Headwear & Garment Co. Ltd.)
* Restart `./scripts/server`
* POST a match request and verify that it returns `ERROR_MATCHING`
```
[curl --request POST \
  --url 'http://localhost:8081/api/facilities/?create=false' \
  --header 'authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' \
  --header 'content-type: application/json' \
  --data '{
    "country": "China",
    "name": "nantong jackbeanie headwear garment co. ltd.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500."
}']
```

### Verify the bug fix

* Check out `feature/jcw/rework-gazetteercache` (this PR)
* Apply  [1076.patch.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/5053894/1076.patch.txt) to your working copy
```patch
diff --git a/docker-compose.yml b/docker-compose.yml
index 68ecb84..2646406 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         - 'oar.wsgi'
     ports:
         - '8081:8081'
-    cpus: 2
+    cpus: 1
 
   app:
     image: node:10-slim
diff --git a/src/django/oar/settings.py b/src/django/oar/settings.py
index e57b315..1d2a344 100644
--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -249,6 +249,10 @@ LOGGING = {
             'handlers': ['console'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
         },
+        'api.matching': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
     },
 }
 

```

* Run `./scripts/resetdb`
* Log in as c8@example.com
* Browse http://localhost:6543/lists/8 and:
  * Reject match index 10 (Huai An Yuan Tong Headwear Mfg. Co. Ltd.)
  * Approve match index 11 (Nantong Jackbeanie Headwear & Garment Co. Ltd.)
* Restart `./scripts/server`
* POST a match request and verify that it returns a successful match.
```
[curl --request POST \
  --url 'http://localhost:8081/api/facilities/?create=false' \
  --header 'authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' \
  --header 'content-type: application/json' \
  --data '{
    "country": "China",
    "name": "nantong jackbeanie headwear garment co. ltd.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500."
}']
```

### Exercise incremental updating

* Run `./scripts/resetdb`
* Restart `./scripts/server` (we have a known issue where log output sometimes does not make it to the console)
* Log in as c8@example.com
* Browse http://localhost:6543/lists/8 and:
  * Reject match index 10 (Huai An Yuan Tong Headwear Mfg. Co. Ltd.)
  * Approve match index 11 (Nantong Jackbeanie Headwear & Garment Co. Ltd.)
* POST a match request and verify that it returns successfully and that debug statements printed to the console show the new facility and the facility match are incrementally added to the model.
```
[curl --request POST \
  --url 'http://localhost:8081/api/facilities/?create=false' \
  --header 'authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' \
  --header 'content-type: application/json' \
  --data '{
    "country": "China",
    "name": "nantong jackbeanie headwear garment co. ltd.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500."
}']
```

```
django_1    | [2020-08-10 23:26:30 +0000] [8] [DEBUG] POST /api/facilities/
django_1    | Indexing facility {'CN2020223FYMR4S': {'country': 'cn', 'name': 'huai an yuan tong headwear mfg. co. ltd.', 'address': 'no.1 yan huang avenue lian shui new industrial zonehuai anjiangsu 223400. china'}}
django_1    | DEBUG:api.matching:Indexing facility {'CN2020223FYMR4S': {'country': 'cn', 'name': 'huai an yuan tong headwear mfg. co. ltd.', 'address': 'no.1 yan huang avenue lian shui new industrial zonehuai anjiangsu 223400. china'}}
django_1    | Indexing match {'CN2020223FYMR4S_MATCH-934': {'country': 'cn', 'name': 'huai an yuan tong headwear mfg. co. ltd.', 'address': 'no.1 yan huang avenue lian shui new industrial zonehuai anjiangsu 223400. china'}}
django_1    | DEBUG:api.matching:Indexing match {'CN2020223FYMR4S_MATCH-934': {'country': 'cn', 'name': 'huai an yuan tong headwear mfg. co. ltd.', 'address': 'no.1 yan huang avenue lian shui new industrial zonehuai anjiangsu 223400. china'}}
django_1    | Indexing match {'CN20202235NS6YK_MATCH-304': {'country': 'cn', 'name': 'nantong jackbeanie headwear garment co. ltd.', 'address': 'no. 808 the third industry park guoyuan town rugao city nantong'}}
django_1    | DEBUG:api.matching:Indexing match {'CN20202235NS6YK_MATCH-304': {'country': 'cn', 'name': 'nantong jackbeanie headwear garment co. ltd.', 'address': 'no. 808 the third industry park guoyuan town rugao city nantong'}}
```

### Exercise failures

* Add an exception on line 573 in `src/django/api/matching.py`
```
            raise Exception('boom')
```
* Restart `./scripts/server`
* POST a match request and verify that it returns successfully and that debug statements printed to the console show the exception and the model being rebuilt from scratch.
```
[curl --request POST \
  --url 'http://localhost:8081/api/facilities/?create=false' \
  --header 'authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' \
  --header 'content-type: application/json' \
  --data '{
    "country": "China",
    "name": "nantong jackbeanie headwear garment co. ltd.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500."
}']
```
```
django_1    | WARNING:api.matching:Rebuilding gazetteer after update exception {'last_successful_facility_version': 904, 'last_successful_match_version': 936} Traceback (most recent call last):
django_1    |   File "/usr/local/src/api/matching.py", line 573, in get_latest
django_1    |     raise Exception('boom')
django_1    | Exception: boom
django_1    |
django_1    | Rebuilding gazetteer
```
* Move the exception to line 571 in `src/django/api/matching.py`
```
                raise Exception('boom')
```
* Restart `./scripts/server`
* POST a match request and verify that it fails and a 500 is logged to the console
```
[curl --request POST \
  --url 'http://localhost:8081/api/facilities/?create=false' \
  --header 'authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' \
  --header 'content-type: application/json' \
  --data '{
    "country": "China",
    "name": "nantong jackbeanie headwear garment co. ltd.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500."
}']
```

```
django_1    | [2020-08-10 23:36:24 +0000] [33] [DEBUG] POST /api/facilities/
django_1    | INFO:oar.startup:Initializing the gazetteer cache...
django_1    | Exception in thread Thread-2:
django_1    | Traceback (most recent call last):
django_1    |   File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
django_1    |     self.run()
django_1    |   File "/usr/local/lib/python3.7/threading.py", line 870, in run
django_1    |     self._target(*self._args, **self._kwargs)
django_1    |   File "/usr/local/src/oar/startup.py", line 12, in _initialize_gazetteer_cache
django_1    |     GazetteerCache.get_latest()
django_1    |   File "/usr/local/src/api/matching.py", line 571, in get_latest
django_1    |     raise Exception('boom')
django_1    | Exception: boom
django_1    |
django_1    | Internal Server Error: /api/facilities/
django_1    | ERROR:django.request:Internal Server Error: /api/facilities/
django_1    | 10.0.2.2 - - [10/Aug/2020:23:36:24 +0000] "POST /api/facilities/?create=false HTTP/1.1" 500 193 "-" "curl/7.64.1"
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
