### PR TITLE
Allow setting NOTIFICATION_EMAIL_TO from a deployment var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+Allow setting NOTIFICATION_EMAIL_TO from a deployment var [#1203](https://github.com/open-apparel-registry/open-apparel-registry/pull/1203)
+
 ### Deprecated
 
 ### Removed

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -134,6 +134,7 @@ data "template_file" "app" {
     oar_client_key = "${var.oar_client_key}"
 
     default_from_email = "${var.default_from_email}"
+    notification_email_to = "${var.notification_email_to}"
 
     app_port = "${var.app_port}"
 
@@ -181,6 +182,7 @@ data "template_file" "app_cli" {
     oar_client_key = "${var.oar_client_key}"
 
     default_from_email = "${var.default_from_email}"
+    notification_email_to = "${var.notification_email_to}"
 
     app_port = "${var.app_port}"
 

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -24,6 +24,7 @@
         { "name": "DJANGO_ENV", "value": "${environment}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
+        { "name": "NOTIFICATION_EMAIL_TO", "value": "${notification_email_to}" },
         { "name": "GOOGLE_SERVER_SIDE_API_KEY", "value": "${google_server_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY", "value": "${google_client_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_ANALYTICS_KEY", "value": "${google_analytics_key}" },

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -15,6 +15,7 @@
         { "name": "DJANGO_ENV", "value": "${environment}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
+        { "name": "NOTIFICATION_EMAIL_TO", "value": "${notification_email_to}" },
         { "name": "GOOGLE_SERVER_SIDE_API_KEY", "value": "${google_server_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_CLIENT_SIDE_API_KEY", "value": "${google_client_side_api_key}" },
         { "name": "REACT_APP_GOOGLE_ANALYTICS_KEY", "value": "${google_analytics_key}" },

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -214,6 +214,8 @@ variable "django_secret_key" {}
 
 variable "default_from_email" {}
 
+variable "notification_email_to" {}
+
 variable "batch_default_ce_spot_fleet_bid_percentage" {
   default = "40"
 }


### PR DESCRIPTION
## Overview

The NOTIFICATION_EMAIL_TO setting is the address to which notifications about API usage limits are sent. We add the ability to set the value via a terraform variable during provisioning.

Connects #1202

## Demo

The ECS task properties after deploying to staging

<img width="962" alt="Screen Shot 2021-01-07 at 3 37 34 PM" src="https://user-images.githubusercontent.com/17363/103952995-8cdad900-50fe-11eb-81a9-8f1ed731f5ad.png">

## Testing Instructions

* Visually inspect the code and verify that task in the staging cluster have the environment variable set, 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
