### PR TITLE
Remove leading and trailing whitespace from country when parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+-   Remove leading and trailing whitespace from country when parsing [#1184](https://github.com/open-apparel-registry/open-apparel-registry/pull/1184)
+
 ### Security
 
 ## [2.37.0] - 2020-11-24

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -87,7 +87,7 @@ def parse_csv_line(line):
 
 def get_country_code(country):
     # TODO: Handle minor spelling errors in country names
-    country = str(country)
+    country = str(country).strip()
     if country.upper() in COUNTRY_NAMES:
         return country.upper()
     elif country.lower() in COUNTRY_CODES:


### PR DESCRIPTION

## Overview

We look up country names in a static list to normalize them into ISO country codes. Having leading or trailing whitespace in the country field was causing the lookup to fail, resulting in a parse error.

Connects #1179

## Demo

### Before

<img width="1178" alt="Screen Shot 2020-12-08 at 9 22 46 PM" src="https://user-images.githubusercontent.com/17363/101585072-488fd800-399c-11eb-9ea3-1701a332494b.png">

### After

<img width="1303" alt="Screen Shot 2020-12-08 at 9 27 54 PM" src="https://user-images.githubusercontent.com/17363/101585087-4cbbf580-399c-11eb-8875-6b951d1bf9aa.png">

## Testing Instructions

* Check out **`develop`**
* Run ./scripts/resetdb
* Log in as `c2@example.com`
* Submit [azavea-country-padding.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/5663504/azavea-country-padding.csv.zip)
* `Run ./scripts/manage batch_process --list-id 16 --action parse`
  * Verify that there is a parse error.
  * Browse http://localhost:6543/lists/16 and click the row to see the error
* Check out **`bugfix/jcw/country-whitespace`**
* Browse http://localhost:6543/contribute and submit [azavea-country-padding.csv.zip](https://github.com/open-apparel-registry/open-apparel-registry/files/5663504/azavea-country-padding.csv.zip) again
* Fully process the list
  * `./scripts/manage batch_process --list-id 16 --action parse`
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Browse http://localhost:6543/lists/17 and verify that the list was successfully processed.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
