### PR TITLE
Increase default gunicorn worker timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 
+## [2.41.1] - 2021-04-19
+
+### Fixed
+
+- Increase default gunicorn worker timeout [#1317](https://github.com/open-apparel-registry/open-apparel-registry/pull/1317)
+
 ## [2.41.0] - 2021-03-12
 
 ### Added
@@ -753,7 +759,8 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 -   Initial release.
 
-[unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/2.41.0...HEAD
+[unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/2.41.1...HEAD
+[2.41.1]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.41.1
 [2.41.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.41.0
 [2.40.0]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.40.0
 [2.39.2]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/2.39.2

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -120,7 +120,8 @@ data "template_file" "app" {
     postgres_password = "${var.rds_database_password}"
     postgres_db       = "${var.rds_database_name}"
 
-    gunicorn_workers = 1
+    gunicorn_workers        = 1
+    gunicorn_worker_timeout = "${var.gunicorn_worker_timeout}"
 
     google_server_side_api_key = "${var.google_server_side_api_key}"
     google_client_side_api_key = "${var.google_client_side_api_key}"

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -6,7 +6,7 @@
     "command": [
       "-b :8080",
       "--workers=${gunicorn_workers}",
-      "--timeout=120",
+      "--timeout=${gunicorn_worker_timeout}",
       "--access-logfile=-",
       "--access-logformat=%({X-Forwarded-For}i)s %(h)s %(l)s %(u)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"",
       "--error-logfile=-",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -198,6 +198,10 @@ variable "app_port" {
   default = "8080"
 }
 
+variable "gunicorn_worker_timeout" {
+  default = "180"
+}
+
 variable "google_server_side_api_key" {}
 
 variable "google_client_side_api_key" {}


### PR DESCRIPTION
## Overview

Creates a variable to tune the timeout for new gunicorn workers to come up. We've needed to increase this timeout to account for `GazetteerCache` taking longer to build as more data has been loaded into the application.

Currently, some tasks are thrashing for long periods of time. We suspect that successful tasks come up just under our current 120 second threshold.

## Testing Instructions

* Verify that tasks come up within 180 seconds in the ECS console, and do not continually stop and restart.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
