### PR TITLE
Add report waffle switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add API for reporting a facility as closed or reopened [#1231](https://github.com/open-apparel-registry/open-apparel-registry/pull/1231)
 - Confirm or reject status reports [#1235](https://github.com/open-apparel-registry/open-apparel-registry/pull/1235)
 - Report Facility Status from Facility Details [#1239](https://github.com/open-apparel-registry/open-apparel-registry/pull/1239)
+- Add Report Waffle Switch [#1246](https://github.com/open-apparel-registry/open-apparel-registry/pull/1246)
 
 ### Changed
 

--- a/scripts/resetdb
+++ b/scripts/resetdb
@@ -25,6 +25,7 @@ function enableswitches() {
     ./scripts/manage waffle_switch vector_tile on
     ./scripts/manage waffle_switch claim_a_facility on
     ./scripts/manage waffle_switch ppe on
+    ./scripts/manage waffle_switch report_a_facility on
 }
 
 function assigngroups() {

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -42,6 +42,7 @@ import {
 import {
     CLAIM_A_FACILITY,
     PPE,
+    REPORT_A_FACILITY,
     facilitiesRoute,
 } from '../util/constants';
 
@@ -298,7 +299,9 @@ class FacilityDetailSidebar extends Component {
                     </FeatureFlag>
                 </div>
                 <div className="facility-detail_data">
-                    {renderStatusRibbon()}
+                    <FeatureFlag flag={REPORT_A_FACILITY}>
+                        {renderStatusRibbon()}
+                    </FeatureFlag>
                     <FacilityDetailsStaticMap data={data} />
                     <div className="control-panel__content">
                         <div className="control-panel__group">
@@ -338,9 +341,11 @@ class FacilityDetailSidebar extends Component {
                                 />
                             </ShowOnly>
                         </FeatureFlag>
-                        <FacilityDetailStatusList
-                            activityReports={data.properties.activity_reports}
-                        />
+                        <FeatureFlag flag={REPORT_A_FACILITY}>
+                            <FacilityDetailStatusList
+                                activityReports={data.properties.activity_reports}
+                            />
+                        </FeatureFlag>
                         <div className="control-panel__group">
                             <div style={detailsSidebarStyles.linkSectionStyle}>
                                 <ShowOnly when={!facilityIsClaimedByCurrentUser}>
@@ -408,7 +413,9 @@ class FacilityDetailSidebar extends Component {
                                         </Link>
                                     </FeatureFlag>
                                 </ShowOnly>
-                                <ReportFacilityStatus data={data} />
+                                <FeatureFlag flag={REPORT_A_FACILITY}>
+                                    <ReportFacilityStatus data={data} />
+                                </FeatureFlag>
                             </div>
                         </div>
                     </div>

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -18,6 +18,8 @@ import get from 'lodash/get';
 import { toast } from 'react-toastify';
 import InfiniteAnyHeight from 'react-infinite-any-height';
 
+import FeatureFlag from './FeatureFlag';
+
 import {
     makeSidebarSearchTabActive,
 } from '../actions/ui';
@@ -29,6 +31,7 @@ import { logDownload } from '../actions/logDownload';
 import { facilityCollectionPropType } from '../util/propTypes';
 
 import {
+    REPORT_A_FACILITY,
     authLoginFormRoute,
     authRegisterFormRoute,
 } from '../util/constants';
@@ -313,11 +316,13 @@ function FilterSidebarFacilitiesTab({
                                                     secondary={address}
                                                 />
                                             </Link>
-                                            {isClosed && (
-                                                <div style={facilitiesTabStyles.closureRibbon}>
-                                                    Closed facility
-                                                </div>
-                                            )}
+                                            <FeatureFlag flag={REPORT_A_FACILITY}>
+                                                {isClosed && (
+                                                    <div style={facilitiesTabStyles.closureRibbon}>
+                                                        Closed facility
+                                                    </div>
+                                                )}
+                                            </FeatureFlag>
                                         </ListItem>
                                     </Fragment>))
                         }

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -426,6 +426,7 @@ export const facilitiesListTableTooltipTitles = Object.freeze({
 export const CLAIM_A_FACILITY = 'claim_a_facility';
 export const VECTOR_TILE = 'vector_tile';
 export const PPE = 'ppe';
+export const REPORT_A_FACILITY = 'report_a_facility';
 
 export const COUNTRY_CODES = Object.freeze({
     default: 'IE',

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -15,6 +15,7 @@ import {
     CLAIM_A_FACILITY,
     VECTOR_TILE,
     PPE,
+    REPORT_A_FACILITY,
     facilityClaimStatusChoicesEnum,
 } from './constants';
 
@@ -214,7 +215,7 @@ export const filtersPropType = shape({
 export const facilityListItemStatusPropType =
     oneOf(Object.values(facilityListItemStatusChoicesEnum).concat('Status'));
 
-export const featureFlagPropType = oneOf([CLAIM_A_FACILITY, VECTOR_TILE, PPE]);
+export const featureFlagPropType = oneOf([CLAIM_A_FACILITY, VECTOR_TILE, PPE, REPORT_A_FACILITY]);
 
 export const facilityClaimsListPropType = arrayOf(shape({
     created_at: string.isRequired,

--- a/src/django/api/migrations/0055_add_report_switch.py
+++ b/src/django/api/migrations/0055_add_report_switch.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def create_report_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.create(name='report_a_facility', active=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0054_rename_taiwan_country_choice'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_report_switch)
+    ]


### PR DESCRIPTION
## Overview

Add a waffle switch around the public facing facility report UI so that these features can be reviewed and approved before being publicly accessible in production. 

Connects #1245 

## Demo

<img width="330" alt="Screen Shot 2021-02-17 at 11 13 36 AM" src="https://user-images.githubusercontent.com/21046714/108233303-a1ed5380-7111-11eb-8b03-715d721bf1bf.png">

## Testing Instructions

* On `develop`, ensure you have at least one closed facility.
* On this branch, run `./scripts/update` and `./scripts/server`
* Navigate to [Switches in Admin](http://localhost:8081/admin/waffle/switch/)
    * report_a_facility should be inactive
* Navigate to [facilities](http://localhost:6543/)
    * You should not see any closure ribbons
* Navigate to a facility which is closed
     * You should not see any status ribbon
     * You should not see a status list
     * You should not see the ‘report facility closure’ button
* Navigate to [Switches in Admin](http://localhost:8081/admin/waffle/switch/) and set report_a_facility to active
* Navigate to [facilities](http://localhost:6543/)
    * You should see closure ribbons
* Navigate to a facility which is closed
     * You should see a status ribbon
     * You should see a status list
     * You should see the ‘report facility closure’ button

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
