### PR TITLE
Add new admin reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Back Button to Facility Claims [#1307](https://github.com/open-apparel-registry/open-apparel-registry/pull/1307)
 - Add models to persist embed config [#1304](https://github.com/open-apparel-registry/open-apparel-registry/pull/1304)
 - Add API to get nonstandard fields for contributor [#1321](https://github.com/open-apparel-registry/open-apparel-registry/pull/1321)
+- Add new admin reports [#1326](https://github.com/open-apparel-registry/open-apparel-registry/pull/1326)
 
 ### Changed
 

--- a/src/django/api/reports/average_affiliations.sql
+++ b/src/django/api/reports/average_affiliations.sql
@@ -1,0 +1,29 @@
+SELECT
+    month,
+    ROUND(AVG(match_count), 2) as average_matches
+FROM (
+    SELECT f.id, COUNT(*) as match_count, zmonth as month
+    FROM api_facility f
+    JOIN (
+        SELECT DISTINCT
+            c.id,
+            fm.facility_id,
+            to_char(fm.created_at, 'YYYY-MM') as created_month,
+            z.month as zmonth
+        FROM api_facilitymatch fm
+        JOIN api_facilitylistitem i
+        ON fm.facility_list_item_id = i.id
+        JOIN api_source s
+        ON i.source_id = s.id
+        JOIN api_contributor c
+        ON s.contributor_id = c.id
+        JOIN (
+            SELECT to_char(m.created_at, 'YYYY-MM') as month
+            FROM api_facilitymatch m group by month
+        ) z ON to_char(fm.created_at, 'YYYY-MM') <= z.month
+        WHERE fm.status NOT IN ('PENDING', 'REJECTED')
+    ) as fm ON f.id = fm.facility_id
+    GROUP BY zmonth, f.id
+) as c
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/industry_data_vs_oar_data.sql
+++ b/src/django/api/reports/industry_data_vs_oar_data.sql
@@ -1,0 +1,22 @@
+SELECT
+  fm.month,
+  ROUND(CAST(
+            (COUNT(CASE WHEN fm.is_public_list THEN 1 ELSE NULL END)*100)
+        as decimal)/COUNT(*), 2) AS oar_data,
+  ROUND(CAST(
+            (COUNT(CASE WHEN NOT fm.is_public_list THEN 1 ELSE NULL END)*100)
+       as decimal)/COUNT(*), 2) AS industry_data
+  FROM (
+      SELECT
+          MIN(to_char(m.created_at, 'YYYY-MM')) AS month,
+          u.email LIKE '%openapparel.org%' AS is_public_list
+      FROM api_facilitymatch m
+          JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+          JOIN api_source s on i.source_id = s.id
+          JOIN api_contributor c ON s.contributor_id = c.id
+          JOIN api_user u ON u.id = c.admin_id
+      WHERE m.status NOT IN ('REJECTED', 'PENDING')
+      GROUP BY m.facility_id, u.email
+  ) as fm
+ GROUP BY fm.month
+ ORDER BY fm.month

--- a/src/django/api/reports/percent_data_by_contributor_type.sql
+++ b/src/django/api/reports/percent_data_by_contributor_type.sql
@@ -1,0 +1,35 @@
+SELECT
+    match.month,
+    contrib_type,
+    ROUND(CAST((COUNT(*)*100) as decimal)/total, 2) as percent_of_data
+FROM (
+    SELECT
+        MIN(to_char(m.created_at, 'YYYY-MM')) AS month,
+        contrib_type
+    FROM api_facilitymatch m
+        JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+        JOIN api_source s on i.source_id = s.id
+        JOIN api_contributor c ON s.contributor_id = c.id
+        JOIN api_user u ON u.id = c.admin_id
+    WHERE m.status NOT IN ('REJECTED', 'PENDING')
+    AND u.email NOT LIKE '%openapparel.org%'
+    GROUP BY m.facility_id, u.email, c.contrib_type
+) as match
+JOIN (
+    SELECT month, count(*) as total
+    FROM (
+        SELECT
+            MIN(to_char(m.created_at, 'YYYY-MM')) AS month
+        FROM api_facilitymatch m
+            JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+            JOIN api_source s on i.source_id = s.id
+            JOIN api_contributor c ON s.contributor_id = c.id
+            JOIN api_user u ON u.id = c.admin_id
+        WHERE m.status NOT IN ('REJECTED', 'PENDING')
+        AND u.email NOT LIKE '%openapparel.org%'
+        GROUP BY m.facility_id, u.email
+    ) as fm
+    GROUP BY month
+    ORDER BY month
+) t ON t.month = match.month
+GROUP BY match.month, contrib_type, total;

--- a/src/django/api/reports/percent_data_by_source_type.sql
+++ b/src/django/api/reports/percent_data_by_source_type.sql
@@ -1,0 +1,31 @@
+SELECT
+    match.month,
+    source_type,
+    ROUND(CAST((COUNT(*)*100) as decimal)/total, 2) as percent_of_data
+FROM (
+    SELECT
+        MIN(to_char(m.created_at, 'YYYY-MM')) AS month,
+        source_type
+    FROM api_facilitymatch m
+        JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+        JOIN api_source s on i.source_id = s.id
+        JOIN api_contributor c ON s.contributor_id = c.id
+    WHERE m.status NOT IN ('REJECTED', 'PENDING')
+    GROUP BY m.facility_id, c.id, s.source_type
+) as match
+JOIN (
+    SELECT month, count(*) as total
+    FROM (
+        SELECT
+            MIN(to_char(m.created_at, 'YYYY-MM')) AS month
+        FROM api_facilitymatch m
+            JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+            JOIN api_source s on i.source_id = s.id
+            JOIN api_contributor c ON s.contributor_id = c.id
+        WHERE m.status NOT IN ('REJECTED', 'PENDING')
+        GROUP BY m.facility_id, c.id
+    ) as fm
+    GROUP BY month
+    ORDER BY month
+) t ON t.month = match.month
+GROUP BY match.month, source_type, total;

--- a/src/django/api/reports/percent_facilities_with_multiple_matches.sql
+++ b/src/django/api/reports/percent_facilities_with_multiple_matches.sql
@@ -1,0 +1,29 @@
+SELECT zmonth as month,
+       ROUND(CAST((facilities_with_multiple_matches*100) as decimal)/total_facilities, 2) as percent_of_data_with_multiple_matches,
+       facilities_with_multiple_matches,
+       total_facilities
+FROM (
+    SELECT
+        zmonth,
+        COUNT(CASE WHEN match_count > 1 THEN 1 ELSE NULL END) as facilities_with_multiple_matches,
+        COUNT(*) AS total_facilities
+    FROM (
+        SELECT facility_id, COUNT(*) as match_count, zmonth
+            FROM
+                (
+                SELECT
+                    fm.facility_id,
+                    z.month as zmonth
+                FROM api_facilitymatch fm
+                JOIN (
+                    SELECT to_char(m.created_at, 'YYYY-MM') as month
+                    FROM api_facilitymatch m group by month
+                ) z ON to_char(fm.created_at, 'YYYY-MM') <= z.month
+                JOIN api_facilitylistitem i ON i.id = fm.facility_list_item_id
+                JOIN api_source s on i.source_id = s.id
+                GROUP BY s.contributor_id, zmonth, fm.facility_id
+            ) as f
+        GROUP BY f.facility_id, zmonth
+    ) as y
+    GROUP BY zmonth
+) as z


### PR DESCRIPTION
## Overview

With the new round of funding from Laudes Foundation, the KPIs we are tracking and reporting on have changed. There is a new set of monthly reports needed.

1) percent of facilities contributed by OAR and percent of facilities contributed by industry
2) percent of facilities contributed by each contributor type (non public sources)
3) percent of facilities contributed via API 
4) percentage of facilities with more than one affiliation
5) average number of affiliations per facility

