### PR TITLE
Report facility status from facility details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add a management command to make CSVs from a CSV download [#1214](https://github.com/open-apparel-registry/open-apparel-registry/pull/1214)
 - Add API for reporting a facility as closed or reopened [#1231](https://github.com/open-apparel-registry/open-apparel-registry/pull/1231)
 - Confirm or reject status reports [#1235](https://github.com/open-apparel-registry/open-apparel-registry/pull/1235)
+- Report Facility Status from Facility Details [#1239](https://github.com/open-apparel-registry/open-apparel-registry/pull/1239)
 
 ### Changed
 

--- a/src/app/src/actions/dashboardActivityReports.js
+++ b/src/app/src/actions/dashboardActivityReports.js
@@ -7,6 +7,7 @@ import {
     makeDashboardActivityReportsURL,
     makeRejectDashboardActivityReportURL,
     makeConfirmDashboardActivityReportURL,
+    makeCreateDashboardActivityReportURL,
 } from '../util/util';
 
 export const startFetchDashboardActivityReports = createAction('START_FETCH_DASHBOARD_ACTIVITY_REPORTS');
@@ -74,3 +75,32 @@ export function confirmDashboardActivityReport({ id, statusChangeReason }) {
                 ));
     };
 }
+
+export const startCreateDashboardActivityReport = createAction('START_CREATE_DASHBOARD_ACTIVITY_REPORT');
+export const failCreateDashboardActivityReport = createAction('FAIL_CREATE_DASHBOARD_ACTIVITY_REPORT');
+export const completeCreateDashboardActivityReport = createAction('COMPLETE_CREATE_DASHBOARD_ACTIVITY_REPORT');
+
+export function createDashboardActivityReport({ id, reasonForReport, closureState }) {
+    return (dispatch) => {
+        dispatch(startCreateDashboardActivityReport());
+
+        return apiRequest
+            .post(makeCreateDashboardActivityReportURL(id), {
+                reason_for_report: reasonForReport,
+                closure_state: closureState,
+            })
+            .then(({ data }) => dispatch(completeCreateDashboardActivityReport({
+                data, message: `Successfully reported facility as ${data.closure_state.toLowerCase()}.`,
+            })))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented creating a facility activity report',
+                        failCreateDashboardActivityReport,
+                    ),
+                ));
+    };
+}
+
+export const resetDashbooardActivityReports = createAction('RESET_DASHBOARD_ACTIVITY_REPORTS');

--- a/src/app/src/components/DashboardActivityReportToast.jsx
+++ b/src/app/src/components/DashboardActivityReportToast.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import { arrayOf, string } from 'prop-types';
+
+import Snackbar from '@material-ui/core/Snackbar';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+
+const gradient = 'linear-gradient(-90deg, rgb(224, 32, 32) 0%, rgb(163, 79, 165) 21%, rgb(0, 145, 255) 51%, rgb(91, 201, 238) 79%, rgb(109, 212, 0) 100%)';
+
+const styles = {
+    message: {
+        bottom: '75px',
+    },
+    messageGradient: {
+        width: '368px',
+        background: gradient,
+        borderRadius: '0px 0px 2px 2px',
+        padding: '0 0 6px 0',
+    },
+    messageContainer: {
+        minHeight: '30px',
+        padding: 0,
+        width: '100%',
+        borderRadius: '0px 0px 2px 2px',
+    },
+    messageContent: {
+        minHeight: '30px',
+        padding: '5px 10px',
+        background: 'white',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    errors: {
+        bottom: '50px',
+    },
+};
+
+function DashboardActivityReportToast({ error, message, resetReports }) {
+    const [showErrors, setShowErrors] = useState(false);
+    const [showMessage, setShowMessage] = useState(false);
+
+    useEffect(() => {
+        if (error && error.length) {
+            setShowErrors(true);
+        } else {
+            setShowErrors(false);
+        }
+    }, [error]);
+
+    useEffect(() => {
+        if (message && message.length) {
+            setShowMessage(true);
+        } else {
+            setShowMessage(false);
+        }
+    }, [message]);
+
+    const handleCloseToast = () => {
+        setShowMessage(false);
+        setShowErrors(false);
+        resetReports();
+    };
+
+    const errorsToast = (
+        <Snackbar
+            anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+            }}
+            open={showErrors}
+            style={styles.errors}
+            autoHideDuration={6000}
+            onClose={handleCloseToast}
+            message={error && error.map(e => <span key={e}>{e}</span>)}
+            action={[
+                <IconButton
+                    key="close"
+                    aria-label="Close"
+                    color="inherit"
+                    onClick={handleCloseToast}
+                >
+                    <CloseIcon />
+                </IconButton>,
+            ]}
+        />
+    );
+
+    const messageToast = (
+        <Snackbar
+            anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+            }}
+            style={styles.message}
+            open={showMessage}
+            autoHideDuration={6000}
+            onClose={handleCloseToast}
+        >
+            <Paper style={styles.messageContainer}>
+                <div style={styles.messageGradient}>
+                    <div style={styles.messageContent}>
+                        <Typography>{message}</Typography>
+                        <IconButton
+                            key="close"
+                            aria-label="Close"
+                            color="inherit"
+                            onClick={handleCloseToast}
+                        >
+                            <CloseIcon />
+                        </IconButton>
+                    </div>
+                </div>
+            </Paper>
+        </Snackbar>
+    );
+
+    return (
+        <>
+            {errorsToast}
+            {messageToast}
+        </>
+    );
+}
+
+DashboardActivityReportToast.propTypes = {
+    error: arrayOf(string),
+    message: string,
+};
+
+export default DashboardActivityReportToast;

