### PR TITLE
Fix vagrant provisioning failure by pinning pip python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Align Facility Matches [#1243](https://github.com/open-apparel-registry/open-apparel-registry/pull/1243)
 - Update Reject Button Text [#1244](https://github.com/open-apparel-registry/open-apparel-registry/pull/1244)
+- Fix vagrant provisioning failure by pinning pip python version [#1262](https://github.com/open-apparel-registry/open-apparel-registry/pull/1262)
 
 ### Security
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,11 @@
 
 Vagrant.require_version ">= 2.1"
 
-ANSIBLE_VERSION = "2.8.*"
+ANSIBLE_VERSION = "2.9.*"
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
 
   config.vm.synced_folder "./", "/vagrant"
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
@@ -28,6 +28,7 @@ Vagrant.configure("2") do |config|
     ansible.compatibility_mode = "2.0"
     ansible.install = true
     ansible.install_mode = "pip_args_only"
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python"
     ansible.pip_args = "ansible==#{ANSIBLE_VERSION}"
     ansible.playbook = "deployment/ansible/open-apparel-registry.yml"
     ansible.galaxy_role_file = "deployment/ansible/roles.yml"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,6 +1,7 @@
 ---
 aws_cli_version: "1.16.*"
 aws_profile: "open-apparel-registry"
+pip_get_pip_version: "2.7"
 
 oar_settings_bucket: "openapparelregistry-development-config-eu-west-1"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,5 @@
 - src: azavea.pip
-  version: 1.0.1
+  version: 2.0.0
 
 - src: azavea.docker
   version: 4.0.0


### PR DESCRIPTION
## Overview

This approach was copied from another project.

The development VM has only Python 2.7 installed, and the default pip was recently upgraded to only work with Python 3. This pinning ensures that the VM provisions successfully.

Updates to the Ansible version and base box are not directly related, but we updated them as well to match a more recent, working project.

Connects #1265

## Testing Instructions

⚠️ Testing this PR involves deleting your VM and your local database ⚠️ 

* Check out this branch
* Delete and recreate your VM `$ vagrant destroy -f && ./scripts/setup`
  - [x] Ensure it succeeds

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
