### PR TITLE
Change monthly to yearly in API notification emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Change monthly to yearly in API notification emails [#1211](https://github.com/open-apparel-registry/open-apparel-registry/pull/1211)
+
 ### Security
 
 ## [2.38.2] - 2021-01-12

--- a/src/django/api/templates/mail/api_limit_admin_body.html
+++ b/src/django/api/templates/mail/api_limit_admin_body.html
@@ -13,12 +13,12 @@
         <p>
             You're receiving this email because {{ contributor_name }} has
             exceeded their limit of {{ grace_limit }} OAR API requests for this
-            month.
+            year.
         </p>
         {% else %}
         <p>
             You're receiving this email because {{ contributor_name }} has
-            exceeded their limit of {{ limit }} OAR API requests for this month.
+            exceeded their limit of {{ limit }} OAR API requests for this year.
         </p>
         {% endif %}
         <p>

--- a/src/django/api/templates/mail/api_limit_admin_body.txt
+++ b/src/django/api/templates/mail/api_limit_admin_body.txt
@@ -3,10 +3,10 @@ Hi,
 
 {% if grace_limit %}
 You're receiving this email because {{ contributor_name }} has exceeded
-their limit of {{ grace_limit }} OAR API requests for this month.
+their limit of {{ grace_limit }} OAR API requests for this year.
 {% else %}
 You're receiving this email because {{ contributor_name }} has exceeded
-their limit of {{ limit }} OAR API requests for this month.
+their limit of {{ limit }} OAR API requests for this year.
 {% endif %}
 
 Best wishes,

--- a/src/django/api/templates/mail/api_limit_body.html
+++ b/src/django/api/templates/mail/api_limit_body.html
@@ -12,12 +12,12 @@
         {% if grace_limit %}
         <p>
             You're receiving this email because you have exceeded your limit of
-            {{ grace_limit }} OAR API requests for this month.
+            {{ grace_limit }} OAR API requests for this year.
         </p>
         {% else %}
         <p>
             You're receiving this email because you have exceeded your limit of
-            {{ limit }} OAR API requests for this month.
+            {{ limit }} OAR API requests for this year.
         </p>
         {% endif %}
         <p>

--- a/src/django/api/templates/mail/api_limit_body.txt
+++ b/src/django/api/templates/mail/api_limit_body.txt
@@ -3,10 +3,10 @@ Hi,
 
 {% if grace_limit %}
 You're receiving this email because you have exceeded
-your limit of {{ grace_limit }} OAR API requests for this month.
+your limit of {{ grace_limit }} OAR API requests for this year.
 {% else %}
 You're receiving this email because you have exceeded
-your limit of {{ limit }} OAR API requests for this month.
+your limit of {{ limit }} OAR API requests for this year.
 {% endif %}
 
 Best wishes,

--- a/src/django/api/templates/mail/api_limit_warning_admin_body.html
+++ b/src/django/api/templates/mail/api_limit_warning_admin_body.html
@@ -11,7 +11,7 @@
         </p>
         <p>
             You're receiving this email because {{ contributor_name }} has used
-            90% of their limit of {{ limit }} OAR API requests for this month.
+            90% of their limit of {{ limit }} OAR API requests for this year.
         </p>
         <p>
             Best wishes,

--- a/src/django/api/templates/mail/api_limit_warning_admin_body.txt
+++ b/src/django/api/templates/mail/api_limit_warning_admin_body.txt
@@ -2,7 +2,7 @@
 Hi,
 
 You're receiving this email because {{ contributor_name }} has used 90% of
-their limit of {{ limit }} OAR API requests for this month.
+their limit of {{ limit }} OAR API requests for this year.
 
 Best wishes,
 

--- a/src/django/api/templates/mail/api_limit_warning_body.html
+++ b/src/django/api/templates/mail/api_limit_warning_body.html
@@ -11,7 +11,7 @@
         </p>
         <p>
             You're receiving this email because you have used 90% of your limit
-            of {{ limit }} OAR API requests for this month.
+            of {{ limit }} OAR API requests for this year.
         </p>
         <p>
             Best wishes,

--- a/src/django/api/templates/mail/api_limit_warning_body.txt
+++ b/src/django/api/templates/mail/api_limit_warning_body.txt
@@ -2,7 +2,7 @@
 Hi,
 
 You're receiving this email because you have used 90% of
-your limit of {{ limit }} OAR API requests for this month.
+your limit of {{ limit }} OAR API requests for this year.
 
 Best wishes,
 


### PR DESCRIPTION
## Overview

Change monthly to yearly in API notification emails. This was mistakenly omitted when converting from counting monthly to counting yearly.

Connects #1186

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
