### PR TITLE
Provide Constant Access to GDPR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Provide Constant Access to GDPR [#1279](https://github.com/open-apparel-registry/open-apparel-registry/pull/1279)
+
 ### Changed
 
 - Use Craco and Prettier [#1271](https://github.com/open-apparel-registry/open-apparel-registry/pull/1271)

--- a/src/app/src/actions/ui.js
+++ b/src/app/src/actions/ui.js
@@ -26,3 +26,5 @@ export const resetSidebarFacilitiesTabTextFilter = createAction(
 export const toggleZoomToSearch = createAction('TOGGLE_ZOOM_TO_SEARCH');
 
 export const showDrawFilter = createAction('SHOW_DRAW_FILTER');
+
+export const setGDPROpen = createAction('SET_GDPR_OPEN');

--- a/src/app/src/components/Footer.jsx
+++ b/src/app/src/components/Footer.jsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import Button from '@material-ui/core/Button';
 import logo from '../styles/images/Creative-Commons-Attribution-ShareAlike-40-International-Public.png';
+
+import { setGDPROpen } from '../actions/ui';
+
+const linkButtonStyle = {
+    textDecoration: 'underline',
+    textTransform: 'capitalize',
+    minHeight: 'auto',
+};
 
 const links = [
     {
@@ -9,6 +19,10 @@ const links = [
         text: 'Azavea',
         external: true,
         newTab: true,
+    },
+    {
+        text: 'Cookie Preferences',
+        button: true,
     },
     {
         href: 'https://info.openapparel.org/tos/',
@@ -24,7 +38,7 @@ const links = [
     },
 ];
 
-export default () => (
+const Footer = ({ openGDPR }) => (
     <footer className="footerContainer results-height-subtract" xs={12}>
         <div className="links">
             {links.map(l => {
@@ -55,6 +69,18 @@ export default () => (
                         </p>
                     );
                 }
+                if (l.button) {
+                    return (
+                        <Button
+                            className="link"
+                            style={linkButtonStyle}
+                            key={l.text}
+                            onClick={openGDPR}
+                        >
+                            {l.text}
+                        </Button>
+                    );
+                }
                 return (
                     <Link to={l.href} href={l.href} key={l.text}>
                         {l.text}
@@ -75,3 +101,11 @@ export default () => (
         </a>
     </footer>
 );
+
+function mapDispatchToProps(dispatch) {
+    return {
+        openGDPR: () => dispatch(setGDPROpen(true)),
+    };
+}
+
+export default connect(null, mapDispatchToProps)(Footer);

--- a/src/app/src/components/GDPRNotification.jsx
+++ b/src/app/src/components/GDPRNotification.jsx
@@ -1,9 +1,12 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import Snackbar from '@material-ui/core/Snackbar';
 import Button from './Button';
 import ShowOnly from './ShowOnly';
 import COLOURS from '../util/COLOURS';
 import CookiePreferencesText from './CookiePreferencesText';
+
+import { setGDPROpen } from '../actions/ui';
 
 import {
     userHasAcceptedOrRejectedGATracking,
@@ -11,11 +14,10 @@ import {
     acceptGATrackingAndStartTracking,
     rejectGATracking,
     startGATrackingIfUserHasAcceptedNotification,
+    clearGATrackingDecision,
 } from '../util/util.ga';
 
-export default class GDPRNotification extends Component {
-    state = { open: false };
-
+class GDPRNotification extends Component {
     componentDidMount() {
         if (userHasAcceptedOrRejectedGATracking()) {
             if (userHasAcceptedGATracking()) {
@@ -25,24 +27,20 @@ export default class GDPRNotification extends Component {
             return null;
         }
 
-        return this.setState(state =>
-            Object.assign({}, state, {
-                open: true,
-            }),
-        );
+        return this.props.openGDPR();
     }
 
-    acceptGDPRAlertAndDismissSnackbar = () =>
-        this.setState(
-            state => Object.assign({}, state, { open: false }),
-            acceptGATrackingAndStartTracking,
-        );
+    acceptGDPRAlertAndDismissSnackbar = () => {
+        clearGATrackingDecision();
+        acceptGATrackingAndStartTracking();
+        this.props.closeGDPR();
+    };
 
-    rejectGDPRAlertAndDismissSnackbar = () =>
-        this.setState(
-            state => Object.assign({}, state, { open: false }),
-            rejectGATracking,
-        );
+    rejectGDPRAlertAndDismissSnackbar = () => {
+        clearGATrackingDecision();
+        rejectGATracking();
+        this.props.closeGDPR();
+    };
 
     render() {
         const GDPRActions = (
@@ -63,10 +61,10 @@ export default class GDPRNotification extends Component {
         );
 
         return (
-            <ShowOnly when={this.state.open}>
+            <ShowOnly when={this.props.open}>
                 <Snackbar
                     className="gdpr-notification"
-                    open={this.state.open}
+                    open={this.props.open}
                     anchorOrigin={{
                         vertical: 'bottom',
                         horizontal: 'right',
@@ -78,3 +76,16 @@ export default class GDPRNotification extends Component {
         );
     }
 }
+
+function mapStateToProps({ ui: { gdprOpen } }) {
+    return { open: gdprOpen };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        openGDPR: () => dispatch(setGDPROpen(true)),
+        closeGDPR: () => dispatch(setGDPROpen(false)),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(GDPRNotification);

--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -3,6 +3,7 @@ import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import Toolbar from '@material-ui/core/Toolbar';
 import Drawer from '@material-ui/core/Drawer';
+import { connect } from 'react-redux';
 
 import { Link, Route } from 'react-router-dom';
 
@@ -14,13 +15,14 @@ import {
     contributeRoute,
     aboutClaimedFacilitiesRoute,
 } from '../util/constants';
+import { setGDPROpen } from '../actions/ui';
 
 const apiDocumentationURL =
     process.env.NODE_ENV === 'development'
         ? 'http://localhost:8081/api/docs/'
         : '/api/docs/';
 
-export default function Navbar({ embed }) {
+function Navbar({ embed, openGDPR }) {
     const [drawerHandler, setDrawerHandler] = useState(false);
     const mobileMenuToggleRef = useRef();
 
@@ -148,6 +150,20 @@ export default function Navbar({ embed }) {
                     CONTRIBUTE
                 </Link>
                 <Button
+                    className="btn-text navButton"
+                    style={{
+                        minHeight: 'auto',
+                        justifyContent: 'flex-start',
+                    }}
+                    disableRipple
+                    onClick={() => {
+                        openGDPR();
+                        setDrawerHandler(false);
+                    }}
+                >
+                    Cookie Preferences
+                </Button>
+                <Button
                     style={{ marginTop: 'auto' }}
                     onClick={() => setDrawerHandler(false)}
                 >
@@ -217,3 +233,11 @@ export default function Navbar({ embed }) {
         </>
     );
 }
+
+function mapDispatchToProps(dispatch) {
+    return {
+        openGDPR: () => dispatch(setGDPROpen(true)),
+    };
+}
+
+export default connect(null, mapDispatchToProps)(Navbar);

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -12,6 +12,7 @@ import {
     reportWindowResize,
     toggleZoomToSearch,
     showDrawFilter,
+    setGDPROpen,
 } from '../actions/ui';
 
 import { completeFetchFacilities } from '../actions/facilities';
@@ -30,6 +31,7 @@ const initialState = Object.freeze({
     }),
     zoomToSearch: true,
     drawFilterActive: false,
+    gdprOpen: false,
 });
 
 export default createReducer(
@@ -105,6 +107,10 @@ export default createReducer(
         [showDrawFilter]: (state, payload) =>
             update(state, {
                 drawFilterActive: { $set: payload },
+            }),
+        [setGDPROpen]: (state, payload) =>
+            update(state, {
+                gdprOpen: { $set: payload },
             }),
     },
     initialState,


### PR DESCRIPTION
## Overview

Allows users to click a link in the footer (on web) or in the dropdown
menu (on mobile) to open the GDPR notification, at which point they
can choose to accept or reject cookies, clearing their previous
selection.

Connects #1261 

## Demo

<img width="1348" alt="Screen Shot 2021-03-11 at 3 02 22 PM" src="https://user-images.githubusercontent.com/21046714/110849363-251b4880-827d-11eb-9627-405a9b2db295.png">
<img width="495" alt="Screen Shot 2021-03-11 at 3 02 10 PM" src="https://user-images.githubusercontent.com/21046714/110849371-264c7580-827d-11eb-994f-8a6ca07ccad2.png">

## Testing Instructions

* Run `./scripts/server` and navigate to [localhost:6543/](http://localhost:6543/)
* Clear your local storage and refresh the page
    - [x] You should see the GDPR notification
* Select Accept or Reject
    - [x] Your preference should be updated in local storage appropriately
* Click on 'Cookie Preferences' in the footer
    - [x] You should see the GDPR notification
* Select Accept or Reject
    - [x] Your preference should be updated in local storage appropriately
* Make the viewport narrow to simulate mobile and click the Menu button
    - [x] You should see a 'Cookie Preferences' button
* Click on the 'Cookie Preferences' menu item
    - [x] You should see the GDPR notification
* Select Accept or Reject
    - [x] Your preference should be updated in local storage appropriately

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
