### PR TITLE
Download Excel Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Download facilities list as Excel [#1293](https://github.com/open-apparel-registry/open-apparel-registry/pull/1293)
+
 ### Changed
 - Remove Sample Data and Update Registration Text [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1291)
 

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -42,7 +42,8 @@
         "redux-logger": "3.0.6",
         "redux-persist": "5.10.0",
         "redux-thunk": "2.3.0",
-        "validator": "10.11.0"
+        "validator": "10.11.0",
+        "xlsx": "^0.16.9"
     },
     "scripts": {
         "start": "craco start",

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -9,15 +9,19 @@ import {
     makeLogDownloadUrl,
     logErrorAndDispatchFailure,
     downloadFacilitiesCSV,
+    downloadFacilitiesXLSX,
 } from '../util/util';
 
 export const startLogDownload = createAction('START_LOG_DOWNLOAD');
 export const failLogDownload = createAction('FAIL_LOG_DOWNLOAD');
 export const completeLogDownload = createAction('COMPLETE_LOG_DOWNLOAD');
 
-export function logDownload() {
+export function logDownload(format) {
     return async (dispatch, getState) => {
         dispatch(startLogDownload());
+
+        const downloadFacilities =
+            format === 'csv' ? downloadFacilitiesCSV : downloadFacilitiesXLSX;
 
         try {
             const {
@@ -50,7 +54,7 @@ export function logDownload() {
                 return apiRequest
                     .post(makeLogDownloadUrl(path, recordCount))
                     .then(() =>
-                        downloadFacilitiesCSV(facilities, {
+                        downloadFacilities(facilities, {
                             includePPEFields: ppeIsActive,
                             includeClosureFields: reportsAreActive,
                         }),
@@ -70,7 +74,7 @@ export function logDownload() {
             await apiRequest.post(makeLogDownloadUrl(path, count));
 
             if (!nextPageURL) {
-                downloadFacilitiesCSV(facilities, {
+                downloadFacilities(facilities, {
                     includePPEFields: ppeIsActive,
                     includeClosureFields: reportsAreActive,
                 });
@@ -111,7 +115,7 @@ export function logDownload() {
                     },
                 } = getState();
 
-                downloadFacilitiesCSV(features, {
+                downloadFacilities(features, {
                     includePPEFields: ppeIsActive,
                     includeClosureFields: reportsAreActive,
                 });

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { arrayOf, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import Button from '@material-ui/core/Button';
+
+import { toast } from 'react-toastify';
+
+import { logDownload } from '../actions/logDownload';
+
+const downloadFacilitiesStyles = Object.freeze({
+    listHeaderButtonStyles: Object.freeze({
+        height: '45px',
+        margin: '5px 0',
+    }),
+});
+
+function DownloadFacilitiesButton({
+    logDownloadError,
+    user,
+    handleDownload,
+    setLoginRequiredDialogIsOpen,
+}) {
+    const [requestedDownload, setRequestedDownload] = useState(false);
+
+    useEffect(() => {
+        if (requestedDownload && logDownloadError) {
+            toast('A problem prevented downloading the facilities');
+            setRequestedDownload(false);
+        }
+    }, [logDownloadError, requestedDownload]);
+
+    return (
+        <Button
+            variant="outlined"
+            color="primary"
+            styles={downloadFacilitiesStyles.listHeaderButtonStyles}
+            onClick={() => {
+                if (user) {
+                    setRequestedDownload(true);
+                    handleDownload();
+                } else {
+                    setLoginRequiredDialogIsOpen(true);
+                }
+            }}
+        >
+            Download CSV
+        </Button>
+    );
+}
+
+DownloadFacilitiesButton.defaultProps = {
+    logDownloadError: null,
+};
+
+DownloadFacilitiesButton.propTypes = {
+    logDownloadError: arrayOf(string),
+    handleDownload: func.isRequired,
+};
+
+function mapStateToProps({
+    auth: {
+        user: { user },
+    },
+    logDownload: { error: logDownloadError },
+}) {
+    return {
+        user,
+        logDownloadError,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        handleDownload: () => dispatch(logDownload()),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(DownloadFacilitiesButton);

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { arrayOf, func, string } from 'prop-types';
 import { connect } from 'react-redux';
 import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
 
 import { toast } from 'react-toastify';
 
@@ -21,6 +23,7 @@ function DownloadFacilitiesButton({
     setLoginRequiredDialogIsOpen,
 }) {
     const [requestedDownload, setRequestedDownload] = useState(false);
+    const [anchorEl, setAnchorEl] = React.useState(null);
 
     useEffect(() => {
         if (requestedDownload && logDownloadError) {
@@ -29,22 +32,45 @@ function DownloadFacilitiesButton({
         }
     }, [logDownloadError, requestedDownload]);
 
+    const handleClick = event => setAnchorEl(event.currentTarget);
+    const handleClose = () => setAnchorEl(null);
+
+    const selectFormatAndDownload = format => {
+        if (user) {
+            setRequestedDownload(true);
+            handleDownload(format);
+        } else {
+            setLoginRequiredDialogIsOpen(true);
+        }
+        handleClose();
+    };
+
     return (
-        <Button
-            variant="outlined"
-            color="primary"
-            styles={downloadFacilitiesStyles.listHeaderButtonStyles}
-            onClick={() => {
-                if (user) {
-                    setRequestedDownload(true);
-                    handleDownload();
-                } else {
-                    setLoginRequiredDialogIsOpen(true);
-                }
-            }}
-        >
-            Download CSV
-        </Button>
+        <div>
+            <Button
+                variant="outlined"
+                color="primary"
+                styles={downloadFacilitiesStyles.listHeaderButtonStyles}
+                aria-owns={anchorEl ? 'download-menu' : undefined}
+                aria-haspopup="true"
+                onClick={handleClick}
+            >
+                Download
+            </Button>
+            <Menu
+                id="download-menu"
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={handleClose}
+            >
+                <MenuItem onClick={() => selectFormatAndDownload('csv')}>
+                    CSV
+                </MenuItem>
+                <MenuItem onClick={() => selectFormatAndDownload('xlsx')}>
+                    Excel
+                </MenuItem>
+            </Menu>
+        </div>
     );
 }
 
@@ -71,7 +97,7 @@ function mapStateToProps({
 
 function mapDispatchToProps(dispatch) {
     return {
-        handleDownload: () => dispatch(logDownload()),
+        handleDownload: format => dispatch(logDownload(format)),
     };
 }
 

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { Fragment, useState } from 'react';
 import { arrayOf, bool, func, number, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -15,16 +15,14 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
 import get from 'lodash/get';
-import { toast } from 'react-toastify';
 import InfiniteAnyHeight from 'react-infinite-any-height';
 
 import FeatureFlag from './FeatureFlag';
+import DownloadFacilitiesButton from './DownloadFacilitiesButton';
 
 import { makeSidebarSearchTabActive } from '../actions/ui';
 
 import { fetchNextPageOfFacilities } from '../actions/facilities';
-
-import { logDownload } from '../actions/logDownload';
 
 import { facilityCollectionPropType } from '../util/propTypes';
 
@@ -58,27 +56,10 @@ const facilitiesTabStyles = Object.freeze({
         padding: '0.25rem',
         maxHeight: '130px',
     }),
-    listStyles: Object.freeze({
-        /* overflowY: 'scroll',
-        position: 'fixed',
-        // sum heights of navbar, tab bar, panel header, and free text search control
-        top: 'calc(64px + 48px + 130px + 110px)',
-        bottom: '47px',
-        width: '33%', */
-    }),
-    listBottomPaddingStyles: Object.freeze({
-        height: '200px',
-    }),
     titleRowStyles: Object.freeze({
         display: 'flex',
         alignItems: 'center',
         padding: '6px 1rem',
-    }),
-    listHeaderTextSearchStyles: Object.freeze({
-        padding: '6px 1rem',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
     }),
     listHeaderButtonStyles: Object.freeze({
         height: '45px',
@@ -104,25 +85,14 @@ function FilterSidebarFacilitiesTab({
     data,
     error,
     windowHeight,
-    logDownloadError,
     downloadingCSV,
-    user,
     returnToSearchTab,
-    handleDownload,
     fetchNextPage,
     isInfiniteLoading,
 }) {
     const [loginRequiredDialogIsOpen, setLoginRequiredDialogIsOpen] = useState(
         false,
     );
-    const [requestedDownload, setRequestedDownload] = useState(false);
-
-    useEffect(() => {
-        if (requestedDownload && logDownloadError) {
-            toast('A problem prevented downloading the facilities');
-            setRequestedDownload(false);
-        }
-    }, [logDownloadError, requestedDownload]);
 
     if (fetching) {
         return (
@@ -234,22 +204,11 @@ function FilterSidebarFacilitiesTab({
                             />
                         </div>
                     ) : (
-                        <Button
-                            variant="outlined"
-                            color="primary"
-                            style={facilitiesTabStyles.listHeaderButtonStyles}
-                            disabled={downloadingCSV}
-                            onClick={() => {
-                                if (user) {
-                                    setRequestedDownload(true);
-                                    handleDownload();
-                                } else {
-                                    setLoginRequiredDialogIsOpen(true);
-                                }
-                            }}
-                        >
-                            Download CSV
-                        </Button>
+                        <DownloadFacilitiesButton
+                            setLoginRequiredDialogIsOpen={
+                                setLoginRequiredDialogIsOpen
+                            }
+                        />
                     )}
                 </div>
             </Typography>
@@ -275,7 +234,7 @@ function FilterSidebarFacilitiesTab({
         <Fragment>
             {listHeaderInsetComponent}
             <div style={filterSidebarStyles.controlPanelContentStyles}>
-                <List style={facilitiesTabStyles.listStyles}>
+                <List>
                     <InfiniteAnyHeight
                         containerHeight={resultListHeight}
                         infiniteLoadBeginEdgeOffset={100}
@@ -392,7 +351,6 @@ function FilterSidebarFacilitiesTab({
 FilterSidebarFacilitiesTab.defaultProps = {
     data: null,
     error: null,
-    logDownloadError: null,
 };
 
 FilterSidebarFacilitiesTab.propTypes = {
@@ -400,18 +358,13 @@ FilterSidebarFacilitiesTab.propTypes = {
     fetching: bool.isRequired,
     error: arrayOf(string),
     windowHeight: number.isRequired,
-    logDownloadError: arrayOf(string),
     downloadingCSV: bool.isRequired,
     returnToSearchTab: func.isRequired,
-    handleDownload: func.isRequired,
     fetchNextPage: func.isRequired,
     isInfiniteLoading: bool.isRequired,
 };
 
 function mapStateToProps({
-    auth: {
-        user: { user },
-    },
     facilities: {
         facilities: { data, error, fetching, isInfiniteLoading },
     },
@@ -419,15 +372,13 @@ function mapStateToProps({
         facilitiesSidebarTabSearch: { filterText },
         window: { innerHeight: windowHeight },
     },
-    logDownload: { fetching: downloadingCSV, error: logDownloadError },
+    logDownload: { fetching: downloadingCSV },
 }) {
     return {
         data,
         error,
         fetching,
         filterText,
-        user,
-        logDownloadError,
         downloadingCSV,
         windowHeight,
         isInfiniteLoading,
@@ -437,7 +388,6 @@ function mapStateToProps({
 function mapDispatchToProps(dispatch) {
     return {
         returnToSearchTab: () => dispatch(makeSidebarSearchTabActive()),
-        handleDownload: () => dispatch(logDownload()),
         fetchNextPage: () => dispatch(fetchNextPageOfFacilities()),
     };
 }

--- a/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { Fragment, useState } from 'react';
 import { arrayOf, bool, func, number, string } from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -14,19 +14,17 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
 import get from 'lodash/get';
-import { toast } from 'react-toastify';
 import InfiniteAnyHeight from 'react-infinite-any-height';
 import includes from 'lodash/includes';
 import lowerCase from 'lodash/lowerCase';
 
 import ControlledTextInput from './ControlledTextInput';
+import DownloadFacilitiesButton from './DownloadFacilitiesButton';
 
 import {
     makeSidebarSearchTabActive,
     updateSidebarFacilitiesTabTextFilter,
 } from '../actions/ui';
-
-import { logDownload } from '../actions/logDownload';
 
 import { facilityCollectionPropType } from '../util/propTypes';
 
@@ -78,17 +76,6 @@ const facilitiesTabStyles = Object.freeze({
         padding: '0.25rem',
         maxHeight: '130px',
     }),
-    listStyles: Object.freeze({
-        /* overflowY: 'scroll',
-        position: 'fixed',
-        // sum heights of navbar, tab bar, panel header, and free text search control
-        top: 'calc(64px + 48px + 130px + 110px)',
-        bottom: '47px',
-        width: '33%', */
-    }),
-    listBottomPaddingStyles: Object.freeze({
-        height: '200px',
-    }),
     titleRowStyles: Object.freeze({
         display: 'flex',
         justifyContent: 'space-between',
@@ -108,24 +95,13 @@ function NonVectorTileFilterSidebarFacilitiesTab({
     data,
     error,
     windowHeight,
-    logDownloadError,
-    user,
     returnToSearchTab,
     filterText,
     updateFilterText,
-    handleDownload,
 }) {
     const [loginRequiredDialogIsOpen, setLoginRequiredDialogIsOpen] = useState(
         false,
     );
-    const [requestedDownload, setRequestedDownload] = useState(false);
-
-    useEffect(() => {
-        if (requestedDownload && logDownloadError) {
-            toast('A problem prevented downloading the facilities');
-            setRequestedDownload(false);
-        }
-    }, [logDownloadError, requestedDownload]);
 
     if (fetching) {
         return (
@@ -239,21 +215,11 @@ function NonVectorTileFilterSidebarFacilitiesTab({
             <Typography variant="subheading" align="center">
                 <div style={facilitiesTabStyles.titleRowStyles}>
                     {headerDisplayString}
-                    <Button
-                        variant="outlined"
-                        color="primary"
-                        styles={facilitiesTabStyles.listHeaderButtonStyles}
-                        onClick={() => {
-                            if (user) {
-                                setRequestedDownload(true);
-                                handleDownload();
-                            } else {
-                                setLoginRequiredDialogIsOpen(true);
-                            }
-                        }}
-                    >
-                        Download CSV
-                    </Button>
+                    <DownloadFacilitiesButton
+                        setLoginRequiredDialogIsOpen={
+                            setLoginRequiredDialogIsOpen
+                        }
+                    />
                 </div>
             </Typography>
             <div style={facilitiesTabStyles.listHeaderTextSearchStyles}>
@@ -278,7 +244,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
         <Fragment>
             {listHeaderInsetComponent}
             <div style={filterSidebarStyles.controlPanelContentStyles}>
-                <List style={facilitiesTabStyles.listStyles}>
+                <List>
                     <InfiniteAnyHeight
                         containerHeight={resultListHeight}
                         list={orderedFacilities.map(
@@ -377,7 +343,6 @@ function NonVectorTileFilterSidebarFacilitiesTab({
 NonVectorTileFilterSidebarFacilitiesTab.defaultProps = {
     data: null,
     error: null,
-    logDownloadError: null,
 };
 
 NonVectorTileFilterSidebarFacilitiesTab.propTypes = {
@@ -385,17 +350,12 @@ NonVectorTileFilterSidebarFacilitiesTab.propTypes = {
     fetching: bool.isRequired,
     error: arrayOf(string),
     windowHeight: number.isRequired,
-    logDownloadError: arrayOf(string),
     returnToSearchTab: func.isRequired,
     filterText: string.isRequired,
     updateFilterText: func.isRequired,
-    handleDownload: func.isRequired,
 };
 
 function mapStateToProps({
-    auth: {
-        user: { user },
-    },
     facilities: {
         facilities: { data, error, fetching },
     },
@@ -403,15 +363,12 @@ function mapStateToProps({
         facilitiesSidebarTabSearch: { filterText },
         window: { innerHeight: windowHeight },
     },
-    logDownload: { error: logDownloadError },
 }) {
     return {
         data,
         error,
         fetching,
         filterText,
-        user,
-        logDownloadError,
         windowHeight,
     };
 }
@@ -423,7 +380,6 @@ function mapDispatchToProps(dispatch) {
             dispatch(
                 updateSidebarFacilitiesTabTextFilter(getValueFromEvent(e)),
             ),
-        handleDownload: () => dispatch(logDownload()),
     };
 }
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -30,6 +30,7 @@ import { isEmail, isURL } from 'validator';
 import { featureCollection, bbox } from '@turf/turf';
 import { saveAs } from 'file-saver';
 import hash from 'object-hash';
+import XLSX from 'xlsx';
 
 import env from './env';
 
@@ -51,7 +52,13 @@ import {
 
 import { createListItemCSV } from './util.listItemCSV';
 
-import { createFacilitiesCSV } from './util.facilitiesCSV';
+import { createFacilitiesCSV, formatDataForCSV } from './util.facilitiesCSV';
+
+export function DownloadXLSX(data, fileName) {
+    saveAs(new Blob([data], { type: 'application/octet-stream' }), fileName);
+
+    return noop();
+}
 
 export function DownloadCSV(data, fileName) {
     saveAs(new Blob([data], { type: 'text/csv;charset=utf-8;' }), fileName);
@@ -67,6 +74,18 @@ export const downloadListItemCSV = (list, items) =>
 
 export const downloadFacilitiesCSV = (facilities, options) =>
     DownloadCSV(createFacilitiesCSV(facilities, options), 'facilities.csv');
+
+export const createFacilitiesXLSX = (facilities, options) => {
+    const data = formatDataForCSV(facilities, options);
+    const worksheet = XLSX.utils.aoa_to_sheet(data);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'facilities');
+    const wopts = { bookType: 'xlsx', bookSST: false, type: 'array' };
+    return XLSX.write(workbook, wopts);
+};
+
+export const downloadFacilitiesXLSX = (facilities, options) =>
+    DownloadXLSX(createFacilitiesXLSX(facilities, options), 'facilities.xlsx');
 
 export const makeUserLoginURL = () => '/user-login/';
 export const makeUserLogoutURL = () => '/user-logout/';

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -3467,6 +3467,14 @@ adjust-sourcemap-loader@3.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
+adler-32@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.2.0.tgz#6a3e6bf0a63900ba15652808cb15c6813d1a5f25"
+  integrity sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -4480,6 +4488,15 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+cfb@^1.1.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.0.tgz#6a4d0872b525ed60349e1ef51fb4b0bf73eca9a8"
+  integrity sha512-sXMvHsKCICVR3Naq+J556K+ExBo9n50iKl6LGarlnvuA2035uMlGA/qVrc0wQtow5P1vJEw9UyrKLCbtIKz+TQ==
+  dependencies:
+    adler-32 "~1.2.0"
+    crc-32 "~1.2.0"
+    printj "~1.1.2"
+
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4640,6 +4657,14 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
+codepage@~1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.14.0.tgz#8cbe25481323559d7d307571b0fff91e7a1d2f99"
+  integrity sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=
+  dependencies:
+    commander "~2.14.1"
+    exit-on-epipe "~1.0.1"
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -4714,6 +4739,16 @@ commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@~2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+  integrity sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==
+
+commander@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+  integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -4929,6 +4964,14 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crc-32@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
 
 create-ecdh@^4.0.0:
   version "4.0.4"
@@ -6237,6 +6280,11 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -6427,6 +6475,11 @@ fbjs@^0.8.1, fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fflate@^0.3.8:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.3.11.tgz#2c440d7180fdeb819e64898d8858af327b042a5d"
+  integrity sha512-Rr5QlUeGN1mbOHlaqcSYMKVpPbgLy0AWT/W0EHxA6NGI12yO1jpoui2zBBvU2G824ltM6Ut8BFgfHSBGfkmS0A==
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -6604,6 +6657,11 @@ forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+
+frac@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
+  integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -10649,6 +10707,11 @@ pretty-format@^26.6.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+printj@~1.1.0, printj@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -12237,6 +12300,13 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+ssf@~0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.11.2.tgz#0b99698b237548d088fc43cdf2b70c1a7512c06c"
+  integrity sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==
+  dependencies:
+    frac "~1.1.2"
+
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
@@ -13506,10 +13576,20 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
+wmf@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wmf/-/wmf-1.0.2.tgz#7d19d621071a08c2bdc6b7e688a9c435298cc2da"
+  integrity sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==
+
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+word@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
+  integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
 workbox-background-sync@^5.1.4:
   version "5.1.4"
@@ -13722,6 +13802,22 @@ ws@^7.2.3:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
   integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
+
+xlsx@^0.16.9:
+  version "0.16.9"
+  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.16.9.tgz#dacd5bb46bda6dd3743940c9c3dc1e2171826256"
+  integrity sha512-gxi1I3EasYvgCX1vN9pGyq920Ron4NO8PNfhuoA3Hpq6Y8f0ECXiy4OLrK4QZBnj1jx3QD+8Fq5YZ/3mPZ5iXw==
+  dependencies:
+    adler-32 "~1.2.0"
+    cfb "^1.1.4"
+    codepage "~1.14.0"
+    commander "~2.17.1"
+    crc-32 "~1.2.0"
+    exit-on-epipe "~1.0.1"
+    fflate "^0.3.8"
+    ssf "~0.11.2"
+    wmf "~1.0.1"
+    word "~0.3.0"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Overview

Allows users to download the facilities list as an `.xlsx` file, in addition to `.csv`.

Connects #955 

## Demo

<img width="460" alt="Screen Shot 2021-03-30 at 10 17 39 AM" src="https://user-images.githubusercontent.com/21046714/113004292-811d1280-9141-11eb-9005-29c75a21e0d3.png">

## Testing Instructions

* `vagrant ssh` and run `./scripts/update`
* Run `./scripts/server`
* Navigate to [:6543](http://localhost:6543/) and click 'download'
     - [x] You should see a dropdown with CSV and Excel
* Click Excel
     - [x] An XLSX file of the data should be downloaded

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
