### PR TITLE
improved UX on facility list tables

### DIFF
--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -725,6 +725,14 @@ hr {
   border: none;
 }
 
+.STATUS_POTENTIAL_MATCH td {
+  border: none !important;
+}
+
+.STATUS_POTENTIAL_MATCH + .STATUS_POTENTIAL_MATCH--SUB-ROW td {
+  border-bottom: 1px solid #e0e0e0 !important;
+}
+
 .facility-list-row__expanded + .facility-list-row__expanded td {
   border-bottom: 1px solid #e0e0e0
 }
@@ -747,4 +755,8 @@ hr {
 
 .STATUS_PARSED:not(:hover) {
   background: #fff !important;
+}
+
+.STATUS_POTENTIAL_MATCH--ACTIONS + .STATUS_POTENTIAL_MATCH--ACTIONS {
+  display: none !important;
 }

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -720,3 +720,31 @@ hr {
   font-size: 12px !important;
   margin: 0 !important;
 }
+
+.facility-list-row__expanded td {
+  border: none;
+}
+
+.facility-list-row__expanded + .facility-list-row__expanded td {
+  border-bottom: 1px solid #e0e0e0
+}
+
+.STATUS_MATCHED_COLLAPSED {
+  background: rgb(243, 243, 243);
+}
+
+.STATUS_MATCHED_COLLAPSED.STATUS_ERROR:hover {
+  background: #ffc7c7 !important;
+}
+
+.STATUS_ERROR {
+  background: #ffe2e2;
+}
+
+.STATUS_ERROR td {
+  border-color: #ffe2e2;
+}
+
+.STATUS_PARSED:not(:hover) {
+  background: #fff !important;
+}

--- a/src/app/src/components/CellElement.jsx
+++ b/src/app/src/components/CellElement.jsx
@@ -6,7 +6,6 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import Tooltip from '@material-ui/core/Tooltip';
 import isObject from 'lodash/isObject';
 
 import { facilityMatchStatusChoicesEnum } from '../util/constants';
@@ -74,25 +73,6 @@ export default class CellElement extends Component {
         } = this.props;
 
         if (!hasActions) {
-            const OverflowTooltip = ({ children }) => {
-                if (item.length > 50) {
-                    return (
-                        <Tooltip
-                            title={item}
-                            placement="top-start"
-                            classes={{ tooltip: 'cell-tooltip' }}
-                            enterDelay={100}
-                        >
-                            <span style={confirmRejectMatchRowStyles.cellOverflowStyles}>
-                                {children}
-                            </span>
-                        </Tooltip>
-                    );
-                }
-
-                return children;
-            };
-
             const insetComponent = (() => {
                 if (stringIsHidden) {
                     return ' ';
@@ -103,7 +83,6 @@ export default class CellElement extends Component {
                         <Link
                             to={linkURL}
                             href={linkURL}
-                            style={confirmRejectMatchRowStyles.cellOverflowStyles}
                         >
                             {item}
                         </Link>
@@ -119,12 +98,10 @@ export default class CellElement extends Component {
                     style={
                         errorState
                             ? confirmRejectMatchRowStyles.errorCellRowStyles
-                            : confirmRejectMatchRowStyles.cellRowStyles
+                            : null
                     }
                 >
-                    <OverflowTooltip>
-                        {insetComponent}
-                    </OverflowTooltip>
+                    {insetComponent}
                 </div>
             );
         }

--- a/src/app/src/components/CellElement.jsx
+++ b/src/app/src/components/CellElement.jsx
@@ -247,6 +247,7 @@ export default class CellElement extends Component {
             <div
                 key={item.id}
                 style={confirmRejectMatchRowStyles.cellRowStyles}
+                className="STATUS_POTENTIAL_MATCH--ACTIONS"
             >
                 <div style={confirmRejectMatchRowStyles.cellActionStyles}>
                     <Button

--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 
@@ -23,6 +24,7 @@ function FacilityListItemsConfirmationTableRow({
     makeRejectMatchFunction,
     fetching,
     readOnly,
+    className,
 }) {
     const [
         matchIDs,
@@ -64,73 +66,139 @@ function FacilityListItemsConfirmationTableRow({
     );
 
     return (
-        <TableRow hover={false} style={{ background: '#e0e0e0', verticalAlign: 'top' }}>
-            <TableCell
-                align="center"
-                padding="default"
-                style={listTableCellStyles.rowIndexStyles}
+        <>
+            <TableRow
+                hover={false}
+                style={{ background: '#dcfbff', verticalAlign: 'top' }}
+                className={className}
             >
-                <FacilityListItemsDetailedTableRowCell
-                    title={item.row_index}
-                    subtitle=" "
-                    stringIsHidden
-                    data={matchIDs}
-                    hasActions={false}
-                />
-            </TableCell>
-            <TableCell
-                align="center"
-                padding="default"
-                style={listTableCellStyles.countryNameStyles}
+                <TableCell
+                    align="center"
+                    padding="default"
+                    style={listTableCellStyles.rowIndexStyles}
+                >
+                    <FacilityListItemsDetailedTableRowCell
+                        title={item.row_index}
+                        stringIsHidden
+                        data={matchIDs}
+                        hasActions={false}
+                    />
+                </TableCell>
+                <TableCell
+                    align="center"
+                    padding="default"
+                    style={listTableCellStyles.countryNameStyles}
+                >
+                    <FacilityListItemsDetailedTableRowCell
+                        title={item.country_name || ' '}
+                        stringIsHidden
+                        data={matchIDs}
+                        hasActions={false}
+                    />
+                </TableCell>
+                <TableCell
+                    padding="default"
+                    style={listTableCellStyles.nameCellStyles}
+                    colSpan={2}
+                >
+                    <FacilityListItemsDetailedTableRowCell
+                        title={item.name || ' '}
+                        stringIsHidden
+                        data={matchNames}
+                        hasActions={false}
+                    />
+                </TableCell>
+                <TableCell
+                    padding="default"
+                    style={listTableCellStyles.addressCellStyles}
+                    colSpan={2}
+                >
+                    <FacilityListItemsDetailedTableRowCell
+                        title={item.address || ' '}
+                        stringIsHidden
+                        data={matchAddresses}
+                        hasActions={false}
+                    />
+                </TableCell>
+                <TableCell
+                    padding="default"
+                    style={listTableCellStyles.statusCellStyles}
+                >
+                    <FacilityListItemsDetailedTableRowCell
+                        title={item.status}
+                        stringIsHidden
+                        data={matchConfirmOrRejectFunctions}
+                        hasActions={false}
+                        fetching={fetching}
+                        readOnly={readOnly}
+                    />
+                </TableCell>
+            </TableRow>
+            <TableRow
+                hover={false}
+                style={{ background: '#dcfbff', verticalAlign: 'top' }}
+                className={`${className} STATUS_POTENTIAL_MATCH--SUB-ROW`}
             >
-                <FacilityListItemsDetailedTableRowCell
-                    title={item.country_name || ' '}
-                    subtitle=" "
-                    stringIsHidden
-                    data={matchIDs}
-                    hasActions={false}
+                <TableCell
+                    align="center"
+                    padding="default"
+                    style={listTableCellStyles.rowIndexStyles}
                 />
-            </TableCell>
-            <TableCell
-                padding="default"
-                style={listTableCellStyles.nameCellStyles}
-            >
-                <FacilityListItemsDetailedTableRowCell
-                    title={item.name || ' '}
-                    subtitle="Matched Name"
-                    stringisHidden={false}
-                    data={matchNames}
-                    hasActions={false}
-                    linkURLs={matchOARIDs.map(makeFacilityDetailLink)}
+                <TableCell
+                    align="center"
+                    padding="default"
+                    style={listTableCellStyles.countryNameStyles}
                 />
-            </TableCell>
-            <TableCell
-                padding="default"
-                style={listTableCellStyles.addressCellStyles}
-            >
-                <FacilityListItemsDetailedTableRowCell
-                    title={item.address || ' '}
-                    subtitle="Matched Address"
-                    stringIsHidden={false}
-                    data={matchAddresses}
-                    hasActions={false}
-                />
-            </TableCell>
-            <TableCell
-                padding="default"
-                style={listTableCellStyles.statusCellStyles}
-            >
-                <FacilityListItemsDetailedTableRowCell
-                    title={item.status}
-                    subtitle="Actions"
-                    stringIsHidden={false}
-                    data={matchConfirmOrRejectFunctions}
-                    hasActions
-                    fetching={fetching}
-                    readOnly={readOnly}
-                />
-            </TableCell>
-        </TableRow>
+                <TableCell
+                    padding="default"
+                    style={listTableCellStyles.nameCellStyles}
+                    colSpan={2}
+                >
+                    {matchOARIDs ? (
+                        <>
+                            <b>Facility Match Name</b>
+                            <br />
+                            <Link
+                                to={makeFacilityDetailLink(matchOARIDs)}
+                                href={makeFacilityDetailLink(matchOARIDs)}
+                            >
+                                {matchNames}
+                            </Link>
+                        </>
+                    ) : (
+                        ' '
+                    )}
+                </TableCell>
+                <TableCell
+                    padding="default"
+                    style={listTableCellStyles.addressCellStyles}
+                    colSpan={2}
+                >
+                    {matchAddresses ? (
+                        <>
+                            <b>Facility Match Address</b>
+                            <br />
+                            {matchAddresses}
+                        </>
+                    ) : (
+                        ' '
+                    )}
+                </TableCell>
+                <TableCell
+                    padding="default"
+                    style={listTableCellStyles.statusCellStyles}
+                >
+                    <FacilityListItemsDetailedTableRowCell
+                        title
+                        stringIsHidden
+                        data={matchConfirmOrRejectFunctions}
+                        hasActions
+                        fetching={fetching}
+                        readOnly={readOnly}
+                    />
+                </TableCell>
+            </TableRow>
+        </>
     );
 }
 

--- a/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
+++ b/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
@@ -2,7 +2,6 @@ import React, { Fragment } from 'react';
 import { arrayOf, bool, func, number, oneOf, oneOfType, shape, string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
-import Tooltip from '@material-ui/core/Tooltip';
 import get from 'lodash/get';
 import isFunction from 'lodash/isFunction';
 
@@ -34,20 +33,6 @@ export default function FacilityListItemsDetailedTableRowCell({
         }
 
         if (!isFunction(handleRemoveItem)) {
-            if (title.length > 50) {
-                return (
-                    <Tooltip
-                        title={title}
-                        placement="top-start"
-                        classes={{ tooltip: 'cell-tooltip' }}
-                        enterDelay={200}
-                    >
-                        <span style={confirmRejectMatchRowStyles.cellOverflowStyles}>
-                            {title}
-                        </span>
-                    </Tooltip>
-                );
-            }
             return title;
         }
 
@@ -57,7 +42,6 @@ export default function FacilityListItemsDetailedTableRowCell({
                     display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'center',
-                    width: '100%',
                 }}
             >
                 <span style={{ marginRight: '5px' }}>
@@ -77,10 +61,8 @@ export default function FacilityListItemsDetailedTableRowCell({
     })();
 
     return (
-        <div style={confirmRejectMatchRowStyles.cellStyles}>
-            <div style={confirmRejectMatchRowStyles.cellTitleStyles}>
-                {statusSection}
-            </div>
+        <>
+            {statusSection}
             <ShowOnly when={!readOnly}>
                 <div style={confirmRejectMatchRowStyles.cellSubtitleStyles}>
                     <Typography variant="body2">
@@ -101,7 +83,7 @@ export default function FacilityListItemsDetailedTableRowCell({
                         </Fragment>))
                 }
             </ShowOnly>
-        </div>
+        </>
     );
 }
 

--- a/src/app/src/components/FacilityListItemsErrorTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsErrorTableRow.jsx
@@ -23,77 +23,117 @@ const FacilityListItemsErrorTableRow = memo(({
     hover,
     errors,
     handleSelectRow,
+    className,
 }) => (
-    <TableRow
-        hover={hover}
-        onClick={handleSelectRow}
-        style={{ verticalAlign: 'top' }}
-    >
-        <TableCell
-            align="center"
-            padding="default"
-            style={listTableCellStyles.rowIndexStyles}
+    <>
+        <TableRow
+            hover={hover}
+            onClick={handleSelectRow}
+            style={{ verticalAlign: 'top' }}
+            className={className}
         >
-            <FacilityListItemsDetailedTableRowCell
-                title={rowIndex}
-                hrIsHidden
-                stringIsHidden
-                data={errors}
-                hasActions={false}
-            />
-        </TableCell>
-        <TableCell
-            align="center"
-            padding="default"
-            style={listTableCellStyles.countryNameStyles}
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.rowIndexStyles}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={rowIndex}
+                    stringIsHidden
+                    data={errors}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.countryNameStyles}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={countryName}
+                    stringIsHidden
+                    data={errors}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.nameCellStyles}
+                colSpan={2}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={name}
+                    stringIsHidden
+                    data={errors}
+                    hasActions={false}
+                    errorState
+                />
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.addressCellStyles}
+                colSpan={2}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={address}
+                    stringIsHidden
+                    data={errors}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.statusCellStyles}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={status}
+                    stringIsHidden
+                    data={errors}
+                    hasActions={false}
+                />
+            </TableCell>
+        </TableRow>
+        <TableRow
+            hover={hover}
+            onClick={handleSelectRow}
+            style={{ verticalAlign: 'top' }}
+            className={`${className} STATUS_ERROR_EXPANDED--SUB-ROW`}
         >
-            <FacilityListItemsDetailedTableRowCell
-                title={countryName}
-                hrIsHidden
-                stringIsHidden
-                data={errors}
-                hasActions={false}
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.rowIndexStyles}
             />
-        </TableCell>
-        <TableCell
-            padding="default"
-            style={listTableCellStyles.nameCellStyles}
-        >
-            <FacilityListItemsDetailedTableRowCell
-                title={name}
-                subtitle="Errors"
-                hrIsHidden={false}
-                stringIsHidden={false}
-                data={errors}
-                hasActions={false}
-                errorState
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.countryNameStyles}
             />
-        </TableCell>
-        <TableCell
-            padding="default"
-            style={listTableCellStyles.addressCellStyles}
-        >
-            <FacilityListItemsDetailedTableRowCell
-                title={address}
-                hrIsHidden
-                stringIsHidden
-                data={errors}
-                hasActions={false}
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.nameCellStyles}
+                colSpan={2}
+            >
+                {errors ? (
+                    <>
+                        <b>Errors</b><br />
+                        <div style={{ color: 'red' }}>
+                            {errors}
+                        </div>
+                    </>
+                ) : ''}
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.addressCellStyles}
+                colSpan={2}
             />
-        </TableCell>
-        <TableCell
-            padding="default"
-            style={listTableCellStyles.statusCellStyles}
-        >
-            <FacilityListItemsDetailedTableRowCell
-                title={status}
-                hrIsHidden
-                stringIsHidden
-                data={errors}
-                hasActions={false}
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.statusCellStyles}
             />
