### PR TITLE
Disable PPE search in embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add contributor embed level field [#1349](https://github.com/open-apparel-registry/open-apparel-registry/pull/1349)
 - Add full-width embedded map support [#1352](https://github.com/open-apparel-registry/open-apparel-registry/pull/1352)
 - Embedded map settings changes [#1353](https://github.com/open-apparel-registry/open-apparel-registry/pull/1353)
+- Disable PPE search in embed mode [#1364](https://github.com/open-apparel-registry/open-apparel-registry/pull/1364)
 
 ### Changed
 

--- a/src/app/src/components/FeatureFlag.jsx
+++ b/src/app/src/components/FeatureFlag.jsx
@@ -5,7 +5,10 @@ import includes from 'lodash/includes';
 
 import { featureFlagPropType } from '../util/propTypes';
 
-import { convertFeatureFlagsObjectToListOfActiveFlags } from '../util/util';
+import {
+    convertFeatureFlagsObjectToListOfActiveFlags,
+    filterFlagsIfAppIsEmbeded,
+} from '../util/util';
 
 function FeatureFlag({
     flag,
@@ -37,9 +40,18 @@ FeatureFlag.propTypes = {
     fetching: bool.isRequired,
 };
 
-function mapStateToProps({ featureFlags: { fetching, flags } }) {
+function mapStateToProps({
+    featureFlags: { fetching, flags },
+    embeddedMap: { embed: isEmbeded },
+}) {
+    const activeFeatureFlags = convertFeatureFlagsObjectToListOfActiveFlags(
+        flags,
+    );
     return {
-        activeFeatureFlags: convertFeatureFlagsObjectToListOfActiveFlags(flags),
+        activeFeatureFlags: filterFlagsIfAppIsEmbeded(
+            activeFeatureFlags,
+            isEmbeded,
+        ),
         fetching,
     };
 }

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -26,6 +26,7 @@ import keys from 'lodash/keys';
 import pickBy from 'lodash/pickBy';
 import every from 'lodash/every';
 import uniqWith from 'lodash/uniqWith';
+import filter from 'lodash/filter';
 import { isEmail, isURL } from 'validator';
 import { featureCollection, bbox } from '@turf/turf';
 import { saveAs } from 'file-saver';
@@ -661,6 +662,10 @@ export const addProtocolToWebsiteURLIfMissing = url => {
 
     return `http://${url}`;
 };
+
+// OAR requested that the PPE features be disabled when in embedded mode
+export const filterFlagsIfAppIsEmbeded = (flags, isEmbeded) =>
+    filter(flags, f => !isEmbeded || f !== 'ppe');
 
 export const convertFeatureFlagsObjectToListOfActiveFlags = featureFlags =>
     keys(pickBy(featureFlags, identity));


### PR DESCRIPTION
## Overview

Requested by OAR. This functionality was already behind a feature flag, so we added a helper to make sure the flag is always disabled in embed mode.

Connects #1354

## Testing Instructions

* Browse http://localhost:6543/ and verify that the text search is labeled "Search a Facility Name, OAR ID, or PPE Product Type" and the "Show only PPE..." checkbox is visible
* Enable embeded mode for contributor 2 and host and browse the index.html below on localhost to test the embed. Verify that the search bar has no mention of ppe

```
<!doctype html>

<html lang="en">
    <head>
        <meta charset="UTF-8"/>
        <title>OAR Embed Demo</title>
    </head>
    <body>
        <h1>
            <div>
                My embedded map
            </div>
        </h1>
        <li>item one</li>
        <li>item b</li>
        <li>item the third</li>


        <!-- embed -->
        <div>
            <div style="position:relative;padding-top:40%;">
                <iframe
                    src="http://localhost:6543/?contributors=2&embed=1"
                    frameborder="0"
                    allowfullscreen
                    style="position:absolute;top:0;
                    left:0;width:100%;height:100%;"
                    title="embedded-map">
                </iframe>
            </div>
        </div>
        <!-- end -->

    </body>
</html>
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
