### PR TITLE
Bump django-ecsmanage to version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make it possible to modify the RDS DB parameter group [#1125](https://github.com/open-apparel-registry/open-apparel-registry/pull/1125)
 
 ### Changed
+- Update `django-ecsmanage` to version 2.0.0 [1129](https://github.com/open-apparel-registry/open-apparel-registry/pull/1129)
 
 ### Deprecated
 

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -301,8 +301,10 @@ WATCHMAN_CHECKS = (
 ECSMANAGE_ENVIRONMENTS = {
     'default': {
         'TASK_DEFINITION_NAME': 'StagingAppCLI',
+        'CONTAINER_NAME': 'django',
         'CLUSTER_NAME': 'ecsStagingCluster',
         'LAUNCH_TYPE': 'FARGATE',
+        'PLATFORM_VERSION': '1.4.0',
         'SECURITY_GROUP_TAGS': {
             'Name': 'sgAppEcsService',
             'Environment': 'Staging',
@@ -317,8 +319,10 @@ ECSMANAGE_ENVIRONMENTS = {
     },
     'production': {
         'TASK_DEFINITION_NAME': 'ProductionAppCLI',
+        'CONTAINER_NAME': 'django',
         'CLUSTER_NAME': 'ecsProductionCluster',
         'LAUNCH_TYPE': 'FARGATE',
+        'PLATFORM_VERSION': '1.4.0',
         'SECURITY_GROUP_TAGS': {
             'Name': 'sgAppEcsService',
             'Environment': 'Production',

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -4,7 +4,7 @@ coreapi==2.3.3
 dedupe==1.9.4
 defusedxml==0.6.0
 django-amazon-ses==2.1.1
-django-ecsmanage==1.1.0
+django-ecsmanage==2.0.0
 django-extensions==2.1.9
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.5


### PR DESCRIPTION
## Overview

Adds support for overriding target container name and Fargate platform version.

## Notes

This PR aids in testing the changes in the following PRs:

- https://github.com/azavea/django-ecsmanage/pull/26
- https://github.com/azavea/django-ecsmanage/pull/27

## Testing Instructions

- Run `update` to ensure that the Django container image includes the changes on `feature/hmc/override-container-name`. Note that this includes the changes in https://github.com/azavea/django-ecsmanage/pull/26 and https://github.com/azavea/django-ecsmanage/pull/27.

- Use `manage` to execute `showmigrations` in the staging ECS cluster; ensure that the platform version used by the task is 1.4.0

```console
$ ./scripts/manage ecsmanage showmigrations
```

- Applying the following patch to the changes in this branch

```diff
diff --git a/src/django/oar/settings.py b/src/django/oar/settings.py
index 6674642..61c71d6 100644
--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -301,7 +301,7 @@ WATCHMAN_CHECKS = (
 ECSMANAGE_ENVIRONMENTS = {
     'default': {
         'TASK_DEFINITION_NAME': 'StagingAppCLI',
-        'CONTAINER_NAME': 'django',
+        'CONTAINER_NAME': 'test',
         'CLUSTER_NAME': 'ecsStagingCluster',
         'LAUNCH_TYPE': 'FARGATE',
         'PLATFORM_VERSION': '1.4.0',
```

- Use `manage` again to execute `showmigrations`; observe that the invocation fails due to there being no container in the task definition named `test`

```
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/ecsmanage/management/commands/ecsmanage.py", line 48, in handle
    task_id = self.run_task(config, task_def_arn, security_group_id, subnet_id, cmd)
  File "/usr/local/lib/python3.7/site-packages/ecsmanage/management/commands/ecsmanage.py", line 199, in run_task
    task = self.parse_response(self.ecs_client.run_task(**kwargs), "tasks", 0)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterException: An error occurred (InvalidParameterException) when calling the RunTask operation: Override for container named test is not a container in the TaskDefinition.
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