-        </TableCell>
-    </TableRow>
+        </TableRow>
+    </>
 ), propsAreEqual);
 
 FacilityListItemsErrorTableRow.defaultProps = {

--- a/src/app/src/components/FacilityListItemsMatchTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsMatchTableRow.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { bool, func, number, oneOfType, shape, string } from 'prop-types';
+import { Link } from 'react-router-dom';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
-
 import FacilityListItemsDetailedTableRowCell from './FacilityListItemsDetailedTableRowCell';
-
 import { listTableCellStyles } from '../util/styles';
-
 import { makeFacilityDetailLink } from '../util/util';
-
 import { facilityListItemStatusPropType } from '../util/propTypes';
 
 const makeTableRowStyle = (isRemoved) => {
@@ -17,12 +14,15 @@ const makeTableRowStyle = (isRemoved) => {
             opacity: '0.6',
             verticalAlign: 'top',
             cursor: 'pointer',
+            textDecoration: 'line-through',
         });
     }
 
     return Object.freeze({
         verticalAlign: 'top',
         cursor: 'pointer',
+        background: '#f3f3f3',
+        borderColor: '#f3f3f3',
     });
 };
 
@@ -39,84 +39,129 @@ const FacilityListItemsMatchTableRow = ({
     handleRemoveItem,
     removeButtonDisabled,
     removeButtonID,
+    className,
 }) => (
-    <TableRow
-        hover={hover}
-        onClick={handleSelectRow}
-        style={makeTableRowStyle(isRemoved)}
-    >
-        <TableCell
-            align="center"
-            padding="default"
-            style={listTableCellStyles.rowIndexStyles}
+    <>
+        <TableRow
+            hover={hover}
+            onClick={handleSelectRow}
+            style={makeTableRowStyle(isRemoved)}
+            className={className}
         >
-            <FacilityListItemsDetailedTableRowCell
-                title={rowIndex}
-                subtitle=" "
-                hrIsHidden
-                stringIsHidden
-                data={[matchedFacility.oar_id]}
-                hasActions={false}
-            />
-        </TableCell>
-        <TableCell
-            align="center"
-            padding="default"
-            style={listTableCellStyles.countryNameStyles}
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.rowIndexStyles}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={rowIndex}
+                    stringIsHidden
+                    data={[matchedFacility.oar_id]}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.countryNameStyles}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={countryName || ' '}
+                    stringIsHidden
+                    data={[matchedFacility.oar_id]}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.nameCellStyles}
+                colSpan={2}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={name || ' '}
+                    stringIsHidden
+                    data={[matchedFacility.name]}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.addressCellStyles}
+                colSpan={2}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={address || ' '}
+                    stringIsHidden
+                    data={[matchedFacility.address]}
+                    hasActions={false}
+                />
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.statusCellStyles}
+            >
+                <FacilityListItemsDetailedTableRowCell
+                    title={status}
+                    stringIsHidden
+                    data={[matchedFacility.oar_id]}
+                    hasActions={false}
+                    isRemoved={isRemoved}
+                    handleRemoveItem={handleRemoveItem}
+                    removeButtonDisabled={removeButtonDisabled}
+                    removeButtonID={removeButtonID}
+                />
+            </TableCell>
+        </TableRow>
+        <TableRow
+            onClick={handleSelectRow}
+            style={makeTableRowStyle(isRemoved)}
+            className={`${className} STATUS_MATCHED_EXPANDED--SUB-ROW`}
         >
