### PR TITLE
Add a dissociate API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
+
 ### Changed
 
 - Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)


### PR DESCRIPTION

## Overview

This new API allows for contributors to remove their affiliation with a facility, mimicking the behavior of the "remove" button in the facility list UI.

Connects #1133

## Testing Instructions

This assumes the database has been populated by running `./scripts/resetdb`

* Log in as c2@example.com
* Browse http://localhost:6543/lists/2, click the link on the first row, and copy the OAR ID from the detail page.
* Browse http://localhost:8081/api/docs/ and Authenticate with `Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051`
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_get_facility_history and submit the OAR ID. Note that there are 2 events, CRATE and ASSOCIATE.
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_dissociate and submit the OAR ID. Verify the `contributors` in the response contains an anonymized contributor name.
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_get_facility_history and submit the OAR ID. Verify there is a 3rd DISSOCIATE event.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
