### PR TITLE
Update contribute page text

### DIFF
--- a/src/app/src/components/Contribute.jsx
+++ b/src/app/src/components/Contribute.jsx
@@ -58,8 +58,12 @@ function ContributeList({
                     <Grid item xs={12}>
                         <p>
                             Read about how your facility lists are processed and
-                            matched in this&nbsp;
-                            <Link to={aboutProcessingRoute} href={aboutProcessingRoute}>guide</Link>
+                            matched in{' '}
+                            <Link
+                                to={aboutProcessingRoute}
+                                href={aboutProcessingRoute}
+                            >this guide
+                            </Link>
                         </p>
 
                         <p>

--- a/src/app/src/components/ContributeHeader.jsx
+++ b/src/app/src/components/ContributeHeader.jsx
@@ -12,35 +12,83 @@ const ContributeHeader = memo(() => (
                     Download the OAR Contributor Template and
                     copy and paste your list into the template.
                 </p>
+                <p>
+                    There are two Contributor Template options:
+                </p>
+                <ol>
+                    <li>
+                        <strong>Standard template:</strong> this is for all
+                        Contributors to the OAR, except for Contributors sharing
+                        data on PPE manufacturing
+                    </li>
+                    <li>
+                        <strong>PPE ONLY template:</strong> this is for any
+                        Contributor sharing information on PPE manufacturing
+                        ONLY and includes columns to specify the type of PPE
+                        being manufactured, e.g. scrubs, face masks, visors,
+                        gowns etc
+                    </li>
+                </ol>
+                <p className="form__label">
+                    Guidance for all uploads
+                </p>
                 <ul className="helper-list">
                     <li className="helper-list__item">
                         Do not change the column heading titles
                         in the first row.
                     </li>
                     <li className="helper-list__item">
-                        Your list should only contain production
-                        facilities, not office addresses or
-                        headquarters. This can include
-                        dyehouses, mills, laundries, cut and
-                        sew, RMG, embellishments and printing.
+                        Once reviewed for style guidance, delete the row of
+                        example facility data.
+                    </li>
+                    <li className="helper-list__item">
+                        The OAR accepts facilities throughout the supply chain,
+                        including dyehouses, mills, laundries, cut and sew, RMG,
+                        embellishments and printing. The OAR does not accept raw
+                        material locations, such as cotton farms or cattle
+                        ranches.
+                    </li>
+                    <li className="helper-list__item">
+                        The OAR only accepts apparel facility data. This
+                        includes facilities contributing to the production of
+                        footwear, accessories, leather goods and home textiles.
+                    </li>
+                    <li className="helper-list__item">
+                        The OAR accepts apparel <strong>production</strong>{' '}
+                        facilities. Your list should only contain production
+                        facilities, not office addresses or headquarters.
                     </li>
                     <li className="helper-list__item">
                         All fields in your list must be in English but may
                         include accented or other Unicode characters. Individual
-                        fields must separated with commas.
+                        fields must be separated with commas.
+                    </li>
+                    <li className="helper-list__item">
+                        Country names must be translated into English in order
+                        to be recognised by the system.
                     </li>
                     <li className="helper-list__item">
                         File size limit: 5MB
                     </li>
                     <li className="helper-list__item">
-                        Save your file as an{' '}
-                        <strong>
-                            Excel file (.xls, .xlsx)
-                        </strong>
-                        {' '}or as a{' '}
-                        <strong>
-                            CSV UTF-8 (.csv)
-                        </strong>
+                        Save your file as an Excel file (.xls, .xlsx)
+                        or as a CSV UTF-8 (.csv)
+                    </li>
+                    <li className="helper-list__item">
+                        Once your upload has been processed, navigate to the “My
+                        Lists” section of your account to review the results of
+                        the upload. Here you will be able to see any errors in
+                        your list, as well as facilities which require you to
+                        manually confirm or reject a match with facilities
+                        already in the database. For guidance on error messages
+                        and the confirm / reject process, see our
+                        <a
+                            href="https://info.openapparel.org/faq/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >{' '}
+                            FAQs
+                        </a>.
                     </li>
                 </ul>
                 <div style={{ margin: '20px 0' }}>
@@ -51,7 +99,7 @@ const ContributeHeader = memo(() => (
                         className="outlined-button outlined-button--inline"
                         href="/contributor-templates/OAR_Contributor_Template.xlsx"
                     >
-                        Download Excel (XLSX) Template
+                        Download Standard Excel (XLSX) Template
                     </MaterialButton>
                     <MaterialButton
                         disableRipple
@@ -60,7 +108,7 @@ const ContributeHeader = memo(() => (
                         className="outlined-button"
                         href="/contributor-templates/OAR_Contributor_Template.csv"
                     >
-                        Download CSV Template
+                        Download Standard CSV Template
                     </MaterialButton>
                 </div>
                 <FeatureFlag flag={PPE}>
@@ -72,7 +120,7 @@ const ContributeHeader = memo(() => (
                             className="outlined-button outlined-button--inline"
                             href="/contributor-templates/OAR_Contributor_Template_With_PPE.xlsx"
                         >
-                            Download Excel (XLSX) Template With PPE Columns
+                            Download PPE (XLSX) Template
                         </MaterialButton>
                         <MaterialButton
                             disableRipple
@@ -81,7 +129,7 @@ const ContributeHeader = memo(() => (
                             className="outlined-button"
                             href="/contributor-templates/OAR_Contributor_Template_With_PPE.csv"
                         >
-                            Download CSV Template With PPE Columns
+                            Download PPE CSV Template
                         </MaterialButton>
                     </div>
                 </FeatureFlag>


### PR DESCRIPTION
## Overview

Updates the /contribute page with new text provided by the OAR team.

Connects #1164 

## Demo

<img width="972" alt="Screen Shot 2020-11-09 at 3 56 40 PM" src="https://user-images.githubusercontent.com/17363/98606284-368b1e80-22a4-11eb-8613-425907fdea23.png">
<img width="973" alt="Screen Shot 2020-11-09 at 3 56 56 PM" src="https://user-images.githubusercontent.com/17363/98606356-5f131880-22a4-11eb-8aa8-d6cd2fc42ca8.png">

## Testing Instructions

* Log in and browse http://localhost:6543/contribute. Verify the content matches https://docs.google.com/document/d/14PzXmoq7AhVH-PF0PM6QgwpWi-SiGA4jhZ-9xLPaQpA/

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