-            <FacilityListItemsDetailedTableRowCell
-                title={countryName || ' '}
-                subtitle=" "
-                hrIsHidden
-                stringIsHidden
-                data={[matchedFacility.oar_id]}
-                hasActions={false}
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.rowIndexStyles}
             />
-        </TableCell>
-        <TableCell
-            padding="default"
-            style={listTableCellStyles.nameCellStyles}
-        >
-            <FacilityListItemsDetailedTableRowCell
-                title={name || ' '}
-                subtitle="Facility Match Name"
-                hrIsHidden={false}
-                stringisHidden={false}
-                data={[matchedFacility.name]}
-                linkURLs={[makeFacilityDetailLink(matchedFacility.oar_id)]}
-                hasActions={false}
+            <TableCell
+                align="center"
+                padding="default"
+                style={listTableCellStyles.countryNameStyles}
             />
-        </TableCell>
-        <TableCell
-            padding="default"
-            style={listTableCellStyles.addressCellStyles}
-        >
-            <FacilityListItemsDetailedTableRowCell
-                title={address || ' '}
-                subtitle="Facility Match Address"
-                hrIsHidden={false}
-                stringIsHidden={false}
-                data={[matchedFacility.address]}
-                hasActions={false}
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.nameCellStyles}
+                colSpan={2}
+            >
+                {matchedFacility ? (
+                    <>
+                        <b>Facility Match Name</b><br />
+                        <Link
+                            to={makeFacilityDetailLink(matchedFacility.oar_id)}
+                            href={makeFacilityDetailLink(matchedFacility.oar_id)}
+                        >
+                            {matchedFacility.name}
+                        </Link>
+                    </>
+                ) : ''}
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.addressCellStyles}
+                colSpan={2}
+            >
+                {matchedFacility ? (
+                    <>
+                        <b>Facility Match Address</b><br />
+                        {matchedFacility.address}
+                    </>
+                ) : ''}
+            </TableCell>
+            <TableCell
+                padding="default"
+                style={listTableCellStyles.statusCellStyles}
             />
