### PR TITLE
Allow setting the contributor on a new ApiLimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
+-   Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
 
 ### Changed
 
-- Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)
+-   Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)
+-   Allow setting the contributor on a new ApiLimit [1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1159)
 
 ### Deprecated
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -135,7 +135,12 @@ class RequestLogAdmin(admin.ModelAdmin):
 class ApiLimitAdmin(admin.ModelAdmin):
     history_list_display = ('contributor', 'monthly_limit', 'created_at',
                             'updated_at')
-    readonly_fields = ('contributor',)
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            return ["contributor", ]
+        else:
+            return []
 
 
 admin_site.register(models.Version)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1764,8 +1764,9 @@ class ApiLimit(models.Model):
     history = HistoricalRecords()
 
     def __str__(self):
-        return ('ApiLimit {id} - Contributor {contributor_id} '
-                'limit {monthly_limit}').format(**self.__dict__)
+        return 'ApiLimit {} - {} ({}) - limit {}'.format(
+            self.id, self.contributor.name, self.contributor.id,
+            self.monthly_limit)
 
 
 class ApiBlock(models.Model):


### PR DESCRIPTION
## Overview

We couldn't create new ApiLimits via the admin because the contributor
field was read only. The contributor is now read only for editing, and
not for creation.

Connects #1149 

## Demo

<img width="447" alt="Screen Shot 2020-10-30 at 8 34 06 AM" src="https://user-images.githubusercontent.com/21046714/97706286-ce5e6080-1a8b-11eb-8ffc-a98c46e7fb33.png">
<img width="519" alt="Screen Shot 2020-10-30 at 8 34 14 AM" src="https://user-images.githubusercontent.com/21046714/97706291-d0c0ba80-1a8b-11eb-81bc-eb835a5c94fe.png">

## Testing Instructions

* Run `./scripts/server`
* Go to [:8081/admin/api/apilimit/](http://localhost:8081/admin/api/apilimit/)
* Create a new ApiLimit. You should be able to select a contributor. Save.
* Go to the ApiLimit you created. You should not be able to edit the contributor. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
