### PR TITLE
Increase app_ecs_grace_period_seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-Directly connect health check to GazetteerCache and remove the use of threading in model training [#1117](https://github.com/open-apparel-registry/open-apparel-registry/pull/1117)
+Directly connect health check to GazetteerCache and remove the use of threading in model training [#1117](https://github.com/open-apparel-registry/open-apparel-registry/pull/1117) [#1123](https://github.com/open-apparel-registry/open-apparel-registry/pull/1123)
 
 ### Deprecated
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -173,7 +173,7 @@ variable "app_ecs_deployment_max_percent" {
 }
 
 variable "app_ecs_grace_period_seconds" {
-  default = "120"
+  default = "180"
 }
 
 variable "app_fargate_cpu" {


### PR DESCRIPTION
## Overview

We were seeing instances not become healthy within 120 seconds, which put us into a loop. We assume that we did not catch this because we were using an experimental value of 6 during the testing of recent changes to the service startup process and then returned it to value of 2.

To choose a new value we modified the grace period through the console and found 150 still resulted in tasks not reaching a healthy status, but 180 allowed sufficient time.

Connects open-apparel-registry/open-apparel-registry-clients#11

## Testing Instructions

* View the staging cluster in the console after this branch is deployed and verify that the instances stabilize.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] DROP commits are dropped
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
