### PR TITLE
Adjust settings so fast refresh works in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
+
 ### Security
 
 ## [2.41.0] - 2021-03-12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,8 @@ services:
     cpus: 2
 
   app:
-    image: node:10-slim
+    image: node:12-slim
+    working_dir: /usr/local/src
     volumes:
       - ./src/app:/usr/local/src
       - /var/cache/open-apparel-registry-node-modules:/usr/local/src/node_modules
@@ -59,7 +60,7 @@ services:
     environment:
       - REACT_APP_GIT_COMMIT=${REACT_APP_GIT_COMMIT:-latest}
       - CHOKIDAR_USEPOLLING=true
-      - CHOKIDAR_INTERVAL=2000
+      - CHOKIDAR_INTERVAL=100
       - PORT=6543
     ports:
       - 6543:6543

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -23,7 +23,7 @@
         "prop-types": "15.6.2",
         "react": "^16.13.1",
         "react-copy-to-clipboard": "5.0.1",
-        "react-dom": "16.8.6",
+        "react-dom": "16.13.1",
         "react-infinite": "0.13.0",
         "react-infinite-any-height": "2.3.0",
         "react-leaflet": "2.4.0",
@@ -45,7 +45,7 @@
         "validator": "10.11.0"
     },
     "scripts": {
-        "start": "PORT=6543 FAST_REFRESH=false CHOKIDAR_USEPOLLING=true craco start",
+        "start": "craco start",
         "build": "craco build",
         "test": "CI=1 craco test --env=node",
         "lint": "prettier --config .prettierrc --check 'src/**/*.js' 'src/**/*.jsx'",

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -10951,15 +10951,15 @@ react-dev-utils@^11.0.2:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+react-dom@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.6"
+    scheduler "^0.19.1"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"
@@ -11821,14 +11821,6 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.19.1:
   version "0.19.1"


### PR DESCRIPTION

## Overview

After upgrading to CRA 4 and craco hot module reloading was not working. We referenced another project that was using fast refresh and copied in settings to match.

We removed the environment variables from the `start` script in `package.json` because they duplicate variable set in docker-compose.yml.

Within `docker-compose.yml` we reduced `CHOKIDAR_INTERVAL`, set `working_dir`, and switched to node 12 to match another project using fast refresh.

On other projects we have kept the versions of react and react-dom in sync, so we updated the version on `react-dom` in `package.json`.

Connects #1252

## Demo

![2021-03-15 11 05 21](https://user-images.githubusercontent.com/17363/111199927-6c0b8580-857e-11eb-9cdf-b590aed09e7a.gif)

## Testing Instructions

* Stop any running services
* Run `./scripts/update` and `./scripts/server`
* Browse the site, edit a JSX file, and verify that fast refresh works.
 
## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
