### PR TITLE
Make it possible to modify the RDS DB parameter group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Make it possible to modify the RDS DB parameter group [#1125](https://github.com/open-apparel-registry/open-apparel-registry/pull/1125)
 
 ### Changed
 

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -14,7 +14,7 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_parameter_group" "default" {
-  name        = "${replace(var.rds_database_identifier, "-enc", "")}"
+  name_prefix = "${replace(var.rds_database_identifier, "-enc", "")}"
   description = "Parameter group for the RDS instances"
   family      = "${var.rds_parameter_group_family}"
 
@@ -62,6 +62,10 @@ resource "aws_db_parameter_group" "default" {
     Name        = "dbpgDatabaseServer"
     Project     = "${var.project}"
     Environment = "${var.environment}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## Overview

Add support for [name_prefix](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group#name_prefix) and the [create_before_destroy](https://www.terraform.io/docs/configuration/resources.html#create_before_destroy) lifecycle customization so that a new parameter group is created and applied before disposing of the old one when making modifications that require a new resource.

Connects #1111 


## Testing Instructions

See that there are no Terraform changes to apply on staging:

```bash
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-4.4# GIT_COMMIT=d39830b ./scripts/infra plan
. . .
No changes. Infrastructure is up-to-date.
```

And the new parameter group is in place:

![image](https://user-images.githubusercontent.com/1774125/95488249-4e008000-0963-11eb-832f-0d9cd06a2049.png)

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
