### PR TITLE
Add API to get non-standard fields for contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Settings Page [#1290](https://github.com/open-apparel-registry/open-apparel-registry/pull/1298)
 - Add Back Button to Facility Claims [#1307](https://github.com/open-apparel-registry/open-apparel-registry/pull/1307)
 - Add models to persist embed config [#1304](https://github.com/open-apparel-registry/open-apparel-registry/pull/1304)
+- Add API to get nonstandard fields for contributor [#1321](https://github.com/open-apparel-registry/open-apparel-registry/pull/1321)
 
 ### Changed
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -6369,3 +6369,128 @@ class ApiLimitTest(TestCase):
                      contributor=self.contrib_two)
         self.assertEqual(notice_two.api_limit_exceeded_sent_on,
                          self.notification_time)
+
+
+class NonstandardFieldsApiTest(APITestCase):
+    def setUp(self):
+        self.url = reverse('nonstandard-fields-list')
+        self.user_email = 'test@example.com'
+        self.user_password = 'example123'
+        self.user = User.objects.create(email=self.user_email)
+        self.user.set_password(self.user_password)
+        self.user.save()
+
+        self.contributor = Contributor \
+            .objects \
+            .create(admin=self.user,
+                    name='test contributor 1',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.list = FacilityList \
+            .objects \
+            .create(header='country,name,address,extra_1',
+                    file_name='one',
+                    name='First List')
+
+        self.list_source = Source \
+            .objects \
+            .create(facility_list=self.list,
+                    source_type=Source.LIST,
+                    is_active=True,
+                    is_public=True,
+                    contributor=self.contributor)
+
+        self.list_item = FacilityListItem \
+            .objects \
+            .create(name='Item',
+                    address='Address',
+                    country_code='US',
+                    row_index=1,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=self.list_source)
+
+        self.api_source = Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    is_active=True,
+                    is_public=True,
+                    contributor=self.contributor)
+
+        self.api_list_item = FacilityListItem \
+            .objects \
+            .create(name='Item',
+                    address='Address',
+                    country_code='US',
+                    raw_data=("{'country': 'US', 'name': 'Item'," +
+                              "'address': 'Address', 'extra_2': 'data'}"),
+                    row_index=1,
+                    geocoded_point=Point(0, 0),
+                    status=FacilityListItem.CONFIRMED_MATCH,
+                    source=self.api_source)
+
+    def test_nonstandard_fields(self):
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        self.assertTrue(2, len(content))
+        self.assertIn('extra_1', content)
+        self.assertIn('extra_2', content)
+
+    def test_doublequote_header(self):
+        self.list.header = '"country","name","address","extra_1"'
+        self.list.save()
+
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        self.assertIn('extra_1', content)
+
+    def test_escaped_singlequote_in_api_data(self):
+        self.api_list_item.raw_data = ("{'country': 'US', 'name': 'Item', " +
+                                       "'address': 'Address', " +
+                                       "'extra_2': 'd\'ataé'}")
+        self.api_list_item.save()
+
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        # We plan to only store raw data as CSV or JSON in the future. Legacy
+        # data can be ignored
+        self.assertNotIn('extra_2', content)
+
+    def test_json_in_api_data(self):
+        self.api_list_item.raw_data = ('{"country": "US", "name": "Item", ' +
+                                       '"address": "Address", "extra_2": ' +
+                                       '"d\'ataé"}')
+        self.api_list_item.save()
+
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        self.assertIn('extra_2', content)
+
+    def test_querydict_in_api_data(self):
+        # Production data at the time this test was written includes a mix of
+        # strigified dicts and stringified QueryDicts
+        self.api_list_item.raw_data = ("<QueryDict: {'name': ['Item'], " +
+                                       "'country': ['US'], 'address': " +
+                                       "['Address'], 'extra_2': ['data']}>")
+        self.api_list_item.save()
+
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        # We plan to only store raw data as CSV or JSON in the future. Legacy
+        # data can be ignored
+        self.assertNotIn('extra_2', content)

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -39,6 +39,8 @@ router.register('facility-activity-reports',
                 views.FacilityActivityReportViewSet,
                 'facility-activity-report')
 router.register('embed-configs', views.EmbedConfigViewSet, 'embed-config')
+router.register('nonstandard-fields', views.NonstandardFieldsViewSet,
+                'nonstandard-fields')
 
 public_apis = [
     url(r'^api/', include(router.urls)),


### PR DESCRIPTION
## Overview

Returns a list of all the field names that a contributor has submitted
either by API or list, minus our standard fields (country, name,
address, ppe_*, lat, lng).

Fields are parsed from list headers and from the keys of single-facility
API submissions.

Connects #1313 

## Demo

<img width="415" alt="Screen Shot 2021-04-23 at 12 07 54 PM" src="https://user-images.githubusercontent.com/21046714/115899634-f91ee580-a42c-11eb-8faf-748ec4ba9a9d.png">

## Testing Instructions

* Login as c2@example.com.
* Navigate to [facilities_create](http://localhost:8081/api/docs/#!/facilities/facilities_create), authorize as c2@example.com, and submit a facility with custom fields:

```
{
	"country": "China",
	"name": "Nantong Jackbeanie Headwear &amp; Garment Co. Ltd.",
	"address": "No.808,the third industry park,Guoyuan Town,Nantong 226500.",
	"ppe_product_types": ["Masks", "Gloves"],
	"ppe_contact_phone": "123-456-7890",
	"ppe_contact_email": "ppe@example.com",
	"ppe_website": "https://example.com/ppe",
	"test": "test data"
}
```
* Submit a second facility with custom fields, some repeating:
```
{
	"country": "China",
	"name": "Nantong Jackbeanie Headwear 2, Garment Co. Ltd.",
	"address": "No.809,the third industry park,Guoyuan Town,Nantong 226500.",
	"ppe_product_types": ["Masks", "Gloves"],
	"ppe_contact_phone": "123-456-7890",
	"ppe_contact_email": "ppe@example.com",
	"ppe_website": "https://example.com/ppe",
	"test": "test data!!",
	"custom_field": "field data"
}
```
* Submit and process a list with custom fields [test_list.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/6366722/OAR_Contributor_Template.csv)
* Navigate to [api/nonstandard-fields/](http://localhost:8081/api/nonstandard-fields/)
     - [x] You should see a list of custom fields with includes each of your custom fields exactly once

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
