### PR TITLE
Apply ST_Transform() when hex_grid table is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Apply `ST_Transform()` when `hex_grid` table is created [#1109](https://github.com/open-apparel-registry/open-apparel-registry/pull/1109)
 
 ### Security
 

--- a/src/django/api/tiler.py
+++ b/src/django/api/tiler.py
@@ -13,11 +13,11 @@ def get_facility_grid_vector_tile(params, layer, z, x, y):
 
     hex_width = abs(xy_bounds.right - xy_bounds.left) / (2 ** GRID_ZOOM_FACTOR)
     hex_grid_query = """
-        CREATE TEMP TABLE hex_grid (geom, mvt_geom) AS (
+        CREATE TEMP TABLE hex_grid (geom, mvt_geom, wgs84_geom) AS (
           SELECT geom, ST_AsMVTGeom(
             ST_Centroid(geom), ST_MakeEnvelope(
                 {xmin}, {ymin}, {xmax}, {ymax}
-            ))
+        )), ST_Transform (geom, 4326)
           FROM generate_hexgrid({width}, {xmin}, {ymin}, {xmax}, {ymax})
         )
     """
@@ -27,7 +27,7 @@ def get_facility_grid_vector_tile(params, layer, z, x, y):
         ymax=xy_bounds.top)
 
     hex_grid_idx_query = \
-        'CREATE INDEX hex_grid_idx ON hex_grid USING gist (geom)'
+        'CREATE INDEX hex_grid_idx ON hex_grid USING gist (wgs84_geom)'
 
     location_query, location_params = Facility \
         .objects \
@@ -39,8 +39,8 @@ def get_facility_grid_vector_tile(params, layer, z, x, y):
     # Exclude geoms on the edges that wrap around the world
     wrap_filter = (
         'abs('
-        '   ST_XMax(ST_Envelope(ST_Transform(hex_grid.geom, 4326)))'
-        ' - ST_XMin(ST_Envelope(ST_Transform(hex_grid.geom, 4326)))'
+        '   ST_XMax(ST_Envelope(hex_grid.wgs84_geom))'
+        ' - ST_XMin(ST_Envelope(hex_grid.wgs84_geom))'
         ') < 180')
 
     if location_query.find('WHERE') >= 0:
@@ -53,12 +53,12 @@ def get_facility_grid_vector_tile(params, layer, z, x, y):
         'SELECT '
         '  hex_grid.mvt_geom, '
         '  count(location), '
-        '  ST_XMin(ST_Envelope(ST_Transform(hex_grid.geom, 4326))) as xmin, '
-        '  ST_YMin(ST_Envelope(ST_Transform(hex_grid.geom, 4326))) as ymin, '
-        '  ST_XMax(ST_Envelope(ST_Transform(hex_grid.geom, 4326))) as xmax, '
-        '  ST_YMax(ST_Envelope(ST_Transform(hex_grid.geom, 4326))) as ymax '
+        '  ST_XMin(ST_Envelope(hex_grid.wgs84_geom)) as xmin, '
+        '  ST_YMin(ST_Envelope(hex_grid.wgs84_geom)) as ymin, '
+        '  ST_XMax(ST_Envelope(hex_grid.wgs84_geom)) as xmax, '
+        '  ST_YMax(ST_Envelope(hex_grid.wgs84_geom)) as ymax '
         'FROM hex_grid JOIN api_facility '
-        '  ON ST_Contains(ST_Transform(hex_grid.geom, 4326), location) '
+        '  ON ST_Contains(hex_grid.wgs84_geom, location) '
         ' {where_clause} '
         'GROUP BY hex_grid.mvt_geom, '
         '  xmin, ymin, xmax, ymax')


### PR DESCRIPTION
## Overview

The `JOIN` in the hex grid query ends up getting applied against each record in the `hex_grid` table multiplied by the number of facilities generated by the `WHERE` filter. As an example, contributor ID 699 causes the join filter to be applied against 800K+ records.

Applying `ST_Transform()` when the `hex_grid` table is created, and then using the resulting `wgs84_geom` reduces the overcall cost of the large `JOIN` (a query that was taking 1.9s went down to 500ms). Further, indexing the `wgs84_geom` column takes the query down to ~200ms.

