### PR TITLE
Send Notification of Facility Report Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Report Waffle Switch [#1246](https://github.com/open-apparel-registry/open-apparel-registry/pull/1246)
 - Add Closure to CSV Download [#1249](https://github.com/open-apparel-registry/open-apparel-registry/pull/1249)
 - Manage Embed Parameter [#1257](https://github.com/open-apparel-registry/open-apparel-registry/pull/1257)
+- Send Notification of Facility Report Response [#1250](https://github.com/open-apparel-registry/open-apparel-registry/pull/1250)
 
 ### Changed
 

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -312,7 +312,7 @@ export const activityReportPropType = shape({
     reported_by_contributor: string.isRequired,
     reported_by_user: string.isRequired,
     status: string.isRequired,
-    status_change_by: number,
+    status_change_by: string,
     status_change_date: string,
     status_change_reason: string,
     updated_at: string.isRequired,

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -307,3 +307,35 @@ def send_admin_api_warning(contributor_name, limit):
         [settings.NOTIFICATION_EMAIL_TO],
         html_message=html_template.render(notice_dictionary)
     )
+
+
+def send_report_result(report):
+    subj_template = get_template(
+        'mail/report_result_subject.txt')
+    text_template = get_template(
+        'mail/report_result_body.txt')
+    html_template = get_template(
+        'mail/report_result_body.html')
+
+    if report.closure_state == 'OPEN':
+        closure_state = 're-opened'
+    else:
+        closure_state = 'closed'
+
+    report_dictionary = {
+        'facility_name': report.facility.name,
+        'is_closure': closure_state == 'closed',
+        'is_reopening': closure_state == 're-opened',
+        'is_confirmed': report.status == 'CONFIRMED',
+        'is_rejected': report.status == 'REJECTED',
+        'closure_state': closure_state,
+        'status_change_reason': report.status_change_reason,
+    }
+
+    send_mail(
+        subj_template.render().rstrip(),
+        text_template.render(report_dictionary),
+        settings.DEFAULT_FROM_EMAIL,
+        [settings.NOTIFICATION_EMAIL_TO],
+        html_message=html_template.render(report_dictionary)
+    )

--- a/src/django/api/templates/mail/report_result_body.html
+++ b/src/django/api/templates/mail/report_result_body.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Open Apparel Registry Facility Report {{ status|title }}
+        </title>
+    </head>
+    <body>
+        <p>
+            Hi there,
+        </p>
+        <p>
+            Thanks for reporting {{ facility_name }} facility as {{ closure_state|lower }}.
+            {% if is_closure and is_rejected %}We have rejected this report and the facility's profile in the OAR has not been changed.{% endif %}{% if is_closure and is_confirmed %}The facility profile in the Open Apparel Registry has now been updated and the facility is marked as closed.{% endif %}{% if is_reopening and is_rejected %}We have rejected this report and the facility's profile in the OAR has not been changed.{% endif %}{% if is_reopening and is_confirmed %}The facility profile in the Open Apparel Registry has now been updated and the facility is no longer marked as closed.{% endif %}
+        </p>
+        {% if status_change_reason|length %}
+        <p>
+            OAR Team review notes: {{ status_change_reason }}
+        </p>
+        {% endif %}
+        {% if is_rejected %}
+        <p>
+            If you have additional evidence that can be used to verify the facility has {{ closure_state|lower }}, this can be shared with: info@openapparel.org
+        </p>
+        {% endif %}
+        {% if is_closure and is_confirmed %}
+        <p>
+            Should you receive reports that the facility is re-opened in the future, you can share this update with the OAR Team.
+        </p>
+        {% endif %}
+
+        <p>
+            Best wishes,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/report_result_body.txt
+++ b/src/django/api/templates/mail/report_result_body.txt
@@ -1,0 +1,15 @@
+{% block content %}
+Hi there,
+
+Thanks for reporting {{ facility_name }} facility as {{ closure_state|lower }}.
+
+{% if is_closure and is_rejected %}We have rejected this report and the facility's profile in the OAR has not been changed.{% endif %}{% if is_closure and is_confirmed %}The facility profile in the Open Apparel Registry has now been updated and the facility is marked as closed.{% endif %}{% if is_reopening and is_rejected %}We have rejected this report and the facility's profile in the OAR has not been changed.{% endif %}{% if is_reopening and is_confirmed %}The facility profile in the Open Apparel Registry has now been updated and the facility is no longer marked as closed.{% endif %}
+
+{% if status_change_reason|length %}OAR Team review notes: {{ status_change_reason }}{% endif %}
+
+{% if is_rejected %}If you have additional evidence that can be used to verify the facility has {{ closure_state|lower }}, this can be shared with: info@openapparel.org{% endif %}{% if is_closure and is_confirmed %}Should you receive reports that the facility is re-opened in the future, you can share this update with the OAR Team.{% endif %}
+
+Best wishes,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/report_result_subject.txt
+++ b/src/django/api/templates/mail/report_result_subject.txt
@@ -1,0 +1,1 @@
+Open Apparel Registry Facility Report {{ status|title }}

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -116,7 +116,8 @@ from api.mail import (send_claim_facility_confirmation_email,
                       send_claim_facility_denial_email,
                       send_claim_facility_revocation_email,
                       send_approved_claim_notice_to_list_contributors,
-                      send_claim_update_notice_to_list_contributors)
+                      send_claim_update_notice_to_list_contributors,
+                      send_report_result)
 from api.exceptions import BadRequestException
 from api.tiler import (get_facilities_vector_tile,
                        get_facility_grid_vector_tile)
@@ -3348,6 +3349,8 @@ def update_facility_activity_report_status(facility_activity_report,
     if status == 'CONFIRMED':
         facility_activity_report.approved_at = now
     facility_activity_report.save()
+
+    send_report_result(facility_activity_report)
 
     return facility_activity_report
 


### PR DESCRIPTION
## Overview

The user who reports a facility as closed or reopened will receive a
notification email when an OAR administrator confirms or rejects the
report.

Connects #1247 

## Demo

Rejected
<img width="565" alt="rejected" src="https://user-images.githubusercontent.com/21046714/108386257-797d5c00-71da-11eb-93f1-8aeccc7a1572.png">

Confirmed
<img width="567" alt="confirmed" src="https://user-images.githubusercontent.com/21046714/108386272-7da97980-71da-11eb-98e2-9df9d2e07605.png">

No Reason Provided
<img width="762" alt="Screen Shot 2021-02-18 at 11 20 59 AM" src="https://user-images.githubusercontent.com/21046714/108387255-6ae37480-71db-11eb-9c6b-e21764b5f2a0.png">

## Notes

We are planning to reopen this and adjust the email content once the finalized notification text is provided. 

## Testing Instructions

* Run `./scripts/server`
* Go to [activity reports](http://localhost:6543/dashboard/activityreports) and confirm one. Enter text explaining the reason for the confirmation.
   * An email should print to the console with the reason included. 
* Reject a report, entering a reason for the rejection.
   * An email should print to the console with the reason included.
* Confirm or reject a report and enter no reason. 
   * An email should print to the console.   

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
