### PR TITLE
Fix Filtering Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Align Facility Matches [#1243](https://github.com/open-apparel-registry/open-apparel-registry/pull/1243)
 - Update Reject Button Text [#1244](https://github.com/open-apparel-registry/open-apparel-registry/pull/1244)
 - Fix vagrant provisioning failure by pinning pip python version [#1262](https://github.com/open-apparel-registry/open-apparel-registry/pull/1262)
+- Fix list filtering [#1272](https://github.com/open-apparel-registry/open-apparel-registry/pull/1272)
 
 ### Security
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure("2") do |config|
     ansible.compatibility_mode = "2.0"
     ansible.install = true
     ansible.install_mode = "pip_args_only"
-    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/2.7/get-pip.py | sudo python"
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python"
     ansible.pip_args = "ansible==#{ANSIBLE_VERSION}"
     ansible.playbook = "deployment/ansible/open-apparel-registry.yml"
     ansible.galaxy_role_file = "deployment/ansible/roles.yml"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -2,6 +2,7 @@
 aws_cli_version: "1.16.*"
 aws_profile: "open-apparel-registry"
 pip_get_pip_version: "2.7"
+pip_version: "20.3.*"
 
 oar_settings_bucket: "openapparelregistry-development-config-eu-west-1"
 

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -224,7 +224,13 @@ class UserProfile extends Component {
                 <React.Fragment>
                     <h3>Facility Lists</h3>
                     {profile.facilityLists.map(
-                        list => <FacilityListSummary key={list.id} contributor={id} {...list} />,
+                        list => (
+                            <FacilityListSummary
+                                key={list.id}
+                                contributor={list.contributor_id}
+                                {...list}
+                            />
+                        ),
                     )}
                 </React.Fragment>)
             : null;

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1234,7 +1234,7 @@ class FacilityManager(models.Manager):
         if len(lists):
             facilities_qs = facilities_qs.filter(
                 id__in=(Source.objects.filter(
-                    facilitylistitem__source_id__in=lists).values_list(
+                    facility_list_id__in=lists).values_list(
                         'facilitylistitem__facility', flat=True)))
 
         if boundary is not None:

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -226,9 +226,17 @@ class UserProfileSerializer(ModelSerializer):
 
 
 class FacilityListSummarySerializer(ModelSerializer):
+    contributor_id = SerializerMethodField()
+
     class Meta:
         model = FacilityList
-        fields = ('id', 'name', 'description')
+        fields = ('id', 'name', 'description', 'contributor_id')
+
+    def get_contributor_id(self, facility_list):
+        try:
+            return facility_list.source.contributor.id
+        except Contributor.DoesNotExist:
+            return None
 
 
 class FacilityListSerializer(ModelSerializer):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4077,6 +4077,100 @@ class FacilityAPITestCaseBase(APITestCase):
         self.list_item.save()
 
 
+class SearchByList(APITestCase):
+    def setUp(self):
+        self.user_email = 'test@example.com'
+        self.user_password = 'example123'
+        self.user = User.objects.create(email=self.user_email)
+        self.user.set_password(self.user_password)
+        self.user.save()
+
+        self.superuser_email = 'super@example.com'
+        self.superuser_password = 'example123'
+        self.superuser = User.objects.create_superuser(
+            email=self.superuser_email,
+            password=self.superuser_password)
+
+        self.contributor = Contributor \
+            .objects \
+            .create(id=111,
+                    admin=self.user,
+                    name='test contributor 1',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.list = FacilityList \
+            .objects \
+            .create(id=123,
+                    header='header',
+                    file_name='one',
+                    name='First List')
+
+        self.source = Source \
+            .objects \
+            .create(id=456,
+                    facility_list=self.list,
+                    source_type=Source.LIST,
+                    is_active=True,
+                    is_public=True,
+                    contributor=self.contributor)
+
+        self.list_item = FacilityListItem \
+            .objects \
+            .create(id=789,
+                    name='Item',
+                    address='Address',
+                    country_code='US',
+                    row_index=1,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=self.source)
+
+        self.facility = Facility \
+            .objects \
+            .create(id='US2021067MMRTSD',
+                    name='Name',
+                    address='Address',
+                    country_code='US',
+                    location=Point(0, 0),
+                    created_from=self.list_item)
+
+        self.match = FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.AUTOMATIC,
+                    facility=self.facility,
+                    facility_list_item=self.list_item,
+                    confidence=0.85,
+                    results='')
+
+        self.list_item.facility = self.facility
+        self.list_item.save()
+
+    def test_fetched_by_contributor(self):
+        url = '/api/facilities/?contributors={}'.format(self.contributor.id)
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], self.facility.id)
+
+    def test_fetched_by_list(self):
+        url = '/api/facilities/?lists={}'.format(self.list.id)
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], self.facility.id)
+
+    def test_fetched_by_list_and_contributor(self):
+        url = '/api/facilities/?contributors={}&lists={}'.format(
+            self.contributor.id, self.list.id)
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], self.facility.id)
+
+
 class UpdateLocationTest(FacilityAPITestCaseBase):
     def setUp(self):
         super(UpdateLocationTest, self).setUp()


### PR DESCRIPTION
## Overview

In the development database, many associated models share the same id; however, in staging and production this is significantly less common. When introducing list filtering, facilities were being filtered based on matching the id to the incorrect model, which was not caught due to the ids matching in all development cases. The filtering is now based on correct models. 

In addition, a new set of tests was added with manually set, non-matching ids in order to verify the fix is working locally. 

Connects #983 

## Notes

Much of the code setting up the tests for this is a duplicate of the code in the `FacilityAPITestCaseBase`, but as I was applying manually set IDs to the data, I felt it was better to separate out the new test cases. 

## Testing Instructions

* Visually confirm that the test cases are accurately testing the use case and the believed source of the bug. 
* Run the tests and confirm they are passing.
    * (Note: If you replace line 1237 in modes.py with `facilitylistitem__source_id__in=lists).values_list(`, the previous text of that line, and run the tests, you can see that they do not pass with the previous code)
* Complete the tests previously described in [#1264](https://github.com/open-apparel-registry/open-apparel-registry/pull/1264)
  - Navigate to [/api/docs/#!/contributor-lists/contributor_lists_list](http://localhost:8081/api/docs/#!/contributor-lists/contributor_lists_list)
  - Enter 2 as the contributor ID 
      - [x] You should get a list of contributor lists as ID/name pairs
  - Navigate to http://localhost:8081/api/docs/#!/facilities/facilities_list
  - Set the list's param to 2
      - [x] You should get a list of facilities from the Summer 2019 Compliance List
  - Navigate to http://localhost:6543/
      - [x] You should not see the contributor lists
  - Select Service Provider A
      - [x] You should see the contributor lists select
  - Select the Summer 2019 Compliance List and search
      - [x] You should get a list of facilities from that list
      - [x] The map should load correctly
  - Select Civil Society Organization A
      - [x] The previously selected listed should no longer be selected
      - [x] You should see multiple lists in the dropdown
  - Select Summer 2019 Apparel List and Summer 2019 Compliance List and search
      - [x] You should get a list of facilities from both lists
  - Refresh the page
      - [x] Both contributors and both lists should remain selected
  - Navigate to http://localhost:6543/profile/2 
      - [x] The Facility List names should be links
  - Click the link
      - [ ] The map should open with the appropriate contributor and list selected

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
