### PR TITLE
Admin updates to allow filtering the source admin list by type and contributor and search users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -666,7 +666,9 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 -   Initial release.
 
-[unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/2.37.1...HEAD
+[unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/2.38.1...HEAD
+[2.38.1]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.38.1
+[2.38.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.38.0
 [2.37.1]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.37.1
 [2.37.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.37.0
 [2.36.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.36.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-Allow setting NOTIFICATION_EMAIL_TO from a deployment var [#1203](https://github.com/open-apparel-registry/open-apparel-registry/pull/1203)
+- Allow setting NOTIFICATION_EMAIL_TO from a deployment var [#1203](https://github.com/open-apparel-registry/open-apparel-registry/pull/1203)
+- Admin updates to allow filtering the source admin list by type and contributor and search users [#1207](https://github.com/open-apparel-registry/open-apparel-registry/pull/1207)
 
 ### Deprecated
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -50,6 +50,8 @@ class OarUserAdmin(UserAdmin):
                            'has_agreed_to_terms_of_service',
                            'groups')}),
     )
+    search_fields = ('email',)
+    list_display = ('email', 'is_active')
 
 
 class FacilityHistoryAdmin(SimpleHistoryAdmin):

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -110,6 +110,7 @@ class FacilityAliasAdmin(SimpleHistoryAdmin):
 
 class SourceAdmin(admin.ModelAdmin):
     readonly_fields = ('source_type', 'facility_list', 'create')
+    list_filter = ('source_type', 'contributor')
 
 
 class RequestLogAdmin(admin.ModelAdmin):


### PR DESCRIPTION


## Overview

Moving ownership of a public list to a new contributor account after they have registered is a common administrative activity. Now that the application is receiving thousands of API submissions, it is impractical to browse the Source list to find a specific list. Adding filters allows for more quickly finding a specific record.

Attempting to search for a user was raising an exception because by default it was attempting to search for `first_name` and `last_name` fields that we do not have on our User model. Setting `search_fields` resolves this.

We don't use `username` on our User model so setting `list_display` suppresses this always empty field in the list view.

Connects #935
Connects #1155

## Demo

<img width="840" alt="Screen Shot 2021-01-08 at 2 33 25 PM" src="https://user-images.githubusercontent.com/17363/104066342-7f852380-51be-11eb-8adf-95336c007e60.png">

<img width="1105" alt="Screen Shot 2021-01-08 at 2 33 00 PM" src="https://user-images.githubusercontent.com/17363/104066350-82801400-51be-11eb-825b-6564bb2f993e.png">


## Testing Instructions

* Log in as `c1@example.com`
* Browse http://localhost:8081/admin/api/source and verify that you can filter by type and contributor
* Browse http://localhost:8081/admin/api/user and verify that the search field at the top works

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
