### PR TITLE
Update reports to consider sources and source.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+
 - Update `django-ecsmanage` to version 2.0.0 [1129](https://github.com/open-apparel-registry/open-apparel-registry/pull/1129)
+- Update reports to consider sources and source.create [#1142](https://github.com/open-apparel-registry/open-apparel-registry/pull/1142)
 
 ### Deprecated
 

--- a/src/django/api/reports/average_list_count_per_contributor.sql
+++ b/src/django/api/reports/average_list_count_per_contributor.sql
@@ -12,6 +12,7 @@ FROM (
   WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
   AND s.is_public = 't'
   AND s.is_active = 't'
+  AND s.create = 't'
   GROUP BY to_char(l.created_at, 'YYYY-MM'), c.id
 ) s
 GROUP BY month

--- a/src/django/api/reports/confirmed_matches.sql
+++ b/src/django/api/reports/confirmed_matches.sql
@@ -1,8 +1,10 @@
 SELECT
   to_char(li.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS list_item_count
-from api_facilitylistitem li
+FROM api_facilitylistitem li
+JOIN api_source s ON li.source_id = s.id
 WHERE status = 'CONFIRMED_MATCH'
-AND to_char(created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+AND s.create = 't'
+AND to_char(li.created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
 GROUP BY to_char(li.created_at, 'YYYY-MM')
 ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/contributor_first_appearance.sql
+++ b/src/django/api/reports/contributor_first_appearance.sql
@@ -1,16 +1,17 @@
 SELECT
   month,
   name
-from (
+FROM (
   SELECT DISTINCT
-    min(to_char(l.created_at, 'YYYY-MM')) AS month,
+    min(to_char(s.created_at, 'YYYY-MM')) AS month,
     c.id
-  FROM api_facilitylist l
-  JOIN api_source s ON s.facility_list_id = l.id
+  FROM api_source s
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  WHERE to_char(s.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  AND s.create = 't'
   AND NOT u.email LIKE '%openapparel.org%'
+  AND NOT u.email LIKE '%azavea.com%'
   GROUP BY c.id
 ) s
 JOIN api_contributor c ON c.id = s.id

--- a/src/django/api/reports/contributor_source_count.sql
+++ b/src/django/api/reports/contributor_source_count.sql
@@ -1,0 +1,10 @@
+SELECT
+  c.name,
+  s.source_type,
+  COUNT(*) AS source_count
+FROM api_source s
+JOIN api_contributor c ON s.contributor_id = c.id
+JOIN api_user u ON u.id = c.admin_id
+WHERE s.create = 't'
+GROUP BY c.name, s.source_type
+ORDER BY COUNT(*) DESC;

--- a/src/django/api/reports/contributors_with_active_facilities.sql
+++ b/src/django/api/reports/contributors_with_active_facilities.sql
@@ -13,6 +13,7 @@ WHERE c.id IN (
   FROM api_source
   WHERE is_active = true
   AND is_public = true
+  AND "create" = true
   AND id IN (
     SELECT source_id
     FROM api_facilitylistitem

--- a/src/django/api/reports/facility_list_items_uploaded.sql
+++ b/src/django/api/reports/facility_list_items_uploaded.sql
@@ -9,5 +9,6 @@ SELECT
          JOIN api_contributor c ON s.contributor_id = c.id
          JOIN api_user u ON u.id = c.admin_id
  WHERE to_char(i.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+ AND s.create = true
  GROUP BY to_char(i.created_at, 'YYYY-MM'), is_public_list
  ORDER BY to_char(i.created_at, 'YYYY-MM'), is_public_list;

--- a/src/django/api/reports/geocode_errors.sql
+++ b/src/django/api/reports/geocode_errors.sql
@@ -1,7 +1,9 @@
 SELECT
   to_char(li.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS error_count
-  FROM api_facilitylistitem li
-WHERE status = 'ERROR_GEOCODING'
+FROM api_facilitylistitem li
+JOIN api_source s ON li.source_id = s.id
+WHERE li.status = 'ERROR_GEOCODING'
+AND s.create = 't'
 GROUP BY to_char(li.created_at, 'YYYY-MM')
 ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/geocode_no_results.sql
+++ b/src/django/api/reports/geocode_no_results.sql
@@ -2,7 +2,9 @@ SELECT
   to_char(li.created_at, 'YYYY-MM') AS month,
   COUNT(*) AS list_item_count
 FROM api_facilitylistitem li
+JOIN api_source s ON li.source_id = s.id
 WHERE status = 'ERROR_MATCHING'
-AND to_char(created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
+AND s.create = true
+AND to_char(li.created_at, 'YYYY-MM') < to_char(now(), 'YYYY-MM')
 GROUP BY to_char(li.created_at, 'YYYY-MM')
 ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/non_public_contributors.sql
+++ b/src/django/api/reports/non_public_contributors.sql
@@ -1,17 +1,20 @@
 SELECT
   month,
+  source_type,
   COUNT(*) AS contributor_count
 FROM (
   SELECT DISTINCT
-    to_char(l.created_at, 'YYYY-MM') AS month,
+    to_char(s.created_at, 'YYYY-MM') AS month,
+    s.source_type,
     c.id
-  FROM api_facilitylist l
-  JOIN api_source s ON s.facility_list_id = l.id
+  FROM api_source s
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  WHERE to_char(s.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  AND s.create = true
   AND NOT u.email LIKE '%openapparel.org%'
-  ORDER BY to_char(l.created_at, 'YYYY-MM'), c.id
-) s
-GROUP BY month
-ORDER BY month;
+  AND NOT u.email LIKE '%azavea.com%'
+  ORDER BY to_char(s.created_at, 'YYYY-MM'), c.id
+) q
+GROUP BY month, source_type
+ORDER BY month, source_type;

--- a/src/django/api/reports/public_contributors.sql
+++ b/src/django/api/reports/public_contributors.sql
@@ -1,17 +1,19 @@
 SELECT
   month,
+  source_type,
   COUNT(*) AS contributor_count
 FROM (
   SELECT DISTINCT
-    to_char(l.created_at, 'YYYY-MM') AS month,
+    to_char(s.created_at, 'YYYY-MM') AS month,
+    s.source_type,
     c.id
-  FROM api_facilitylist l
-  JOIN api_source s ON s.facility_list_id = l.id
+  FROM api_source s
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  WHERE to_char(s.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  AND s.create = true
   AND u.email LIKE '%openapparel.org%'
-  ORDER BY to_char(l.created_at, 'YYYY-MM'), c.id
-) s
-GROUP BY month
-ORDER BY month;
+  ORDER BY to_char(s.created_at, 'YYYY-MM'), c.id
+) q
+GROUP BY month, source_type
+ORDER BY month, source_type;

--- a/src/django/api/reports/unique_contributor_count_by_type.sql
+++ b/src/django/api/reports/unique_contributor_count_by_type.sql
@@ -4,16 +4,17 @@ SELECT
   COUNT(*) AS contributor_count
 FROM (
   SELECT distinct
-    min(to_char(l.created_at, 'YYYY-MM')) AS month,
+    min(to_char(s.created_at, 'YYYY-MM')) AS month,
     c.id,
     c.contrib_type
-  FROM api_facilitylist l
-  JOIN api_source s ON s.facility_list_id = l.id
+  FROM api_source s
   JOIN api_contributor c ON s.contributor_id = c.id
   JOIN api_user u ON u.id = c.admin_id
-  WHERE to_char(l.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  WHERE to_char(s.created_at, 'YYYY-MM') != to_char(now(), 'YYYY-MM')
+  AND s.create = true
   AND NOT u.email like '%openapparel.org%'
+  AND NOT u.email like '%azavea.com%'
   GROUP BY c.id, c.contrib_type
-) s
+) q
 GROUP BY month, contrib_type
 ORDER BY month, contrib_type;


### PR DESCRIPTION
## Overview

We introduced the `Source` model to unify list-based contributions and one-at-a-time contributions from the API. We had not updated our reports to incorporate this change, and we are now starting to get real data from API contributions.

In addition to focusing more on `Source` we also need to consider the `Source.create` property. We allow API users to set `create=false` on their POST requests which prevents the creation of `Facility` and `FacilityMatch` records. These "test" requests were inflating the numbers in some of the reports.

Connects #1137

## Notes

Here is the complete review of all the existing reports. Reports marked with ✅ were added or updated in this PR, but the output may not have changed.

- Api Request By User
  - No change desired
- Api Requests
  - No change desired
- Api Tokens
  - No change required
-  ✅ Average List Count Per Contributor
  - Results unchanged
- Average Matches Per Facility
  - Unchanged
  - Matches are not created when `create=false`
- Average Matches Per Facility By Type
  - Unchanged
  - Matches are not created when `create=false`
- ✅ Confirmed Matches
  - Results unchanged
  - Matches are not created when `create=false`
- ✅ Contributor First Appearance 
  - Discovered a “bug”
  - This report was list-centric
- Contributor List Count 
  - No change desired
  - This report is list focused
- ✅ Contributor Source Count
  - New report based on Contributor List Count but using sources with create=true
- ✅ Contributors With Active Facilities
  - Results unchanged
- Contributors
  - No change desired.
  - This is just a “dump” of the contributors table.
- Country First Appearance
  - No change desired.
- Facilities Created Not Matched
  - Unchanged. 
  - `create=false` does not create facility records.
- Facilities Matched
  - Unchanged. 
  - `create=false` does not create match records.
- Facility Country Count 
  - No change desired.
- Facility Counts By Country
  - No change desired.
- ✅ Facility List Items Uploaded
  - Updated to use `Source`
- Facility Lists Uploaded
  - Unchanged
  - This report is list-centric and lists are always `create=true`
- ✅ Geocode Errors
  - Updated to exclude `create=false` by joining `Source`
- ✅ Geocode No Results
  - Updated to exclude `create=false` by joining `Source`
Mailing List Recipients
 - No change desired.
- ✅ Non Public Contributors
  - Discovered a “bug”
  - This report was list-centric
  - The new version includes a source type column and picks up contributions via the API with create=true
- ✅ Public Contributors
  - No real change to the numbers, but we updated the report to match the non-public contributors report and not be list-centric in case we end up using the API to add public data in the future
- Rejected Matches
  - No change desired.
  - `create=false` does not create match records
- ✅ Unique Contributor Count By Type
  - Discovered a “bug”
  - This report was list-centric and now includes API only contributors with create=true
- Unique Public List Count
  - No change desired. 
  - This is a list-centric report.
- Updated Lists
  - No change desired. 
  - This is a list-centric report.

## Testing Instructions

NOTE: If you are using the development data created from ./scripts/resetdb then some of these reports are expected to be empty.

* Do a visual audit of the SQL statements and verify them for correctness
* Log in as c1@example.com
* Browse http://localhost:8081/admin/reports/ and verify that all the reports run without error

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
