### PR TITLE
Fix pending matches bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -   Remove leading and trailing whitespace from country when parsing [#1184](https://github.com/open-apparel-registry/open-apparel-registry/pull/1184)
+-   Fix pending matches bug [#1189](https://github.com/open-apparel-registry/open-apparel-registry/pull/1189)
 
 ### Security
 

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -693,7 +693,7 @@ hr {
   .form__action {
     margin-bottom: 5px;
   }
-  
+
   .filter-sidebar-tabgroup {
     position: sticky !important;
     top: -11px;
@@ -755,8 +755,4 @@ hr {
 
 .STATUS_PARSED:not(:hover) {
   background: #fff !important;
-}
-
-.STATUS_POTENTIAL_MATCH--ACTIONS + .STATUS_POTENTIAL_MATCH--ACTIONS {
-  display: none !important;
 }

--- a/src/app/src/components/CellElement.jsx
+++ b/src/app/src/components/CellElement.jsx
@@ -247,7 +247,6 @@ export default class CellElement extends Component {
             <div
                 key={item.id}
                 style={confirmRejectMatchRowStyles.cellRowStyles}
-                className="STATUS_POTENTIAL_MATCH--ACTIONS"
             >
                 <div style={confirmRejectMatchRowStyles.cellActionStyles}>
                     <Button

--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
 
@@ -154,42 +153,35 @@ function FacilityListItemsConfirmationTableRow({
                     style={listTableCellStyles.nameCellStyles}
                     colSpan={2}
                 >
-                    {matchOARIDs ? (
-                        <>
-                            <b>Facility Match Name</b>
-                            <br />
-                            <Link
-                                to={makeFacilityDetailLink(matchOARIDs)}
-                                href={makeFacilityDetailLink(matchOARIDs)}
-                            >
-                                {matchNames}
-                            </Link>
-                        </>
-                    ) : (
-                        ' '
-                    )}
+                    <b>Facility Match Name</b>
+                    <FacilityListItemsDetailedTableRowCell
+                        title=" "
+                        stringisHidden={false}
+                        data={matchNames}
+                        hasActions={false}
+                        linkURLs={matchOARIDs.map(makeFacilityDetailLink)}
+                    />
                 </TableCell>
                 <TableCell
                     padding="default"
                     style={listTableCellStyles.addressCellStyles}
                     colSpan={2}
                 >
-                    {matchAddresses ? (
-                        <>
-                            <b>Facility Match Address</b>
-                            <br />
-                            {matchAddresses}
-                        </>
-                    ) : (
-                        ' '
-                    )}
+                    <b>Facility Match Address</b>
+                    <FacilityListItemsDetailedTableRowCell
+                        title=" "
+                        stringIsHidden={false}
+                        data={matchAddresses}
+                        hasActions={false}
+                    />
                 </TableCell>
                 <TableCell
                     padding="default"
                     style={listTableCellStyles.statusCellStyles}
                 >
+                    <b>Actions</b>
                     <FacilityListItemsDetailedTableRowCell
-                        title
+                        title=" "
                         stringIsHidden
                         data={matchConfirmOrRejectFunctions}
                         hasActions

--- a/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
+++ b/src/app/src/components/FacilityListItemsDetailedTableRowCell.jsx
@@ -71,7 +71,7 @@ export default function FacilityListItemsDetailedTableRowCell({
                 </div>
                 {
                     data.map((item, index) => (
-                        <Fragment key={hasActions ? item.id : item}>
+                        <Fragment key={item.id ? item.id : item}>
                             <CellElement
                                 item={item}
                                 fetching={fetching}


### PR DESCRIPTION
## Overview

During confirm/reject analysis of a list, the following bug was noticed.
When an entry had multiple potential matches, names and address of the
multiple facilities were not broken by line items. The links were
linked to an incorrect address. Additionally, the confirm and reject
button showed only for the top-most potential match.

When facilities have multiple potential matches, the matches show in
individual line items with a Confirm and Reject option for each
potential match.

There were a minor propType warning and key warning which have also
been corrected.

Connects #1185

## Demo

<img width="1185" alt="Screen Shot 2020-12-11 at 1 28 30 PM" src="https://user-images.githubusercontent.com/21046714/101945461-40ae7e80-3bbc-11eb-8485-77589c3bea2e.png">

## Notes

The line items aren't currently perfectly aligned. This PR fixes the functionality issue, but additional styling might be desired in the future. 

Currently, the matches are all stored in a single row, with each cell containing the section header and multiple matches' data for that value. Due to the varying height of the cells, and the cell component being used in multiple places, my attempts to fix this with styling were inefficient. I also worried that a set height to the cell content would cause overflow issues. 

My suggested long-term fix for the styling is to refactor this section to render the headers and each facility match as separate rows in the table, which would keep the line-items aligned despite the variable height. 

## Testing Instructions

* Checkout this branch.
* Run `vagrant ssh` and `./scripts/server`
* Navigate to [a list item with two pending matches](http://localhost:6543/lists/8?search=Hanes%20Choloma&page=1&rowsPerPage=20)
* The matches should be rendered as distinct items.
* The Facility Match Name link should lead to the correct facilities. 
* Selecting 'confirm' or 'reject' should confirm or reject the correct facility. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