Connects #1306

## Demo

<img width="425" alt="Screen Shot 2021-05-04 at 3 01 09 PM" src="https://user-images.githubusercontent.com/21046714/117055878-ade8ba80-ace9-11eb-81d5-933036b146c2.png">
<img width="493" alt="Screen Shot 2021-05-04 at 3 02 51 PM" src="https://user-images.githubusercontent.com/21046714/117056009-d1136a00-ace9-11eb-91b3-a798dc7f264b.png">
<img width="433" alt="Screen Shot 2021-05-04 at 3 03 27 PM" src="https://user-images.githubusercontent.com/21046714/117056080-e7b9c100-ace9-11eb-9603-509883d94690.png">
<img width="626" alt="Screen Shot 2021-05-04 at 3 04 08 PM" src="https://user-images.githubusercontent.com/21046714/117056175-015b0880-acea-11eb-9e2d-6014fa86d7e9.png">
<img width="326" alt="Screen Shot 2021-05-04 at 3 04 35 PM" src="https://user-images.githubusercontent.com/21046714/117056222-0e77f780-acea-11eb-80d0-1608647327d8.png">

## Testing Instructions

* Run `./scripts/server` and login as an admin
* For each of the reports, confirm that the SQL logic makes sense and the results are as requested:
     - [ ] [percent of facilities contributed by OAR and percent of facilities contributed by industry](http://localhost:8081/admin/reports/industry-data-vs-oar-data/)
    -  [ ] [percent of facilities contributed by each contributor type (non public sources)](http://localhost:8081/admin/reports/percent-data-by-contributor-type/)
     - [ ] [percent of facilities contributed via API](http://localhost:8081/admin/reports/percent-data-by-source-type/)
     - [ ] [percentage of facilities with more than one affiliation](http://localhost:8081/admin/reports/percent-facilities-with-multiple-matches/)
     - [ ] [average number of affiliations per facility](http://localhost:8081/admin/reports/average-affiliations/)

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
