### PR TITLE
Render Appropriately in Embedded Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Closure to CSV Download [#1249](https://github.com/open-apparel-registry/open-apparel-registry/pull/1249)
 - Manage Embed Parameter [#1257](https://github.com/open-apparel-registry/open-apparel-registry/pull/1257)
 - Send Notification of Facility Report Response [#1250](https://github.com/open-apparel-registry/open-apparel-registry/pull/1250)
+- Render Appropriately in Embed Mode [#1260](https://github.com/open-apparel-registry/open-apparel-registry/pull/1260)
 
 ### Changed
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -88,15 +88,17 @@ class App extends Component {
     }
 
     render() {
-        const { fetchingFeatureFlags } = this.props;
+        const { fetchingFeatureFlags, embed } = this.props;
 
+        const mainPanelStyle = embed ? { ...appStyles.mainPanelStyle, bottom: 0, top: 0 }
+            : appStyles.mainPanelStyle;
         return (
             <ErrorBoundary>
                 <Router history={history}>
                     <div className="App">
                         <Translate />
-                        <Navbar />
-                        <main style={appStyles.mainPanelStyle} className="mainPanel">
+                        <Navbar embed={embed} />
+                        <main style={mainPanelStyle} className="mainPanel">
                             <Switch>
                                 <Route
                                     exact
@@ -208,7 +210,7 @@ class App extends Component {
                                 <Route render={() => <RouteNotFound />} />
                             </Switch>
                         </main>
-                        <Footer />
+                        {embed ? null : <Footer />}
                         <ToastContainer
                             position="bottom-center"
                             transition={Slide}
@@ -231,9 +233,13 @@ function mapStateToProps({
     featureFlags: {
         fetching: fetchingFeatureFlags,
     },
+    embeddedMap: {
+        embed,
+    },
 }) {
     return {
         fetchingFeatureFlags,
+        embed: !!embed,
     };
 }
 

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -41,7 +41,10 @@ import {
     GOOGLE_CLIENT_SIDE_API_KEY,
 } from '../util/constants.facilitiesMap';
 
-import { makeFacilityDetailLink } from '../util/util';
+import {
+    makeFacilityDetailLink,
+    getLocationWithoutEmbedParam,
+} from '../util/util';
 
 const selectedMarkerURL = '/images/selectedmarker.png';
 const unselectedMarkerURL = '/images/marker.png';
@@ -261,7 +264,7 @@ function FacilitiesMap({
             />
             <Control position="topright">
                 <CopyToClipboard
-                    text={window.location.href}
+                    text={getLocationWithoutEmbedParam()}
                     onCopy={() => toast('Copied search to clipboard')}
                 >
                     <Button

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -223,16 +223,20 @@ class FacilityDetailSidebar extends Component {
             if (!report) return null;
             if (report.status === 'PENDING') {
                 return (
-                    <div style={detailsSidebarStyles.pendingRibbon}>
-                        Reported as {report.closure_state.toLowerCase()} (status pending).
-                    </div>
+                    <FeatureFlag flag={REPORT_A_FACILITY}>
+                        <div style={detailsSidebarStyles.pendingRibbon}>
+                            Reported as {report.closure_state.toLowerCase()} (status pending).
+                        </div>
+                    </FeatureFlag>
                 );
             }
             if (data.properties.is_closed) {
                 return (
-                    <div style={detailsSidebarStyles.closureRibbon}>
-                        This facility is closed.
-                    </div>
+                    <FeatureFlag flag={REPORT_A_FACILITY}>
+                        <div style={detailsSidebarStyles.closureRibbon}>
+                            This facility is closed.
+                        </div>
+                    </FeatureFlag>
                 );
             }
             return null;
@@ -357,9 +361,7 @@ class FacilityDetailSidebar extends Component {
                     </FeatureFlag>
                 </div>
                 <div className="facility-detail_data">
-                    <FeatureFlag flag={REPORT_A_FACILITY}>
-                        {renderStatusRibbon()}
-                    </FeatureFlag>
+                    {renderStatusRibbon()}
                     <FacilityDetailsStaticMap data={data} />
                     <div className="control-panel__content">
                         <div className="control-panel__group">

--- a/src/app/src/components/FacilityDetailSidebarInfo.jsx
+++ b/src/app/src/components/FacilityDetailSidebarInfo.jsx
@@ -26,6 +26,7 @@ const FacilityDetailSidebarInfo = memo(({
     data,
     label,
     isContributorsList,
+    embed,
 }) => {
     const makeContributorListItem =
         ({ id, name, is_verified: isVerified }) => (
@@ -39,7 +40,7 @@ const FacilityDetailSidebarInfo = memo(({
                     </span>
                 </ShowOnly>
                 {
-                    id ? (
+                    id && !embed ? (
                         <Link
                             to={makeProfileRouteLink(id)}
                             href={makeProfileRouteLink(id)}

--- a/src/app/src/components/FacilitySidebarSearchTabFacilitiesCount.jsx
+++ b/src/app/src/components/FacilitySidebarSearchTabFacilitiesCount.jsx
@@ -18,6 +18,8 @@ const FacilitySidebarSearchTabFacilitiesCount = ({
         <div style={{
             margin: 0,
             verticalAlign: 'center',
+            marginRight: '5px',
+            flex: 1,
         }}
         >
             <p style={{

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -88,13 +88,14 @@ class FilterSidebar extends Component {
             makeFacilitiesTabActive,
             vectorTileFeatureIsActive,
             fetchingFeatureFlags,
+            embed,
         } = this.props;
 
         if (fetchingFeatureFlags) {
             return <CircularProgress />;
         }
 
-        const header = (
+        const header = !embed ? (
             <div className="panel-header results-height-subtract">
                 <h3 className="panel-header__title">
                     Open Apparel Registry
@@ -102,11 +103,15 @@ class FilterSidebar extends Component {
                 <p className="panel-header__subheading">
                     The open map of global apparel facilities.
                 </p>
-            </div>);
+            </div>) : null;
 
-        const orderedTabsForSidebar = vectorTileFeatureIsActive
+        let orderedTabsForSidebar = vectorTileFeatureIsActive
             ? filterSidebarTabs.slice().reverse()
             : filterSidebarTabs;
+
+        if (embed) {
+            orderedTabsForSidebar = orderedTabsForSidebar.filter(({ tab }) => tab !== 'guide');
+        }
 
         const activeTabIndex = orderedTabsForSidebar
             .findIndex(({ tab }) => tab === activeFilterSidebarTab);
@@ -230,6 +235,9 @@ function mapStateToProps({
         flags,
         fetching: fetchingFeatureFlags,
     },
+    embeddedMap: {
+        embed,
+    },
 }) {
     return {
         activeFilterSidebarTab,
@@ -238,6 +246,7 @@ function mapStateToProps({
         countriesData,
         vectorTileFeatureIsActive: get(flags, 'vector_tile', false),
         fetchingFeatureFlags,
+        embed,
     };
 }
 

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -316,13 +316,13 @@ function FilterSidebarFacilitiesTab({
                                                     secondary={address}
                                                 />
                                             </Link>
-                                            <FeatureFlag flag={REPORT_A_FACILITY}>
-                                                {isClosed && (
+                                            {isClosed ? (
+                                                <FeatureFlag flag={REPORT_A_FACILITY}>
                                                     <div style={facilitiesTabStyles.closureRibbon}>
                                                         Closed facility
                                                     </div>
-                                                )}
-                                            </FeatureFlag>
+                                                </FeatureFlag>
+                                            ) : null}
                                         </ListItem>
                                     </Fragment>))
                         }

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -274,84 +274,86 @@ function FilterSidebarSearchTab({
                         </Popover>
                     </div>
                 </FeatureFlag>
-                <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={CONTRIBUTORS}
-                        style={filterSidebarSearchTabStyles.inputLabelStyle}
-                    >
-                        Filter by Contributor
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={CONTRIBUTORS}
-                        name={CONTRIBUTORS}
-                        className="basic-multi-select notranslate"
-                        classNamePrefix="select"
-                        options={contributorOptions}
-                        value={contributors}
-                        onChange={updateContributor}
-                        disabled={fetchingOptions || fetchingFacilities}
-                    />
-                    <ShowOnly when={contributors && contributors.length > 1}>
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={!!combineContributors}
-                                    onChange={updateCombineContributors}
-                                    color="primary"
-                                    value={combineContributors}
-                                />
-                            }
-                            label="Show only shared facilities"
+                <ShowOnly when={!embed}>
+                    <div className="form__field">
+                        <InputLabel
+                            shrink={false}
+                            htmlFor={CONTRIBUTORS}
+                            style={filterSidebarSearchTabStyles.inputLabelStyle}
+                        >
+                            Filter by Contributor
+                        </InputLabel>
+                        <ReactSelect
+                            isMulti
+                            id={CONTRIBUTORS}
+                            name={CONTRIBUTORS}
+                            className="basic-multi-select notranslate"
+                            classNamePrefix="select"
+                            options={contributorOptions}
+                            value={contributors}
+                            onChange={updateContributor}
+                            disabled={fetchingOptions || fetchingFacilities}
                         />
-                        <IconButton onClick={
-                            // eslint-disable-next-line no-confusing-arrow
-                            e => contributorPopoverAnchorEl
-                                ? null
-                                :
-                                setContributorPopoverAnchorEl(e.currentTarget)}
+                        <ShowOnly when={contributors && contributors.length > 1}>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={!!combineContributors}
+                                        onChange={updateCombineContributors}
+                                        color="primary"
+                                        value={combineContributors}
+                                    />
+                                }
+                                label="Show only shared facilities"
+                            />
+                            <IconButton onClick={
+                                // eslint-disable-next-line no-confusing-arrow
+                                e => contributorPopoverAnchorEl
+                                    ? null
+                                    :
+                                    setContributorPopoverAnchorEl(e.currentTarget)}
+                            >
+                                <InfoIcon />
+                            </IconButton>
+                            <Popover
+                                id="contributor-info-popover"
+                                anchorOrigin={{
+                                    vertical: 'center',
+                                    horizontal: 'right',
+                                }}
+                                transformOrigin={{
+                                    vertical: 'center',
+                                    horizontal: 'left',
+                                }}
+                                open={!!contributorPopoverAnchorEl}
+                                anchorEl={contributorPopoverAnchorEl}
+                                onClick={() => setContributorPopoverAnchorEl(null)}
+                            >
+                                {contributorInfoPopoverContent}
+                            </Popover>
+                        </ShowOnly>
+                    </div>
+                    <div className="form__field">
+                        <InputLabel
+                            shrink={false}
+                            htmlFor={CONTRIBUTOR_TYPES}
+                            style={filterSidebarSearchTabStyles.inputLabelStyle}
                         >
-                            <InfoIcon />
-                        </IconButton>
-                        <Popover
-                            id="contributor-info-popover"
-                            anchorOrigin={{
-                                vertical: 'center',
-                                horizontal: 'right',
-                            }}
-                            transformOrigin={{
-                                vertical: 'center',
-                                horizontal: 'left',
-                            }}
-                            open={!!contributorPopoverAnchorEl}
-                            anchorEl={contributorPopoverAnchorEl}
-                            onClick={() => setContributorPopoverAnchorEl(null)}
-                        >
-                            {contributorInfoPopoverContent}
-                        </Popover>
-                    </ShowOnly>
-                </div>
-                <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={CONTRIBUTOR_TYPES}
-                        style={filterSidebarSearchTabStyles.inputLabelStyle}
-                    >
-                        Filter by Contributor Type
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={CONTRIBUTOR_TYPES}
-                        name="contributorTypes"
-                        className="basic-multi-select notranslate"
-                        classNamePrefix="select"
-                        options={contributorTypeOptions}
-                        value={contributorTypes}
-                        onChange={updateContributorType}
-                        disabled={fetchingOptions || fetchingFacilities}
-                    />
-                </div>
+                            Filter by Contributor Type
+                        </InputLabel>
+                        <ReactSelect
+                            isMulti
+                            id={CONTRIBUTOR_TYPES}
+                            name="contributorTypes"
+                            className="basic-multi-select notranslate"
+                            classNamePrefix="select"
+                            options={contributorTypeOptions}
+                            value={contributorTypes}
+                            onChange={updateContributorType}
+                            disabled={fetchingOptions || fetchingFacilities}
+                        />
+                    </div>
+                </ShowOnly>
                 <div className="form__field">
                     <InputLabel
                         shrink={false}
@@ -383,13 +385,15 @@ function FilterSidebarSearchTab({
                     {boundaryButton}
                 </div>
                 <div className="form__action">
-                    <a
-                        className="control-link"
-                        href="mailto:info@openapparel.org?subject=Reporting an issue"
-                    >
-                        Report an issue
-                    </a>
-                    <div className="offset offset-right">
+                    {!embed ? (
+                        <a
+                            className="control-link"
+                            href="mailto:info@openapparel.org?subject=Reporting an issue"
+                        >
+                            Report an issue
+                        </a>
+                    ) : null}
+                    <div className="offset offset-right" style={{ flex: 1 }}>
                         <Button
                             size="small"
                             variant="outlined"

--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -19,9 +19,13 @@ const apiDocumentationURL = process.env.NODE_ENV === 'development'
     ? 'http://localhost:8081/api/docs/'
     : '/api/docs/';
 
-export default function Navbar() {
+export default function Navbar({ embed }) {
     const [drawerHandler, setDrawerHandler] = useState(false);
     const mobileMenuToggleRef = useRef();
+
+    if (embed) {
+        return <div id="google_translate_element" />;
+    }
 
     const aboutLinks = [
         {

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -19,7 +19,10 @@ import PolygonalSearchControl from './PolygonalSearchControl';
 
 import { COUNTRY_CODES } from '../util/constants';
 
-import { makeFacilityDetailLink } from '../util/util';
+import {
+    makeFacilityDetailLink,
+    getLocationWithoutEmbedParam,
+} from '../util/util';
 
 import { facilityDetailsPropType } from '../util/propTypes';
 
@@ -137,7 +140,7 @@ function VectorTileFacilitiesMap({
             </Control>
             <Control position="topright">
                 <CopyToClipboard
-                    text={window.location.href}
+                    text={getLocationWithoutEmbedParam()}
                     onCopy={() => toast('Copied search to clipboard')}
                 >
                     <Button

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -687,3 +687,6 @@ export const removeDuplicatesFromOtherLocationsData = otherLocationsData => uniq
         return false;
     },
 );
+
+export const getLocationWithoutEmbedParam = () =>
+    window.location.href.replace('&embed=1', '').replace('embed=1', '');


### PR DESCRIPTION
## Overview

When OAR is acting as an embedded map, various components should be hidden or behave differently. 

Page
- Remove header and footer

Sidebar:
- Remove contributor filter
- Remove contributor type filter
- Remove report link. 
- Remove Guide tab
- Remove the "The open map of..." Header
- Remove actions: Claim, Suggest an Edit, Report as Closed and replace with 'view in OAR' link (`target=`)
- Make contributor links plain text

Connects #1256 

## Demo

<img width="1275" alt="Screen Shot 2021-02-23 at 1 56 18 PM" src="https://user-images.githubusercontent.com/21046714/109181231-b062ed00-7759-11eb-84ff-0314eddf4e5f.png">
<img width="1193" alt="Screen Shot 2021-02-23 at 1 11 48 PM" src="https://user-images.githubusercontent.com/21046714/109181238-b22cb080-7759-11eb-9506-f1dd2bfd6ef2.png">

## Testing Instructions

* Run `./scripts/server` in vagrant
* Navigate to http://localhost:6543/ 
     - [x] The site should behave as before
* Navigate to http://localhost:6543/?contributors=8&embed=1
* Navigate to http://localhost:6543/?contributors=8&embed=1
     - [x] The page header and footer should not be displayed
     - [x] The contributor and contributor type filters should not be displayed
     - [x] The guide tab should not be displayed
     - [x] The sidebar OAR header should not be displayed
     - [x] The ‘report a problem’ link should not be displayed
* Click the ’share search’ button
     - [x] The current page link with the embed code removed should be added to the clipboard
* Navigate to a facility
     - [x] The contributor names should be plain text
     - [x] The action links (claim, suggest an edit, report as closed) should be replaced with a single ‘view in OAR’
* Click the ‘view in OAR’ link
     - [x] It should open the same page in a new tab without the ‘embed’ code

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
