### PR TITLE
Include confirm and reject urls in API response examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+-   Include confirm and reject urls in API response examples [#1180](https://github.com/open-apparel-registry/open-apparel-registry/pull/1180)
+
 ### Deprecated
 
 ### Removed

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -916,7 +916,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     "claim_info": null,
                     "other_locations": []
                   },
-                  "confidence": 0.7686
+                  "confidence": 0.7686,
+                  "confirm_match_url": "/api/facility-matches/135005/confirm/",
+                  "reject_match_url": "/api/facility-matches/135005/reject/"
                 }
               ],
               "item_id": 959,
@@ -965,6 +967,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     "other_locations": []
                   },
                   "confidence": 0,
+                  "confirm_match_url": "/api/facility-matches/135005/confirm/",
+                  "reject_match_url": "/api/facility-matches/135005/reject/"
                   "text_only_match": true
                 }
               ],


### PR DESCRIPTION
## Overview

The pending match example JSON in existing API documentation did not include the `confirm_match_url` and `reject_match_url` fields that are returned when create=true.

## Notes

This omission was discovered when replying to a support email from an API user. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
