### PR TITLE
Hide translation element on embedded map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
 - Fix raw data formatting [#1343](https://github.com/open-apparel-registry/open-apparel-registry/pull/1343)
 - Update embed permission check and return a detail message when returing 403 from an embed update [#1350](https://github.com/open-apparel-registry/open-apparel-registry/pull/1350)
+Hide translation element on embedded map [#1357](https://github.com/open-apparel-registry/open-apparel-registry/pull/1357)
 
 ### Security
 

--- a/src/app/src/Routes.jsx
+++ b/src/app/src/Routes.jsx
@@ -99,7 +99,7 @@ class Routes extends Component {
                 <Router history={history}>
                     <div className="App">
                         <Translate />
-                        <Navbar embed={embed} />
+                        {!embed ? <Navbar /> : null}
                         <main style={mainPanelStyle} className="mainPanel">
                             <Switch>
                                 <Route

--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -22,13 +22,9 @@ const apiDocumentationURL =
         ? 'http://localhost:8081/api/docs/'
         : '/api/docs/';
 
-function Navbar({ embed, openGDPR }) {
+function Navbar({ openGDPR }) {
     const [drawerHandler, setDrawerHandler] = useState(false);
     const mobileMenuToggleRef = useRef();
-
-    if (embed) {
-        return <div id="google_translate_element" />;
-    }
 
     const aboutLinks = [
         {


### PR DESCRIPTION
## Overview

Since the app bar is hidden in embed mode, the translation element should also be hidden. Otherwise it is attached to the page on load, but is hidden once the map fully loads, which results in a visual blip.

Connects #1356

## Demo

![May-26-2021 15-41-34](https://user-images.githubusercontent.com/1042475/119721210-e5eea380-be38-11eb-9ac4-adf8c276fc26.gif)

## Testing Instructions

- Visit an embedded map. Verify that the "Select Language" is not displayed before the map is loaded.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