Fixes https://github.com/open-apparel-registry/open-apparel-registry/issues/1008
Fixes https://github.com/open-apparel-registry/open-apparel-registry/issues/1010
Fixes https://github.com/open-apparel-registry/open-apparel-registry/issues/1080
Fixes https://github.com/open-apparel-registry/open-apparel-registry/issues/1084

## Demo

An example of the original query:

<details>

```sql
EXPLAIN ANALYZE
SELECT
    ST_AsMVT (q,
        'facilitygrid')
FROM (
    SELECT
        hex_grid.mvt_geom,
        count(LOCATION),
        ST_XMin (ST_Envelope (ST_Transform (hex_grid.geom, 4326))) AS xmin,
        ST_YMin (ST_Envelope (ST_Transform (hex_grid.geom, 4326))) AS ymin,
        ST_XMax (ST_Envelope (ST_Transform (hex_grid.geom, 4326))) AS xmax,
        ST_YMax (ST_Envelope (ST_Transform (hex_grid.geom, 4326))) AS ymax
    FROM
        hex_grid
        JOIN api_facility ON ST_Contains (ST_Transform (hex_grid.geom,
                4326),
            LOCATION)
    WHERE
        "api_facility"."id" IN (
            SELECT
                U2. "facility_id"
            FROM
                "api_source" U0
                INNER JOIN "api_facilitylistitem" U2 ON (U0. "id" = U2. "source_id")
                INNER JOIN "api_facilitymatch" U3 ON (U2. "id" = U3. "facility_list_item_id")
            WHERE (U0. "contributor_id" IN (699)
                AND U3. "is_active" = TRUE
                AND U3. "status" IN ('AUTOMATIC', 'CONFIRMED')
                AND U0. "is_active" = TRUE
                AND U0. "is_public" = TRUE))
        AND abs(ST_XMax (ST_Envelope (ST_Transform (hex_grid.geom, 4326))) - ST_XMin (ST_Envelope (ST_Transform (hex_grid.geom, 4326)))) < 180
    GROUP BY
        hex_grid.mvt_geom,
        xmin,
        ymin,
        xmax,
        ymax) AS q;
```

</details>

Output of `EXPLAIN ANALYZE` for that query:

<details>

