### PR TITLE
Update facility claims when merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+-    Update facility claims when merging [#1181](https://github.com/open-apparel-registry/open-apparel-registry/pull/1181)
+
 ### Security
 
 ## [2.36.0] - 2020-11-09


### PR DESCRIPTION
## Overview

When merging facilities, the duplicate facility is deleted, however we encountered exceptions when the facility to be deleted had related claim records.

To resolve this we associate claim records with the target facility and modify the status of the modified claim if appropriate.

Connects #1150

## Testing Instructions

* Check out `develop`
* Log in as c2@example.com
* Browse http://localhost:6543/, run a search, and copy the OAR IDs for three facilities
* Browse the detail page for the first facility, click the "claim this facility" link, and complete the wizard. 
* Browse the detail page for the second facility, click the "claim this facility" link, and complete the wizard for this facility as well. 
* Log in as c1@example.com and browse http://localhost:6543/dashboard/mergefacilities
* Enter the third (unclaimed) facility ID as the target and the claimed facility ID as the "merge," clicking "search" for each to load the details. 
* Click "Merge Facilities" and verify that an error is returned.
* Check out this branch
* Click "Merge Facilities" and verify that it succeeds
* Browse http://localhost:6543/dashboard/claims/ and verify that the claim has been associated with the target, third facility.
* Approve the claim on the third facility
* Browse http://localhost:6543/dashboard/mergefacilities and set the third facility with the approved claim as the target and the second facility with the pending claim as the merge facility.
* Click "Merge Facilities" and verify that it succeeds
* Browse http://localhost:6543/dashboard/claims/ and verify that the pending claim is denied and that both claims are associated with the target facility.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
