### PR TITLE
Update the development environment to use PostgreSQL 12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)
+
 ### Deprecated
 
 ### Removed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   database:
-    image: quay.io/azavea/postgis:2.4-postgres10.9-slim
+    image: quay.io/azavea/postgis:3-postgres12.4-slim
     environment:
       - POSTGRES_USER=openapparelregistry
       - POSTGRES_PASSWORD=openapparelregistry

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -8,7 +8,10 @@ RUN set -ex \
     && buildDeps=" \
     build-essential \
     " \
-    && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+    && deps=" \
+    postgresql-client-12 \
+    " \
+    && apt-get update && apt-get install -y $buildDeps $deps --no-install-recommends \
     && pip install --no-cache-dir -r requirements.txt \
     && apt-get purge -y --auto-remove $buildDeps
 


### PR DESCRIPTION
## Overview

Update the development environment to make use of PostgreSQL 12.4 and PostGIS 3.

Fixes https://github.com/open-apparel-registry/open-apparel-registry/issues/948

## Testing Instructions

- Ensure that all container instances are taken down and associated volumes pruned

```console
vagrant@vagrant:/vagrant$ docker-compose down
vagrant@vagrant:/vagrant$ docker volume prune
vagrant@vagrant:/vagrant$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
vagrant@vagrant:/vagrant$ docker volume ls
DRIVER              VOLUME NAME
```

- Setup the development environment

```console
vagrant@vagrant:/vagrant$ ./scripts/update
vagrant@vagrant:/vagrant$ ./scripts/resetdb
```

- Connect to the database using `dbshell` and verify the PostgreSQL and PostGIS versions

```console
vagrant@vagrant:/vagrant$ ./scripts/manage dbshell
Starting vagrant_database_1 ... done
psql (12.4 (Debian 12.4-1.pgdg100+1))
Type "help" for help.

openapparelregistry=# select version();
                                                     version
------------------------------------------------------------------------------------------------------------------
 PostgreSQL 12.4 (Debian 12.4-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
(1 row)

openapparelregistry=# select postgis_version();
            postgis_version
---------------------------------------
 3.0 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
(1 row)
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
