### PR TITLE
Returned merged facilities in contributor searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
 - Fix raw data formatting [#1343](https://github.com/open-apparel-registry/open-apparel-registry/pull/1343)
 - Update embed permission check and return a detail message when returing 403 from an embed update [#1350](https://github.com/open-apparel-registry/open-apparel-registry/pull/1350)
-Hide translation element on embedded map [#1357](https://github.com/open-apparel-registry/open-apparel-registry/pull/1357)
+- Hide translation element on embedded map [#1357](https://github.com/open-apparel-registry/open-apparel-registry/pull/1357)
+- Returned merged facilities in contributor searches [#1369](https://github.com/open-apparel-registry/open-apparel-registry/pull/1369)
 
 ### Security
 

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -341,6 +341,7 @@ def create_facility_history_list(entries, facility_id, user=None):
         .filter(status__in=[
             FacilityMatch.CONFIRMED,
             FacilityMatch.AUTOMATIC,
+            FacilityMatch.MERGED,
         ])
         .filter(facility_id=facility_id)
     ]

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1190,7 +1190,8 @@ class FacilityManager(models.Manager):
                 .filter(id__in=FacilityMatch
                         .objects
                         .filter(status__in=[FacilityMatch.AUTOMATIC,
-                                            FacilityMatch.CONFIRMED])
+                                            FacilityMatch.CONFIRMED,
+                                            FacilityMatch.MERGED])
                         .filter(is_active=True)
                         .filter(facility_list_item__source__contributor__contrib_type__in=contributor_types) # NOQA
                         .filter(facility_list_item__source__is_active=True)
@@ -1208,7 +1209,8 @@ class FacilityManager(models.Manager):
                     facilitylistitem__facilitymatch__is_active=True,
                     facilitylistitem__facilitymatch__status__in=[
                         FacilityMatch.AUTOMATIC,
-                        FacilityMatch.CONFIRMED]).values(
+                        FacilityMatch.CONFIRMED,
+                        FacilityMatch.MERGED]).values(
                             'facilitylistitem__facility')
 
                 # Next, count the number of times each specified contributor
@@ -1245,7 +1247,8 @@ class FacilityManager(models.Manager):
                         facilitylistitem__facilitymatch__is_active=True,
                         facilitylistitem__facilitymatch__status__in=[
                             FacilityMatch.AUTOMATIC,
-                            FacilityMatch.CONFIRMED],
+                            FacilityMatch.CONFIRMED,
+                            FacilityMatch.MERGED],
                         contributor__in=contributors).values_list(
                             'facilitylistitem__facility', flat=True)))
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -644,6 +644,7 @@ class FacilityDetailsSerializer(FacilitySerializer):
             .filter(status__in=[
                 FacilityMatch.CONFIRMED,
                 FacilityMatch.AUTOMATIC,
+                FacilityMatch.MERGED,
             ])
             .filter(is_active=True)
             if l.facility_list_item.geocoded_point != facility.location

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4706,7 +4706,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            3,
+            4,
         )
 
     @override_flag('can_get_facility_history', active=True)
@@ -4756,7 +4756,7 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
 
         self.assertEqual(
             len(data),
-            3,
+            4,
         )
 
     @override_flag('can_get_facility_history', active=True)


### PR DESCRIPTION
## Overview

Facility matches in the MERGED status were not returned in filter by
contributor searches because the filter_by_query_params method only
allowed matches with a status of AUTOMATIC or CONFIRMED. Allows MERGED
facilities to be returned from the contributor search.

Connects #1366 

## Testing Instructions

* On `develop`, run `./scripts/server` and login as c1@example.com
* Merge VN202114667Y223 (belonging to Civil Society Organization A) into JO2021146CS21Q8 (belonging to Auditor A)
* [Search](http://localhost:6543/facilities?q=Classic%20Fashion&contributors=8) for the facility while filtering by Civil Society Organization A. The facility won't be found. 
* Checkout this branch, and [Search](http://localhost:6543/facilities?q=Classic%20Fashion&contributors=8) for the facility while filtering by Civil Society Organization A. The facility will be found.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
