### PR TITLE
Update embed permission check and return a detail message when returing 403 from an embed update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
 - Fix raw data formatting [#1343](https://github.com/open-apparel-registry/open-apparel-registry/pull/1343)
+- Update embed permission check and return a detail message when returing 403 from an embed update [#1350](https://github.com/open-apparel-registry/open-apparel-registry/pull/1350)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3598,7 +3598,7 @@ class EmbedConfigViewSet(mixins.ListModelMixin,
 
         embed_config = EmbedConfig.objects.get(id=pk)
 
-        if embed_config.contributor.id is not contributor.id:
+        if embed_config.contributor.id != contributor.id:
             error_data = {'error': (
                 f'Update failed because embed contributor ID '
                 f'{embed_config.contributor.id} does not match the '

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3599,7 +3599,13 @@ class EmbedConfigViewSet(mixins.ListModelMixin,
         embed_config = EmbedConfig.objects.get(id=pk)
 
         if embed_config.contributor.id is not contributor.id:
-            return Response(status=status.HTTP_403_FORBIDDEN)
+            error_data = {'error': (
+                f'Update failed because embed contributor ID '
+                f'{embed_config.contributor.id} does not match the '
+                f'contributor ID {contributor.id}')}
+            return Response(error_data,
+                            content_type='application/json',
+                            status=status.HTTP_403_FORBIDDEN)
 
         fields_data = request.data.pop('embed_fields', [])
 


### PR DESCRIPTION
## Overview

We resolve 403 responses in staging by changing an `is not` comparison to `!=`. To aid in debugging this and potential future issues we also return a message along with the 403.

Connects #1347

## Demo

Error message before applying the fix

<img width="683" alt="Screen Shot 2021-05-24 at 12 44 49 PM" src="https://user-images.githubusercontent.com/17363/119405914-db94a400-bc96-11eb-9ac6-66354548a51c.png">

Screenshare after applying the fix

![2021-05-24 13 44 46](https://user-images.githubusercontent.com/17363/119405958-ee0edd80-bc96-11eb-8fe0-34df91d6b0f5.gif)

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Open the Network tab of your browser developer tools
* Browse https://staging.openapparel.org/settings and select the Embed tab
* Make make several edits to the embedded map settings on staging and ensure that all the PUT requests succeed.

## Checklist

- [x] **DROP** the temporary commit 
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
