### PR TITLE
Return distinct source names from the facility API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
-## [2.31.1] - 2020-09-09
+## [2.31.1] - 2020-09-21
 
 ### Added
 
@@ -481,7 +481,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/2.31.0...HEAD
+[Unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/2.31.1...HEAD
+[2.31.1]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.31.1
 [2.31.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.31.0
 [2.30.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.30.0
 [2.29.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Return distinct source names from the facility API [#1113](https://github.com/open-apparel-registry/open-apparel-registry/pull/1113)
+
 ### Security
 
 ## [2.31.1] - 2020-09-09

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -451,11 +451,15 @@ class FacilitySerializer(GeoFeatureModelSerializer):
         request = self.context.get('request') \
             if self.context is not None else None
         user = request.user if request is not None else None
-        return [
-            format_source(source)
-            for source
-            in facility.sources(user=user)
-        ]
+        distinct_names = []
+        distinct_sources = []
+        formatted_sources = [
+            format_source(source) for source in facility.sources(user=user)]
+        for formatted_source in formatted_sources:
+            if formatted_source['name'] not in distinct_names:
+                distinct_names.append(formatted_source['name'])
+                distinct_sources.append(formatted_source)
+        return distinct_sources
 
 
 class FacilityDetailsSerializer(FacilitySerializer):


### PR DESCRIPTION

## Overview

A problem with duplicate contributor names appearing on the facility detail page emerged when contributors began submitting the same facility via the API multiple times. To avoid this we update the facility serializer to process the list of sources and remove duplicates.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/12

## Testing Instructions

* Check out `develop`
* Run `./scripts/resetdb`
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_create and Authenticate with the token created during `./scripts/resetdb`
* POST the following **twice**
```
{
    "country": "US",
    "address": "990 Spring Garden, Philadelphia",
    "name": "Azavea"
}
```
* Go to the details page for the new facility and verify the unwanted behavior: the contributor appears twice.
* Download and rename [azavea.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/5271395/azavea.csv.txt) to `azavea.csv`
* Browse http://localhost:6543/contribute and upload the list without specifying a name
* Run this command to create a bash helper function
```
function batch_process { ./scripts/manage batch_process --list-id $1 --action parse && ./scripts/manage batch_process --list-id $1 --action geocode && ./scripts/manage batch_process --list-id $1 --action match; }
```
* Process the list with `batch_process 16`
* Browse http://localhost:6543/contribute and submit the same list. 
* Process the list with `batch_process 17`
* Browse the facility details page and verify that there are now 4 contributors, two API submissions and 2 list submissions
* Checkout this branch and refresh the facility details page. Verify that there are now 2 items in the contributors list.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
