### PR TITLE
Update ecsmanage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Rename Taiwan
   [#1234](https://github.com/open-apparel-registry/open-apparel-registry/pull/1234) [#1238](https://github.com/open-apparel-registry/open-apparel-registry/pull/1238)
+- Update ecsmanage [#1240](https://github.com/open-apparel-registry/open-apparel-registry/pull/1240)
 
 ### Deprecated
 

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -4,7 +4,7 @@ coreapi==2.3.3
 dedupe==1.9.4
 defusedxml==0.6.0
 django-amazon-ses==2.1.1
-django-ecsmanage==2.0.0
+django-ecsmanage==2.0.1
 django-extensions==2.1.9
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.5


### PR DESCRIPTION
## Overview

The 2.0.1 update includes a bugfix that prints the correct URL to the launched task to the console.

Connects #1148

## Testing Instructions

* Check out develop
* Run `./scripts manage escmanage showmigrations` and verify that the URL printed to the console does not contain a task ID
* Check out `feature/jcw/update-ecsmanage` and run `./scripts/update`
* Run `./scripts manage escmanage showmigrations` and verify that the URL does contain a task ID
 
## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