```
 Aggregate  (cost=109.73..109.74 rows=1 width=32) (actual time=1828.065..1828.065 rows=1 loops=1)
   ->  Subquery Scan on q  (cost=109.55..109.72 rows=1 width=56) (actual time=1828.060..1828.060 rows=0 loops=1)
         ->  GroupAggregate  (cost=109.55..109.71 rows=1 width=72) (actual time=1828.059..1828.059 rows=0 loops=1)
               Group Key: hex_grid.mvt_geom, (st_xmin((st_envelope(st_transform(hex_grid.geom, 4326)))::box3d)), (st_ymin((st_envelope(st_transform(hex_grid.geom, 4326)))::box3d)), (st_xmax((st_envelope(st_transfo
rm(hex_grid.geom, 4326)))::box3d)), (st_ymax((st_envelope(st_transform(hex_grid.geom, 4326)))::box3d))
               ->  Sort  (cost=109.55..109.56 rows=1 width=96) (actual time=1828.058..1828.058 rows=0 loops=1)
                     Sort Key: hex_grid.mvt_geom, (st_xmin((st_envelope(st_transform(hex_grid.geom, 4326)))::box3d)), (st_ymin((st_envelope(st_transform(hex_grid.geom, 4326)))::box3d)), (st_xmax((st_envelope(st_tr
ansform(hex_grid.geom, 4326)))::box3d)), (st_ymax((st_envelope(st_transform(hex_grid.geom, 4326)))::box3d))
                     Sort Method: quicksort  Memory: 25kB
                     ->  Nested Loop  (cost=34.76..109.54 rows=1 width=96) (actual time=1828.047..1828.047 rows=0 loops=1)
                           Join Filter: ((st_transform(hex_grid.geom, 4326) ~ api_facility.location) AND _st_contains(st_transform(hex_grid.geom, 4326), api_facility.location))
                           Rows Removed by Join Filter: 843192
                           ->  Seq Scan on hex_grid  (cost=0.00..16.40 rows=42 width=64) (actual time=0.319..1.581 rows=126 loops=1)
                                 Filter: (abs((st_xmax((st_envelope(st_transform(geom, 4326)))::box3d) - st_xmin((st_envelope(st_transform(geom, 4326)))::box3d))) < '180'::double precision)
                           ->  Materialize  (cost=34.76..36.33 rows=5 width=32) (actual time=0.180..0.709 rows=6692 loops=126)
                                 ->  Nested Loop  (cost=34.76..36.31 rows=5 width=32) (actual time=22.721..39.486 rows=6692 loops=1)
                                       ->  HashAggregate  (cost=34.47..34.52 rows=5 width=16) (actual time=22.710..24.480 rows=6692 loops=1)
                                             Group Key: (u2.facility_id)::text
                                             ->  Nested Loop  (cost=1.13..34.46 rows=5 width=16) (actual time=0.051..20.424 rows=6693 loops=1)
                                                   ->  Nested Loop  (cost=0.71..31.01 rows=7 width=20) (actual time=0.017..6.181 rows=8205 loops=1)
                                                         ->  Index Scan using api_source_contributor_id_562a443b on api_source u0  (cost=0.29..2.70 rows=1 width=4) (actual time=0.005..0.006 rows=1 loops=1)
                                                               Index Cond: (contributor_id = 699)
                                                               Filter: (is_active AND is_public)
                                                         ->  Index Scan using api_facilitylistitem_source_id_bae2daea on api_facilitylistitem u2  (cost=0.42..28.03 rows=28 width=24) (actual time=0.011..5.415 rows=
8205 loops=1)
                                                               Index Cond: (source_id = u0.id)
                                                   ->  Index Scan using api_facilitymatch_facility_list_item_id_ac429b38 on api_facilitymatch u3  (cost=0.42..0.48 rows=1 width=4) (actual time=0.001..0.001 rows=1 l
oops=8205)
                                                         Index Cond: (facility_list_item_id = u2.id)
                                                         Filter: (is_active AND ((status)::text = ANY ('{AUTOMATIC,CONFIRMED}'::text[])))
                                                         Rows Removed by Filter: 0
                                       ->  Index Scan using api_facility_id_cd5004e6_like on api_facility  (cost=0.29..0.36 rows=1 width=48) (actual time=0.002..0.002 rows=1 loops=6692)
                                             Index Cond: ((id)::text = (u2.facility_id)::text)

 Planning time: 0.870 ms
 Execution time: 1828.284 ms
```

</details>

An example of the adjusted query:

<details>

```sql
SELECT
    ST_AsMVT (q,
        'facilitygrid')
FROM (
    SELECT
        hex_grid.mvt_geom,
        count(LOCATION),
        ST_XMin (ST_Envelope (hex_grid.wgs84_geom)) AS xmin,
        ST_YMin (ST_Envelope (hex_grid.wgs84_geom)) AS ymin,
        ST_XMax (ST_Envelope (hex_grid.wgs84_geom)) AS xmax,
        ST_YMax (ST_Envelope (hex_grid.wgs84_geom)) AS ymax
    FROM
        hex_grid
        JOIN api_facility ON ST_Contains(hex_grid.wgs84_geom, LOCATION)
    WHERE
        "api_facility"."id" IN (
            SELECT
                U2. "facility_id"
            FROM
                "api_source" U0
                INNER JOIN "api_facilitylistitem" U2 ON (U0. "id" = U2. "source_id")
                INNER JOIN "api_facilitymatch" U3 ON (U2. "id" = U3. "facility_list_item_id")
            WHERE (U0. "contributor_id" IN (699)
                AND U3. "is_active" = TRUE
                AND U3. "status" IN ('AUTOMATIC', 'CONFIRMED')
                AND U0. "is_active" = TRUE
                AND U0. "is_public" = TRUE))
        AND abs(ST_XMax (ST_Envelope (hex_grid.wgs84_geom)) - ST_XMin (ST_Envelope (hex_grid.wgs84_geom))) < 180
    GROUP BY
        hex_grid.mvt_geom,
        xmin,
        ymin,
        xmax,
        ymax) AS q;
```

</details>

Output of `EXPLAIN ANALYZE` for the adjusted query _with an index_:

<details>

