### PR TITLE
Connect embed section of settings page to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add models to persist embed config [#1304](https://github.com/open-apparel-registry/open-apparel-registry/pull/1304)
 - Add API to get nonstandard fields for contributor [#1321](https://github.com/open-apparel-registry/open-apparel-registry/pull/1321)
 - Add new admin reports [#1326](https://github.com/open-apparel-registry/open-apparel-registry/pull/1326)
+- Connect embed section of settings page to API [#1329](https://github.com/open-apparel-registry/open-apparel-registry/pull/1329)
 
 ### Changed
 

--- a/src/app/src/components/AppGrid.jsx
+++ b/src/app/src/components/AppGrid.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import PropTypes from 'prop-types';
 
+import { OARFont } from '../util/constants';
+
 export default function AppGrid({
     style,
     title,
@@ -23,7 +25,7 @@ export default function AppGrid({
                     <Grid item xs={12}>
                         <h2
                             style={{
-                                fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+                                fontFamily: OARFont,
                                 fontWeight: 'normal',
                                 fontSize: '32px',
                             }}

--- a/src/app/src/components/EmbeddedMapCode.jsx
+++ b/src/app/src/components/EmbeddedMapCode.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
-import { shape, string, bool } from 'prop-types';
+import { string, bool } from 'prop-types';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import noop from 'lodash/noop';
 import { toast } from 'react-toastify';
 
 import { createIFrameHTML } from '../util/util';
+import { OARFont } from '../util/constants';
 
 const styles = {
     sectionHeader: {
@@ -32,7 +33,7 @@ const styles = {
         width: '90%',
         marginTop: '20px',
         color: 'rgb(0, 0, 0)',
-        fontFamily: 'ff-tisa-sans-web-pro,sans-serif',
+        fontFamily: OARFont,
         padding: '10px',
     },
     embedButton: {
@@ -43,17 +44,8 @@ const styles = {
     },
 };
 
-function EmbeddedMapCode({
-    color,
-    font,
-    width,
-    height,
-    fullWidth,
-    contributor,
-}) {
+function EmbeddedMapCode({ width, height, fullWidth, contributor }) {
     const mapSettings = {
-        color,
-        font,
         width,
         height,
         fullWidth,
@@ -82,19 +74,10 @@ function EmbeddedMapCode({
     );
 }
 
-EmbeddedMapCode.defaultProps = {
-    font: null,
-};
-
 EmbeddedMapCode.propTypes = {
     width: string.isRequired,
     height: string.isRequired,
     fullWidth: bool.isRequired,
-    color: string.isRequired,
-    font: shape({
-        label: string,
-        value: string,
-    }),
 };
 
 export default EmbeddedMapCode;

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
+import { func, shape, string, bool } from 'prop-types';
 
 import { userPropType } from '../util/propTypes';
 import { getEmbeddedMapSrc } from '../util/util';
@@ -29,30 +29,28 @@ const styles = {
     },
 };
 
-function EmbeddedMapConfig({ user }) {
-    // TODO: Replace with backend configuration data
-    const [fields, setFields] = useState([
-        { included: true, label: 'Years active', value: 'years_active' },
-        { included: true, label: 'num_widgets', value: 'num_widgets' },
-        {
-            included: false,
-            label: 'some_other_field_name',
-            value: 'some_other_field_name',
-        },
-    ]);
-    const [
+function EmbeddedMapConfig({
+    user,
+    embedConfig: {
         includeOtherContributorFields,
-        setIncludeOtherContributorFields,
-    ] = useState(true);
-    const [color, setColor] = useState('#C74444');
-    const [font, setFont] = useState(null);
-    const [width, setWidth] = useState('780');
-    const [fullWidth, setFullWidth] = useState(false);
-    const [height, setHeight] = useState('440');
-
-    const mapSettings = {
         color,
         font,
+        width,
+        fullWidth,
+        height,
+    },
+    setEmbedConfig,
+    fields,
+    setFields,
+    errors,
+}) {
+    const updateEmbedConfig = field => value =>
+        setEmbedConfig(config => ({
+            ...config,
+            [field]: value,
+        }));
+
+    const mapSettings = {
         width,
         height,
         fullWidth,
@@ -72,23 +70,26 @@ function EmbeddedMapConfig({ user }) {
                     includeOtherContributorFields={
                         includeOtherContributorFields
                     }
-                    setIncludeOtherContributorFields={
-                        setIncludeOtherContributorFields
-                    }
+                    setIncludeOtherContributorFields={updateEmbedConfig(
+                        'includeOtherContributorFields',
+                    )}
+                    errors={errors}
                 />
                 <EmbeddedMapThemeConfig
                     color={color}
-                    setColor={setColor}
+                    setColor={updateEmbedConfig('color')}
                     font={font}
-                    setFont={setFont}
+                    setFont={updateEmbedConfig('font')}
+                    errors={errors}
                 />
                 <EmbeddedMapSizeConfig
                     width={width}
-                    setWidth={setWidth}
+                    setWidth={updateEmbedConfig('width')}
                     height={height}
-                    setHeight={setHeight}
+                    setHeight={updateEmbedConfig('height')}
                     fullWidth={fullWidth}
-                    setFullWidth={setFullWidth}
+                    setFullWidth={updateEmbedConfig('fullWidth')}
+                    errors={errors}
                 />
             </Grid>
             <Grid item xs={6} style={{ ...styles.section, padding: '20px' }}>
@@ -122,16 +123,16 @@ EmbeddedMapConfig.defaultProps = {
 
 EmbeddedMapConfig.propTypes = {
     user: userPropType,
+    embedConfig: shape({
+        color: string.isRequired,
+        font: string.isRequired,
+        width: string.isRequired,
+        height: string.isRequired,
+        fullWidth: bool.isRequired,
+        includeOtherContributorFields: bool.isRequired,
+    }).isRequired,
+    setEmbedConfig: func.isRequired,
+    setFields: func.isRequired,
 };
 
-function mapStateToProps({
-    auth: {
-        user: { user },
-    },
-}) {
-    return {
-        user,
-    };
-}
-
-export default connect(mapStateToProps)(EmbeddedMapConfig);
+export default EmbeddedMapConfig;

--- a/src/app/src/components/EmbeddedMapConfigWrapper.jsx
+++ b/src/app/src/components/EmbeddedMapConfigWrapper.jsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { connect } from 'react-redux';
+import { toast } from 'react-toastify';
+
+import { userPropType } from '../util/propTypes';
+import { makeNonStandardFieldsURL, makeEmbedConfigURL } from '../util/util';
+import apiRequest from '../util/apiRequest';
+import EmbeddedMapConfig from './EmbeddedMapConfig';
+import {
+    formatExistingConfig,
+    formatExistingFields,
+    combineEmbedAndNonstandardFields,
+    formatEmbedConfigForServer,
+    getErrorMessage,
+} from '../util/embeddedMap';
+
+function EmbeddedMapConfigWrapper({ user }) {
+    const [loading, setLoading] = useState(true);
+    // Used for field-specific validation errors
+    const [errors, setError] = useState(null);
+    const [embedConfig, setEmbedConfig] = useState(
+        formatExistingConfig(user.embed_config),
+    );
+    const [embedFields, setEmbedFields] = useState(
+        formatExistingFields(embedConfig.embed_fields),
+    );
+
+    const handleError = e => {
+        const errorMessage = getErrorMessage(e);
+        if (Array.isArray(errorMessage)) {
+            toast.error(`Error: ${errorMessage.join(', ')}`, {
+                position: 'bottom-left',
+            });
+        } else {
+            setError(errorMessage);
+        }
+        setLoading(false);
+    };
+
+    const handleSuccess = () => {
+        setLoading(false);
+        setError(null);
+    };
+
+    const fetchFields = useCallback(() => {
+        setLoading(true);
+        apiRequest
+            .get(makeNonStandardFieldsURL())
+            .then(({ data }) => {
+                setEmbedFields(
+                    combineEmbedAndNonstandardFields(
+                        user.embed_config.embed_fields,
+                        data,
+                    ),
+                );
+                handleSuccess();
+            })
+            .catch(e => handleError(e));
+    }, [user]);
+
+    const createConfig = () => {
+        setLoading(true);
+        apiRequest
+            .post(
+                makeEmbedConfigURL(),
+                formatEmbedConfigForServer(embedConfig, embedFields),
+            )
+            .then(({ data }) => {
+                setEmbedConfig(formatExistingConfig(data));
+                handleSuccess();
+            })
+            .catch(e => handleError(e));
+    };
+
+    const updateConfig = () => {
+        setLoading(true);
+        apiRequest
+            .put(
+                makeEmbedConfigURL(embedConfig.id),
+                formatEmbedConfigForServer(embedConfig, embedFields),
+            )
+            .then(({ data }) => {
+                setEmbedConfig(formatExistingConfig(data));
+                handleSuccess();
+            })
+            .catch(e => handleError(e));
+    };
+
+    // Fetches and merges nonstandard fields from the database with fields
+    // from the user's EmbedConfig
+    useEffect(() => fetchFields(), [user, fetchFields]);
+
+    /* eslint-disable react-hooks/exhaustive-deps */
+    // Disabled exhaustive dependencies warning because we don't want to rerun
+    // in response to the loading state changing
+    // When the embed config or fields are updated, wait for 500ms. If no
+    // additional changes are made, update/create the embed config in the database.
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            if (loading) return;
+            if (embedConfig.id) {
+                updateConfig();
+            } else {
+                createConfig();
+            }
+        }, 500);
+
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [embedConfig, embedFields]);
+
+    return (
+        <EmbeddedMapConfig
+            user={user}
+            embedConfig={embedConfig}
+            setEmbedConfig={setEmbedConfig}
+            fields={embedFields}
+            setFields={setEmbedFields}
+            errors={errors}
+        />
+    );
+}
+
+EmbeddedMapConfigWrapper.defaultProps = {
+    user: null,
+};
+
+EmbeddedMapConfigWrapper.propTypes = {
+    user: userPropType,
+};
+
+function mapStateToProps({
+    auth: {
+        user: { user },
+    },
+}) {
+    return {
+        user,
+    };
+}
+
+export default connect(mapStateToProps)(EmbeddedMapConfigWrapper);

--- a/src/app/src/components/EmbeddedMapFieldsConfig.jsx
+++ b/src/app/src/components/EmbeddedMapFieldsConfig.jsx
@@ -42,9 +42,10 @@ function EmbeddedMapFieldsConfig({
     includeOtherContributorFields,
     setIncludeOtherContributorFields,
     classes,
+    errors,
 }) {
     const updateItem = item => {
-        const index = fields.findIndex(f => f.value === item.value);
+        const index = fields.findIndex(f => f.columnName === item.columnName);
         const newFields = [
             ...fields.slice(0, index),
             item,
@@ -52,42 +53,49 @@ function EmbeddedMapFieldsConfig({
         ];
         setFields(newFields);
     };
-    const allSelected = !fields.some(f => !f.included);
-    const someSelected = fields.some(f => f.included) && !allSelected;
+    const allSelected = !fields.some(f => !f.visible);
+    const someSelected = fields.some(f => f.visible) && !allSelected;
 
-    const renderField = ({ included, label, value }) => (
-        <li style={styles.listItem} key={value}>
+    const renderField = ({ visible, displayName, columnName, order }) => (
+        <li style={styles.listItem} key={columnName}>
             <Checkbox
-                checked={included}
+                checked={visible}
                 onChange={e =>
-                    updateItem({ label, value, included: e.target.checked })
+                    updateItem({
+                        displayName,
+                        columnName,
+                        visible: e.target.checked,
+                        order,
+                    })
                 }
-                value="included"
+                value="visible"
                 style={styles.checkbox}
             />
             <TextField
-                id={`field-${value}`}
-                value={label}
+                id={`field-${columnName}`}
+                value={displayName}
                 onChange={e =>
                     updateItem({
-                        included,
-                        value,
-                        label: e.target.value,
+                        visible,
+                        columnName,
+                        displayName: e.target.value,
+                        order,
                     })
                 }
                 margin="normal"
                 variant="outlined"
-                disabled={!included}
+                disabled={!visible}
                 style={styles.textInput}
                 InputProps={{
-                    endAdornment: value !== label && (
+                    endAdornment: columnName !== displayName && (
                         <InputAdornment position="end">
                             <IconButton
                                 onClick={() =>
                                     updateItem({
-                                        included,
-                                        value,
-                                        label: value,
+                                        visible,
+                                        columnName,
+                                        displayName: columnName,
+                                        order,
                                     })
                                 }
                             >
@@ -109,6 +117,17 @@ function EmbeddedMapFieldsConfig({
                 Choose which fields to display – and what to call them. Facility
                 name, address, and country will always be included.
             </Typography>
+            {errors?.embed_fields && (
+                <Typography style={{ color: 'red' }}>
+                    Error: {errors.embed_fields.join(', ')}
+                </Typography>
+            )}
+            {errors?.show_other_contributor_information && (
+                <Typography style={{ color: 'red' }}>
+                    Error:{' '}
+                    {errors.show_other_contributor_information.join(', ')}
+                </Typography>
+            )}
             <ul>
                 <li style={styles.listItemNonEditable}>
                     <FormControlLabel
@@ -119,7 +138,7 @@ function EmbeddedMapFieldsConfig({
                                     setFields(
                                         fields.map(f => ({
                                             ...f,
-                                            included: e.target.checked,
+                                            visible: e.target.checked,
                                         })),
                                     )
                                 }
@@ -134,7 +153,7 @@ function EmbeddedMapFieldsConfig({
                         }}
                     />
                 </li>
-                {fields.map(renderField)}
+                {fields.sort((a, b) => a.order - b.order).map(renderField)}
                 <li style={styles.listItemNonEditable}>
                     <FormControlLabel
                         control={

--- a/src/app/src/components/EmbeddedMapSizeConfig.jsx
+++ b/src/app/src/components/EmbeddedMapSizeConfig.jsx
@@ -40,10 +40,21 @@ function EmbeddedMapSizeConfig({
     setHeight,
     fullWidth,
     setFullWidth,
+    errors,
 }) {
     return (
         <div style={styles.section}>
             <Typography style={styles.sectionHeader}>Size</Typography>
+            {errors?.width && (
+                <Typography style={{ color: 'red' }}>
+                    Error: {errors.width.join(', ')}
+                </Typography>
+            )}
+            {errors?.height && (
+                <Typography style={{ color: 'red' }}>
+                    Error: {errors.height.join(', ')}
+                </Typography>
+            )}
             <div style={styles.contentContainer}>
                 <div style={styles.widthContainer}>
                     <TextField

--- a/src/app/src/components/EmbeddedMapThemeConfig.jsx
+++ b/src/app/src/components/EmbeddedMapThemeConfig.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 import Select from 'react-select';
 
-import { func, shape, string } from 'prop-types';
+import { func, string } from 'prop-types';
+
+import { OARFont } from '../util/constants';
 
 const styles = {
     section: {
@@ -30,6 +32,7 @@ const styles = {
 };
 
 const fontOptions = [
+    { label: 'OAR Website Font', value: OARFont },
     { label: 'Arial', value: 'Arial,sans-serif' },
     { label: 'Georgia', value: 'Georgia,serif' },
     { label: 'Courier New', value: 'Courier New,monospace' },
@@ -47,7 +50,8 @@ const fontSelectStyles = {
     }),
 };
 
-function EmbeddedMapThemeConfig({ color, setColor, font, setFont }) {
+function EmbeddedMapThemeConfig({ color, setColor, font, setFont, errors }) {
+    const value = fontOptions.find(f => font === f.value) || OARFont;
     return (
         <div style={styles.section}>
             <Typography style={styles.sectionHeader}>Theme</Typography>
@@ -57,6 +61,11 @@ function EmbeddedMapThemeConfig({ color, setColor, font, setFont }) {
                     Use a color with sufficient contrast against white
                     backgrounds & labels.
                 </Typography>
+                {errors?.color && (
+                    <Typography style={{ color: 'red' }}>
+                        Error: {errors.color.join(', ')}
+                    </Typography>
+                )}
                 <div style={styles.colorContainer}>
                     <input
                         type="color"
@@ -73,12 +82,17 @@ function EmbeddedMapThemeConfig({ color, setColor, font, setFont }) {
                     Optional. If no font selected, OAR website font will be
                     used.
                 </Typography>
+                {errors?.font && (
+                    <Typography style={{ color: 'red' }}>
+                        Error: {errors.font.join(', ')}
+                    </Typography>
+                )}
                 <Select
                     styles={fontSelectStyles}
                     options={fontOptions}
                     id="font"
-                    value={font}
-                    onChange={item => setFont(item)}
+                    value={value}
+                    onChange={item => setFont(item.value)}
                     placeholder="Select a font"
                 />
             </div>
@@ -86,17 +100,10 @@ function EmbeddedMapThemeConfig({ color, setColor, font, setFont }) {
     );
 }
 
-EmbeddedMapThemeConfig.defaultProps = {
-    font: null,
-};
-
 EmbeddedMapThemeConfig.propTypes = {
     color: string.isRequired,
     setColor: func.isRequired,
-    font: shape({
-        label: string,
-        value: string,
-    }),
+    font: string.isRequired,
     setFont: func.isRequired,
 };
 

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -20,6 +20,7 @@ import {
 } from '../actions/facilityListDetails';
 
 import {
+    OARFont,
     listsRoute,
     facilityListItemsRoute,
     aboutProcessingRoute,
@@ -53,7 +54,7 @@ const facilityListItemsStyles = Object.freeze({
         width: '90%',
     }),
     tableTitleStyles: Object.freeze({
-        fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+        fontFamily: OARFont,
         fontWeight: 'normal',
         fontSize: '32px',
     }),

--- a/src/app/src/components/Settings.jsx
+++ b/src/app/src/components/Settings.jsx
@@ -11,7 +11,7 @@ import UserProfile from './UserProfile';
 import UserAPITokens from './UserAPITokens';
 import AppOverflow from './AppOverflow';
 import AppGrid from './AppGrid';
-import EmbeddedMapConfig from './EmbeddedMapConfig';
+import EmbeddedMapConfigWrapper from './EmbeddedMapConfigWrapper';
 
 import { userPropType } from '../util/propTypes';
 import { authLoginFormRoute, EMBEDDED_MAP_FLAG } from '../util/constants';
@@ -86,7 +86,9 @@ function Settings({
                 {user && tabs[activeTabIndex] === PROFILE_TAB && (
                     <UserProfile allowEdits id={user.id.toString()} />
                 )}
-                {tabs[activeTabIndex] === EMBED_TAB && <EmbeddedMapConfig />}
+                {tabs[activeTabIndex] === EMBED_TAB && (
+                    <EmbeddedMapConfigWrapper />
+                )}
                 {tabs[activeTabIndex] === TOKEN_TAB && (
                     <AppGrid>
                         <UserAPITokens />

--- a/src/app/src/components/VectorTileGridLegend.jsx
+++ b/src/app/src/components/VectorTileGridLegend.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import COLOURS from '../util/COLOURS';
+import { OARFont } from '../util/constants';
 
 import { maxVectorTileFacilitiesGridZoom } from '../util/constants.facilitiesMap';
 
@@ -8,7 +9,7 @@ const legendStyles = Object.freeze({
     legendStyle: Object.freeze({
         background: 'white',
         border: `1px solid ${COLOURS.NAVY_BLUE}`,
-        fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+        fontFamily: OARFont,
         fontSize: '13px',
         display: 'flex',
         justifyContent: 'space-between',

--- a/src/app/src/components/ZoomToSearchControl.jsx
+++ b/src/app/src/components/ZoomToSearchControl.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import { OARFont } from '../util/constants';
 import { toggleZoomToSearch } from '../actions/ui';
 
 const zoomStyles = Object.freeze({
     zoomStyle: Object.freeze({
         background: 'white',
-        fontFamily: 'ff-tisa-sans-web-pro, sans-serif',
+        fontFamily: OARFont,
         fontSize: '13px',
         display: 'flex',
         justifyContent: 'space-between',

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -8,10 +8,11 @@ import { unregister } from './registerServiceWorker';
 import { store } from './configureStore';
 import './index.css';
 import App from './App';
+import { OARFont } from './util/constants';
 
 const theme = createMuiTheme({
     typography: {
-        fontFamily: ['ff-tisa-sans-web-pro', 'sans-serif'].join(','),
+        fontFamily: OARFont,
     },
     palette: {
         primary: {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -517,3 +517,5 @@ export const PPE_FIELD_NAMES = Object.freeze([
     'ppe_contact_email',
     'ppe_website',
 ]);
+
+export const OARFont = 'ff-tisa-sans-web-pro,sans-serif';

--- a/src/app/src/util/embeddedMap.js
+++ b/src/app/src/util/embeddedMap.js
@@ -1,0 +1,103 @@
+import sortBy from 'lodash/sortBy';
+
+import { OARFont } from './constants';
+
+const DEFAULT_WIDTH = '1000';
+const DEFAULT_HEIGHT = '800';
+
+const getHeight = embedConfig =>
+    embedConfig.height ? embedConfig.height : DEFAULT_HEIGHT;
+
+const formatExistingWidth = ({ width = DEFAULT_WIDTH }) => {
+    const fullWidth = width[width.length - 1] === '%';
+    if (!width) {
+        return { fullWidth, width: DEFAULT_WIDTH };
+    }
+    return { fullWidth, width };
+};
+
+export const formatExistingConfig = embedConfig => {
+    if (!embedConfig) {
+        return {
+            width: DEFAULT_WIDTH,
+            color: '#3d2f8c',
+            font: OARFont,
+            includeOtherContributorFields: false,
+            height: DEFAULT_HEIGHT,
+        };
+    }
+    return {
+        ...embedConfig,
+        ...formatExistingWidth(embedConfig),
+        color: embedConfig.color ? embedConfig.color : '#3d2f8c',
+        font: embedConfig.font ? embedConfig.font : OARFont,
+        includeOtherContributorFields:
+            embedConfig.show_other_contributor_information,
+        height: getHeight(embedConfig),
+    };
+};
+
+export const formatExistingFields = (fields = []) =>
+    fields.map(field => ({
+        columnName: field.column_name,
+        displayName: field.display_name,
+        visible: field.visible,
+        order: field.order,
+    }));
+
+const doesExist = (field, existingFields) =>
+    existingFields.some(f => f.columnName === field);
+
+const filterAndFormatNonstandardFields = ({
+    nonstandardFields,
+    existingFields,
+}) =>
+    nonstandardFields
+        .filter(field => !doesExist(field, existingFields))
+        .map(field => ({
+            columnName: field,
+            displayName: field,
+            visible: true,
+        }));
+
+export const combineEmbedAndNonstandardFields = (
+    embedFields,
+    nonstandardFields,
+) => {
+    const existingFields = formatExistingFields(embedFields);
+    const newFields = filterAndFormatNonstandardFields({
+        nonstandardFields,
+        existingFields,
+    });
+    return sortBy([...existingFields, ...newFields], f => f.order).map(
+        (f, i) => ({
+            ...f,
+            order: f.order || i,
+        }),
+    );
+};
+
+const formatEmbedFieldsForServer = fields =>
+    sortBy(fields, f => f.order).map((f, i) => ({
+        visible: f.visible,
+        order: i,
+        display_name: f.displayName,
+        column_name: f.columnName,
+    }));
+
+const formatWidthForServer = ({ width, fullWidth }) => {
+    if (fullWidth) return '100%';
+    if (!width || width === '100%') return DEFAULT_WIDTH;
+    return width;
+};
+
+export const formatEmbedConfigForServer = (embedConfig, embedFields) => ({
+    ...embedConfig,
+    show_other_contributor_information:
+        embedConfig.includeOtherContributorFields,
+    width: formatWidthForServer(embedConfig),
+    height: getHeight(embedConfig),
+    embed_fields: formatEmbedFieldsForServer(embedFields),
+});
+
+export const getErrorMessage = e => e.response.data || e.message;

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -25,6 +25,7 @@ import {
     VECTOR_TILE,
     PPE,
     REPORT_A_FACILITY,
+    EMBEDDED_MAP_FLAG,
     facilityClaimStatusChoicesEnum,
 } from './constants';
 
@@ -243,6 +244,7 @@ export const featureFlagPropType = oneOf([
     VECTOR_TILE,
     PPE,
     REPORT_A_FACILITY,
+    EMBEDDED_MAP_FLAG,
 ]);
 
 export const facilityClaimsListPropType = arrayOf(

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -174,6 +174,10 @@ export const makeLogDownloadUrl = (path, recordCount) =>
 export const makeUpdateFacilityLocationURL = oarID =>
     `/api/facilities/${oarID}/update-location/`;
 
+export const makeEmbedConfigURL = id =>
+    `/api/embed-configs/${id ? `${id}/` : ''}`;
+export const makeNonStandardFieldsURL = () => '/api/nonstandard-fields/';
+
 export const getValueFromObject = ({ value }) => value;
 
 const createCompactSortedQuerystringInputObject = (inputObject = []) =>
@@ -757,13 +761,11 @@ export const removeDuplicatesFromOtherLocationsData = otherLocationsData =>
 export const getLocationWithoutEmbedParam = () =>
     window.location.href.replace('&embed=1', '').replace('embed=1', '');
 
-export const getEmbeddedMapSrc = ({ font, color, contributor }) =>
+export const getEmbeddedMapSrc = ({ contributor }) =>
     window.location.href.replace(
         'settings',
         `?${querystring.stringify({
-            color,
             contributor,
-            font: font ? font.value : '',
             embed: 1,
         })}`,
     );


### PR DESCRIPTION
## Overview

Connects the Embed Configuration settings tab to the API, allowing
data fetching, creation, and update. Additionally, adds some UI error
handling, and updates the components to reflect API data structure.

A small, unrelated second commit fixes an error in the proptypes for Feature Flags. 

Connects #1312 

## Demo

<img width="519" alt="Screen Shot 2021-05-06 at 1 44 07 PM" src="https://user-images.githubusercontent.com/21046714/117352967-993d2b80-ae7d-11eb-833e-8fd8a32313e6.png">

## Testing Instructions

* Login as c1@example.com and navigate to [settings](http://localhost:6543/settings). Select EMBED.
	- [x] You should see an error message.
* Login as a different user, with no nonstandard fields, and navigate to [settings](http://localhost:6543/settings). Select EMBED.
	- [x] The page should show no extra fields.
	- [x] The other settings should be the defaults. 
* Update each of the values on the page. 
	- [x] The fields should update as before. 
* Refresh the page. 
	- [x] The updated values should be maintained. 
* Login as a user with nonstandard fields. 
	- [x] The fields should be listed. 
* Update some (not all) of the fields and refresh the page. 
	- [x] The updated fields should show the new values. 
	- [x] The untouched fields should still appear correctly. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
