### PR TITLE
Embedded map settings changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable custom styles [#1348](https://github.com/open-apparel-registry/open-apparel-registry/pull/1348)
 - Add contributor embed level field [#1349](https://github.com/open-apparel-registry/open-apparel-registry/pull/1349)
 - Add full-width embedded map support [#1352](https://github.com/open-apparel-registry/open-apparel-registry/pull/1352)
+- Embedded map settings changes [#1353](https://github.com/open-apparel-registry/open-apparel-registry/pull/1353)
 
 ### Changed
 

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -12,6 +12,7 @@ import EmbeddedMapFieldsConfig from './EmbeddedMapFieldsConfig';
 import EmbeddedMapThemeConfig from './EmbeddedMapThemeConfig';
 import EmbeddedMapSizeConfig from './EmbeddedMapSizeConfig';
 import EmbeddedMapCode from './EmbeddedMapCode';
+import EmbeddedMapUnauthorized from './EmbeddedMapUnauthorized';
 
 const styles = {
     container: {
@@ -76,6 +77,8 @@ function EmbeddedMapConfig({
     errors,
     timestamp,
 }) {
+    if (!user.embed_level) return <EmbeddedMapUnauthorized />;
+
     const updateEmbedConfig = field => value =>
         setEmbedConfig(config => ({
             ...config,

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -5,6 +5,8 @@ import { func, shape, string, bool } from 'prop-types';
 
 import { userPropType } from '../util/propTypes';
 import { getEmbeddedMapSrc } from '../util/util';
+import { EmbeddedMapInfoLink } from '../util/constants';
+
 import AppGrid from './AppGrid';
 import EmbeddedMapFieldsConfig from './EmbeddedMapFieldsConfig';
 import EmbeddedMapThemeConfig from './EmbeddedMapThemeConfig';
@@ -90,9 +92,38 @@ function EmbeddedMapConfig({
 
     return (
         <AppGrid style={styles.container} title="">
-            <Typography>
-                Generate a custom OAR map to embed in your website. The map will
-                include all facilities you have contributed.
+            <Typography paragraph>
+                Generate a customized OAR Embedded Map for your website.
+            </Typography>
+            <Typography paragraph>
+                To begin,{' '}
+                <a href="https://openapparel.org/contribute">
+                    contribute your supplier data
+                </a>{' '}
+                (via upload or API) to the OAR with all of the data fields you
+                wish to have displayed on your map using the template supplied
+                to you by the OAR Team.{' '}
+                <strong>
+                    This list must include any additional data points you would
+                    like to display on your customized map, such as facility
+                    type, number of workers etc.
+                </strong>{' '}
+                Those fields will then populate below. The Embedded Map will
+                display all facilities included in your lists.
+            </Typography>
+            <Typography paragraph>
+                Adjust the below settings to your liking, such as the ordering
+                of the data points. You can turn individual data points on and
+                off as you wish.
+            </Typography>
+            <Typography paragraph>
+                Once complete, copy the Embed Code to add to your website.
+            </Typography>
+            <Typography paragraph style={{ width: '100%' }}>
+                <strong>Have questions?</strong> Check out the FAQs on our{' '}
+                <a href={EmbeddedMapInfoLink}>Embedded Map info page</a> or
+                email{' '}
+                <a href="mailto:info@openapparel.org">info@openapparel.org</a>.
             </Typography>
             <Grid item xs={6}>
                 {user.embed_level === 3 ? (

--- a/src/app/src/components/EmbeddedMapFieldsConfig.jsx
+++ b/src/app/src/components/EmbeddedMapFieldsConfig.jsx
@@ -107,8 +107,10 @@ function EmbeddedMapFieldsConfig({ fields, setFields, classes, errors }) {
                 Include these fields
             </Typography>
             <Typography>
-                Choose which fields to display – and what to call them. Facility
-                name, address, and country will always be included.
+                Choose which fields to display on your map (the number of fields
+                you are able to display corresponds to your Embedded Map
+                package). Facility name, address, and OAR ID will always be
+                included.
             </Typography>
             {errors?.embed_fields && (
                 <Typography style={{ color: 'red' }}>

--- a/src/app/src/components/EmbeddedMapSizeConfig.jsx
+++ b/src/app/src/components/EmbeddedMapSizeConfig.jsx
@@ -62,6 +62,12 @@ function EmbeddedMapSizeConfig({
     return (
         <div style={styles.section}>
             <Typography style={styles.sectionHeader}>Size</Typography>
+            <Typography>
+                Please select the desired dimensions of the embedded map for
+                your website. Checking the 100% box will ensure that the map
+                fills to whatever width is available on your website, with the
+                height automatically adjusting from there.
+            </Typography>
             {errors?.width && (
                 <Typography style={{ color: 'red' }}>
                     Error: {errors.width.join(', ')}

--- a/src/app/src/components/EmbeddedMapThemeConfig.jsx
+++ b/src/app/src/components/EmbeddedMapThemeConfig.jsx
@@ -70,6 +70,10 @@ function EmbeddedMapThemeConfig({
     return (
         <div style={styles.section}>
             <Typography style={styles.sectionHeader}>Theme</Typography>
+            <Typography>
+                Availability of theme customization will depend on your Embedded
+                Map package.{' '}
+            </Typography>
             <div style={styles.subsection}>
                 <Typography style={styles.subsectionHeader}>Color</Typography>
                 {embedLevel === 1 ? (
@@ -137,8 +141,7 @@ function EmbeddedMapThemeConfig({
                         Font
                     </Typography>
                     <Typography>
-                        Optional. If no font selected, OAR website font will be
-                        used.
+                        If no font is selected, the OAR font will be used.
                     </Typography>
                     {errors?.font && (
                         <Typography style={{ color: 'red' }}>

--- a/src/app/src/components/EmbeddedMapUnauthorized.jsx
+++ b/src/app/src/components/EmbeddedMapUnauthorized.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import { EmbeddedMapInfoLink } from '../util/constants';
+import AppGrid from './AppGrid';
+
+const styles = {
+    container: {
+        marginBottom: '200px',
+    },
+};
+
+function EmbeddedMapUnauthorized() {
+    return (
+        <AppGrid style={styles.container} title="">
+            <Typography paragraph>
+                Looking to display your supplier data on your website?
+            </Typography>
+            <Typography paragraph style={{ width: '100%' }}>
+                The Open Apparel registry offers an easy-to-use embedded map
+                option for your website.
+            </Typography>
+            <Typography paragraph>
+                To activate this paid-for feature, check out the{' '}
+                <a href={EmbeddedMapInfoLink}>OAR Embedded Map</a> page on our
+                website for packages and pricing options.
+            </Typography>
+            <Typography paragraph>
+                Once you have activated it, your OAR Embedded Map Settings will
+                appear on this tab.
+            </Typography>
+        </AppGrid>
+    );
+}
+
+export default EmbeddedMapUnauthorized;

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -520,3 +520,5 @@ export const PPE_FIELD_NAMES = Object.freeze([
 
 export const OARFont = 'ff-tisa-sans-web-pro,sans-serif';
 export const OARColor = '#0427a4';
+
+export const EmbeddedMapInfoLink = 'https://info.openapparel.org/embedded-map';

--- a/src/app/src/util/embeddedMap.js
+++ b/src/app/src/util/embeddedMap.js
@@ -53,7 +53,7 @@ const filterAndFormatNonstandardFields = ({
         .map(field => ({
             columnName: field,
             displayName: field,
-            visible: true,
+            visible: false,
         }));
 
 export const combineEmbedAndNonstandardFields = (


### PR DESCRIPTION
## Overview

Several elements of the embedded map settings page required minor updates.

* Updated the text copy to reflect the updated content in the wireframes.
* Set the individual contributor fields to be turned off by default, to reflect the actual initial state of the data (the EmbedFields aren't created until a change is made on the settings page).
* When a user with an embed_level of null (ie no embedded map access) attempts to access the settings page, shows a message stating that they aren't authorized to access the page and should reach out to OAR staff for access.

Connects #1351 

## Demo

Unauthorized:
<img width="928" alt="Screen Shot 2021-05-25 at 4 53 14 PM" src="https://user-images.githubusercontent.com/21046714/119567857-d01aa900-bd7a-11eb-86f8-9bdad00418ff.png">

Authorized: 
<img width="1118" alt="Screen Shot 2021-05-25 at 4 55 02 PM" src="https://user-images.githubusercontent.com/21046714/119567859-d1e46c80-bd7a-11eb-8fe9-41006e1fc053.png">

## Notes

[Text copy](https://docs.google.com/document/d/1r2eEhiXLpTw3a1u4Yz50jh0bFyVZUZwYHgFFvN1NfBk/edit)

## Testing Instructions

* Run `./scripts/server` and login with a user with a null embed_level.
* Navigate to settings.
     - [x] On the embed tab, you should see the message from the text copy. 
* Change the user permissions to the highest embed level and refresh the settings.
     - [x] You should see the usual page. 
     - [x] The text should be updated. 
     - [x] The contributor fields should not be selected by default. 
* Select the contributor fields.
     - [x] The fields should be selectable and maintain their selection on refresh as before. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
