### PR TITLE
Update PostgreSQL for RDS engine default to 12.x

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -45,11 +45,11 @@ variable "rds_allocated_storage" {
 }
 
 variable "rds_engine_version" {
-  default = "10.6"
+  default = "12.4"
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres10"
+  default = "postgres12"
 }
 
 variable "rds_instance_type" {


### PR DESCRIPTION
## Overview

Ensure that these defaults reflect the current state of the OAR AWS environments.

Fixes #1126 
Fixes #1128 

## Demo

```sql
openapparelregistry=> select version();
                                                 version
---------------------------------------------------------------------------------------------------------
 PostgreSQL 12.4 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11), 64-bit
(1 row)

openapparelregistry=> select postgis_version();
            postgis_version
---------------------------------------
 3.0 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
(1 row)
```

## Notes

The `rds_parameter_group_family` was not being overwritten in the production Terraform variables, but was in the staging version. I added it to the production Terraform variables in addition to the changes in this PR.

## Testing Instructions

Review the changes and ensure that they align with the [RDS configuration](https://eu-west-1.console.aws.amazon.com/rds/home?region=eu-west-1#database:id=openapparelregistry-enc-prd;is-cluster=false;tab=configuration).

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
~- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~
