### PR TITLE
Update facility details API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remove Sample Data and Update Registration Text [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1291)
 - Update Dependencies [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1303)
+- Update facility details API [#1333](https://github.com/open-apparel-registry/open-apparel-registry/pull/1333)
 
 ### Deprecated
 


### PR DESCRIPTION
## Overview

The embedded map feature supports a contributor showing additional
fields they have added that are not visible on OAR. When a contributor
id and embed=1 are passed to the facility details API, an array of
additional fields, as defined by that contributor's embedded map
settings, are returned with the facility details.

Connects #1218 

## Demo

<img width="266" alt="Screen Shot 2021-05-11 at 1 24 36 PM" src="https://user-images.githubusercontent.com/21046714/117859596-37096f80-b25d-11eb-8cc5-a955a4a77f02.png">

## Notes

We previously discussed the format of the fields being: `{ "label": "Test Field", "value": "1234" }` This works well when the contributor has only submitted the facility once; however, in some cases contributors submit a facility multiple times, which can result in multiple available values for a field. 

Currently, instead, all of the available values for the field are returned as an array `{ "label": "Test Field", "value": ["1234", "abc"] }`. This seemed like the most honest presentation of the available data, but other options would be to only use the most recently submitted FacilityListItem for the facility (regardless of whether the submission includes all of the fields in question), or to use the most recently submitted FacilityListItem where the field is present for each field. 

## Testing Instructions

* Run `vagrant ssh` and `./scripts/test`. 
     - [x] All tests should pass.
* Sign in and submit a facility by API with custom fields. Ensure that it has been matched or created.
* Submit a facility via list. 
* Manually add the custom fields as EmbedFields for the account you're signed into, ensuring they are set to 'visible'. 
* `GET` the details for the facilities you submitted, passing embed=1 and your contributor id as query params. 
     `http://localhost:6543/api/facilities/{facility id}/?embed=1&contributor={id}`
     - [x] The contributor fields should be provided.
     - [x] The fields should show the display name and the provided value(s). 
     - [x] The fields should be in the order defined by the EmbedFields. 
   
## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
