### PR TITLE
Hide "filter by contributor type" control in embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update facility details API [#1333](https://github.com/open-apparel-registry/open-apparel-registry/pull/1333)
 - Show footer in embed mode [#1339](https://github.com/open-apparel-registry/open-apparel-registry/pull/1339)
 - Remove "show other contributor info" embed option and hide other contributor information in embed mode [#1342](https://github.com/open-apparel-registry/open-apparel-registry/pull/1342)
+- Hide "filter by contributor type" control in embed mode [#1358](https://github.com/open-apparel-registry/open-apparel-registry/pull/1358)
 
 ### Deprecated
 

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -397,24 +397,26 @@ function FilterSidebarSearchTab({
                     </ShowOnly>
                 </div>
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={CONTRIBUTOR_TYPES}
-                        className={classes.inputLabelStyle}
-                    >
-                        Filter by Contributor Type
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={CONTRIBUTOR_TYPES}
-                        name="contributorTypes"
-                        className={`basic-multi-select notranslate ${classes.selectStyle}`}
-                        classNamePrefix="select"
-                        options={contributorTypeOptions}
-                        value={contributorTypes}
-                        onChange={updateContributorType}
-                        disabled={fetchingOptions || fetchingFacilities}
-                    />
+                    <ShowOnly when={!embed}>
+                        <InputLabel
+                            shrink={false}
+                            htmlFor={CONTRIBUTOR_TYPES}
+                            className={classes.inputLabelStyle}
+                        >
+                            Filter by Contributor Type
+                        </InputLabel>
+                        <ReactSelect
+                            isMulti
+                            id={CONTRIBUTOR_TYPES}
+                            name="contributorTypes"
+                            className={`basic-multi-select notranslate ${classes.selectStyle}`}
+                            classNamePrefix="select"
+                            options={contributorTypeOptions}
+                            value={contributorTypes}
+                            onChange={updateContributorType}
+                            disabled={fetchingOptions || fetchingFacilities}
+                        />
+                    </ShowOnly>
                 </div>
                 <div className="form__field">
                     <InputLabel
@@ -578,7 +580,7 @@ function mapStateToProps({
             fetchingContributors ||
             fetchingContributorTypes ||
             fetchingCountries,
-        embed,
+        embed: !!embed,
         fetchingLists,
     };
 }


### PR DESCRIPTION
## Overview

Embedded maps are setup for a specific contributor, so filtering by contributor type is not applicable in embed mode.

Connects #1355

## Demo

**Before**
![image](https://user-images.githubusercontent.com/1042475/119725360-d6be2480-be3d-11eb-8c65-d431bd0494d1.png)

**After**
![image](https://user-images.githubusercontent.com/1042475/119725285-c5751800-be3d-11eb-867f-a9c06fc0bb36.png)


## Testing Instructions

- View an embedded map, and verify the "Filter by contributor type" control is not displayed.
- Visit the main app, and verify the control is displayed.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