--- a/src/app/src/components/DashboardActivityReportToast.jsx
+++ b/src/app/src/components/DashboardActivityReportToast.jsx
@@ -14,7 +14,8 @@ const styles = {
         bottom: '75px',
     },
     messageGradient: {
-        width: '368px',
+        minWidth: '368px',
+        width: '100%',
         background: gradient,
         borderRadius: '0px 0px 2px 2px',
         padding: '0 0 6px 0',

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -20,6 +20,7 @@ import FeatureFlag from './FeatureFlag';
 import BadgeUnclaimed from './BadgeUnclaimed';
 import BadgeVerified from './BadgeVerified';
 import ShowOnly from './ShowOnly';
+import ReportFacilityStatus from './ReportFacilityStatus';
 
 import {
     fetchSingleFacility,
@@ -361,6 +362,7 @@ class FacilityDetailSidebar extends Component {
                                         </Link>
                                     </FeatureFlag>
                                 </ShowOnly>
+                                <ReportFacilityStatus data={data} />
                             </div>
                         </div>
                     </div>

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -16,6 +16,7 @@ import FacilityDetailSidebarInfo from './FacilityDetailSidebarInfo';
 import FacilityDetailsSidebarOtherLocations from './FacilityDetailsSidebarOtherLocations';
 import FacilityDetailSidebarClaimedInfo from './FacilityDetailSidebarClaimedInfo';
 import FacilityDetailSidebarPPE from './FacilityDetailSidebarPPE';
+import FacilityDetailStatusList from './FacilityDetailStatusList';
 import FeatureFlag from './FeatureFlag';
 import BadgeUnclaimed from './BadgeUnclaimed';
 import BadgeVerified from './BadgeVerified';
@@ -66,6 +67,27 @@ const detailsSidebarStyles = Object.freeze({
     linkStyle: Object.freeze({
         display: 'inline-block',
         fontSize: '16px',
+    }),
+    closureRibbon: Object.freeze({
+        background: 'rgb(255, 218, 162)',
+        borderRadius: '4px',
+        border: '1px solid rgb(134, 65, 15)',
+        color: 'rgb(85, 43, 12)',
+        fontSize: '14px',
+        fontWeight: 'bold',
+        padding: '5px',
+        margin: '10px 5px 0 5px',
+        textAlign: 'center',
+    }),
+    pendingRibbon: Object.freeze({
+        borderRadius: '4px',
+        border: '1px solid rgb(134, 65, 15)',
+        color: 'rgb(85, 43, 12)',
+        fontSize: '14px',
+        fontWeight: 'bold',
+        padding: '5px',
+        margin: '10px 5px 0 5px',
+        textAlign: 'center',
     }),
 });
 
@@ -193,6 +215,26 @@ class FacilityDetailSidebar extends Component {
 
         const facilityClaimID = get(data, 'properties.claim_info.id', null);
 
+        const report = get(data, 'properties.activity_reports[0]');
+        const renderStatusRibbon = () => {
+            if (!report) return null;
+            if (report.status === 'PENDING') {
+                return (
+                    <div style={detailsSidebarStyles.pendingRibbon}>
+                        Reported as {report.closure_state.toLowerCase()} (status pending).
+                    </div>
+                );
+            }
+            if (data.properties.is_closed) {
+                return (
+                    <div style={detailsSidebarStyles.closureRibbon}>
+                        This facility is closed.
+                    </div>
+                );
+            }
+            return null;
+        };
+
         return (
             <div className="control-panel facility-detail">
                 <div className="panel-header display-flex">
@@ -256,6 +298,7 @@ class FacilityDetailSidebar extends Component {
                     </FeatureFlag>
                 </div>
                 <div className="facility-detail_data">
+                    {renderStatusRibbon()}
                     <FacilityDetailsStaticMap data={data} />
                     <div className="control-panel__content">
                         <div className="control-panel__group">
@@ -295,6 +338,9 @@ class FacilityDetailSidebar extends Component {
                                 />
                             </ShowOnly>
                         </FeatureFlag>
+                        <FacilityDetailStatusList
+                            activityReports={data.properties.activity_reports}
+                        />
                         <div className="control-panel__group">
                             <div style={detailsSidebarStyles.linkSectionStyle}>
                                 <ShowOnly when={!facilityIsClaimedByCurrentUser}>

--- a/src/app/src/components/FacilityDetailStatusList.jsx
+++ b/src/app/src/components/FacilityDetailStatusList.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import moment from 'moment';
+
+import ShowOnly from './ShowOnly';
+
+const styles = {
+    list: {
+        marginBottom: '12px',
+    },
+};
+
+const formatDate = date => moment(date).format('MMM. D, YYYY');
+
+function FacilityDetailStatusList({ activityReports }) {
+    return (
+        <ShowOnly when={!!activityReports.length}>
+            <div className="control-panel__group">
+                <h1 className="control-panel__heading">
+                    Status
+                </h1>
+                <div className="control-panel__body">
+                    {activityReports.map((report) => {
+                        const {
+                            closure_state: closureState,
+                            reported_by_contributor: user,
+                            created_at: created,
+                            status_change_date: statusChangeDate,
+                            status,
+                        } = report;
+                        const state = closureState.toLowerCase();
+                        return (
+                            <ul key={report.id} style={styles.list}>
+                                <li>Reported {state} by {user} on {formatDate(created)}</li>
+                                {status === 'CONFIRMED' && (
+                                    <li>
+                                        Verified as {state} on {formatDate(statusChangeDate)}
+                                    </li>
+                                )}
+                            </ul>
+                        );
+                    })}
+                </div>
+            </div>
+        </ShowOnly>
+    );
+}
+
+export default FacilityDetailStatusList;

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -51,6 +51,8 @@ const facilitiesTabStyles = Object.freeze({
     }),
     listItemStyles: Object.freeze({
         wordWrap: 'anywhere',
+        flexDirection: 'column',
+        alignItems: 'start',
     }),
     listHeaderStyles: Object.freeze({
         backgroundColor: COLOURS.WHITE,
@@ -85,6 +87,16 @@ const facilitiesTabStyles = Object.freeze({
     }),
     downloadLabelStyles: Object.freeze({
         margin: '5px 0',
+    }),
+    closureRibbon: Object.freeze({
+        background: 'rgb(255, 218, 162)',
+        borderRadius: '4px',
+        border: '1px solid rgb(134, 65, 15)',
+        color: 'rgb(85, 43, 12)',
+        fontSize: '14px',
+        fontWeight: 'bold',
+        padding: '0 5px',
+        marginTop: '5px',
     }),
 });
 
@@ -277,6 +289,7 @@ function FilterSidebarFacilitiesTab({
                                         name,
                                         country_name: countryName,
                                         oar_id: oarID,
+                                        is_closed: isClosed,
                                     },
                                 }) => (
                                     <Fragment key={oarID}>
@@ -300,6 +313,11 @@ function FilterSidebarFacilitiesTab({
                                                     secondary={address}
                                                 />
                                             </Link>
+                                            {isClosed && (
+                                                <div style={facilitiesTabStyles.closureRibbon}>
+                                                    Closed facility
+                                                </div>
+                                            )}
                                         </ListItem>
                                     </Fragment>))
                         }

--- a/src/app/src/components/ReportFacilityStatus.jsx
+++ b/src/app/src/components/ReportFacilityStatus.jsx
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+
+import Button from '@material-ui/core/Button';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import DashboardActivityReportToast from './DashboardActivityReportToast';
+import ShowOnly from './ShowOnly';
+
+import {
+    createDashboardActivityReport,
+    resetDashbooardActivityReports,
+} from '../actions/dashboardActivityReports';
+
+import { facilityDetailsPropType } from '../util/propTypes';
+
+const styles = Object.freeze({
+    linkStyle: Object.freeze({
+        display: 'inline-block',
+        fontSize: '16px',
+        background: 'none',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+    }),
+    facilityName: Object.freeze({
+        padding: '5px 0 15px',
+    }),
+    description: Object.freeze({
+        fontWeight: 'bold',
+        color: 'rgb(27, 27, 26)',
+        fontSize: '16px',
+    }),
+    dialogActionsStyles: Object.freeze({
+        display: 'flex',
+        justifyContent: 'space-evenly',
+        alignItems: 'center',
+        padding: '10px',
+    }),
+    dialogContainerStyles: Object.freeze({
+        padding: '10px',
+    }),
+    dialogTextFieldStyles: Object.freeze({
+        width: '100%',
+        marginTop: '10px',
+        minWidth: '300px',
+    }),
+});
+
+function ReportFacilityStatus({
+    data,
+    user,
+    dashboardActivityReports: { activityReports },
+    submitReport,
+    resetReports,
+}) {
+    const [showDialog, setShowDialog] = useState(false);
+    const [reasonForReport, setReportReason] = useState('');
+
+    const closeDialog = () => {
+        setShowDialog(false);
+        setReportReason('');
+    };
+
+    const handleSubmit = () => {
+        if (!reasonForReport.length) return;
+        const closureState = data.properties.is_closed ? 'OPEN' : 'CLOSED';
+        submitReport({ id: data.id, reasonForReport, closureState });
+        closeDialog();
+    };
+
+    const dialog = (
+        <Dialog
+            open={showDialog}
+            onClose={closeDialog}
+            aria-labelledby="status-dialogue"
+            aria-describedby="status-dialog-description"
+            style={styles.dialogContainerStyles}
+        >
+            <DialogTitle id="status-dialog-title">
+                {`Report facility ${
+                    data.properties.is_closed ? 'reopened' : 'closed'
+                }`}
+                <Typography style={styles.facilityName}>
+                    {data.properties.name}
+                </Typography>
+                <Divider />
+            </DialogTitle>
+            <DialogContent>
+                <DialogContentText
+                    id="status-dialog-description"
+                    style={styles.description}
+                >
+                    Please provide information the OAR team can use to
+                    verify this status change.
+                </DialogContentText>
+                <TextField
+                    autoFocus
+                    margin="dense"
+                    id="report-reason"
+                    variant="outlined"
+                    multiline
+                    rows={4}
+                    value={reasonForReport}
+                    style={styles.dialogTextFieldStyles}
+                    onChange={e => setReportReason(e.target.value)}
+                />
+            </DialogContent>
+            <DialogActions
+                style={styles.dialogActionsStyles}
+            >
+                <Button onClick={closeDialog}>
+                  Cancel
+                </Button>
+                <Button onClick={handleSubmit} color="primary" variant="contained">
+                  Report
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+
+    return (
+        <div>
+            <ShowOnly when={!!user}>
+                <button
+                    className="link-underline small"
+                    style={styles.linkStyle}
+                    to="#"
+                    onClick={() => setShowDialog(true)}
+                    type="button"
+                >
+                    Report facility as {data.properties.is_closed ? 'reopened' : 'closed'}
+                </button>
+            </ShowOnly>
+            {dialog}
+            <DashboardActivityReportToast
+                {...activityReports}
+                resetReports={resetReports}
+            />
+        </div>
+    );
+}
+
+ReportFacilityStatus.propTypes = {
+    data: facilityDetailsPropType.isRequired,
+};
+
+function mapStateToProps({ dashboardActivityReports, auth: { user: { user } } }) {
+    return { dashboardActivityReports, user };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        submitReport: data => dispatch(createDashboardActivityReport(data)),
+        resetReports: () => dispatch(resetDashbooardActivityReports()),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(ReportFacilityStatus);

--- a/src/app/src/components/ReportFacilityStatus.jsx
+++ b/src/app/src/components/ReportFacilityStatus.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import Button from '@material-ui/core/Button';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -10,8 +11,8 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import Divider from '@material-ui/core/Divider';
+
 import DashboardActivityReportToast from './DashboardActivityReportToast';
-import ShowOnly from './ShowOnly';
 
 import {
     createDashboardActivityReport,
@@ -19,6 +20,7 @@ import {
 } from '../actions/dashboardActivityReports';
 
 import { facilityDetailsPropType } from '../util/propTypes';
+import { authLoginFormRoute } from '../util/constants';
 
 const styles = Object.freeze({
     linkStyle: Object.freeze({
@@ -75,6 +77,18 @@ function ReportFacilityStatus({
         closeDialog();
     };
 
+    const loginButton = (
+        <Button
+            variant="contained"
+            color="primary"
+            onClick={closeDialog}
+            component={Link}
+            to={authLoginFormRoute}
+        >
+            Log In
+        </Button>
+    );
+
     const dialog = (
         <Dialog
             open={showDialog}
@@ -92,52 +106,71 @@ function ReportFacilityStatus({
                 </Typography>
                 <Divider />
             </DialogTitle>
-            <DialogContent>
-                <DialogContentText
-                    id="status-dialog-description"
-                    style={styles.description}
+            {!user ? (
+                <DialogContent>
+                    <DialogContentText
+                        id="status-dialog-description"
+                        style={styles.description}
+                    >
+                        {`You must be logged in to report this facility as ${
+                            data.properties.is_closed ? 'reopened' : 'closed'
+                        }`}
+                    </DialogContentText>
+                </DialogContent>
+            ) : (
+                <DialogContent>
+                    <DialogContentText
+                        id="status-dialog-description"
+                        style={styles.description}
+                    >
+                        Please provide information the OAR team can use to
+                        verify this status change.
+                    </DialogContentText>
+                    <TextField
+                        autoFocus
+                        margin="dense"
+                        id="report-reason"
+                        variant="outlined"
+                        multiline
+                        rows={4}
+                        value={reasonForReport}
+                        style={styles.dialogTextFieldStyles}
+                        onChange={e => setReportReason(e.target.value)}
+                    />
+                </DialogContent>
+            )}
+            {!user ? (
+                <DialogActions
+                    style={styles.dialogActionsStyles}
                 >
-                    Please provide information the OAR team can use to
-                    verify this status change.
-                </DialogContentText>
-                <TextField
-                    autoFocus
-                    margin="dense"
-                    id="report-reason"
-                    variant="outlined"
-                    multiline
-                    rows={4}
-                    value={reasonForReport}
-                    style={styles.dialogTextFieldStyles}
-                    onChange={e => setReportReason(e.target.value)}
-                />
-            </DialogContent>
-            <DialogActions
-                style={styles.dialogActionsStyles}
-            >
-                <Button onClick={closeDialog}>
-                  Cancel
-                </Button>
-                <Button onClick={handleSubmit} color="primary" variant="contained">
-                  Report
-                </Button>
-            </DialogActions>
+                    {loginButton}
+                </DialogActions>
+            ) : (
+                <DialogActions
+                    style={styles.dialogActionsStyles}
+                >
+                    <Button onClick={closeDialog}>
+                      Cancel
+                    </Button>
+                    <Button onClick={handleSubmit} color="primary" variant="contained">
+                      Report
+                    </Button>
+                </DialogActions>
+            )}
         </Dialog>
     );
 
     return (
         <div>
-            <ShowOnly when={!!user}>
-                <button
-                    className="link-underline small"
-                    style={styles.linkStyle}
-                    to="#"
-                    onClick={() => setShowDialog(true)}
-                    type="button"
-                >
-                    Report facility as {data.properties.is_closed ? 'reopened' : 'closed'}
-                </button>
-            </ShowOnly>
+            <button
+                className="link-underline small"
+                style={styles.linkStyle}
+                to="#"
+                onClick={() => setShowDialog(true)}
+                type="button"
+            >
+                Report facility as {data.properties.is_closed ? 'reopened' : 'closed'}
+            </button>
             {dialog}
             <DashboardActivityReportToast
                 {...activityReports}

--- a/src/app/src/reducers/DashboardActivityReportsReducer.js
+++ b/src/app/src/reducers/DashboardActivityReportsReducer.js
@@ -8,6 +8,10 @@ import {
     startUpdateDashboardActivityReport,
     failUpdateDashboardActivityReport,
     completeUpdateDashboardActivityReport,
+    startCreateDashboardActivityReport,
+    failCreateDashboardActivityReport,
+    completeCreateDashboardActivityReport,
+    resetDashbooardActivityReports,
 } from '../actions/dashboardActivityReports';
 
 import { completeSubmitLogOut } from '../actions/auth';
@@ -17,6 +21,7 @@ const initialState = Object.freeze({
         data: Object.freeze([]),
         fetching: false,
         error: null,
+        message: null,
     }),
 });
 
@@ -27,6 +32,7 @@ export default createReducer(
                 activityReports: {
                     fetching: { $set: true },
                     error: { $set: null },
+                    message: { $set: null },
                 },
             }),
         [failFetchDashboardActivityReports]: (state, payload) =>
@@ -34,6 +40,7 @@ export default createReducer(
                 activityReports: {
                     fetching: { $set: false },
                     error: { $set: payload },
+                    message: { $set: null },
                 },
             }),
         [completeFetchDashboardActivityReports]: (state, payload) =>
@@ -42,18 +49,21 @@ export default createReducer(
                     fetching: { $set: false },
                     error: { $set: null },
                     data: { $set: payload },
+                    message: { $set: null },
                 },
             }),
         [startUpdateDashboardActivityReport]: state =>
             update(state, {
                 activityReports: {
                     error: { $set: null },
+                    message: { $set: null },
                 },
             }),
         [failUpdateDashboardActivityReport]: (state, payload) =>
             update(state, {
                 activityReports: {
                     error: { $set: payload },
+                    message: { $set: null },
                 },
             }),
         [completeUpdateDashboardActivityReport]: (state, payload) =>
@@ -65,8 +75,32 @@ export default createReducer(
                         return [...data.slice(0, index), payload, ...data.slice(index + 1)];
                     },
                     },
+                    message: { $set: null },
                 },
             }),
+        [startCreateDashboardActivityReport]: state =>
+            update(state, {
+                activityReports: {
+                    error: { $set: null },
+                    message: { $set: null },
+                },
+            }),
+        [failCreateDashboardActivityReport]: (state, payload) =>
+            update(state, {
+                activityReports: {
+                    error: { $set: payload },
+                    message: { $set: null },
+                },
+            }),
+        [completeCreateDashboardActivityReport]: (state, payload) =>
+            update(state, {
+                activityReports: {
+                    error: { $set: null },
+                    data: { $unshift: [payload.data] },
+                    message: { $set: payload.message },
+                },
+            }),
+        [resetDashbooardActivityReports]: () => initialState,
         [completeSubmitLogOut]: () => initialState,
     },
     initialState,

--- a/src/app/src/reducers/FacilitiesReducer.js
+++ b/src/app/src/reducers/FacilitiesReducer.js
@@ -28,6 +28,10 @@ import {
     updateAllFilters,
 } from '../actions/filters';
 
+import {
+    completeCreateDashboardActivityReport,
+} from '../actions/dashboardActivityReports';
+
 import { makeFeatureCollectionFromSingleFeature } from '../util/util';
 
 import { completeSubmitLogOut } from '../actions/auth';
@@ -160,4 +164,13 @@ export default createReducer({
     [resetAllFilters]: clearFacilitiesDataOnFilterChange,
     [updateAllFilters]: clearFacilitiesDataOnFilterChange,
     [completeSubmitLogOut]: clearFacilitiesDataOnFilterChange,
+    [completeCreateDashboardActivityReport]: (state, payload) => update(state, {
+        singleFacility: {
+            data: {
+                properties: {
+                    activity_reports: { $unshift: [payload.data] },
+                },
+            },
+        },
+    }),
 }, initialState);

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -88,6 +88,7 @@ export const makeDashboardApiBlockURL = id => `/api/api-blocks/${id}/`;
 export const makeDashboardActivityReportsURL = () => '/api/facility-activity-reports/';
 export const makeRejectDashboardActivityReportURL = id => `/api/facility-activity-reports/${id}/reject/`;
 export const makeConfirmDashboardActivityReportURL = id => `/api/facility-activity-reports/${id}/approve/`;
+export const makeCreateDashboardActivityReportURL = oarId => `/api/facilities/${oarId}/report/`;
 
 export const makeAPITokenURL = () => '/api-token-auth/';
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1490,6 +1490,13 @@ class Facility(PPEMixin):
 
         return '{}-{}'.format(timestamp, tile_version)
 
+    def activity_reports(self):
+        return FacilityActivityReport.objects \
+                    .filter(facility=self.id,
+                            status__in=[FacilityActivityReport.PENDING,
+                                        FacilityActivityReport.CONFIRMED]) \
+                    .order_by('-created_at')
+
 
 class FacilityMatch(models.Model):
     """

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -470,6 +470,7 @@ class FacilityDetailsSerializer(FacilitySerializer):
     other_locations = SerializerMethodField()
     country_name = SerializerMethodField()
     claim_info = SerializerMethodField()
+    activity_reports = SerializerMethodField()
 
     class Meta:
         model = Facility
@@ -477,7 +478,8 @@ class FacilityDetailsSerializer(FacilitySerializer):
                   'oar_id', 'other_names', 'other_addresses', 'contributors',
                   'country_name', 'claim_info', 'other_locations',
                   'ppe_product_types', 'ppe_contact_phone',
-                  'ppe_contact_email', 'ppe_website',  'is_closed')
+                  'ppe_contact_email', 'ppe_website',  'is_closed',
+                  'activity_reports')
         geo_field = 'location'
 
     def get_other_names(self, facility):
@@ -579,6 +581,10 @@ class FacilityDetailsSerializer(FacilitySerializer):
             }
         except FacilityClaim.DoesNotExist:
             return None
+
+    def get_activity_reports(self, facility):
+        return FacilityActivityReportSerializer(
+            facility.activity_reports(), many=True).data
 
 
 class FacilityCreateBodySerializer(Serializer):
@@ -1034,6 +1040,7 @@ class FacilityActivityReportSerializer(ModelSerializer):
     reported_by_user = SerializerMethodField()
     reported_by_contributor = SerializerMethodField()
     facility_name = SerializerMethodField()
+    status_change_by = SerializerMethodField()
 
     class Meta:
         model = FacilityActivityReport
@@ -1051,3 +1058,9 @@ class FacilityActivityReportSerializer(ModelSerializer):
 
     def get_facility_name(self, instance):
         return instance.facility.name
+
+    def get_status_change_by(self, instance):
+        if instance.status_change_by is not None:
+            return instance.status_change_by.email
+        else:
+            return None

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -427,7 +427,7 @@ class FacilitySerializer(GeoFeatureModelSerializer):
         fields = ('id', 'name', 'address', 'country_code', 'location',
                   'oar_id', 'country_name', 'contributors',
                   'ppe_product_types', 'ppe_contact_phone',
-                  'ppe_contact_email', 'ppe_website')
+                  'ppe_contact_email', 'ppe_website', 'is_closed')
         geo_field = 'location'
 
     # Added to ensure including the OAR ID in the geojson properties map

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2118,7 +2118,11 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         except Facility.DoesNotExist:
             raise NotFound('Facility with OAR ID {} not found'.format(pk))
 
-        contributor = request.user.contributor
+        try:
+            contributor = request.user.contributor
+        except Contributor.DoesNotExist:
+            raise ValidationError('Contributor not found for requesting user.')
+
         facility_activity_report = FacilityActivityReport.objects.create(
             facility=facility,
             reported_by_user=request.user,


### PR DESCRIPTION
## Overview

Allows users to report a facility as closed or reopened through a link in the facility details. 
Shows a ribbon in the facilities list and the facility details if a facility is closed, and shows a pending ribbon in the details. 
Shows a list of pending and confirmed status change requests. 

Connects #1232 

## Demo

Closed
<img width="447" alt="Screen Shot 2021-02-15 at 8 45 06 AM" src="https://user-images.githubusercontent.com/21046714/107955048-4e410580-6f6b-11eb-8d2a-5f2a30287c5b.png">
<img width="449" alt="Screen Shot 2021-02-15 at 8 45 19 AM" src="https://user-images.githubusercontent.com/21046714/107955060-51d48c80-6f6b-11eb-8d9b-79682c36315c.png">

Pending
<img width="436" alt="Screen Shot 2021-02-15 at 8 45 43 AM" src="https://user-images.githubusercontent.com/21046714/107955079-5a2cc780-6f6b-11eb-81bf-546b74c89dfc.png">

Status List
<img width="444" alt="Screen Shot 2021-02-15 at 8 45 37 AM" src="https://user-images.githubusercontent.com/21046714/107955075-58630400-6f6b-11eb-8332-007a26fb8706.png">

Success Ribbon
<img width="411" alt="Screen Shot 2021-02-15 at 8 46 19 AM" src="https://user-images.githubusercontent.com/21046714/107955085-5bf68b00-6f6b-11eb-8131-647cfcd8b1a8.png">

## Testing Instructions

* Run `vagrant ssh` and `./scripts/server`
* Navigate to a facility
    * You should not see a ‘report facility’ button
* Login as c8@example.com and navigate to a facility
    * You should see a ‘Report Facility as closed’ button
* Press ‘report facility as closed’
    * You should see a dialog
* Press ‘report’ without entering any text
    * The report should not submit
* Enter text and press ‘cancel’, then reopen the dialog
    * The dialog textbox should be cleared after cancelling
* Enter text and press ‘report’
    * The dialog should close
    * There should be a success alert
    * There should be a ‘pending’ ribbon in the facility details
    * There should be a ‘Status’ list with a ‘reported as closed’ item only
* Return to the facility list
    * The facility you reported should not have a ribbon on the list
* Report an additional facility
* Logout and login as c1@example.com
* Navigate to http://localhost:6543/dashboard/activityreports
    * There should be pending requests to close the facilities you reported
* Confirm one report and reject the other.
* Return to the facility list. 
    * The confirmed facility should have a closed ribbon. 
    * The rejected facility should have no ribbon.
* Navigate to the rejected facility.
    * It should have no ribbon and no Status items.
* Navigate to the confirmed facility. 
    * It should have a closed ribbon and two status items - request and verified.
    * The button should say, ‘Report facility as reopened’
* Attempt to report the facility as reopened.
    * You should get an error message about not having a contributor.
* Log out and log back in as c8@example.com, then again attempt to reopen the facility.
    * It should succeed.
    * There should be a pending ribbon. 
    * The new status item should be at the top of the Statuses list.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
