### PR TITLE
Show custom facility fields when in embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add API to get nonstandard fields for contributor [#1321](https://github.com/open-apparel-registry/open-apparel-registry/pull/1321)
 - Add new admin reports [#1326](https://github.com/open-apparel-registry/open-apparel-registry/pull/1326)
 - Connect embed section of settings page to API [#1329](https://github.com/open-apparel-registry/open-apparel-registry/pull/1329)
+- Show custom facility fields when in embed mode  [#1341](https://github.com/open-apparel-registry/open-apparel-registry/pull/1341)
 
 ### Changed
 

--- a/src/app/src/actions/facilities.js
+++ b/src/app/src/actions/facilities.js
@@ -14,6 +14,7 @@ import {
     makeGetFacilityByOARIdURL,
     makeFacilityDetailLink,
     createQueryStringFromSearchFilters,
+    makeGetFacilityByOARIdURLWithContributorId,
 } from '../util/util';
 
 import { makeSidebarFacilitiesTabActive } from './ui';
@@ -125,7 +126,11 @@ export function fetchNextPageOfFacilities() {
     };
 }
 
-export function fetchSingleFacility(oarID = null) {
+export function fetchSingleFacility(
+    oarID = null,
+    embed = 0,
+    contributorId = null,
+) {
     return dispatch => {
         dispatch(startFetchSingleFacility());
 
@@ -139,8 +144,16 @@ export function fetchSingleFacility(oarID = null) {
             );
         }
 
+        const fetchUrl = embed
+            ? makeGetFacilityByOARIdURLWithContributorId(
+                  oarID,
+                  embed,
+                  contributorId,
+              )
+            : makeGetFacilityByOARIdURL(oarID);
+
         return apiRequest
-            .get(makeGetFacilityByOARIdURL(oarID))
+            .get(fetchUrl)
             .then(({ data }) => dispatch(completeFetchSingleFacility(data)))
             .catch(err =>
                 dispatch(

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -6,6 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { Link } from 'react-router-dom';
 import head from 'lodash/head';
+import filter from 'lodash/filter';
 import last from 'lodash/last';
 import get from 'lodash/get';
 import includes from 'lodash/includes';
@@ -95,7 +96,10 @@ const detailsSidebarStyles = Object.freeze({
 
 class FacilityDetailSidebar extends Component {
     componentDidMount() {
-        return this.props.fetchFacility();
+        return this.props.fetchFacility(
+            Number(this.props.embed),
+            this.props.user.user.id,
+        );
     }
 
     componentDidUpdate({
@@ -236,6 +240,11 @@ class FacilityDetailSidebar extends Component {
             return null;
         };
 
+        const contributorFields = filter(
+            get(data, 'properties.contributor_fields', null),
+            field => field.value !== null,
+        );
+
         const claimedFacilitySection = (
             <ShowOnly when={!facilityIsClaimedByCurrentUser}>
                 <>
@@ -373,6 +382,19 @@ class FacilityDetailSidebar extends Component {
                             </p>
                         </div>
                         {canonicalFacilityLocation}
+                        {contributorFields.map(field => (
+                            <div
+                                className="control-panel__group"
+                                key={field.label}
+                            >
+                                <h1 className="control-panel__heading">
+                                    {field.label}
+                                </h1>
+                                <p className="control-panel__body">
+                                    {field.value}
+                                </p>
+                            </div>
+                        ))}
                         <FacilityDetailsSidebarOtherLocations
                             data={removeDuplicatesFromOtherLocationsData(
                                 otherLocationsData,
@@ -536,7 +558,8 @@ function mapDispatchToProps(
     },
 ) {
     return {
-        fetchFacility: () => dispatch(fetchSingleFacility(oarID)),
+        fetchFacility: (embed, contributorId) =>
+            dispatch(fetchSingleFacility(oarID, embed, contributorId)),
         clearFacility: () => dispatch(resetSingleFacility()),
     };
 }

--- a/src/app/src/components/FacilityDetailsStaticMap.jsx
+++ b/src/app/src/components/FacilityDetailsStaticMap.jsx
@@ -36,7 +36,7 @@ function FacilityDetailsStaticMap({
                     lat,
                     lng,
                 })}
-                alt={`Facility ${name} at latitide ${lat} and longitude ${lng}`}
+                alt={`Facility ${name} at latitude ${lat} and longitude ${lng}`}
                 className="facility-detail_map"
             />
         </ShowOnly>

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -122,6 +122,11 @@ export const makeGetCountriesURL = () => '/api/countries/';
 
 export const makeGetFacilitiesURL = () => '/api/facilities/';
 export const makeGetFacilityByOARIdURL = oarId => `/api/facilities/${oarId}/`;
+export const makeGetFacilityByOARIdURLWithContributorId = (
+    oarId,
+    embed,
+    contributorId,
+) => `/api/facilities/${oarId}/?embed=${embed}&contributor=${contributorId}`;
 export const makeGetFacilitiesURLWithQueryString = (qs, pageSize) =>
     `/api/facilities/?${qs}&pageSize=${pageSize}`;
 export const makeClaimFacilityAPIURL = oarId =>


### PR DESCRIPTION
## Overview

When viewing the details of a facility in embed mode, render the custom fields in the details sidebar.

Only the custom fields that were added by the contributor to a facility are displayed. Custom fields added by another user to the same facility will not be displayed.

Connects #1334

## Demo

*The `test` field is not displayed because it has a null value*
![image](https://user-images.githubusercontent.com/1042475/118551277-bd292880-b72b-11eb-9341-f00ac2dd9a36.png)

![Screen Shot 2021-05-17 at 4 03 28 PM](https://user-images.githubusercontent.com/1042475/118549442-79352400-b729-11eb-9873-6ef60a05addd.png)

## Testing Instructions

- Log in as a contributor, and go to Settings > Embed
- View the example map, and find a facility that you have added custom fields to.
- View the facility details, and ensure the custom fields are shown in the sidebar. 
- Ensure any fields that have a `null` value are not displayed.
- Toggle some of the custom field checkboxes in the "Include these fields" config section, and ensure the fields that are unchecked do not appear in the sidebar.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