```
 Aggregate  (cost=39.02..39.03 rows=1 width=32) (actual time=126.312..126.312 rows=1 loops=1)
   ->  Subquery Scan on q  (cost=38.85..39.01 rows=1 width=56) (actual time=126.307..126.307 rows=0 loops=1)
         ->  GroupAggregate  (cost=38.85..39.00 rows=1 width=72) (actual time=126.306..126.306 rows=0 loops=1)
               Group Key: hex_grid.mvt_geom, (st_xmin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_ymin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_xmax((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_ym
ax((st_envelope(hex_grid.wgs84_geom))::box3d))
               ->  Sort  (cost=38.85..38.86 rows=1 width=96) (actual time=126.306..126.306 rows=0 loops=1)
                     Sort Key: hex_grid.mvt_geom, (st_xmin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_ymin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_xmax((st_envelope(hex_grid.wgs84_geom))::box3d)), (
st_ymax((st_envelope(hex_grid.wgs84_geom))::box3d))
                     Sort Method: quicksort  Memory: 25kB
                     ->  Nested Loop  (cost=34.90..38.84 rows=1 width=96) (actual time=126.298..126.298 rows=0 loops=1)
                           ->  Nested Loop  (cost=34.76..36.31 rows=5 width=32) (actual time=29.256..47.291 rows=6692 loops=1)
                                 ->  HashAggregate  (cost=34.47..34.52 rows=5 width=16) (actual time=29.245..31.224 rows=6692 loops=1)
                                       Group Key: (u2.facility_id)::text
                                       ->  Nested Loop  (cost=1.13..34.46 rows=5 width=16) (actual time=0.055..26.306 rows=6693 loops=1)
                                             ->  Nested Loop  (cost=0.71..31.01 rows=7 width=20) (actual time=0.021..9.015 rows=8205 loops=1)
                                                   ->  Index Scan using api_source_contributor_id_562a443b on api_source u0  (cost=0.29..2.70 rows=1 width=4) (actual time=0.010..0.011 rows=1 loops=1)
                                                         Index Cond: (contributor_id = 699)
                                                         Filter: (is_active AND is_public)
                                                   ->  Index Scan using api_facilitylistitem_source_id_bae2daea on api_facilitylistitem u2  (cost=0.42..28.03 rows=28 width=24) (actual time=0.011..7.931 rows=8205 l
oops=1)
                                                         Index Cond: (source_id = u0.id)
                                             ->  Index Scan using api_facilitymatch_facility_list_item_id_ac429b38 on api_facilitymatch u3  (cost=0.42..0.48 rows=1 width=4) (actual time=0.002..0.002 rows=1 loops=8
205)
                                                   Index Cond: (facility_list_item_id = u2.id)
                                                   Filter: (is_active AND ((status)::text = ANY ('{AUTOMATIC,CONFIRMED}'::text[])))
                                                   Rows Removed by Filter: 0
                                 ->  Index Scan using api_facility_id_cd5004e6_like on api_facility  (cost=0.29..0.36 rows=1 width=48) (actual time=0.002..0.002 rows=1 loops=6692)
                                       Index Cond: ((id)::text = (u2.facility_id)::text)
                           ->  Index Scan using hex_grid_wgs84_idx on hex_grid  (cost=0.14..0.47 rows=1 width=64) (actual time=0.012..0.012 rows=0 loops=6692)
                                 Index Cond: (wgs84_geom ~ api_facility.location)
                                 Filter: ((abs((st_xmax((st_envelope(wgs84_geom))::box3d) - st_xmin((st_envelope(wgs84_geom))::box3d))) < '180'::double precision) AND _st_contains(wgs84_geom, api_facility.location
))
 Planning time: 0.891 ms
 Execution time: 126.440 ms
```

</details>

Output of `EXPLAIN ANALYZE` for the adjusted query _with no index_:

<details>

