### PR TITLE
Look up contributor via token when checking API blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Look up contributor via token when checking API blocks [#1280](https://github.com/open-apparel-registry/open-apparel-registry/pull/1280)
+
 ### Security
 
 ## [2.40.0] - 2021-03-10

--- a/src/django/api/middleware.py
+++ b/src/django/api/middleware.py
@@ -1,6 +1,7 @@
 import sys
 import datetime
 import logging
+import json
 
 from django.utils import timezone
 from django.conf import settings
@@ -124,7 +125,9 @@ class RequestMeterMiddleware:
         is_blocked = has_active_block(request)
 
         if is_blocked and not is_docs:
-            return HttpResponse('API limit exceeded', status=402)
+            return HttpResponse(json.dumps({'detail': 'API limit exceeded'}),
+                                content_type='application/json',
+                                status=402)
         else:
             response = self.get_response(request)
             return response


### PR DESCRIPTION
## Overview

Our block check middleware appears to be running before the Django REST Framework token auth handling has set `request.user`. As a result, our block checking is exiting too soon and allowing requests through which should be blocked.

This commit addresses this by attempting to fetch a `Token` model instance using the auth header value to get the related user and contributor

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/23

## Testing Instructions

* Check out `develop`
* Run `./scripts/resetdb`
* Run `./scripts/server`
* On your host, make 51 API requests. Verify that they all succeed.
```
for i in {1..51}; \
  do curl -X GET \
  --header 'Accept: application/json' \
  --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' \
  'http://localhost:8081/api/contributor-lists/?contributors=3'; \
done
```
* Run `./scripts/manage check_api_limits`. Verify that emails are printed to the console.
* Make an API request. It should be blocked but it will incorrectly return a successful response.
```
curl -X GET   --header 'Accept: application/json'   --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051'   'http://localhost:8081/api/contributor-lists/?contributors=3';
```
* Check out `bugfix/jcw/api-block-fix` and wait for the server to restart.
* Make an API request. Verify that it returns `{"detail": "API limit exceeded"}`
```
curl -X GET   --header 'Accept: application/json'   --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051'   'http://localhost:8081/api/contributor-lists/?contributors=3';
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
