### PR TITLE
Allow IFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Embedded map settings changes [#1353](https://github.com/open-apparel-registry/open-apparel-registry/pull/1353)
 - Disable PPE search in embed mode [#1364](https://github.com/open-apparel-registry/open-apparel-registry/pull/1364)
 - Enable the default embed map custom fields by default [#1365](https://github.com/open-apparel-registry/open-apparel-registry/pull/1365)
+- Allow IFrames [#1367](https://github.com/open-apparel-registry/open-apparel-registry/pull/1367)
 
 ### Changed
 

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -166,7 +166,8 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # Clickjacking protection is turned off to allow iframes:
+    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'spa.middleware.SPAMiddleware',
     'rollbar.contrib.django.middleware.RollbarNotifierMiddlewareExcluding404',
     'simple_history.middleware.HistoryRequestMiddleware',


### PR DESCRIPTION
## Overview

Currently, OAR has clickjacking protection turned on, which prevents
iframes from working. Turns off clickjacking protection to allow
iframes.

Connects #1361 

## Testing Instructions

* Checkout this branch and run `vagrant ssh`, `./scripts/update`, and `./scripts/server`
* Navigate to [an external embedded map](https://taiwilkin.github.io/test-iframe/).
     - [x] The embedded map should load. 

## Checklist

- [x] **DROP** testing commit 
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
