### PR TITLE
Exclude contributors if all sources are create=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Return distinct source names from the facility API [#1113](https://github.com/open-apparel-registry/open-apparel-registry/pull/1113)
+- Exclude contributors if all sources are create=False [#1114](https://github.com/open-apparel-registry/open-apparel-registry/pull/1114)
 
 ### Security
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -1298,6 +1298,7 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.email_four = 'four@example.com'
         self.email_five = 'five@example.com'
         self.email_six = 'six@example.com'
+        self.email_seven = 'seven@example.com'
 
         self.contrib_one_name = 'contributor that should be included'
         self.contrib_two_name = 'contributor with no lists'
@@ -1305,6 +1306,7 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.contrib_four_name = 'contributor with a non public list'
         self.contrib_five_name = 'contributor with only error items'
         self.contrib_six_name = 'contributor with one good and one error item'
+        self.contrib_seven_name = 'contributor with create=False API source'
 
         self.country_code = 'US'
         self.list_one_name = 'one'
@@ -1313,6 +1315,7 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.list_four_name = 'four'
         self.list_five_name = 'five'
         self.list_six_name = 'six'
+        self.list_seven_name = 'seven'
 
         self.user_one = User.objects.create(email=self.email_one)
         self.user_two = User.objects.create(email=self.email_two)
@@ -1320,6 +1323,7 @@ class ContributorsListAPIEndpointTests(TestCase):
         self.user_four = User.objects.create(email=self.email_four)
         self.user_five = User.objects.create(email=self.email_five)
         self.user_six = User.objects.create(email=self.email_six)
+        self.user_seven = User.objects.create(email=self.email_seven)
 
         self.contrib_one = Contributor \
             .objects \
@@ -1355,6 +1359,12 @@ class ContributorsListAPIEndpointTests(TestCase):
             .objects \
             .create(admin=self.user_six,
                     name=self.contrib_six_name,
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.contrib_seven = Contributor \
+            .objects \
+            .create(admin=self.user_seven,
+                    name=self.contrib_seven_name,
                     contrib_type=Contributor.OTHER_CONTRIB_TYPE)
 
         self.list_one = FacilityList \
@@ -1463,6 +1473,20 @@ class ContributorsListAPIEndpointTests(TestCase):
             .objects \
             .create(row_index=1,
                     source=self.source_six,
+                    status=FacilityListItem.MATCHED)
+
+        # Test to ensure contributors don't appear in the list if all of their
+        # sources have create=False
+        self.source_seven = Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    create=False,
+                    contributor=self.contrib_seven)
+
+        self.list_item_seven = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_seven,
                     status=FacilityListItem.MATCHED)
 
     def test_contributors_list_has_only_contributors_with_active_lists(self):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -391,7 +391,7 @@ def all_contributors(request):
         ]
     """
     valid_sources = Source.objects.filter(
-        is_active=True, is_public=True,
+        is_active=True, is_public=True, create=True,
         facilitylistitem__status__in=FacilityListItem.COMPLETE_STATUSES)
     response_data = [
         (contributor.id, contributor.name)


### PR DESCRIPTION
## Overview

If a contributor only submits data via the API and has submitted all facilities with the `create` option set to false then they will not have any publicly visible data and should therefore be excluded from the contributors list.

Connects #1101

## Testing Instructions

* Checkout `develop`
* Run `./scripts/resetdb`
* Register a new account. If the confirmation email does not appear you can manually activate the account with
```
vagrant@vagrant:/vagrant$ echo "UPDATE api_user SET is_active = 't' WHERE is_active = 'f';" | ./scripts/manage dbshell
vagrant@vagrant:/vagrant$ echo "UPDATE account_emailaddress SET verified = 't' WHERE verified = 'f';" | ./scripts/manage dbshell
```
* Log in as the **admin** user c1@example.com and browse http://localhost:8081/admin/api/user/101/change/
* Add the newly register user to all the groups and save.
* Log in as the new user, browse http://localhost:6543/profile/101 and create an API token
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_create and "Authorize" with the token, making sure that you enter `Token abc123...`
* Set `create` to `false` and POST the following
```
{
    "country": "US",
    "address": "990 Spring Garden, Philadelphia",
    "name": "Azavea"
}
```
* Browse http://localhost:6543/ and confirm the incorrect behavior. The new user will be listed in the Contributors dropdown but clicking "Search" after selecting that contributor returns no results.
* Check out this branch and refresh http://localhost:6543/. Verify that the contributors list is still populated but the new user is excluded.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
