### PR TITLE
Fix S3 permissions to allow CloudFront logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix S3 permissions to allow CloudFront logging [#1208](https://github.com/open-apparel-registry/open-apparel-registry/pull/1208)
+
 ### Security
 
 ## [2.38.1] - 2021-01-06

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -85,7 +85,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   logging_config {
     include_cookies = false
-    bucket          = "${aws_s3_bucket.logs.id}.s3.amazonaws.com"
+    bucket          = "${aws_s3_bucket.logs.bucket_domain_name}"
     prefix          = "CDN"
   }
 

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,6 +1,22 @@
+data "aws_canonical_user_id" "current" {}
+
+#
+# S3 resources
+#
 resource "aws_s3_bucket" "logs" {
   bucket = "${lower(replace(var.project, " ", ""))}-${lower(var.environment)}-logs-${var.aws_region}"
-  acl    = "private"
+
+  grant {
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+    id          = "${data.aws_canonical_user_id.current.id}"
+  }
+
+  grant {
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+    id          = "${var.aws_cloudfront_canonical_user_id}"
+  }
 
   tags {
     Name        = "${lower(replace(var.project, " ", ""))}-${lower(var.environment)}-logs-${var.aws_region}"
@@ -9,6 +25,9 @@ resource "aws_s3_bucket" "logs" {
   }
 }
 
+#
+# ECR resources
+#
 module "ecr_repository_app" {
   source = "github.com/azavea/terraform-aws-ecr-repository?ref=0.1.0"
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -273,3 +273,6 @@ variable "aws_lambda_service_role_policy_arn" {
 
 variable "oar_client_key" {}
 
+variable "aws_cloudfront_canonical_user_id" {
+  default = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+}


### PR DESCRIPTION
## Overview

Creates grants to prevent Terraform removing implicit grants that are usually created by AWS when creating a CloudFront distribution through the console. These grants have recently become necessary for CloudFront to persist access logs to S3.

The AWS canonical user grant replicates the permissions granted by the `private` canned ACL, and the CloudFront canonical user ID replicates the permissions granted when creating a distribution through the console.

## Testing Instructions

- Disable CloudFront logging for the staging distribution via the [AWS console](https://console.aws.amazon.com/cloudfront/v2/home#/logs/EBYID6SLCOLH6)
- Execute a Terraform plan/apply cycle using the changes on this branch and ensure that logging is reconfigured for the distribution

```console
bash-5.0# GIT_COMMIT="4090799" ./scripts/infra plan
bash-5.0# GIT_COMMIT="4090799" ./scripts/infra apply
```

- Interact with the [staging website](https://staging.openapparel.org/); ensure new log entries exist in the [S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/openapparelregistry-staging-logs-eu-west-1?region=eu-west-1&tab=objects)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
