### PR TITLE
Add Closure to CSV Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Confirm or reject status reports [#1235](https://github.com/open-apparel-registry/open-apparel-registry/pull/1235)
 - Report Facility Status from Facility Details [#1239](https://github.com/open-apparel-registry/open-apparel-registry/pull/1239)
 - Add Report Waffle Switch [#1246](https://github.com/open-apparel-registry/open-apparel-registry/pull/1246)
+- Add Closure to CSV Download [#1249](https://github.com/open-apparel-registry/open-apparel-registry/pull/1249)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.facilitiesCSV.tests.js
+++ b/src/app/src/__tests__/utils.facilitiesCSV.tests.js
@@ -207,3 +207,86 @@ it('creates a 2-d array including PPE headers and values', () => {
         formatDataForCSV(facilities, { includePPEFields: true }),
     ).toEqual(expected2DArray);
 });
+
+it('creates a 2-d array including closure headers and values', () => {
+    const facilities = [
+        {
+            properties: {
+                name: 'name',
+                address: 'address',
+                country_code: 'country_code',
+                country_name: 'country_name',
+                oar_id: 'oar_id',
+                contributors: [
+                    {
+                        id: 1,
+                        name: 'contributor_name',
+                        verified: false,
+                    },
+                ],
+                is_closed: true,
+            },
+            geometry: {
+                coordinates: [
+                    'lng',
+                    'lat',
+                ],
+            },
+        },
+        {
+            properties: {
+                name: 'name',
+                address: 'address',
+                country_code: 'country_code',
+                country_name: 'country_name',
+                oar_id: 'oar_id',
+                contributors: [
+                    {
+                        id: 1,
+                        name: 'contributor_name',
+                        verified: false,
+                    },
+                ],
+                is_closed: false,
+            },
+            geometry: {
+                coordinates: [
+                    'lng',
+                    'lat',
+                ],
+            },
+        },
+    ];
+
+    const expected2DArray = [
+        csvHeaders.concat([
+            'is_closed',
+        ]),
+        [
+            'oar_id',
+            'name',
+            'address',
+            'country_code',
+            'country_name',
+            'lat',
+            'lng',
+            'contributor_name',
+            'CLOSED',
+        ],
+        [
+            'oar_id',
+            'name',
+            'address',
+            'country_code',
+            'country_name',
+            'lat',
+            'lng',
+            'contributor_name',
+            null,
+        ],
+    ];
+
+    expect(
+        formatDataForCSV(facilities, { includeClosureFields: true }),
+    ).toEqual(expected2DArray);
+});

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -38,6 +38,7 @@ export function logDownload() {
 
             const vectorTileFlagIsActive = get(featureFlags, 'flags.vector_tile', false);
             const ppeIsActive = get(featureFlags, 'flags.ppe', false);
+            const reportsAreActive = get(featureFlags, 'flags.report_a_facility', false);
 
             const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 
@@ -48,7 +49,10 @@ export function logDownload() {
                     .post(makeLogDownloadUrl(path, recordCount))
                     .then(() => downloadFacilitiesCSV(
                         facilities,
-                        { includePPEFields: ppeIsActive },
+                        {
+                            includePPEFields: ppeIsActive,
+                            includeClosureFields: reportsAreActive,
+                        },
                     ))
                     .then(() => dispatch(completeLogDownload()))
                     .catch(err => dispatch(logErrorAndDispatchFailure(
@@ -61,7 +65,10 @@ export function logDownload() {
             await apiRequest.post(makeLogDownloadUrl(path, count));
 
             if (!nextPageURL) {
-                downloadFacilitiesCSV(facilities, { includePPEFields: ppeIsActive });
+                downloadFacilitiesCSV(facilities, {
+                    includePPEFields: ppeIsActive,
+                    includeClosureFields: reportsAreActive,
+                });
             } else {
                 let nextFacilitiesSetURL = nextPageURL;
 
@@ -103,7 +110,10 @@ export function logDownload() {
                     },
                 } = getState();
 
-                downloadFacilitiesCSV(features, { includePPEFields: ppeIsActive });
+                downloadFacilitiesCSV(features, {
+                    includePPEFields: ppeIsActive,
+                    includeClosureFields: reportsAreActive,
+                });
             }
 
             return dispatch(completeLogDownload());

--- a/src/app/src/util/util.facilitiesCSV.js
+++ b/src/app/src/util/util.facilitiesCSV.js
@@ -24,6 +24,7 @@ export const createFacilityRowFromFeature = (feature, options) => {
             country_name,
             oar_id,
             contributors,
+            is_closed,
         },
         geometry: {
             coordinates: [
@@ -41,6 +42,8 @@ export const createFacilityRowFromFeature = (feature, options) => {
                 : feature.properties[f],
         )
         : [];
+    const closureFields = options && options.includeClosureFields
+        ? [is_closed ? 'CLOSED' : null] : [];
 
     return Object.freeze([
         oar_id,
@@ -51,18 +54,22 @@ export const createFacilityRowFromFeature = (feature, options) => {
         lat,
         lng,
         contributors ? contributors.map(c => c.name).join('|') : '',
-    ].concat(ppeFields));
+    ].concat(ppeFields).concat(closureFields));
 };
 
 export const makeFacilityReducer = options => (acc, next) =>
     acc.concat([createFacilityRowFromFeature(next, options)]);
 
-export const makeHeaderRow = options =>
-    [
-        options && options.includePPEFields
-            ? csvHeaders.concat(PPE_FIELD_NAMES)
-            : csvHeaders,
-    ];
+export const makeHeaderRow = (options) => {
+    let headerRow = csvHeaders;
+    if (options && options.includePPEFields) {
+        headerRow = headerRow.concat(PPE_FIELD_NAMES);
+    }
+    if (options && options.includeClosureFields) {
+        headerRow = headerRow.concat(['is_closed']);
+    }
+    return [headerRow];
+};
 
 export const formatDataForCSV = (facilities, options = {}) =>
     facilities.reduce(


### PR DESCRIPTION
## Overview

Add the facility closure status to the CSV downloads in the case that
the `report_a_facility` switch is on.

Connects #1248 

## Demo

<img width="753" alt="Screen Shot 2021-02-17 at 3 10 53 PM" src="https://user-images.githubusercontent.com/21046714/108271387-bb58c480-713e-11eb-973b-f123716c5240.png">

## Testing Instructions

* Run `./scripts/server`
* Turn off the Reports switch and download the facilities CSV
    - [ ] It should not have an 'is_closed' column
* Turn on the Reports switch and download the facilities CSV
    - [ ] It should have an 'is_closed' column with appropriate data

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
