### PR TITLE
Align Facility Matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Align Facility Matches [#1243](https://github.com/open-apparel-registry/open-apparel-registry/pull/1243)
 
 ### Security
 

--- a/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsConfirmationTableRow.jsx
@@ -3,8 +3,9 @@ import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
-
 import FacilityListItemsDetailedTableRowCell from './FacilityListItemsDetailedTableRowCell';
+import CellElement from './CellElement';
+import ShowOnly from './ShowOnly';
 
 import {
     confirmFacilityListItemMatch,
@@ -25,50 +26,15 @@ function FacilityListItemsConfirmationTableRow({
     readOnly,
     className,
 }) {
-    const [
-        matchIDs,
-        matchOARIDs,
-        matchNames,
-        matchAddresses,
-        matchConfirmOrRejectFunctions,
-    ] = item.matches.reduce(
-        ([ids, oarIDs, names, addresses, confirmOrRejectFunctions], {
-            id,
-            oar_id, // eslint-disable-line camelcase
-            name,
-            address,
-            status,
-        }) =>
-            Object.freeze([
-                Object.freeze(ids.concat(id)),
-                Object.freeze(oarIDs.concat(oar_id)),
-                Object.freeze(names.concat(name)),
-                Object.freeze(addresses.concat(address)),
-                Object.freeze(confirmOrRejectFunctions.concat(Object.freeze({
-                    confirmMatch: makeConfirmMatchFunction(id),
-                    rejectMatch: makeRejectMatchFunction(id),
-                    id,
-                    status,
-                    matchName: name,
-                    matchAddress: address,
-                    itemName: item.name,
-                    itemAddress: item.address,
-                }))),
-            ]),
-        Object.freeze([
-            Object.freeze([]),
-            Object.freeze([]),
-            Object.freeze([]),
-            Object.freeze([]),
-            Object.freeze([]),
-        ]),
-    );
-
     return (
         <>
             <TableRow
                 hover={false}
-                style={{ background: '#dcfbff', verticalAlign: 'top' }}
+                style={{
+                    background: '#dcfbff',
+                    verticalAlign: 'top',
+                    borderTop: '1px solid #e0e0e0',
+                }}
                 className={className}
             >
                 <TableCell
@@ -76,11 +42,8 @@ function FacilityListItemsConfirmationTableRow({
                     padding="default"
                     style={listTableCellStyles.rowIndexStyles}
                 >
-                    <FacilityListItemsDetailedTableRowCell
-                        title={item.row_index}
-                        stringIsHidden
-                        data={matchIDs}
-                        hasActions={false}
+                    <CellElement
+                        item={item.row_index}
                     />
                 </TableCell>
                 <TableCell
@@ -88,11 +51,8 @@ function FacilityListItemsConfirmationTableRow({
                     padding="default"
                     style={listTableCellStyles.countryNameStyles}
                 >
-                    <FacilityListItemsDetailedTableRowCell
-                        title={item.country_name || ' '}
-                        stringIsHidden
-                        data={matchIDs}
-                        hasActions={false}
+                    <CellElement
+                        item={item.country_name || ' '}
                     />
                 </TableCell>
                 <TableCell
@@ -100,11 +60,8 @@ function FacilityListItemsConfirmationTableRow({
                     style={listTableCellStyles.nameCellStyles}
                     colSpan={2}
                 >
-                    <FacilityListItemsDetailedTableRowCell
-                        title={item.name || ' '}
-                        stringIsHidden
-                        data={matchNames}
-                        hasActions={false}
+                    <CellElement
+                        item={item.name || ' '}
                     />
                 </TableCell>
                 <TableCell
@@ -112,11 +69,8 @@ function FacilityListItemsConfirmationTableRow({
                     style={listTableCellStyles.addressCellStyles}
                     colSpan={2}
                 >
-                    <FacilityListItemsDetailedTableRowCell
-                        title={item.address || ' '}
-                        stringIsHidden
-                        data={matchAddresses}
-                        hasActions={false}
+                    <CellElement
+                        item={item.address || ' '}
                     />
                 </TableCell>
                 <TableCell
@@ -126,70 +80,107 @@ function FacilityListItemsConfirmationTableRow({
                     <FacilityListItemsDetailedTableRowCell
                         title={item.status}
                         stringIsHidden
-                        data={matchConfirmOrRejectFunctions}
                         hasActions={false}
                         fetching={fetching}
                         readOnly={readOnly}
+                        data={[]}
                     />
                 </TableCell>
             </TableRow>
             <TableRow
                 hover={false}
-                style={{ background: '#dcfbff', verticalAlign: 'top' }}
-                className={`${className} STATUS_POTENTIAL_MATCH--SUB-ROW`}
+                style={{ background: '#dcfbff', verticalAlign: 'top', border: 0 }}
+                className={className}
             >
                 <TableCell
-                    align="center"
                     padding="default"
-                    style={listTableCellStyles.rowIndexStyles}
-                />
-                <TableCell
-                    align="center"
-                    padding="default"
-                    style={listTableCellStyles.countryNameStyles}
-                />
-                <TableCell
-                    padding="default"
-                    style={listTableCellStyles.nameCellStyles}
+                    variant="head"
                     colSpan={2}
+                />
+                <TableCell
+                    padding="default"
+                    variant="head"
+                    colSpan={2}
+                    style={listTableCellStyles.headerCellStyles}
                 >
                     <b>Facility Match Name</b>
-                    <FacilityListItemsDetailedTableRowCell
-                        title=" "
-                        stringisHidden={false}
-                        data={matchNames}
-                        hasActions={false}
-                        linkURLs={matchOARIDs.map(makeFacilityDetailLink)}
-                    />
                 </TableCell>
                 <TableCell
                     padding="default"
-                    style={listTableCellStyles.addressCellStyles}
+                    variant="head"
+                    style={listTableCellStyles.headerCellStyles}
                     colSpan={2}
                 >
                     <b>Facility Match Address</b>
-                    <FacilityListItemsDetailedTableRowCell
-                        title=" "
-                        stringIsHidden={false}
-                        data={matchAddresses}
-                        hasActions={false}
-                    />
                 </TableCell>
                 <TableCell
                     padding="default"
-                    style={listTableCellStyles.statusCellStyles}
+                    variant="head"
+                    style={listTableCellStyles.headerCellStyles}
                 >
                     <b>Actions</b>
-                    <FacilityListItemsDetailedTableRowCell
-                        title=" "
-                        stringIsHidden
-                        data={matchConfirmOrRejectFunctions}
-                        hasActions
-                        fetching={fetching}
-                        readOnly={readOnly}
-                    />
                 </TableCell>
             </TableRow>
+            {item.matches.map(({
+                id, status, address, oar_id, name, // eslint-disable-line camelcase
+            }) => (
+                <TableRow
+                    hover={false}
+                    style={{ background: '#dcfbff', verticalAlign: 'top' }}
+                    className={className}
+                    key={id}
+                >
+                    <TableCell
+                        padding="default"
+                        variant="head"
+                        colSpan={2}
+                    />
+                    <TableCell
+                        padding="default"
+                        colSpan={2}
+                        style={listTableCellStyles.nameCellStyles}
+                    >
+                        <CellElement
+                            item={name}
+                            linkURL={makeFacilityDetailLink(oar_id)}
+                        />
+                    </TableCell>
+                    <TableCell
+                        padding="default"
+                        style={listTableCellStyles.addressCellStyles}
+                        colSpan={2}
+                    >
+                        <CellElement
+                            item={address}
+                        />
+                    </TableCell>
+                    <TableCell
+                        padding="default"
+                        variant="head"
+                        style={listTableCellStyles.headerCellStyles}
+                    >
+                        <ShowOnly when={!readOnly}>
+                            {
+                                <CellElement
+                                    item={{
+                                        confirmMatch: makeConfirmMatchFunction(id),
+                                        rejectMatch: makeRejectMatchFunction(id),
+                                        id,
+                                        status,
+                                        matchName: name,
+                                        matchAddress: address,
+                                        itemName: item.name,
+                                        itemAddress: item.address,
+                                    }}
+                                    fetching={fetching}
+                                    hasActions
+                                    stringIsHidden
+                                />
+                            }
+                        </ShowOnly>
+                    </TableCell>
+                </TableRow>
+            ))}
         </>
     );
 }

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -34,6 +34,11 @@ export const listTableCellStyles = Object.freeze({
         padding: '10px 24px',
         borderColor: '#f3f3f3',
     }),
+    headerCellStyles: Object.freeze({
+        fontSize: '16px',
+        padding: '10px 24px',
+        color: 'black',
+    }),
 });
 
 export const confirmRejectMatchRowStyles = Object.freeze({


### PR DESCRIPTION
## Overview

Previously, the facility list confirmation row component contained two
rows:
- one row for the facility item
- one row containing all of the facility matches and their headers

This caused the confirm/reject buttons to become misaligned with the
facility matches to which they referred.

Now, the facilities are split into: 
- one row for the facility item,
- one row for the facility match headers,
- plus one row for each facility match. 

This keeps the items aligned.

Connects #1242, #1189

## Demo

<img width="1252" alt="Screen Shot 2021-02-16 at 8 30 23 AM" src="https://user-images.githubusercontent.com/21046714/108072027-66c92280-7034-11eb-9dd2-76817480084c.png">

## Testing Instructions

* Run `./scripts/server`
* View list items with [potential matches](http://localhost:6543/lists/8?status=POTENTIAL_MATCH&page=1&rowsPerPage=20)
    * The items should be aligned.
    * Clicking the match names should take you to the match facility. 
    * Clicking confirm/reject should correctly confirm or reject the match. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
