### PR TITLE
Add a management command to make CSVs from a CSV download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a management command to make CSVs from a CSV download [#1214](https://github.com/open-apparel-registry/open-apparel-registry/pull/1214)
+
 ### Changed
 
 ### Deprecated

--- a/scripts/makefixtures
+++ b/scripts/makefixtures
@@ -17,6 +17,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        docker-compose exec django /bin/bash -c "pip install -q -r requirements.dev.txt && ./manage.py makefixtures"
+        docker-compose exec django /bin/bash -c "pip install -q -r requirements.dev.txt && ./manage.py makefixtures $*"
     fi
 fi

--- a/src/django/api/management/commands/makecsvs.py
+++ b/src/django/api/management/commands/makecsvs.py
@@ -1,0 +1,89 @@
+import csv
+import os
+import random
+from django.core.management.base import BaseCommand
+
+
+# Taken from https://stackoverflow.com/a/312464
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i: i + n]
+
+
+class Command(BaseCommand):
+    help = 'Take a downloaded facility CSV and make uploadable CSVs'
+
+    def add_arguments(self, parser):
+        parser.add_argument('csvfile',
+                            help='Path to a CSV downloaded from OAR')
+
+        parser.add_argument(
+            '-f',
+            '--filecount',
+            type=int,
+            help='The total number of files to create',
+            default=1,
+        )
+
+        parser.add_argument(
+            '-r',
+            '--rowcount',
+            type=int,
+            help='The total number of rows to create',
+            default=1,
+        )
+
+        parser.add_argument(
+            '-o',
+            '--outdir',
+            help='The existing directory into which files should be written',
+            default='./',
+        )
+
+    def handle(self, *args, **options):
+        csv_file = options['csvfile']
+        file_count = options['filecount']
+        row_count = options['rowcount']
+        out_dir = options['outdir']
+
+        random.seed(8675309)
+
+        rows = []
+        with open(csv_file) as f:
+            for row in csv.DictReader(f):
+                rows.append(
+                    {
+                        'country': row['country_code'],
+                        'name': row['name'],
+                        'address': row['address'],
+                        'lat': row['lat'],
+                        'lng': row['lng'],
+                    }
+                )
+
+        if row_count > len(rows):
+
+            def shuffle_words(text):
+                segments = text.split(' ')
+                return ' '.join(random.sample(segments, len(segments))).strip()
+
+            max_file_row = len(rows) - 1
+            for _ in range(len(rows), row_count):
+                new_row = rows[random.randint(0, max_file_row)].copy()
+                new_row['name'] = shuffle_words(new_row['name'])
+                new_row['address'] = shuffle_words(new_row['address'])
+                rows.append(new_row)
+
+        random.shuffle(rows)
+
+        chunk_size = len(rows) // file_count
+        for i, chunk in enumerate(chunks(rows, chunk_size)):
+            out_file = os.path.join(out_dir, '{}.csv'.format(i + 1))
+            with open(out_file, 'w') as f:
+                writer = csv.DictWriter(
+                    f, fieldnames=['country', 'name', 'address', 'lat', 'lng']
+                )
+                writer.writeheader()
+                for row in chunk:
+                    writer.writerow(row)

--- a/src/django/api/management/commands/makefixtures.py
+++ b/src/django/api/management/commands/makefixtures.py
@@ -409,31 +409,67 @@ class Command(BaseCommand):
         parser.add_argument('-m', '--match', action='store_true',
                             help='Create facilities and matches')
 
+        parser.add_argument(
+            '-u',
+            '--usercount',
+            type=int,
+            help='The number of user records to create',
+            default=100,
+        )
+
+        parser.add_argument(
+            '-c',
+            '--maxcontribid',
+            type=int,
+            help='The maximum contributor id. Range starts at 2',
+            default=99,
+        )
+
+        parser.add_argument(
+            '-l',
+            '--maxlistid',
+            type=int,
+            help='The maximum facility list id. Range starts at 2',
+            default=15,
+        )
+
+        parser.add_argument(
+            '-s',
+            '--maxsourceid',
+            type=int,
+            help='The maximum source id. Range starts at 2',
+            default=15,
+        )
+
     def handle(self, *args, **options):
         match = options['match']