-        </TableCell>
-        <TableCell
-            padding="default"
-            style={listTableCellStyles.statusCellStyles}
-        >
-            <FacilityListItemsDetailedTableRowCell
-                title={status}
-                hrIsHidden
-                stringIsHidden
-                data={[matchedFacility.oar_id]}
-                hasActions={false}
-                isRemoved={isRemoved}
-                handleRemoveItem={handleRemoveItem}
-                removeButtonDisabled={removeButtonDisabled}
-                removeButtonID={removeButtonID}
-            />
-        </TableCell>
-    </TableRow>
+        </TableRow>
+    </>
 );
 
 FacilityListItemsMatchTableRow.defaultProps = {

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -345,6 +345,7 @@ class FacilityListItemsTable extends Component {
                 direction="row"
                 justify="space-between"
                 alignItems="center"
+                className="TABLE_PAGINATION"
             >
                 <Grid
                     item
@@ -389,6 +390,7 @@ class FacilityListItemsTable extends Component {
                             handleRemoveItem={() => this.handleRemoveButtonClick(item)}
                             removeButtonDisabled={isRemovingItem}
                             removeButtonID={REMOVE_BUTTON_ID}
+                            className="STATUS_POTENTIAL_MATCH facility-list-row__expanded"
                         />
                     );
                 }
@@ -412,6 +414,7 @@ class FacilityListItemsTable extends Component {
                             handleRemoveItem={() => this.handleRemoveButtonClick(item)}
                             removeButtonDisabled={isRemovingItem}
                             removeButtonID={REMOVE_BUTTON_ID}
+                            className="STATUS_NEW_FACILITY"
                         />
                     );
                 }