```
 Aggregate  (cost=384.51..384.52 rows=1 width=32) (actual time=235.543..235.543 rows=1 loops=1)
   ->  Subquery Scan on q  (cost=384.35..384.51 rows=1 width=56) (actual time=235.538..235.538 rows=0 loops=1)
         ->  GroupAggregate  (cost=384.35..384.50 rows=1 width=72) (actual time=235.537..235.537 rows=0 loops=1)
               Group Key: hex_grid.mvt_geom, (st_xmin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_ymin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_xmax((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_ym
ax((st_envelope(hex_grid.wgs84_geom))::box3d))
               ->  Sort  (cost=384.35..384.35 rows=1 width=96) (actual time=235.536..235.536 rows=0 loops=1)
                     Sort Key: hex_grid.mvt_geom, (st_xmin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_ymin((st_envelope(hex_grid.wgs84_geom))::box3d)), (st_xmax((st_envelope(hex_grid.wgs84_geom))::box3d)), (
st_ymax((st_envelope(hex_grid.wgs84_geom))::box3d))
                     Sort Method: quicksort  Memory: 25kB
                     ->  Nested Loop  (cost=34.76..384.34 rows=1 width=96) (actual time=235.521..235.521 rows=0 loops=1)
                           Join Filter: ((hex_grid.wgs84_geom ~ api_facility.location) AND _st_contains(hex_grid.wgs84_geom, api_facility.location))
                           Rows Removed by Join Filter: 843192
                           ->  Seq Scan on hex_grid  (cost=0.00..60.38 rows=217 width=64) (actual time=0.021..0.574 rows=126 loops=1)
                                 Filter: (abs((st_xmax((st_envelope(wgs84_geom))::box3d) - st_xmin((st_envelope(wgs84_geom))::box3d))) < '180'::double precision)
                           ->  Materialize  (cost=34.76..36.33 rows=5 width=32) (actual time=0.176..0.655 rows=6692 loops=126)
                                 ->  Nested Loop  (cost=34.76..36.31 rows=5 width=32) (actual time=22.203..38.716 rows=6692 loops=1)
                                       ->  HashAggregate  (cost=34.47..34.52 rows=5 width=16) (actual time=22.191..23.950 rows=6692 loops=1)
                                             Group Key: (u2.facility_id)::text
                                             ->  Nested Loop  (cost=1.13..34.46 rows=5 width=16) (actual time=0.075..19.987 rows=6693 loops=1)
                                                   ->  Nested Loop  (cost=0.71..31.01 rows=7 width=20) (actual time=0.017..6.342 rows=8205 loops=1)
                                                         ->  Index Scan using api_source_contributor_id_562a443b on api_source u0  (cost=0.29..2.70 rows=1 width=4) (actual time=0.007..0.008 rows=1 loops=1)
                                                               Index Cond: (contributor_id = 699)
                                                               Filter: (is_active AND is_public)
                                                         ->  Index Scan using api_facilitylistitem_source_id_bae2daea on api_facilitylistitem u2  (cost=0.42..28.03 rows=28 width=24) (actual time=0.009..5.584 rows=
8205 loops=1)
                                                               Index Cond: (source_id = u0.id)
                                                   ->  Index Scan using api_facilitymatch_facility_list_item_id_ac429b38 on api_facilitymatch u3  (cost=0.42..0.48 rows=1 width=4) (actual time=0.001..0.001 rows=1 l
oops=8205)
                                                         Index Cond: (facility_list_item_id = u2.id)
                                                         Filter: (is_active AND ((status)::text = ANY ('{AUTOMATIC,CONFIRMED}'::text[])))
                                                         Rows Removed by Filter: 0
                                       ->  Index Scan using api_facility_id_cd5004e6_like on api_facility  (cost=0.29..0.36 rows=1 width=48) (actual time=0.002..0.002 rows=1 loops=6692)
                                             Index Cond: ((id)::text = (u2.facility_id)::text)
 Planning time: 0.852 ms
 Execution time: 235.672 ms
```

</details>

## Testing Instructions

With the changes in this PR applied to staging, test the following map interactions and observe the resulting tile request latencies. With a `db.t3.xlarge`, I was seeing max latencies < 3s while zooming and panning the map. Previously (albeit with a `db.t3.small` database instance), these queries would exceed 20s and take services offline.

- Filter [by contributor](https://staging.openapparel.org/?contributors=699)
- Filter [by contributor and contributor type](https://staging.openapparel.org/?contributors=699&contributor_types=Brand%2FRetailer)
- Filter [by contributor and large filer area](https://staging.openapparel.org/?contributors=699&boundary=%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-21.127538%2C61.100789%5D%2C%5B48.141259%2C62.995158%5D%2C%5B51.481632%2C32.842674%5D%2C%5B-16.908119%2C25.958045%5D%2C%5B-21.127538%2C61.100789%5D%5D%5D%7D)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