+        user_count = options['usercount']
+        max_contributor_id = options['maxcontribid']
+        max_list_id = options['maxlistid']
+        max_source_id = options['maxsourceid']
 
         try:
-            list_items = make_facility_list_items()
+            list_items = make_facility_list_items(max_list_pk=max_list_id)
             if match:
                 facilities, matches = make_facilities_and_matches(list_items)
             else:
                 self.stderr.write("Skipped making facilities and matches")
 
             with open('/usr/local/src/api/fixtures/users.json', 'w') as f:
-                json.dump(make_users(), f, separators=(',', ': '),
-                          indent=4)
+                json.dump(make_users(count=user_count), f,
+                          separators=(',', ': '), indent=4)
             with open('/usr/local/src/api/fixtures/contributors.json',
                       'w') as f:
-                json.dump(make_contributors(), f, separators=(',', ': '),
-                          indent=4)
+                json.dump(make_contributors(max_id=max_contributor_id), f,
+                          separators=(',', ': '), indent=4)
             with open('/usr/local/src/api/fixtures/facility_lists.json',
                       'w') as f:
-                json.dump(make_facility_lists(), f, separators=(',', ': '),
-                          indent=4)
+                json.dump(make_facility_lists(max_id=max_list_id), f,
+                          separators=(',', ': '), indent=4)
             with open('/usr/local/src/api/fixtures/sources.json',
                       'w') as f:
-                json.dump(make_sources(), f, separators=(',', ': '),
-                          indent=4)
+                json.dump(make_sources(max_id=max_source_id), f,
+                          separators=(',', ': '), indent=4)
             with open('/usr/local/src/api/fixtures/facility_list_items.json',
                       'w') as f:
                 json.dump(list_items, f, separators=(',', ': '), indent=4)

--- a/src/django/api/management/commands/processfixtures.py
+++ b/src/django/api/management/commands/processfixtures.py
@@ -5,8 +5,27 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = 'Run all processing steps on data loaded from fixtures'
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-s',
+            '--startid',
+            type=int,
+            help='The start of the list ID range to process',
+            default=2,
+        )
+
+        parser.add_argument(
+            '-e',
+            '--endid',
+            type=int,
+            help='The end of the list ID range to process',
+            default=16,
+        )
+
     def handle(self, *args, **options):
-        for list_id in range(2, 16):
+        start_id = options['startid']
+        end_id = options['endid']
+        for list_id in range(start_id, end_id):
             for action in ('parse', 'geocode', 'match'):
                 call_command('batch_process',
                              '--list-id', list_id,


### PR DESCRIPTION
## Overview

Add a tool that allows us to generate a collection of CSV files suitable for uploading
by processing a CSV downloaded from the running application with the option of generating more output rows than exist in the input. Parameterize `makefixtures` and `processfixtures` so that they can be run with larger input sets.

Connects #1205

## Testing Instructions

* Run `./scripts/server`
* Download and unzip `{secure file storage}/Open\ Apparel\ Registry/data-dumps-for-testing/facilities-2021-01-25.csv.zip` into `src/django/facilities-2021-01-25.csv`
* `mkdir src/django/out`
* Run makecsvs 
```
vagrant@vagrant:/vagrant$ ./scripts/manage makecsvs -f 100 -r 100000 -o out facilities-2021-01-25.csv
```
* Copy the new csvs into place
```
vagrant@vagrant:/vagrant$ cp src/django/out/*.csv src/django/api/management/commands/facility_lists/geocoded/
```
* Verify `src/django/out` contains 100 files. Inspect one and make sure the structure looks good
* Run makefixtures 
```
vagrant@vagrant:/vagrant$ ./scripts/makefixtures -u 1000 -c 999 -l 100 -s 100
```
* Run `./scripts/resetdb` and `./scripts/manage processfixtures --startid 16 --endid 101`. The `processfixtures` process will take a while because it needs to run 84 addition files through the matcher. (the first 16 are handled by `resetdb`)
* Verify that it runs without failure (parse and match errors that do not crash the process are fine)
* Browse http://localhost:6543/ and verify there are about 90k facilities (There are some parse errors the number of matches created will be different each time, so there is not an exact target number of facilities)
* After testing clean up your working copy
```
rm src/django/api/management/commands/facility_lists/geocoded/*.csv
git checkout src/django/api/management/commands/facility_lists/geocoded
```  
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