@@ -431,21 +434,7 @@ class FacilityListItemsTable extends Component {
                             handleRemoveItem={() => this.handleRemoveButtonClick(item)}
                             removeButtonDisabled={isRemovingItem}
                             removeButtonID={REMOVE_BUTTON_ID}
-                        />
-                    );
-                }
-
-                if (facilityListItemErrorStatuses.includes(item.status)) {
-                    return (
-                        <FacilityListItemsErrorTableRow
-                            key={item.row_index}
-                            rowIndex={item.row_index}
-                            countryName={item.country_name}
-                            name={item.name}
-                            address={item.address}
-                            status={item.status}
-                            errors={item.processing_errors}
-                            handleSelectRow={handleSelectRow}
+                            className={`STATUS_MATCHED_COLLAPSED ${(facilityListItemErrorStatuses.includes(item.status) ? 'STATUS_ERROR' : '')} STATUS_${item.status.toString()}`}
                         />
                     );
                 }
@@ -466,6 +455,23 @@ class FacilityListItemsTable extends Component {
                             handleRemoveItem={() => this.handleRemoveButtonClick(item)}
                             removeButtonDisabled={isRemovingItem}
                             removeButtonID={REMOVE_BUTTON_ID}
+                            className="STATUS_MATCHED_EXPANDED facility-list-row__expanded"
+                        />
+                    );
+                }
+
+                if (facilityListItemErrorStatuses.includes(item.status)) {
+                    return (
+                        <FacilityListItemsErrorTableRow
+                            key={item.row_index}
+                            rowIndex={item.row_index}
+                            countryName={item.country_name}
+                            name={item.name}
+                            address={item.address}
+                            status={item.status}
+                            errors={item.processing_errors}
+                            handleSelectRow={handleSelectRow}
+                            className="STATUS_ERROR"
                         />
                     );
                 }
@@ -481,6 +487,7 @@ class FacilityListItemsTable extends Component {
                         handleSelectRow={handleSelectRow}
                         hover
                         isRemoved={anyListItemMatchesAreInactive(item)}
+                        className={`STATUS_${item.status}`}
                     />
                 );
             });
