### PR TITLE
Move AWS specific Gunicorn settings to ECS task definition

### DIFF
--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -100,15 +100,16 @@ data "template_file" "app" {
   template = "${file("task-definitions/app.json")}"
 
   vars = {
-    cpu    = "${var.app_fargate_cpu}"
     image  = "${local.app_image}"
-    memory = "${var.app_fargate_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database_enc.port}"
     postgres_user     = "${var.rds_database_username}"
     postgres_password = "${var.rds_database_password}"
     postgres_db       = "${var.rds_database_name}"
+
+    # See: https://docs.gunicorn.org/en/stable/design.html#how-many-workers
+    gunicorn_workers = "${ceil((2 * (__builtin_StringToFloat(var.app_fargate_cpu) / 1024)) + 1)}"
 
     google_server_side_api_key = "${var.google_server_side_api_key}"
     google_client_side_api_key = "${var.google_client_side_api_key}"
@@ -149,9 +150,7 @@ data "template_file" "app_cli" {
   template = "${file("task-definitions/app_cli.json")}"
 
   vars = {
-    cpu    = "${var.cli_fargate_cpu}"
     image  = "${local.app_image}"
-    memory = "${var.cli_fargate_memory}"
 
     postgres_host     = "${aws_route53_record.database.name}"
     postgres_port     = "${module.database_enc.port}"

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -2,8 +2,18 @@
   {
     "name": "django",
     "image": "${image}",
-    "cpu": ${cpu},
-    "memory": ${memory},
+    "cpu": 0,
+    "command": [
+      "-b :8080",
+      "--workers=${gunicorn_workers}",
+      "--timeout=60",
+      "--access-logfile=-",
+      "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"",
+      "--error-logfile=-",
+      "--log-level=info",
+      "--capture-output",
+      "oar.wsgi"
+    ],
     "environment": [
         { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },
         { "name": "POSTGRES_HOST", "value": "${postgres_host}" },

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -2,9 +2,7 @@
   {
     "name": "django",
     "image": "${image}",
-    "cpu": ${cpu},
-    "memory": ${memory},
-    "essential": true,
+    "cpu": 0,
     "entryPoint": ["./manage.py"],
     "environment": [
         { "name": "PYTHONUNBUFFERED", "value": "1" },


### PR DESCRIPTION
## Overview

Specify the Gunicorn configuration settings tuned for AWS ECS directly in the task definition for the Django application. These values have been ported over from the Dockerfile, except `--workers`, which is now derived by the following formula:

```
  (2 x vCPUs) + 1 = (2 x 1) + 1 = 3
```

See: https://docs.gunicorn.org/en/stable/design.html#how-many-workers

Resolves #1082 

## Testing Instructions

I scaled `app_fargate_cpu` to `1024`. See that Terraform worker count is at `3`.

![image](https://user-images.githubusercontent.com/1774125/90682547-1ca4e700-e233-11ea-9264-d96c32e96b02.png)

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
