### PR TITLE
Add an admin-only ApiBlock REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 -   Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
+-   Add an admin-only ApiBlock API [#1161](https://github.com/open-apparel-registry/open-apparel-registry/pull/1161)
 
 ### Changed
 

--- a/src/django/api/limits.py
+++ b/src/django/api/limits.py
@@ -61,6 +61,7 @@ def check_contributor_api_limit(at_datetime, c):
             grace_limit = apiBlock.grace_limit
             if request_count > grace_limit:
                 with transaction.atomic():
+                    apiBlock.actual = request_count
                     apiBlock.active = True
                     apiBlock.save()
                 send_api_notice(contributor, limit, grace_limit)

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -34,7 +34,8 @@ from api.models import (FacilityList,
                         Contributor,
                         ProductType,
                         ProductionType,
-                        Source)
+                        Source,
+                        ApiBlock)
 from api.countries import COUNTRY_NAMES, COUNTRY_CHOICES
 from api.processing import get_country_code
 from waffle import switch_is_active
@@ -986,3 +987,43 @@ class FacilityUpdateLocationParamsSerializer(Serializer):
         if not Contributor.objects.filter(id=contributor_id).exists():
             raise ValidationError(
                 'Contributor {} does not exist.'.format(contributor_id))
+
+
+class ApiBlockSerializer(ModelSerializer):
+    contributor = SerializerMethodField()
+
+    class Meta:
+        model = ApiBlock
+        fields = ('contributor', 'until', 'active', 'limit', 'actual',
+                  'grace_limit', 'grace_created_by', 'grace_reason',
+                  'created_at', 'updated_at')
+
+    def get_contributor(self, instance):
+        return instance.contributor.name
+
+    def update(self, instance, validated_data):
+        grace_limit = validated_data.get('grace_limit')
+        active = validated_data.get('active', instance.active)
+        if instance.grace_limit != grace_limit:
+            limit = validated_data.get('limit')
+            actual = validated_data.get('actual')
+            if grace_limit <= limit or grace_limit <= actual:
+                raise ValidationError('Grace limit must be greater than ' +
+                                      'request limit and actual request ' +
+                                      'count.')
+            else:
+                active = False
+
+        instance.until = validated_data.get('until', instance.until)
+        instance.active = active
+        instance.limit = validated_data.get('limit', instance.limit)
+        instance.actual = validated_data.get('actual', instance.actual)
+        instance.grace_limit = validated_data.get('grace_limit',
+                                                  instance.grace_limit)
+        instance.grace_created_by = validated_data.get(
+            'grace_created_by', instance.grace_created_by)
+        instance.grace_reason = validated_data.get('grace_reason',
+                                                   instance.grace_reason)
+        instance.save()
+
+        return instance

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -34,6 +34,7 @@ router.register('facility-claims', views.FacilityClaimViewSet,
                 'facility-claim')
 router.register('facility-matches', views.FacilityMatchViewSet,
                 'facility-match')
+router.register('api-blocks', views.ApiBlockViewSet, 'api-block')
 
 public_apis = [
     url(r'^api/', include(router.urls)),
@@ -72,6 +73,7 @@ internal_apis = [
     path(r'tile/<layer>/<cachekey>/<int:z>/<int:x>/<int:y>.<ext>',
          views.get_tile, name='tile'),
     url(r'^api/current_tile_cache_key', views.current_tile_cache_key),
+    url(r'api-blocks', views.ApiBlockViewSet, 'api-block')
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 urlpatterns = public_apis + internal_apis


### PR DESCRIPTION
## Overview

Adds an admin-only API for ApiBlock records, offering list, retrieve,
and update actions.

In the update handler, we return a 400 if the caller attempts to update
the `grace_limit` to a value that is not greater than `limit` and
`actual`.

We set `active` to false when the `grace_limit` is updated.

Connects #1143

## Demo

<img width="1073" alt="Screen Shot 2020-11-02 at 9 33 46 AM" src="https://user-images.githubusercontent.com/21046714/97883579-0b785c00-1cf3-11eb-80dd-020215ab732c.png">

<img width="1051" alt="Screen Shot 2020-11-02 at 9 34 06 AM" src="https://user-images.githubusercontent.com/21046714/97883587-0e734c80-1cf3-11eb-9661-7354503ede5a.png">

<img width="1075" alt="Screen Shot 2020-11-02 at 9 34 14 AM" src="https://user-images.githubusercontent.com/21046714/97883591-10d5a680-1cf3-11eb-9722-2b29eaff75b9.png">

## Testing Instructions

* Run `./scripts/server`
* Add an ApiLimit to a contributor, then make enough requests that an ApiBlock is created. 
* Login as 'c1@example.com'. Navigate to [:8081/api/api-blocks/](http://localhost:8081/api/api-blocks/).
* You should see a list of ApiBlocks. 
* Navigate to the ApiBlock you created at [:8081/api/api-blocks/:id](http://localhost:8081/api/api-blocks/1) (place address with appropriate id).
* You should see the ApiBlock details and an editing form.
* Use the form to edit the ApiBlock to increase the grace_limit above the limit and actual counts. 
* Your ApiBlock should be updated. The ApiBlock should now be inactive. 
* Update the ApiBlock to have a grace_limit that is lower than or equal to the limit and actual. 
* You should see a 400 error. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