@@ -529,11 +536,11 @@ class FacilityListItemsTable extends Component {
                     </ShowOnly>
                 </div>
                 {paginationControlsRow}
-                <div style={facilityListItemsTableStyles.tableWrapperStyles}>
-                    <Table>
+                <div className="TABLE_WRAPPER" style={facilityListItemsTableStyles.tableWrapperStyles}>
+                    <Table style={{ tableLayout: 'fixed', minWidth: '1200px' }}>
                         <TableHead>
                             <FacilityListItemsTableRow
-                                rowIndex="CSV Row Index"
+                                rowIndex="Row Index"
                                 countryName="Country Name"
                                 name="Name"
                                 address="Address"

--- a/src/app/src/components/FacilityListItemsTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsTableRow.jsx
@@ -15,6 +15,7 @@ import { makeFacilityDetailLink } from '../util/util';
 const makeTableRowStyles = ({ handleSelectRow, isRemoved }) => ({
     cursor: isFunction(handleSelectRow) ? 'pointer' : 'auto',
     opacity: isRemoved ? '0.6' : '1.0',
+    textDecoration: isRemoved ? 'line-through' : 'initial',
 });
 
 const FacilityListItemsTableRow = ({
@@ -31,11 +32,13 @@ const FacilityListItemsTableRow = ({
     handleRemoveItem,
     removeButtonDisabled,
     removeButtonID,
+    className,
 }) => (
     <TableRow
         hover={hover}
         onClick={handleSelectRow}
         style={makeTableRowStyles({ handleSelectRow, isRemoved })}
+        className={className}
     >
         <TableCell
             align="center"
@@ -54,6 +57,7 @@ const FacilityListItemsTableRow = ({
         <TableCell
             padding="default"
             style={listTableCellStyles.nameCellStyles}
+            colSpan={2}
         >
             {
                 (newFacility && oarID)
@@ -70,6 +74,7 @@ const FacilityListItemsTableRow = ({
         <TableCell
             padding="default"
             style={listTableCellStyles.addressCellStyles}
+            colSpan={2}
         >
             {address}
         </TableCell>

--- a/src/app/src/components/FacilityListsTable.jsx
+++ b/src/app/src/components/FacilityListsTable.jsx
@@ -21,145 +21,153 @@ const facilityListsTableStyles = Object.freeze({
     }),
     activeListStyles: Object.freeze({
         backgroundColor: '#f3fafe',
-        outlineWidth: '0.75px',
-        outlineStyle: 'solid',
-        outlineColor: '#1a9fe3',
         cursor: 'pointer',
+    }),
+    activeCellStyles: Object.freeze({
+        borderColor: '#d1e1e9',
     }),
 });
 
-function FacilityListsTable({
-    facilityLists,
-    history: {
-        push,
-    },
-}) {
+function FacilityListsTable({ facilityLists, history: { push } }) {
     return (
         <Paper style={{ width: '100%' }}>
-            <Table>
-                <TableHead>
-                    <TableRow>
-                        <TableCell>
-                            Name
-                        </TableCell>
-                        <TableCell>
-                            Description
-                        </TableCell>
-                        <TableCell>
-                            File Name
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Total
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Uploaded
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Parsed
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Geocoded
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Matched
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Error
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Potential Match
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Deleted
-                        </TableCell>
-                        <TableCell padding="dense">
-                            Active
-                        </TableCell>
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    {
-                        facilityLists
-                            .map(list => (
-                                <TableRow
-                                    key={list.id}
-                                    hover
-                                    onClick={() => push(makeFacilityListItemsDetailLink(list.id))}
+            <div className="TABLE_WRAPPER" style={{ overflowX: 'auto' }}>
+                <Table style={{ tableLayout: 'fixed', minWidth: '1200px' }}>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell colSpan={2}>Name</TableCell>
+                            <TableCell colSpan={2}>Description</TableCell>
+                            <TableCell colSpan={2}>File Name</TableCell>
+                            <TableCell padding="dense">Total</TableCell>
+                            <TableCell padding="dense">Uploaded</TableCell>
+                            <TableCell padding="dense">Parsed</TableCell>
+                            <TableCell padding="dense">Geocoded</TableCell>
+                            <TableCell padding="dense">Matched</TableCell>
+                            <TableCell padding="dense">Error</TableCell>
+                            <TableCell padding="dense">
+                                Potential Match
+                            </TableCell>
+                            <TableCell padding="dense">Deleted</TableCell>
+                            <TableCell padding="dense" colSpan={2}>
+                                Status
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {facilityLists.map(list => (
+                            <TableRow
+                                key={list.id}
+                                hover
+                                onClick={() =>
+                                    push(
+                                        makeFacilityListItemsDetailLink(list.id),
+                                    )
+                                }
+                                style={
+                                    list.is_active
+                                        ? facilityListsTableStyles.activeListStyles
+                                        : facilityListsTableStyles.inactiveListStyles
+                                }
+                            >
+                                <TableCell
+                                    colSpan={2}
                                     style={
                                         list.is_active
-                                            ? facilityListsTableStyles.activeListStyles
-                                            : facilityListsTableStyles.inactiveListStyles
+                                            ? facilityListsTableStyles.activeCellStyles
+                                            : null
                                     }
                                 >
-                                    <TableCell>
-                                        {list.name}
-                                    </TableCell>
-                                    <TableCell>
-                                        {list.description}
-                                    </TableCell>
-                                    <TableCell>
-                                        {list.file_name}
-                                    </TableCell>
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={facilitiesListTableTooltipTitles.total}
-                                        tableCellText={list.item_count}
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={facilitiesListTableTooltipTitles.uploaded}
-                                        tableCellText={list.status_counts.UPLOADED}
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={facilitiesListTableTooltipTitles.parsed}
-                                        tableCellText={list.status_counts.PARSED}
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={facilitiesListTableTooltipTitles.geocoded}
-                                        tableCellText={
-                                            sum([
-                                                list.status_counts.GEOCODED,
-                                                list.status_counts.GEOCODED_NO_RESULTS,
-                                            ])
-                                        }
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={facilitiesListTableTooltipTitles.matched}
-                                        tableCellText={
-                                            sum([
-                                                list.status_counts.MATCHED,
-                                                list.status_counts.CONFIRMED_MATCH,
-                                            ])
-                                        }
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={facilitiesListTableTooltipTitles.error}
-                                        tableCellText={
-                                            sum([
-                                                list.status_counts.ERROR,
-                                                list.status_counts.ERROR_PARSING,
-                                                list.status_counts.ERROR_GEOCODING,
-                                                list.status_counts.ERROR_MATCHING,
-                                            ])
-                                        }
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={
-                                            facilitiesListTableTooltipTitles.potentialMatch
-                                        }
-                                        tableCellText={list.status_counts.POTENTIAL_MATCH}
-                                    />
-                                    <FacilityListsTooltipTableCell
-                                        tooltipTitle={
-                                            facilitiesListTableTooltipTitles.deleted
-                                        }
-                                        tableCellText={list.status_counts.DELETED}
-                                    />
-                                    <TableCell padding="dense">
-                                        {list.is_active ? 'Active' : 'Inactive'}
-                                    </TableCell>
-                                </TableRow>))
-                    }
-                </TableBody>
-            </Table>
+                                    {list.name}
+                                </TableCell>
+                                <TableCell
+                                    colSpan={2}
+                                    style={
+                                        list.is_active
+                                            ? facilityListsTableStyles.activeCellStyles
+                                            : null
+                                    }
+                                >
+                                    {list.description}
+                                </TableCell>
+                                <TableCell
+                                    colSpan={2}
+                                    style={
+                                        list.is_active
+                                            ? facilityListsTableStyles.activeCellStyles
+                                            : null
+                                    }
+                                >
+                                    {list.file_name}
+                                </TableCell>
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.total
+                                    }
+                                    tableCellText={list.item_count}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.uploaded
+                                    }
+                                    tableCellText={list.status_counts.UPLOADED}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.parsed
+                                    }
+                                    tableCellText={list.status_counts.PARSED}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.geocoded
+                                    }
+                                    tableCellText={sum([
+                                        list.status_counts.GEOCODED,
+                                        list.status_counts.GEOCODED_NO_RESULTS,
+                                    ])}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.matched
+                                    }
+                                    tableCellText={sum([
+                                        list.status_counts.MATCHED,
+                                        list.status_counts.CONFIRMED_MATCH,
+                                    ])}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.error
+                                    }
+                                    tableCellText={sum([
+                                        list.status_counts.ERROR,
+                                        list.status_counts.ERROR_PARSING,
+                                        list.status_counts.ERROR_GEOCODING,
+                                        list.status_counts.ERROR_MATCHING,
+                                    ])}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.potentialMatch
+                                    }
+                                    tableCellText={
+                                        list.status_counts.POTENTIAL_MATCH
+                                    }
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.deleted
+                                    }
+                                    tableCellText={list.status_counts.DELETED}
+                                />
+                                <TableCell padding="dense" colSpan={2}>
+                                    {list.is_active ? 'Active' : 'Inactive'}
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
         </Paper>
     );
 }

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -84,7 +84,6 @@ export const facilityListItemPropType = shape({
     country_name: string.isRequired,
     geocoded_point: string,
     geocoded_address: string,
-    facility_list: number.isRequired,
     processing_errors: arrayOf(string.isRequired),
     matched_facility: shape({
         oar_id: string.isRequired,

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -22,7 +22,7 @@ export const listTableCellStyles = Object.freeze({
     addressCellStyles: Object.freeze({
         fontSize: '16px',
         padding: '10px 24px',
-
+        wordBreak: 'break-word',
     }),
     statusCellStyles: Object.freeze({
         fontSize: '16px',

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -8,35 +8,30 @@ export const formValidationErrorMessageStyle = Object.freeze({
 
 export const listTableCellStyles = Object.freeze({
     rowIndexStyles: Object.freeze({
-        flex: '1',
         fontSize: '16px',
-        paddingTop: '10px',
-        paddingBottom: '10px',
+        padding: '10px 24px',
     }),
     countryNameStyles: Object.freeze({
-        flex: '1',
         fontSize: '16px',
-        paddingTop: '10px',
-        paddingBottom: '10px',
+        padding: '10px 24px',
     }),
     nameCellStyles: Object.freeze({
-        flex: '2',
         fontSize: '16px',
-        paddingTop: '10px',
-        paddingBottom: '10px',
+        padding: '10px 24px',
     }),
     addressCellStyles: Object.freeze({
-        flex: '2',
         fontSize: '16px',
-        paddingTop: '10px',
-        paddingBottom: '10px',
+        padding: '10px 24px',
     }),
     statusCellStyles: Object.freeze({
-        flex: '2',
         fontSize: '16px',
-        paddingRight: '30px',
-        paddingTop: '10px',
-        paddingBottom: '10px',
+        padding: '10px 24px',
+        width: '300px',
+    }),
+    compareCellStyles: Object.freeze({
+        fontSize: '16px',
+        padding: '10px 24px',
+        borderColor: '#f3f3f3',
     }),
 });
 
@@ -65,22 +60,9 @@ export const confirmRejectMatchRowStyles = Object.freeze({
         alignItems: 'center',
         maxWidth: '400px',
     }),
-    cellTitleStyles: Object.freeze({
-        height: '75px',
-        minHeight: '75px',
-        display: 'flex',
-        alignItems: 'top',
-        maxWidth: '400px',
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'hidden',
-    }),
     errorCellRowStyles: Object.freeze({
-        height: '75px',
-        minHeight: '75px',
         display: 'flex',
         alignItems: 'center',
-        maxWidth: '400px',
         color: 'red',
     }),
     cellHiddenHRStyles: Object.freeze({

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -22,6 +22,7 @@ export const listTableCellStyles = Object.freeze({
     addressCellStyles: Object.freeze({
         fontSize: '16px',
         padding: '10px 24px',
+
     }),
     statusCellStyles: Object.freeze({
         fontSize: '16px',

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -487,6 +487,7 @@ class FacilityListItem(PPEMixin):
     REMOVED = 'REMOVED'
 
     # These status choices must be kept in sync with the client's
+    # If a new status is added, consider adding supporting styles within src/app/src/App.css
     # `facilityListItemStatusChoicesEnum`.
     STATUS_CHOICES = (
         (UPLOADED, UPLOADED),

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -487,7 +487,7 @@ class FacilityListItem(PPEMixin):
     REMOVED = 'REMOVED'
 
     # These status choices must be kept in sync with the client's
-    # If a new status is added, consider adding supporting styles within src/app/src/App.css
+    # If a new status is added, add supporting styles src/app/src/App.css
     # `facilityListItemStatusChoicesEnum`.
     STATUS_CHOICES = (
         (UPLOADED, UPLOADED),


### PR DESCRIPTION
## Overview

- Better highlighting/visualization of certain status'
- Expanded row content will now render in a new table row instead of as extra divs within columns. This will fix alignment issues and overflow issues.
- Fixed table layouts. Several columns now have `colspans` defined which prevent shrinking/expanding based on content.
- Removed truncation and tooltips from longer addresses and names. These are longer required.

Connects #XXX

## Demo

**Highlight areas which require specific actions:**
<img width="1804" alt="Screen Shot 2020-10-23 at 4 07 06 PM" src="https://user-images.githubusercontent.com/1928955/97193275-360c6700-177f-11eb-8197-b8bb212f0e66.png">

**Highlight rows which have expandable rows**
<img width="1804" alt="Screen Shot 2020-10-23 at 4 07 19 PM" src="https://user-images.githubusercontent.com/1928955/97193290-399fee00-177f-11eb-80c9-0b547de69c9b.png">
<img width="1804" alt="Screen Shot 2020-10-23 at 4 07 23 PM" src="https://user-images.githubusercontent.com/1928955/97193301-3d337500-177f-11eb-8ef0-334f3f49f8a2.png">

**Improved highlighting of rows with errors**
<img width="1804" alt="Screen Shot 2020-10-23 at 4 07 30 PM" src="https://user-images.githubusercontent.com/1928955/97193312-3efd3880-177f-11eb-8969-499ac6854f7d.png">
<img width="1804" alt="Screen Shot 2020-10-23 at 4 07 35 PM" src="https://user-images.githubusercontent.com/1928955/97193322-415f9280-177f-11eb-8e7b-8d1296cebb25.png">

**Deleted rows will now be crossed-out**
<img width="1804" alt="Screen Shot 2020-10-23 at 4 08 07 PM" src="https://user-images.githubusercontent.com/1928955/97193326-43295600-177f-11eb-9aed-4428732c8140.png">

**Deleted rows that are expandable will still be highlighted**
<img width="1804" alt="Screen Shot 2020-10-23 at 4 08 11 PM" src="https://user-images.githubusercontent.com/1928955/97193328-43c1ec80-177f-11eb-845b-08af1646a137.png">
<img width="1804" alt="Screen Shot 2020-10-23 at 4 08 15 PM" src="https://user-images.githubusercontent.com/1928955/97193332-43c1ec80-177f-11eb-86f1-4b92b61519c1.png">

**Long names/addresses will no longer truncate and tooltip.**
<img width="1804" alt="Screen Shot 2020-10-23 at 4 09 47 PM" src="https://user-images.githubusercontent.com/1928955/97193336-445a8300-177f-11eb-8c35-f653248da909.png">


## Notes

I was originally going to try and refactor the code-base for these layouts. This proved to be a time-consuming and confusing process. So instead of spending a ton of time trying to rewrite, I instead focused on usability. 

There is a ton of duplicate code and functionality, but I felt improving the UX was a better way of spending time.

One UX issues to note: Some rows can be "expanded" but they don't have any extra content to reveal. I never figured out how to resolve this. 

## Testing Instructions

* Open up facility list tables
* Things to check:
    * Long names and address' (should not truncate)
    * Deleted rows (should be crossed-out)
    * Errors (should be highlighted in red)
    * Potential Match (should be highlighted blue)
    * Expandable rows (should render new row when open. Alignment issues should be resolved. Titles and content will be lined up correctly)

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
