### PR TITLE
Manage Embed Query Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Report Facility Status from Facility Details [#1239](https://github.com/open-apparel-registry/open-apparel-registry/pull/1239)
 - Add Report Waffle Switch [#1246](https://github.com/open-apparel-registry/open-apparel-registry/pull/1246)
 - Add Closure to CSV Download [#1249](https://github.com/open-apparel-registry/open-apparel-registry/pull/1249)
+- Manage Embed Parameter [#1257](https://github.com/open-apparel-registry/open-apparel-registry/pull/1257)
 
 ### Changed
 

--- a/src/app/src/actions/embeddedMap.js
+++ b/src/app/src/actions/embeddedMap.js
@@ -1,0 +1,21 @@
+import querystring from 'querystring';
+import { createAction } from 'redux-act';
+import startsWith from 'lodash/startsWith';
+
+export const setEmbeddedMapStatus = createAction('SET_EMBEDDED_MAP_STATUS');
+
+export function setEmbeddedMapStatusFromQueryString(qs = '') {
+    return (dispatch) => {
+        if (!qs) {
+            return null;
+        }
+
+        const qsToParse = startsWith(qs, '?')
+            ? qs.slice(1)
+            : qs;
+
+        const { embed = '' } = querystring.parse(qsToParse);
+
+        return dispatch(setEmbeddedMapStatus(embed));
+    };
+}

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -5,6 +5,7 @@ import {
     createFiltersFromQueryString,
     updateListWithLabels,
 } from '../util/util';
+import { setEmbeddedMapStatusFromQueryString } from '../actions/embeddedMap';
 
 export const updateFacilityFreeTextQueryFilter =
     createAction('UPDATE_FACILITY_FREE_TEXT_QUERY_FILTER');
@@ -22,6 +23,8 @@ export function setFiltersFromQueryString(qs = '') {
         if (!qs) {
             return null;
         }
+
+        dispatch(setEmbeddedMapStatusFromQueryString(qs));
 
         // If contributor data already exists in the state, use it to match
         // filters from the query string with labels. Otherwise, use the

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -95,6 +95,7 @@ function FilterSidebarSearchTab({
     boundary,
     ppe,
     updatePPE,
+    embed,
 }) {
     const [contributorPopoverAnchorEl, setContributorPopoverAnchorEl] =
           useState(null);
@@ -392,7 +393,7 @@ function FilterSidebarSearchTab({
                         <Button
                             size="small"
                             variant="outlined"
-                            onClick={resetFilters}
+                            onClick={() => resetFilters(embed)}
                             disableRipple
                             color="primary"
                             className="outlined-button"
@@ -488,6 +489,9 @@ function mapStateToProps({
         },
     },
     featureFlags,
+    embeddedMap: {
+        embed,
+    },
 }) {
     const vectorTileFlagIsActive = get(featureFlags, 'flags.vector_tile', false);
 
@@ -508,6 +512,7 @@ function mapStateToProps({
         fetchingOptions: fetchingContributors
             || fetchingContributorTypes
             || fetchingCountries,
+        embed,
     };
 }
 
@@ -533,9 +538,9 @@ function mapDispatchToProps(dispatch, {
         updateCombineContributors: e => dispatch(
             updateCombineContributorsFilterOption(e.target.checked ? 'AND' : ''),
         ),
-        resetFilters: () => {
+        resetFilters: (embedded) => {
             dispatch(recordSearchTabResetButtonClick());
-            return dispatch(resetAllFilters());
+            return dispatch(resetAllFilters(embedded));
         },
         searchForFacilities: vectorTilesAreActive => dispatch(fetchFacilities({
             pageSize: vectorTilesAreActive ? FACILITIES_REQUEST_PAGE_SIZE : 50,

--- a/src/app/src/reducers/EmbeddedMapReducer.js
+++ b/src/app/src/reducers/EmbeddedMapReducer.js
@@ -1,0 +1,18 @@
+import { createReducer } from 'redux-act';
+import update from 'immutability-helper';
+
+import {
+    setEmbeddedMapStatus,
+} from '../actions/embeddedMap';
+
+import { completeSubmitLogOut } from '../actions/auth';
+
+const initialState = Object.freeze({
+    embed: '',
+});
+
+export default createReducer({
+    [setEmbeddedMapStatus]: (state, isEmbedded) =>
+        update(state, { embed: { $set: isEmbedded } }),
+    [completeSubmitLogOut]: () => initialState,
+}, initialState);

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -71,7 +71,12 @@ export default createReducer({
     [updatePPEFilter]: (state, payload) => update(state, {
         ppe: { $set: payload },
     }),
-    [resetAllFilters]: () => initialState,
+    [resetAllFilters]: (state, payload) => update(initialState, {
+        contributors: {
+            $set: payload ? state.contributors
+                : initialState.contributors,
+        },
+    }),
     [updateAllFilters]: (_state, payload) => payload,
     [completeFetchContributorOptions]: maybeSetFromQueryString('contributors'),
     [completeFetchContributorTypeOptions]: maybeSetFromQueryString('contributorTypes'),

--- a/src/app/src/reducers/index.js
+++ b/src/app/src/reducers/index.js
@@ -31,6 +31,7 @@ import AdjustFacilityMatchesReducer from './AdjustFacilityMatchesReducer';
 import LogDownloadReducer from './LogDownloadReducer';
 import VectorTileLayer from './VectorTileLayer';
 import UpdateFacilityLocationReducer from './UpdateFacilityLocationReducer';
+import EmbeddedMapReducer from './EmbeddedMapReducer';
 
 export default combineReducers({
     auth: AuthReducer,
@@ -58,4 +59,5 @@ export default combineReducers({
     logDownload: LogDownloadReducer,
     vectorTileLayer: VectorTileLayer,
     updateFacilityLocation: UpdateFacilityLocationReducer,
+    embeddedMap: EmbeddedMapReducer,
 });

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -149,7 +149,7 @@ export const createQueryStringFromSearchFilters = ({
     combineContributors = '',
     boundary = {},
     ppe = '',
-}) => {
+}, withEmbed) => {
     const inputForQueryString = Object.freeze({
         q: facilityFreeTextQuery,
         contributors: createCompactSortedQuerystringInputObject(contributors),
@@ -158,6 +158,7 @@ export const createQueryStringFromSearchFilters = ({
         combine_contributors: combineContributors,
         boundary: isEmpty(boundary) ? '' : JSON.stringify(boundary),
         ppe,
+        embed: !withEmbed ? '' : '1',
     });
 
     return querystring.stringify(omitBy(inputForQueryString, isEmpty));

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -31,6 +31,9 @@ export default function withQueryStringSync(WrappedComponent) {
                 filters,
                 hydrateFiltersFromQueryString,
                 vectorTileFeatureIsActive,
+                embeddedMap: {
+                    embed,
+                },
             } = this.props;
 
             // This check returns null when the component mounts on the facility details route
@@ -49,7 +52,7 @@ export default function withQueryStringSync(WrappedComponent) {
 
             return search
                 ? hydrateFiltersFromQueryString(search, fetchFacilitiesOnMount)
-                : replace(`?${createQueryStringFromSearchFilters(filters)}`);
+                : replace(`?${createQueryStringFromSearchFilters(filters, embed)}`);
         }
 
         componentDidUpdate({ resetButtonClickCount: prevResetButtonClickCount }) {
@@ -64,9 +67,12 @@ export default function withQueryStringSync(WrappedComponent) {
                 resetButtonClickCount,
                 hydrateFiltersFromQueryString,
                 vectorTileFeatureIsActive,
+                embeddedMap: {
+                    embed,
+                },
             } = this.props;
 
-            const newQueryString = `?${createQueryStringFromSearchFilters(filters)}`;
+            const newQueryString = `?${createQueryStringFromSearchFilters(filters, embed)}`;
 
             if (resetButtonClickCount !== prevResetButtonClickCount && vectorTileFeatureIsActive) {
                 replace(newQueryString);
@@ -120,12 +126,14 @@ export default function withQueryStringSync(WrappedComponent) {
             flags,
             fetching: fetchingFeatureFlags,
         },
+        embeddedMap,
     }) {
         return {
             filters,
             resetButtonClickCount,
             vectorTileFeatureIsActive: get(flags, 'vector_tile', false),
             fetchingFeatureFlags,
+            embeddedMap,
         };
     }
 


### PR DESCRIPTION
## Overview

The embedded map view is denoted by the query parameter `embed=1`.

- Adds the embed parameter as a key in a new embeddedMap reducer
- Updates the existing filter management code to ensure the embed parameter isn't lost when filters change
- Prevents the contributor from being cleared when the reset button is hit in embed mode

Connects #1255 

## Testing Instructions

* Run `./scripts/server` in vagrant
* Navigate to http://localhost:6543/ and search with various combinations of filters
    * The site should behave as before
* Navigate to http://localhost:6543/?contributors=8 and click 'reset'
    * The site should behave as before
    * The contributor filter should be cleared
* Navigate to http://localhost:6543/?embed=1
    * The embed code should remain in the url
    * In the Developer console, confirm that state.embeddedMap.embed = "1".
* Click 'reset'
    * The embed code should remain in the url
* Navigate to http://localhost:6543/?contributors=8&embed=1
    * Click 'reset'
    * The embed code and the contributor filter should remain selected

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
