### PR TITLE
Add RequestMeter middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
 -   Add an admin-only ApiBlock API [#1161](https://github.com/open-apparel-registry/open-apparel-registry/pull/1161)
+-   Add RequestMeter middleware [#1166](https://github.com/open-apparel-registry/open-apparel-registry/pull/1166)
 
 ### Changed
 

--- a/src/django/api/limits.py
+++ b/src/django/api/limits.py
@@ -17,6 +17,11 @@ def get_end_of_month(at_datetime):
             + relativedelta(months=1) - relativedelta(seconds=1))
 
 
+def get_api_block(contributor):
+    return ApiBlock.objects.filter(
+                contributor=contributor).order_by('-until').first()
+
+
 @transaction.atomic
 def check_contributor_api_limit(at_datetime, c):
     contributor = Contributor.objects.get(id=c.get('contributor'))
@@ -40,8 +45,7 @@ def check_contributor_api_limit(at_datetime, c):
             notification.api_limit_warning_sent_on = at_datetime
             notification.save()
     if request_count > limit:
-        apiBlock = ApiBlock.objects.filter(
-                    contributor=contributor).order_by('-until').first()
+        apiBlock = get_api_block(contributor)
         if apiBlock is None or apiBlock.until < at_datetime:
             until = get_end_of_month(at_datetime)
             ApiBlock.objects.create(contributor=contributor,

--- a/src/django/api/middleware.py
+++ b/src/django/api/middleware.py
@@ -1,11 +1,15 @@
 import sys
+import datetime
 
+from django.utils import timezone
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework.authentication import get_authorization_header
-
+from django.http import HttpResponse
 
 from api.models import RequestLog
+from api.limits import get_api_block
 
 
 def _report_error_to_rollbar(request, auth):
@@ -44,3 +48,33 @@ class RequestLogMiddleware:
                 pass  # We don't want this logging middleware to fail a request
 
         return response
+
+
+def has_active_block(request):
+    try:
+        if request.user and request.user.is_authenticated:
+            auth = get_authorization_header(request)
+            if auth and auth.split()[0].lower() == 'token'.encode():
+                contributor = request.user.contributor
+                apiBlock = get_api_block(contributor)
+                at_datetime = datetime.datetime.now(tz=timezone.utc)
+                return (apiBlock is not None and
+                        apiBlock.until > at_datetime and apiBlock.active)
+    except ObjectDoesNotExist:
+        return False
+    return False
+
+
+class RequestMeterMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        is_docs = request.get_full_path() == '/api/docs/?format=openapi'
+        is_blocked = has_active_block(request)
+
+        if is_blocked and not is_docs:
+            return HttpResponse('API limit exceeded', status=402)
+        else:
+            response = self.get_response(request)
+            return response

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -172,6 +172,7 @@ MIDDLEWARE = [
     'simple_history.middleware.HistoryRequestMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'api.middleware.RequestLogMiddleware',
+    'api.middleware.RequestMeterMiddleware',
 ]
 
 ROOT_URLCONF = 'oar.urls'


### PR DESCRIPTION
## Overview

Adds RequestMeter middleware that returns 402 if a request was made
with a token and there is an active, unexpired ApiBlock record
associated with the contributor.

Explicitly excludes the '/api/docs/?format=openapi' path. When authenticating
the user, this route is called to fetch the Swagger UI, but was falling under the 
category of token-authenticated route. Excluding it allows users to authenticate 
and to then access the Swagger UI even if they are over their request limit. 

Connects #1140 

## Demo

<img width="856" alt="Screen Shot 2020-11-03 at 12 22 48 PM" src="https://user-images.githubusercontent.com/21046714/98029094-0263b980-1ddd-11eb-91cb-5a83bf9cc1c3.png">

## Testing Instructions

* Create an ApiBlock for c2@example.com which is active until a future date.
* Log in as c2@example.com.
* Browse [:8081/api/docs/](http://localhost:8081/api/docs/) and Authenticate with Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051
* Submit an authenticated request through the Swagger UI. You should be blocked with a 402 status.
* Navigate to [:6543/](http://localhost:6543/) and view the facilities list. The facilities should load without issue. 
* Change the block to be inactive or in the past. 
* Submit another authenticated request. You should not be blocked. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
