### PR TITLE
Only show cookie preferences for the logged in user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Only show cookie preferences for the logged in user [#1229](https://github.com/open-apparel-registry/open-apparel-registry/pull/1229)
+
 ### Security
 
 ## [2.39.0] - 2021-01-28

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -233,6 +233,10 @@ class UserProfile extends Component {
             ? <UserAPITokens />
             : null;
 
+        const cookiePreferences = isEditableProfile
+            ? <UserCookiePreferences />
+            : null;
+
         return (
             <AppOverflow>
                 <AppGrid
@@ -244,7 +248,7 @@ class UserProfile extends Component {
                         {facilityLists}
                         {errorMessages}
                         {submitButton}
-                        <UserCookiePreferences />
+                        {cookiePreferences}
                         {apiTokensSection}
                     </Grid>
                 </AppGrid>


### PR DESCRIPTION
## Overview

It is confusing to show the cookie preferences section on the profile pages for users other than the currently logged in user since it appears that they would have the ability to change the preferences for other users.

Connects #1228

## Testing Instructions

These steps assume `./scripts/resetdb` has been run

* Log out
* Browse http://localhost:6543/profile/2 and verify that the cookie preferences section is not shown.
* Log in as c2@example.com:password
* Browse http://localhost:6543/profile/2 and verify that the cookie preferences section appears
* Browse http://localhost:6543/profile/3 and verify that the cookie preferences section is not shown.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
