### PR TITLE
Rename Taiwan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Rename Taiwan [#1234](https://github.com/open-apparel-registry/open-apparel-registry/pull/1234)
+
 ### Deprecated
 
 ### Removed

--- a/src/django/api/countries.py
+++ b/src/django/api/countries.py
@@ -217,7 +217,7 @@ COUNTRY_CHOICES = [
     ('SE', 'Sweden'),
     ('CH', 'Switzerland'),
     ('SY', 'Syrian Arab Republic'),
-    ('TW', 'Taiwan, Province of China'),
+    ('TW', 'Taiwan'),
     ('TJ', 'Tajikistan'),
     ('TZ', 'Tanzania, United Republic of'),
     ('TH', 'Thailand'),


### PR DESCRIPTION
## Overview

China's claim on Taiwan is not recognised by US nor international law.
We have been advised to switch Taiwan's listing in the OAR to reflect
this.

Connects #1226 

## Demo

<img width="416" alt="Screen Shot 2021-02-08 at 11 32 04 AM" src="https://user-images.githubusercontent.com/21046714/107251321-39f88800-6a02-11eb-9254-ff1f7a6a9914.png">

## Testing Instructions

* Run `./scripts/server`
* Confirm that Taiwan is named appropriately in the countries dropdown at [:6543](http://localhost:6543/)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
