### PR TITLE
Notify Contributors when List Completes Processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Download facilities list as Excel [#1293](https://github.com/open-apparel-registry/open-apparel-registry/pull/1293)
 - Add scripts/console [#1295](https://github.com/open-apparel-registry/open-apparel-registry/pull/1295)
+- Notify contributors when lists complete processing [#1290](https://github.com/open-apparel-registry/open-apparel-registry/pull/1290)
 
 ### Changed
 

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -121,6 +121,11 @@ resource "aws_iam_role_policy_attachment" "ec2_service_role" {
   policy_arn = "${var.ec2_service_role_policy_arn}"
 }
 
+resource "aws_iam_role_policy_attachment" "ses_send_email_from_batch" {
+  role       = "${aws_iam_role.container_instance_ec2.name}"
+  policy_arn = "${aws_iam_role_policy.ses_send_email.policy.arn}"
+}
+
 resource "aws_iam_instance_profile" "container_instance" {
   name = "${aws_iam_role.container_instance_ec2.name}"
   role = "${aws_iam_role.container_instance_ec2.name}"

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -121,9 +121,10 @@ resource "aws_iam_role_policy_attachment" "ec2_service_role" {
   policy_arn = "${var.ec2_service_role_policy_arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "ses_send_email_from_batch" {
+resource "aws_iam_role_policy" "ses_send_email_from_batch" {
+  name       = "ses${var.environment}EmailSendingPolicy"
   role       = "${aws_iam_role.container_instance_ec2.name}"
-  policy_arn = "${aws_iam_role_policy.ses_send_email.policy.arn}"
+  policy     = "${data.aws_iam_policy_document.ses_send_email.json}"
 }
 
 resource "aws_iam_instance_profile" "container_instance" {

--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -148,12 +148,28 @@ def submit_jobs(environment, facility_list, skip_parse=False):
     # MATCH
     started = str(datetime.utcnow())
     match_job_id = submit_job('match', depends_on=depends_on)
+    depends_on = [{'jobId': match_job_id}]
     job_ids.append(match_job_id)
     finished = str(datetime.utcnow())
     append_processing_result({
         'action': ProcessingAction.SUBMIT_JOB,
         'type': 'match',
         'job_id': match_job_id,
+        'error': False,
+        'is_array': False,
+        'started_at': started,
+        'finished_at': finished,
+    })
+
+    # NOTIFY
+    started = str(datetime.utcnow())
+    notify_job_id = submit_job('notify_complete', depends_on=depends_on)
+    job_ids.append(notify_job_id)
+    finished = str(datetime.utcnow())
+    append_processing_result({
+        'action': ProcessingAction.SUBMIT_JOB,
+        'type': 'notify_complete',
+        'job_id': notify_job_id,
         'error': False,
         'is_array': False,
         'started_at': started,

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -20,6 +20,7 @@ class ProcessingAction:
     PROMOTE_MATCH = 'promote_match'
     MERGE_FACILITY = 'merge_facility'
     SPLIT_FACILITY = 'split_facility'
+    NOTIFY_COMPLETE = 'notify_complete'
 
 
 class FacilitiesQueryParams:

--- a/src/django/api/management/commands/batch_process.py
+++ b/src/django/api/management/commands/batch_process.py
@@ -10,13 +10,14 @@ from api.matching import match_facility_list_items
 from api.processing import (parse_facility_list_item,
                             geocode_facility_list_item,
                             save_match_details)
+from api.mail import notify_facility_list_complete
 
 LINE_ITEM_ACTIONS = {
     ProcessingAction.PARSE: parse_facility_list_item,
     ProcessingAction.GEOCODE: geocode_facility_list_item,
 }
 
-LIST_ACTIONS = set([ProcessingAction.MATCH])
+LIST_ACTIONS = set([ProcessingAction.MATCH, ProcessingAction.NOTIFY_COMPLETE])
 
 VALID_ACTIONS = list(LINE_ITEM_ACTIONS.keys()) + list(LIST_ACTIONS)
 
@@ -85,6 +86,8 @@ class Command(BaseCommand):
                     self.style.ERROR(
                         '{}: {} failures'.format(
                             action, fail_count)))
+        elif action == ProcessingAction.NOTIFY_COMPLETE:
+            notify_facility_list_complete(list_id)
 
     def process_items(self, facility_list, action, process):
         row_index = os.environ.get('AWS_BATCH_JOB_ARRAY_INDEX')

--- a/src/django/api/templates/mail/facility_list_complete_body.html
+++ b/src/django/api/templates/mail/facility_list_complete_body.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Open Apparel Registry List Processing Completed
+        </title>
+    </head>
+    <body>
+        <p>
+            Hi there,
+        </p>
+        <p>
+            Thanks for submitting {{ list_name }} to the Open Apparel Registry. The list has now been processed by our system and the results are available here: <a href="{{ list_url }}">{{ list_url }}</a>.
+        </p>
+        <strong>What next?</strong>
+        <ul>
+            <li>
+                <strong> Review your list </strong> to see which facilities already exist in the OAR, access their unique OAR IDs and understand which other organisations share connections to the facilities you’re working with. What collaborations could you explore working on together? You’ll also see <strong> New Facilities </strong> in instances where you’ve added a new entry to the system, also allocated their own unique OAR IDs.
+            </li>
+            <li>
+                <strong> Confirm or Reject Potential Matches: </strong> In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool (for more on how the OAR processes data, read this technical blog). Here we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I supposed to do on the confirm / reject page?” section of our FAQ page.
+            </li>
+            <li>
+                <strong> Resolve Errors: </strong> Some entries may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. Once you have pin-pointed the cause, you can re-upload a list of those facilities with cleaned data.
+            </li>
+        </ul>
+        <p>
+            For any questions, feel free to reach out to the OAR team: <a href="mailto:info@openapparel.org">info@openapparel.org</a>
+        </p>
+        <p>
+            All the best,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/facility_list_complete_body.txt
+++ b/src/django/api/templates/mail/facility_list_complete_body.txt
@@ -1,0 +1,19 @@
+{% block content %}
+Hi there,
+
+Thanks for submitting {{ list_name }} to the Open Apparel Registry. The list has now been processed by our system and the results are available here: {{list_url}}.
+
+What next?
+
+Review your list to see which facilities already exist in the OAR, access their unique OAR IDs and understand which other organisations share connections to the facilities you’re working with. What collaborations could you explore working on together? You’ll also see New Facilities in instances where you’ve added a new entry to the system, also allocated their own unique OAR IDs.
+
+Confirm or Reject Potential Matches: In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool (for more on how the OAR processes data, read this technical blog). Here we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I supposed to do on the confirm / reject page?” section of our FAQ page.
+
+Resolve Errors: Some entries may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. Once you have pin-pointed the cause, you can re-upload a list of those facilities with cleaned data.
+
+For any questions, feel free to reach out to the OAR team: info@openapparel.org
+
+All the best,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/facility_list_complete_subject.txt
+++ b/src/django/api/templates/mail/facility_list_complete_subject.txt
@@ -1,0 +1,1 @@
+Open Apparel Registry List Processing Completed


### PR DESCRIPTION
## Overview

The length of time the system takes to process a list upload varies
dependent on multiple factors. To save users having to repeatedly check
back to see if their upload has finished processing, and to prompt them
to complete the Confirm / Reject process, we send an automated email
notification letting users know when their upload has been processed.

Connects #928 

## Demo

<img width="844" alt="Screen Shot 2021-03-23 at 12 22 12 PM" src="https://user-images.githubusercontent.com/21046714/112182703-e6b64f80-8bd3-11eb-9b4c-b2791cd412c1.png">
<img width="856" alt="Screen Shot 2021-03-23 at 12 23 12 PM" src="https://user-images.githubusercontent.com/21046714/112182710-e8801300-8bd3-11eb-8b2b-dfac666bbb58.png">

## Notes

We intend to later adjust this to send a different message to contributors who have additional lists already in the database. 

## Testing Instructions

* In vagrant, run `./scripts/manage batch_process -l 7 -a "notify_complete"`
    - [ ] An email should print with the correct contributor email (list admin). 
    - [ ] The email text should match [provided text](https://docs.google.com/document/d/1PlrtRFlf_FiKtMB93YQM7ON7BPBqrB4ZZVmAJuC0pQ4/edit)

## Checklist

- [ ] Temporary `DROP` commit has been removed 
- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
