### PR TITLE
Always return accept/reject links with potential matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Always return accept/reject links with potential matches [#1131](https://github.com/open-apparel-registry/open-apparel-registry/pull/1131)
+
 ### Security
 
 ## [2.33.0] - 2020-10-07

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1162,7 +1162,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                         facility, context=context).data
                     # calling `round` alone was not trimming digits
                     facility_dict['confidence'] = float(str(round(score, 4)))
-                    if score < automatic_threshold:
+                    # If there is a single match for an item, it only needs to
+                    # be confirmed if it has a low score.
+                    if score < automatic_threshold or len(match_objects) > 1:
                         if should_create:
                             facility_dict['confirm_match_url'] = reverse(
                                 'facility-match-confirm',


### PR DESCRIPTION

## Overview

In some cases POSTing a facility to the API will produce two matches with over 80% confidence. Prior to this commit the accept and reject links were not being included in the API responses, but we must always return these links so that clients can resolve pending matches.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/13

## Demo

```
[open-apparel-registry (bugfix/jcw/api-accept-reject)]$ curl -s -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' -d '{
     "country": "US",
     "address": "990 Spring Garden, Philadelphia, PA 19123",
     "name": "Azavea"
 }
 ' 'http://localhost:8081/api/facilities/?create=true&public=false&textonlyfallback=true' | jq | grep _url
      "confirm_match_url": "/api/facility-matches/44604/confirm/",
      "reject_match_url": "/api/facility-matches/44604/reject/"
      "confirm_match_url": "/api/facility-matches/44605/confirm/",
      "reject_match_url": "/api/facility-matches/44605/reject/"
```

## Testing Instructions

NOTE each time the server is restarted it trains a new model. It is possible that only one match will be returned. Try restarting the server.

* If you don't have [jq](https://stedolan.github.io/jq/) and grep available on your host, install them.
* Download and rename [two-azaveas.csv.txt](https://github.com/open-apparel-registry/open-apparel-registry/files/5368057/two-azaveas.csv.txt)
* Check out the `develop` branch
* Run `./scripts/resetdb`
* Log in as `c2@example.com` and upload `two-azaveas.csv`
* Fully process the uploaded list
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Run this `curl` command and verify that two matches are returned
```
$ curl -s -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' -d '{
     "country": "US",
     "address": "990 Spring Garden, Philadelphia, PA 19123",
     "name": "Azavea"
 }
 ' 'http://localhost:8081/api/facilities/?create=true&public=false&textonlyfallback=true' | jq | grep confidence
      "confidence": 0.9588
      "confidence": 0.8207
```
* Reproduce the bug by running this `curl` command and verifying that there is no output
```
$ curl -s -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' -d '{
     "country": "US",
     "address": "990 Spring Garden, Philadelphia, PA 19123",
     "name": "Azavea"
 }
 ' 'http://localhost:8081/api/facilities/?create=true&public=false&textonlyfallback=true' | jq | grep _url
```
* Check out this branch and repeat the previous curl command, verifying that the matches now include links.
```
$ curl -s -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' -d '{
     "country": "US",
     "address": "990 Spring Garden, Philadelphia, PA 19123",
     "name": "Azavea"
 }
 ' 'http://localhost:8081/api/facilities/?create=true&public=false&textonlyfallback=true' | jq | grep _url
      "confirm_match_url": "/api/facility-matches/44604/confirm/",
      "reject_match_url": "/api/facility-matches/44604/reject/"
      "confirm_match_url": "/api/facility-matches/44605/confirm/",
      "reject_match_url": "/api/facility-matches/44605/reject/"
```


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
