### PR TITLE
Filter by List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Manage Embed Parameter [#1257](https://github.com/open-apparel-registry/open-apparel-registry/pull/1257)
 - Send Notification of Facility Report Response [#1250](https://github.com/open-apparel-registry/open-apparel-registry/pull/1250)
 - Render Appropriately in Embed Mode [#1260](https://github.com/open-apparel-registry/open-apparel-registry/pull/1260)
+- Filter Facilities by List [#1264](https://github.com/open-apparel-registry/open-apparel-registry/pull/1264)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -244,6 +244,7 @@ it('creates a set of filters from a querystring', () => {
         ],
         contributorTypes: [],
         countries: [],
+        lists: [],
         combineContributors: '',
         boundary: null,
         ppe: '',
@@ -268,6 +269,7 @@ it('creates a set of filters from a querystring', () => {
         ],
         contributorTypes: [],
         countries: [],
+        lists: [],
         combineContributors: 'AND',
         boundary: null,
         ppe: '',
@@ -277,6 +279,31 @@ it('creates a set of filters from a querystring', () => {
         createFiltersFromQueryString(combinedContributorsString),
     ).toEqual(expectedCombinedContributorsMatch);
 
+    const listsString = '?contributors=1&lists=2';
+    const expectedListsMatch = {
+        facilityFreeTextQuery: '',
+        contributors: [
+            {
+                value: 1,
+                label: '1',
+            },
+        ],
+        contributorTypes: [],
+        countries: [],
+        lists: [
+            {
+                value: 2,
+                label: '2',
+            },
+        ],
+        combineContributors: '',
+        boundary: null,
+        ppe: '',
+    };
+
+    expect(
+        createFiltersFromQueryString(listsString),
+    ).toEqual(expectedListsMatch);
 
     const typesString = '?contributor_types=Union&contributor_types=Service Provider';
     const expectedTypesMatch = {
@@ -293,6 +320,7 @@ it('creates a set of filters from a querystring', () => {
             },
         ],
         countries: [],
+        lists: [],
         combineContributors: '',
         boundary: null,
         ppe: '',
@@ -317,6 +345,7 @@ it('creates a set of filters from a querystring', () => {
                 label: 'CN',
             },
         ],
+        lists: [],
         combineContributors: '',
         boundary: null,
         ppe: '',
@@ -337,6 +366,7 @@ it('creates a set of filters from a querystring', () => {
             },
         ],
         countries: [],
+        lists: [],
         combineContributors: '',
         boundary: null,
         ppe: '',
@@ -352,6 +382,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        lists: [],
         combineContributors: '',
         boundary: null,
         ppe: 'true',

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -1,10 +1,12 @@
 import { createAction } from 'redux-act';
+import querystring from 'querystring';
 
 import apiRequest from '../util/apiRequest';
 
 import {
     logErrorAndDispatchFailure,
     makeGetContributorsURL,
+    makeGetListsURL,
     makeGetContributorTypesURL,
     makeGetCountriesURL,
     mapDjangoChoiceTuplesToSelectOptions,
@@ -14,6 +16,11 @@ export const startFetchContributorOptions = createAction('START_FETCH_CONTRIBUTO
 export const failFetchContributorOptions = createAction('FAIL_FETCH_CONTRIBUTOR_OPTIONS');
 export const completeFetchContributorOptions =
     createAction('COMPLETE_FETCH_CONTRIBUTOR_OPTIONS');
+
+export const startFetchListOptions = createAction('START_FETCH_LIST_OPTIONS');
+export const failFetchListOptions = createAction('FAIL_FETCH_LIST_OPTIONS');
+export const completeFetchListOptions =
+    createAction('COMPLETE_FETCH_LIST_OPTIONS');
 
 export const startFetchContributorTypeOptions =
     createAction('START_FETCH_CONTRIBUTOR_TYPE_OPTIONS');
@@ -40,6 +47,29 @@ export function fetchContributorOptions() {
                 err,
                 'An error prevented fetching contributor options',
                 failFetchContributorOptions,
+            )));
+    };
+}
+
+export function fetchListOptions() {
+    return (dispatch, getState) => {
+        const { filters: { contributors } } = getState();
+
+        dispatch(startFetchListOptions());
+
+        const url = makeGetListsURL();
+        const qs = `?${querystring.stringify({
+            contributors: contributors.map(c => c.value),
+        })}`;
+
+        return apiRequest
+            .get(`${url}${qs}`)
+            .then(({ data }) => mapDjangoChoiceTuplesToSelectOptions(data))
+            .then(data => dispatch(completeFetchListOptions(data)))
+            .catch(err => dispatch(logErrorAndDispatchFailure(
+                err,
+                'An error prevented fetching list options',
+                failFetchListOptions,
             )));
     };
 }

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -33,15 +33,28 @@ export function setFiltersFromQueryString(qs = '') {
         // contributor data is loaded.
 
         const filters = createFiltersFromQueryString(qs);
-        const { filterOptions: { contributors: { data } } } = getState();
+        const {
+            filterOptions: {
+                contributors: { data },
+                lists,
+            },
+        } = getState();
 
-        const payload = data.length
+        let payload = data.length
             ? update(filters, {
                 contributors: {
                     $set: updateListWithLabels(filters.contributors, data),
                 },
             })
             : filters;
+
+        payload = lists.data.length
+            ? update(payload, {
+                lists: {
+                    $set: updateListWithLabels(filters.lists, lists.data),
+                },
+            })
+            : payload;
 
         return dispatch(updateAllFilters(payload));
     };

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -11,6 +11,7 @@ export const updateFacilityFreeTextQueryFilter =
     createAction('UPDATE_FACILITY_FREE_TEXT_QUERY_FILTER');
 export const updateContributorFilter = createAction('UPDATE_CONTRIBUTOR_FILTER');
 export const updateContributorTypeFilter = createAction('UPDATE_CONTRIBUTOR_TYPE_FILTER');
+export const updateListFilter = createAction('UPDATE_LIST_FILTER');
 export const updateCountryFilter = createAction('UPDATE_COUNTRY_FILTER');
 export const updateCombineContributorsFilterOption = createAction('UPDATE_COMBINE_CONTRIBUTORS_FILTER_OPTION');
 export const updateBoundaryFilter = createAction('UPDATE_BOUNDARY_FILTER');

--- a/src/app/src/components/FacilityListSummary.jsx
+++ b/src/app/src/components/FacilityListSummary.jsx
@@ -15,10 +15,17 @@ const facilityListSummaryStyles = Object.freeze({
 });
 
 
-function FacilityListSummary({ name, description }) {
+function FacilityListSummary({ name, description, id, contributor }) {
     return (
         <div>
-            <p style={facilityListSummaryStyles.nameStyles}>{name}</p>
+            <a
+                style={facilityListSummaryStyles.nameStyles}
+                href={`/?contributors=${contributor}&lists=${id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                {name}
+            </a>
             <p style={facilityListSummaryStyles.descriptionStyles}>{description}</p>
         </div>
     );

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -29,6 +29,7 @@ import {
 
 import {
     fetchContributorOptions,
+    fetchListOptions,
     fetchContributorTypeOptions,
     fetchCountryOptions,
     fetchAllFilterOptions,
@@ -57,8 +58,10 @@ class FilterSidebar extends Component {
             countriesData,
             fetchFilterOptions,
             fetchContributors,
+            fetchLists,
             fetchContributorTypes,
             fetchCountries,
+            contributors,
         } = this.props;
 
         if (allListsAreEmpty(contributorsData, contributorTypesData, countriesData)) {
@@ -77,7 +80,17 @@ class FilterSidebar extends Component {
             fetchCountries();
         }
 
+        if (contributors && contributors.length) {
+            fetchLists();
+        }
+
         return null;
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.contributors !== prevProps.contributors) {
+            this.props.fetchLists();
+        }
     }
 
     render() {
@@ -224,6 +237,9 @@ function mapStateToProps({
         contributors: {
             data: contributorsData,
         },
+        lists: {
+            data: listsData,
+        },
         contributorTypes: {
             data: contributorTypesData,
         },
@@ -238,15 +254,18 @@ function mapStateToProps({
     embeddedMap: {
         embed,
     },
+    filters: { contributors },
 }) {
     return {
         activeFilterSidebarTab,
         contributorsData,
         contributorTypesData,
         countriesData,
+        listsData,
         vectorTileFeatureIsActive: get(flags, 'vector_tile', false),
         fetchingFeatureFlags,
         embed,
+        contributors,
     };
 }
 
@@ -257,6 +276,7 @@ function mapDispatchToProps(dispatch) {
         makeFacilitiesTabActive: () => dispatch(makeSidebarFacilitiesTabActive()),
         fetchFilterOptions: () => dispatch(fetchAllFilterOptions()),
         fetchContributors: () => dispatch(fetchContributorOptions()),
+        fetchLists: () => dispatch(fetchListOptions()),
         fetchContributorTypes: () => dispatch(fetchContributorTypeOptions()),
         fetchCountries: () => dispatch(fetchCountryOptions()),
     };

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -30,10 +30,7 @@ import {
 
 import { fetchFacilities } from '../actions/facilities';
 
-import {
-    recordSearchTabResetButtonClick,
-    showDrawFilter,
-} from '../actions/ui';
+import { recordSearchTabResetButtonClick, showDrawFilter } from '../actions/ui';
 
 import {
     contributorOptionsPropType,
@@ -103,10 +100,11 @@ function FilterSidebarSearchTab({
     updateList,
     lists,
 }) {
-    const [contributorPopoverAnchorEl, setContributorPopoverAnchorEl] =
-          useState(null);
-    const [ppePopoverAnchorEl, setPpePopoverAnchorEl] =
-          useState(null);
+    const [
+        contributorPopoverAnchorEl,
+        setContributorPopoverAnchorEl,
+    ] = useState(null);
+    const [ppePopoverAnchorEl, setPpePopoverAnchorEl] = useState(null);
 
     if (fetchingOptions) {
         return (
@@ -160,7 +158,10 @@ function FilterSidebarSearchTab({
                 Do you want to see only facilities which these contributors
                 share? If so, tick this box.
             </p>
-            <p>There are now two ways to filter a Contributor search on the OAR:</p>
+            <p>
+                There are now two ways to filter a Contributor search on the
+                OAR:
+            </p>
             <ol>
                 <li style={styles.popoverLineItem}>
                     You can search for all the facilities of multiple
@@ -191,27 +192,28 @@ function FilterSidebarSearchTab({
         </div>
     );
 
-    const boundaryButton = boundary == null ? (
-        <Button
-            variant="outlined"
-            onClick={activateDrawFilter}
-            disableRipple
-            color="primary"
-            className="outlined-button outlined-button--full-width"
-        >
-            DRAW AREA
-        </Button>
-    ) : (
-        <Button
-            variant="outlined"
-            onClick={clearDrawFilter}
-            disableRipple
-            color="primary"
-            className="outlined-button outlined-button--full-width"
-        >
-            REMOVE AREA
-        </Button>
-    );
+    const boundaryButton =
+        boundary == null ? (
+            <Button
+                variant="outlined"
+                onClick={activateDrawFilter}
+                disableRipple
+                color="primary"
+                className="outlined-button outlined-button--full-width"
+            >
+                DRAW AREA
+            </Button>
+        ) : (
+            <Button
+                variant="outlined"
+                onClick={clearDrawFilter}
+                disableRipple
+                color="primary"
+                className="outlined-button outlined-button--full-width"
+            >
+                REMOVE AREA
+            </Button>
+        );
 
     return (
         <div
@@ -220,15 +222,12 @@ function FilterSidebarSearchTab({
         >
             <div>
                 <div className="form__field" style={{ marginBottom: '10px' }}>
-                    <InputLabel
-                        htmlFor={FACILITIES}
-                        className="form__label"
-                    >
+                    <InputLabel htmlFor={FACILITIES} className="form__label">
                         <FeatureFlag
                             flag="ppe"
                             alternative="Search a Facility Name or OAR ID"
                         >
-                              Search a Facility Name, OAR ID, or PPE Product Type
+                            Search a Facility Name, OAR ID, or PPE Product Type
                         </FeatureFlag>
                     </InputLabel>
                     <TextField
@@ -241,7 +240,10 @@ function FilterSidebarSearchTab({
                     />
                 </div>
                 <FeatureFlag flag="ppe">
-                    <div className="form__field" style={{ marginBottom: '16px', marginLeft: '10px' }}>
+                    <div
+                        className="form__field"
+                        style={{ marginBottom: '16px' }}
+                    >
                         <FormControlLabel
                             control={
                                 <Checkbox
@@ -252,13 +254,17 @@ function FilterSidebarSearchTab({
                                 />
                             }
                             label="Show only PPE facilities"
+                            style={{ marginRight: '8px' }}
                         />
-                        <IconButton onClick={
-                            // eslint-disable-next-line no-confusing-arrow
-                            e => ppePopoverAnchorEl
-                                ? null
-                                :
-                                setPpePopoverAnchorEl(e.currentTarget)}
+                        <IconButton
+                            onClick={
+                                // eslint-disable-next-line no-confusing-arrow
+                                e =>
+                                    ppePopoverAnchorEl
+                                        ? null
+                                        : setPpePopoverAnchorEl(e.currentTarget)
+                            }
+                            style={{ padding: '4px', color: 'rgba(0,0,0,0.3)' }}
                         >
                             <InfoIcon />
                         </IconButton>
@@ -280,8 +286,8 @@ function FilterSidebarSearchTab({
                         </Popover>
                     </div>
                 </FeatureFlag>
-                <ShowOnly when={!embed}>
-                    <div className="form__field">
+                <div className="form__field">
+                    <ShowOnly when={!embed}>
                         <InputLabel
                             shrink={false}
                             htmlFor={CONTRIBUTORS}
@@ -301,51 +307,66 @@ function FilterSidebarSearchTab({
                             disabled={fetchingOptions || fetchingFacilities}
                         />
                         <ShowOnly when={contributors && contributors.length > 1}>
-                        <div style={{ marginLeft: '20px' }}>
-                            <FormControlLabel
-                                control={
-                                    <Checkbox
-                                        checked={!!combineContributors}
-                                        onChange={updateCombineContributors}
-                                        color="primary"
-                                        value={combineContributors}
-                                    />
-                                }
-                                label="Show only shared facilities"
-                            />
-                            <IconButton onClick={
-                                // eslint-disable-next-line no-confusing-arrow
-                                e => contributorPopoverAnchorEl
-                                    ? null
-                                    :
-                                    setContributorPopoverAnchorEl(e.currentTarget)}
-                            >
-                                <InfoIcon />
-                            </IconButton>
-                            <Popover
-                                id="contributor-info-popover"
-                                anchorOrigin={{
-                                    vertical: 'center',
-                                    horizontal: 'right',
-                                }}
-                                transformOrigin={{
-                                    vertical: 'center',
-                                    horizontal: 'left',
-                                }}
-                                open={!!contributorPopoverAnchorEl}
-                                anchorEl={contributorPopoverAnchorEl}
-                                onClick={() => setContributorPopoverAnchorEl(null)}
-                            >
-                                {contributorInfoPopoverContent}
-                            </Popover>
-                        </div>
+                            <div style={{ marginLeft: '16px' }}>
+                                <FormControlLabel
+                                    control={
+                                        <Checkbox
+                                            checked={!!combineContributors}
+                                            onChange={updateCombineContributors}
+                                            color="primary"
+                                            value={combineContributors}
+                                        />
+                                    }
+                                    label="Show only shared facilities"
+                                />
+                                <IconButton
+                                    onClick={
+                                        // eslint-disable-next-line no-confusing-arrow
+                                        e =>
+                                            contributorPopoverAnchorEl
+                                                ? null
+                                                : setContributorPopoverAnchorEl(
+                                                    e.currentTarget,
+                                                )
+                                    }
+                                >
+                                    <InfoIcon />
+                                </IconButton>
+                                <Popover
+                                    id="contributor-info-popover"
+                                    anchorOrigin={{
+                                        vertical: 'center',
+                                        horizontal: 'right',
+                                    }}
+                                    transformOrigin={{
+                                        vertical: 'center',
+                                        horizontal: 'left',
+                                    }}
+                                    open={!!contributorPopoverAnchorEl}
+                                    anchorEl={contributorPopoverAnchorEl}
+                                    onClick={() =>
+                                        setContributorPopoverAnchorEl(null)
+                                    }
+                                >
+                                    {contributorInfoPopoverContent}
+                                </Popover>
+                            </div>
+                        </ShowOnly>
                     </ShowOnly>
-                    <ShowOnly when={contributors && !!contributors.length && !fetchingLists}>
-                        <div style={{ marginLeft: '20px' }}>
+                    <ShowOnly
+                        when={
+                            contributors &&
+                            !!contributors.length &&
+                            !fetchingLists
+                        }
+                    >
+                        <div style={{ marginLeft: embed ? 0 : '16px', marginTop: '12px' }}>
                             <InputLabel
                                 shrink={false}
                                 htmlFor={LISTS}
-                                style={filterSidebarSearchTabStyles.inputLabelStyle}
+                                style={
+                                    filterSidebarSearchTabStyles.inputLabelStyle
+                                }
                             >
                                 Filter by Contributor List
                             </InputLabel>
@@ -434,27 +455,27 @@ function FilterSidebarSearchTab({
                         >
                             Reset
                         </Button>
-                        {
-                            fetchingFacilities
-                                ? (
-                                    <CircularProgress
-                                        size={30}
-                                        className="margin-left-16"
-                                    />)
-                                : (
-                                    <Button
-                                        variant="contained"
-                                        size="small"
-                                        type="submit"
-                                        color="primary"
-                                        className="margin-left-16 blue-background"
-                                        style={{ boxShadow: 'none' }}
-                                        onClick={() => searchForFacilities(vectorTileFlagIsActive)}
-                                        disabled={fetchingOptions}
-                                    >
-                                        Search
-                                    </Button>)
-                        }
+                        {fetchingFacilities ? (
+                            <CircularProgress
+                                size={30}
+                                className="margin-left-16"
+                            />
+                        ) : (
+                            <Button
+                                variant="contained"
+                                size="small"
+                                type="submit"
+                                color="primary"
+                                className="margin-left-16 blue-background"
+                                style={{ boxShadow: 'none' }}
+                                onClick={() =>
+                                    searchForFacilities(vectorTileFlagIsActive)
+                                }
+                                disabled={fetchingOptions}
+                            >
+                                Search
+                            </Button>
+                        )}
                     </div>
                 </div>
                 {noFacilitiesFoundMessage}
@@ -497,18 +518,12 @@ function mapStateToProps({
             data: contributorOptions,
             fetching: fetchingContributors,
         },
-        lists: {
-            data: listOptions,
-            fetching: fetchingLists,
-        },
+        lists: { data: listOptions, fetching: fetchingLists },
         contributorTypes: {
             data: contributorTypeOptions,
             fetching: fetchingContributorTypes,
         },
-        countries: {
-            data: countryOptions,
-            fetching: fetchingCountries,
-        },
+        countries: { data: countryOptions, fetching: fetchingCountries },
     },
     filters: {
         facilityFreeTextQuery,
@@ -521,17 +536,16 @@ function mapStateToProps({
         ppe,
     },
     facilities: {
-        facilities: {
-            data: facilities,
-            fetching: fetchingFacilities,
-        },
+        facilities: { data: facilities, fetching: fetchingFacilities },
     },
     featureFlags,
-    embeddedMap: {
-        embed,
-    },
+    embeddedMap: { embed },
 }) {
-    const vectorTileFlagIsActive = get(featureFlags, 'flags.vector_tile', false);
+    const vectorTileFlagIsActive = get(
+        featureFlags,
+        'flags.vector_tile',
+        false,
+    );
 
     return {
         vectorTileFlagIsActive,
@@ -549,19 +563,16 @@ function mapStateToProps({
         facilities,
         boundary,
         ppe,
-        fetchingOptions: fetchingContributors
-            || fetchingContributorTypes
-            || fetchingCountries,
+        fetchingOptions:
+            fetchingContributors ||
+            fetchingContributorTypes ||
+            fetchingCountries,
         embed,
         fetchingLists,
     };
 }
 
-function mapDispatchToProps(dispatch, {
-    history: {
-        push,
-    },
-}) {
+function mapDispatchToProps(dispatch, { history: { push } }) {
     return {
         updateFacilityFreeTextQuery: e =>
             dispatch(updateFacilityFreeTextQueryFilter(getValueFromEvent(e))),
@@ -574,23 +585,29 @@ function mapDispatchToProps(dispatch, {
         updateContributorType: v => dispatch(updateContributorTypeFilter(v)),
         updateList: v => dispatch(updateListFilter(v)),
         updateCountry: v => dispatch(updateCountryFilter(v)),
-        updatePPE: e => dispatch(updatePPEFilter(
-            e.target.checked ? 'true' : '',
-        )),
-        updateCombineContributors: e => dispatch(
-            updateCombineContributorsFilterOption(e.target.checked ? 'AND' : ''),
-        ),
+        updatePPE: e =>
+            dispatch(updatePPEFilter(e.target.checked ? 'true' : '')),
+        updateCombineContributors: e =>
+            dispatch(
+                updateCombineContributorsFilterOption(
+                    e.target.checked ? 'AND' : '',
+                ),
+            ),
         resetFilters: (embedded) => {
             dispatch(recordSearchTabResetButtonClick());
             return dispatch(resetAllFilters(embedded));
         },
-        searchForFacilities: vectorTilesAreActive => dispatch(fetchFacilities({
-            pageSize: vectorTilesAreActive ? FACILITIES_REQUEST_PAGE_SIZE : 50,
-            pushNewRoute: push,
-        })),
-        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(
-            () => dispatch(fetchFacilities(push)),
-        ),
+        searchForFacilities: vectorTilesAreActive =>
+            dispatch(
+                fetchFacilities({
+                    pageSize: vectorTilesAreActive
+                        ? FACILITIES_REQUEST_PAGE_SIZE
+                        : 50,
+                    pushNewRoute: push,
+                }),
+            ),
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(() =>
+            dispatch(fetchFacilities(push))),
         activateDrawFilter: () => dispatch(showDrawFilter(true)),
         clearDrawFilter: () => {
             dispatch(showDrawFilter(false));
@@ -600,4 +617,7 @@ function mapDispatchToProps(dispatch, {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(FilterSidebarSearchTab);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(FilterSidebarSearchTab);

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -19,6 +19,7 @@ import FeatureFlag from './FeatureFlag';
 import {
     updateFacilityFreeTextQueryFilter,
     updateContributorFilter,
+    updateListFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
     updateCombineContributorsFilterOption,
@@ -67,10 +68,12 @@ const filterSidebarSearchTabStyles = Object.freeze({
 const FACILITIES = 'FACILITIES';
 const CONTRIBUTORS = 'CONTRIBUTORS';
 const CONTRIBUTOR_TYPES = 'CONTRIBUTOR_TYPES';
+const LISTS = 'LISTS';
 const COUNTRIES = 'COUNTRIES';
 
 function FilterSidebarSearchTab({
     contributorOptions,
+    listOptions,
     contributorTypeOptions,
     countryOptions,
     resetFilters,
@@ -96,6 +99,9 @@ function FilterSidebarSearchTab({
     ppe,
     updatePPE,
     embed,
+    fetchingLists,
+    updateList,
+    lists,
 }) {
     const [contributorPopoverAnchorEl, setContributorPopoverAnchorEl] =
           useState(null);
@@ -235,7 +241,7 @@ function FilterSidebarSearchTab({
                     />
                 </div>
                 <FeatureFlag flag="ppe">
-                    <div className="form__field" style={{ marginBottom: '16px' }}>
+                    <div className="form__field" style={{ marginBottom: '16px', marginLeft: '10px' }}>
                         <FormControlLabel
                             control={
                                 <Checkbox
@@ -295,6 +301,7 @@ function FilterSidebarSearchTab({
                             disabled={fetchingOptions || fetchingFacilities}
                         />
                         <ShowOnly when={contributors && contributors.length > 1}>
+                        <div style={{ marginLeft: '20px' }}>
                             <FormControlLabel
                                 control={
                                     <Checkbox
@@ -331,29 +338,51 @@ function FilterSidebarSearchTab({
                             >
                                 {contributorInfoPopoverContent}
                             </Popover>
-                        </ShowOnly>
-                    </div>
-                    <div className="form__field">
-                        <InputLabel
-                            shrink={false}
-                            htmlFor={CONTRIBUTOR_TYPES}
-                            style={filterSidebarSearchTabStyles.inputLabelStyle}
-                        >
-                            Filter by Contributor Type
-                        </InputLabel>
-                        <ReactSelect
-                            isMulti
-                            id={CONTRIBUTOR_TYPES}
-                            name="contributorTypes"
-                            className="basic-multi-select notranslate"
-                            classNamePrefix="select"
-                            options={contributorTypeOptions}
-                            value={contributorTypes}
-                            onChange={updateContributorType}
-                            disabled={fetchingOptions || fetchingFacilities}
-                        />
-                    </div>
-                </ShowOnly>
+                        </div>
+                    </ShowOnly>
+                    <ShowOnly when={contributors && !!contributors.length && !fetchingLists}>
+                        <div style={{ marginLeft: '20px' }}>
+                            <InputLabel
+                                shrink={false}
+                                htmlFor={LISTS}
+                                style={filterSidebarSearchTabStyles.inputLabelStyle}
+                            >
+                                Filter by Contributor List
+                            </InputLabel>
+                            <ReactSelect
+                                isMulti
+                                id={LISTS}
+                                name={LISTS}
+                                className="basic-multi-select notranslate"
+                                classNamePrefix="select"
+                                options={listOptions}
+                                value={lists}
+                                onChange={updateList}
+                                disabled={fetchingLists || fetchingFacilities}
+                            />
+                        </div>
+                    </ShowOnly>
+                </div>
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={CONTRIBUTOR_TYPES}
+                        style={filterSidebarSearchTabStyles.inputLabelStyle}
+                    >
+                        Filter by Contributor Type
+                    </InputLabel>
+                    <ReactSelect
+                        isMulti
+                        id={CONTRIBUTOR_TYPES}
+                        name="contributorTypes"
+                        className="basic-multi-select notranslate"
+                        classNamePrefix="select"
+                        options={contributorTypeOptions}
+                        value={contributorTypes}
+                        onChange={updateContributorType}
+                        disabled={fetchingOptions || fetchingFacilities}
+                    />
+                </div>
                 <div className="form__field">
                     <InputLabel
                         shrink={false}
@@ -468,6 +497,10 @@ function mapStateToProps({
             data: contributorOptions,
             fetching: fetchingContributors,
         },
+        lists: {
+            data: listOptions,
+            fetching: fetchingLists,
+        },
         contributorTypes: {
             data: contributorTypeOptions,
             fetching: fetchingContributorTypes,
@@ -480,6 +513,7 @@ function mapStateToProps({
     filters: {
         facilityFreeTextQuery,
         contributors,
+        lists,
         contributorTypes,
         countries,
         combineContributors,
@@ -502,10 +536,12 @@ function mapStateToProps({
     return {
         vectorTileFlagIsActive,
         contributorOptions,
+        listOptions,
         contributorTypeOptions,
         countryOptions,
         facilityFreeTextQuery,
         contributors,
+        lists,
         contributorTypes,
         countries,
         combineContributors,
@@ -517,6 +553,7 @@ function mapStateToProps({
             || fetchingContributorTypes
             || fetchingCountries,
         embed,
+        fetchingLists,
     };
 }
 
@@ -535,6 +572,7 @@ function mapDispatchToProps(dispatch, {
             dispatch(updateContributorFilter(v));
         },
         updateContributorType: v => dispatch(updateContributorTypeFilter(v)),
+        updateList: v => dispatch(updateListFilter(v)),
         updateCountry: v => dispatch(updateCountryFilter(v)),
         updatePPE: e => dispatch(updatePPEFilter(
             e.target.checked ? 'true' : '',

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -224,7 +224,7 @@ class UserProfile extends Component {
                 <React.Fragment>
                     <h3>Facility Lists</h3>
                     {profile.facilityLists.map(
-                        list => <FacilityListSummary key={list.id} {...list} />,
+                        list => <FacilityListSummary key={list.id} contributor={id} {...list} />,
                     )}
                 </React.Fragment>)
             : null;

--- a/src/app/src/reducers/FilterOptionsReducer.js
+++ b/src/app/src/reducers/FilterOptionsReducer.js
@@ -5,6 +5,9 @@ import {
     startFetchContributorOptions,
     failFetchContributorOptions,
     completeFetchContributorOptions,
+    startFetchListOptions,
+    failFetchListOptions,
+    completeFetchListOptions,
     startFetchContributorTypeOptions,
     failFetchContributorTypeOptions,
     completeFetchContributorTypeOptions,
@@ -16,6 +19,11 @@ import {
 
 const initialState = Object.freeze({
     contributors: Object.freeze({
+        data: Object.freeze([]),
+        fetching: false,
+        error: null,
+    }),
+    lists: Object.freeze({
         data: Object.freeze([]),
         fetching: false,
         error: null,
@@ -47,6 +55,25 @@ export default createReducer({
     }),
     [completeFetchContributorOptions]: (state, payload) => update(state, {
         contributors: {
+            fetching: { $set: false },
+            error: { $set: null },
+            data: { $set: payload },
+        },
+    }),
+    [startFetchListOptions]: state => update(state, {
+        lists: {
+            fetching: { $set: true },
+            error: { $set: null },
+        },
+    }),
+    [failFetchListOptions]: (state, payload) => update(state, {
+        lists: {
+            fetching: { $set: false },
+            error: { $set: payload },
+        },
+    }),
+    [completeFetchListOptions]: (state, payload) => update(state, {
+        lists: {
             fetching: { $set: false },
             error: { $set: null },
             data: { $set: payload },

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -4,6 +4,7 @@ import update from 'immutability-helper';
 import {
     updateFacilityFreeTextQueryFilter,
     updateContributorFilter,
+    updateListFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
     updatePPEFilter,
@@ -33,6 +34,7 @@ const initialState = Object.freeze({
     combineContributors: '',
     boundary: null,
     ppe: '',
+    lists: Object.freeze([]),
 });
 
 export const maybeSetFromQueryString = field => (state, payload) => {
@@ -55,6 +57,7 @@ export default createReducer({
     }),
     [updateContributorFilter]: (state, payload) => update(state, {
         contributors: { $set: payload },
+        lists: { $set: initialState.lists },
     }),
     [updateContributorTypeFilter]: (state, payload) => update(state, {
         contributorTypes: { $set: payload },
@@ -70,6 +73,9 @@ export default createReducer({
     }),
     [updatePPEFilter]: (state, payload) => update(state, {
         ppe: { $set: payload },
+    }),
+    [updateListFilter]: (state, payload) => update(state, {
+        lists: { $set: payload },
     }),
     [resetAllFilters]: (state, payload) => update(initialState, {
         contributors: {

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -93,6 +93,7 @@ export const makeCreateDashboardActivityReportURL = oarId => `/api/facilities/${
 export const makeAPITokenURL = () => '/api-token-auth/';
 
 export const makeGetContributorsURL = () => '/api/contributors/';
+export const makeGetListsURL = () => '/api/contributor-lists/';
 export const makeGetContributorTypesURL = () => '/api/contributor-types/';
 export const makeGetCountriesURL = () => '/api/countries/';
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -147,6 +147,7 @@ export const createQueryStringFromSearchFilters = ({
     contributors = [],
     contributorTypes = [],
     countries = [],
+    lists = [],
     combineContributors = '',
     boundary = {},
     ppe = '',
@@ -154,6 +155,7 @@ export const createQueryStringFromSearchFilters = ({
     const inputForQueryString = Object.freeze({
         q: facilityFreeTextQuery,
         contributors: createCompactSortedQuerystringInputObject(contributors),
+        lists: createCompactSortedQuerystringInputObject(lists),
         contributor_types: createCompactSortedQuerystringInputObject(contributorTypes),
         countries: createCompactSortedQuerystringInputObject(countries),
         combine_contributors: combineContributors,
@@ -200,6 +202,7 @@ export const createFiltersFromQueryString = (qs) => {
     const {
         q: facilityFreeTextQuery = '',
         contributors = [],
+        lists = [],
         contributor_types: contributorTypes = [],
         countries = [],
         combine_contributors: combineContributors = '',
@@ -210,6 +213,7 @@ export const createFiltersFromQueryString = (qs) => {
     return Object.freeze({
         facilityFreeTextQuery,
         contributors: createSelectOptionsFromParams(contributors),
+        lists: createSelectOptionsFromParams(lists),
         contributorTypes: createSelectOptionsFromParams(contributorTypes),
         countries: createSelectOptionsFromParams(countries),
         combineContributors,

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -26,6 +26,7 @@ class FacilitiesQueryParams:
     Q = 'q'
     NAME = 'name'
     CONTRIBUTORS = 'contributors'
+    LISTS = 'lists'
     CONTRIBUTOR_TYPES = 'contributor_types'
     COUNTRIES = 'countries'
     COMBINE_CONTRIBUTORS = 'combine_contributors'

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1121,6 +1121,8 @@ class FacilityManager(models.Manager):
 
         contributors = params.getlist(FacilitiesQueryParams.CONTRIBUTORS)
 
+        lists = params.getlist(FacilitiesQueryParams.LISTS)
+
         contributor_types = params \
             .getlist(FacilitiesQueryParams.CONTRIBUTOR_TYPES)
 
@@ -1228,6 +1230,12 @@ class FacilityManager(models.Manager):
                             FacilityMatch.CONFIRMED],
                         contributor__in=contributors).values_list(
                             'facilitylistitem__facility', flat=True)))
+
+        if len(lists):
+            facilities_qs = facilities_qs.filter(
+                id__in=(Source.objects.filter(
+                    facilitylistitem__source_id__in=lists).values_list(
+                        'facilitylistitem__facility', flat=True)))
 
         if boundary is not None:
             facilities_qs = facilities_qs.filter(

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1064,3 +1064,10 @@ class FacilityActivityReportSerializer(ModelSerializer):
             return instance.status_change_by.email
         else:
             return None
+
+
+class ContributorListQueryParamsSerializer(Serializer):
+    contributors = ListField(
+        child=IntegerField(required=False),
+        required=False,
+    )

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -381,6 +381,10 @@ class FacilityQueryParamsSerializer(Serializer):
         child=IntegerField(required=False),
         required=False,
     )
+    lists = ListField(
+        child=IntegerField(required=False),
+        required=False,
+    )
     contributor_types = ListField(
         child=CharField(required=False),
         required=False,

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -526,6 +526,13 @@ class FacilitiesAPIFilterBackend(BaseFilterBackend):
                     description='Contributor ID',
                 ),
                 coreapi.Field(
+                    name='lists',
+                    location='query',
+                    type='integer',
+                    required=False,
+                    description='List ID',
+                ),
+                coreapi.Field(
                     name='contributor_types',
                     location='query',
                     type='string',

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -92,6 +92,7 @@ from api.serializers import (FacilityListSerializer,
                              FacilityListItemsQueryParamsSerializer,
                              FacilityQueryParamsSerializer,
                              FacilityListQueryParamsSerializer,
+                             ContributorListQueryParamsSerializer,
                              FacilitySerializer,
                              FacilityDetailsSerializer,
                              FacilityMatchSerializer,
@@ -3438,5 +3439,46 @@ class FacilityActivityReportViewSet(viewsets.GenericViewSet):
     def list(self, request):
         response_data = FacilityActivityReportSerializer(
             FacilityActivityReport.objects.all(), many=True).data
+
+        return Response(response_data)
+
+
+class ContributorFacilityListAutoSchema(AutoSchema):
+    def get_serializer_fields(self, path, method):
+        if method == 'GET':
+            return [
+                coreapi.Field(
+                    name='contributors',
+                    location='query',
+                    description=('The contributor ID.'),
+                    required=True,
+                )
+            ]
+        return super(ContributorFacilityListAutoSchema,
+                     self).get_serializer_fields(path, method)
+
+
+@schema(ContributorFacilityListAutoSchema())
+class ContributorFacilityListViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    View active Facility Lists filtered by Contributor.
+    """
+    queryset = FacilityList.objects.filter(source__is_active=True)
+
+    def list(self, request):
+        params = ContributorListQueryParamsSerializer(
+            data=request.query_params)
+
+        if not params.is_valid():
+            raise ValidationError(params.errors)
+
+        contributors = params.data.get('contributors', [])
+
+        response_data = [
+            (list.id, list.name)
+            for list
+            in self.queryset.filter(
+                source__contributor__id__in=contributors).order_by('name')
+        ]
 
         return Response(response_data)

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -46,6 +46,9 @@ public_apis = [
     url(r'^api/contributor-types/', views.all_contributor_types,
         name='all_contributor_types'),
     url(r'^api/countries/', views.all_countries, name='all_countries'),
+    url(r'^api/contributor-lists/',
+        views.ContributorFacilityListViewSet.as_view({'get': 'list'}),
+        name='contributor_lists'),
     url(r'^api/log-download/', views.log_download, name='log_download'),
 ]
 


### PR DESCRIPTION
## Overview

Enables users to filter down to the individual list level. 

Examples for use of this filtering would be the Accord on Fire and Building Safety in Bangladesh consolidating their two separate accounts into one, with users being able to filter to each separate upload; users being able to filter by the different lists for tiers of supply chains uploaded by brands; certification schemes having separate lists for different levels of certification, e.g. Gold, Silver, Bronze, which users can then filter by.

Connects #983 

## Demo

<img width="994" alt="Screen Shot 2021-03-02 at 11 21 10 AM" src="https://user-images.githubusercontent.com/21046714/109681893-eb936080-7b4b-11eb-8da2-7885a9c73502.png">
<img width="642" alt="Screen Shot 2021-03-02 at 11 35 55 AM" src="https://user-images.githubusercontent.com/21046714/109681899-ecc48d80-7b4b-11eb-8342-f9cffc6cb150.png">
<img width="407" alt="Screen Shot 2021-03-02 at 11 36 03 AM" src="https://user-images.githubusercontent.com/21046714/109681908-ee8e5100-7b4b-11eb-8934-1510cc076594.png">
<img width="430" alt="Screen Shot 2021-03-02 at 11 36 10 AM" src="https://user-images.githubusercontent.com/21046714/109681916-efbf7e00-7b4b-11eb-9de3-7fa816b35631.png">

## Testing Instructions

* Run `vagrant ssh` and `./scripts/server`
* Navigate to [/api/docs/#!/contributor-lists/contributor_lists_list](http://localhost:8081/api/docs/#!/contributor-lists/contributor_lists_list)
* Enter 2 as the contributor ID 
    - [x] You should get a list of contributor lists as ID/name pairs
* Navigate to http://localhost:8081/api/docs/#!/facilities/facilities_list
* Set the list's param to 2
    - [x] You should get a list of facilities from the Summer 2019 Compliance List
* Navigate to http://localhost:6543/
    - [x] You should not see the contributor lists
* Select Service Provider A
    - [x] You should see the contributor lists select
* Select the Summer 2019 Compliance List and search
    - [x] You should get a list of facilities from that list
    - [x] The map should load correctly
* Select Civil Society Organization A
    - [x] The previously selected listed should no longer be selected
    - [x] You should see multiple lists in the dropdown
* Select Summer 2019 Apparel List and Summer 2019 Compliance List and search
    - [x] You should get a list of facilities from both lists
* Refresh the page
    - [x] Both contributors and both lists should remain selected
* Navigate to http://localhost:6543/profile/2 
    - [x] The Facility List names should be links
* Click the link
    - [x] The map should open with the appropriate contributor and list selected

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
