### PR TITLE
Enable temporary survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)
 -   Allow setting the contributor on a new ApiLimit [1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1159)
+-   Reenable survey popup [#1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1167)
 
 ### Deprecated
 

--- a/src/app/src/components/SurveyDialogNotification.jsx
+++ b/src/app/src/components/SurveyDialogNotification.jsx
@@ -10,7 +10,7 @@ import attempt from 'lodash/attempt';
 import isError from 'lodash/isError';
 import moment from 'moment';
 
-const surveyURL = 'http://bit.ly/OARSurvey';
+const surveyURL = 'https://openapparelregistry.typeform.com/to/ue3mV6OD';
 
 const surveyDialogStyles = Object.freeze({
     containerStyles: Object.freeze({
@@ -25,31 +25,55 @@ const surveyDialogStyles = Object.freeze({
     }),
 });
 
-const InvisibleDiv = constant(<div style={{ display: 'none ' }} />);
-
-const surveyEndDate = moment('2019-11-10');
-const currentDate = moment();
+// We previously stored SURVEY_DIALOG_HAS_BEEN_DISPLAYED to determine
+// whether to show the survey popup. We are removing this key to avoid
+// confusion.
 const SURVEY_DIALOG_HAS_BEEN_DISPLAYED = 'SURVEY_DIALOG_HAS_BEEN_DISPLAYED';
-
-const trySetDialogHasBeenDisplayedToLocalStorage = () => attempt(
-    () => window.localStorage.setItem(
-        SURVEY_DIALOG_HAS_BEEN_DISPLAYED,
-        SURVEY_DIALOG_HAS_BEEN_DISPLAYED,
-    ),
-);
-
-const dialogEntryIsNotSavedInLocalStorage = () => {
-    const result = attempt(
+const removeSurveyDialogueHasBeenDisplayed = () => {
+    const surveyDialogueHasBeenDisplayed = attempt(
         () => window.localStorage.getItem(SURVEY_DIALOG_HAS_BEEN_DISPLAYED),
     );
 
-    return isError(result) ? true : !result;
+    if (!isError(surveyDialogueHasBeenDisplayed) &&
+        !!surveyDialogueHasBeenDisplayed) {
+        attempt(
+            () => window.localStorage.removeItem(
+                SURVEY_DIALOG_HAS_BEEN_DISPLAYED,
+            ),
+        );
+    }
+};
+removeSurveyDialogueHasBeenDisplayed();
+
+const InvisibleDiv = constant(<div style={{ display: 'none ' }} />);
+
+const dateFormat = 'YYYY-MM-DD';
+const surveyStartDate = moment('2020-11-5', dateFormat);
+const surveyEndDate = moment('2020-12-13', dateFormat);
+const currentDate = moment();
+
+const SURVEY_DIALOG_DISMISSED_DATE = 'SURVEY_DIALOG_DISMISSED_DATE';
+
+const trySetDialogHasBeenDisplayedToLocalStorage = () => attempt(
+    () => window.localStorage.setItem(
+        SURVEY_DIALOG_DISMISSED_DATE,
+        currentDate.format(dateFormat),
+    ),
+);
+
+const dialogDateIsNotSavedAndCurrentInLocalStorage = () => {
+    const result = attempt(
+        () => window.localStorage.getItem(SURVEY_DIALOG_DISMISSED_DATE),
+    );
+
+    return isError(result) || moment(result).isBefore(surveyStartDate) || !result;
 };
 
 export default function SurveyDialogNotification() {
     const [dialogIsOpen, setDialogIsOpen] = useState(
+        currentDate.isSameOrAfter(surveyStartDate) &&
         currentDate.isBefore(surveyEndDate) &&
-            dialogEntryIsNotSavedInLocalStorage(),
+            dialogDateIsNotSavedAndCurrentInLocalStorage(),
     );
 
     const closeDialog = () => {


### PR DESCRIPTION
## Overview

Re-enables the temporary survey popup until December 13th, 2020.

Connects #1151 

## Demo

<img width="1313" alt="Screen Shot 2020-11-03 at 2 43 56 PM" src="https://user-images.githubusercontent.com/21046714/98035853-1e6c5880-1de7-11eb-9aea-74d390d31fb2.png">

## Testing Instructions

* Run `./scripts/server`
* Navigate to [:6543/](http://localhost:6543/). You should see the survey popup with the updated link. Close the popup. 
* Refresh the page. You should no longer see the popup. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
