### PR TITLE
Fix Raw Data Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
+- Fix raw data formatting [#1343](https://github.com/open-apparel-registry/open-apparel-registry/pull/1343)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3,6 +3,7 @@ import os
 import sys
 import traceback
 import csv
+import json
 
 from datetime import datetime
 from functools import reduce
@@ -1091,7 +1092,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         item = FacilityListItem.objects.create(
             source=source,
             row_index=0,
-            raw_data=request.data,
+            raw_data=json.dumps(request.data),
             status=FacilityListItem.PARSED,
             name=name,
             address=address,


### PR DESCRIPTION
## Overview

The raw data sent with a facility creation request was being stored in
a variety of formats, including QueryDicts and stringified
Python objects. It is now stored as JSON.

Connects #1052 

## Notes

We are not attempting to migrate legacy data due to current time constraints. Legacy data on production has minimal to no extra fields supplied by contributors, which is the main portion of the raw_data we are interested in accessing. 

## Testing Instructions

* Run `vagrant ssh` and `./scripts/test`
     - [x] All tests should pass
* Run `./scripts/server`
* Submit a facility via API 
* The returned facility information will include an item_id. Find that item in the [facility list items](http://localhost:8081/admin/api/facilitylistitem).
     - [x] The raw data should be formatted as JSON. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
