### PR TITLE
Prevent embedded map use without authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Disable PPE search in embed mode [#1364](https://github.com/open-apparel-registry/open-apparel-registry/pull/1364)
 - Enable the default embed map custom fields by default [#1365](https://github.com/open-apparel-registry/open-apparel-registry/pull/1365)
 - Allow IFrames [#1367](https://github.com/open-apparel-registry/open-apparel-registry/pull/1367)
+- Prevent embedded map use without authorization [#1370](https://github.com/open-apparel-registry/open-apparel-registry/pull/1370)
 
 ### Changed
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -5,10 +5,18 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import Routes from './Routes';
 import { fetchEmbedConfig } from './actions/embeddedMap';
 import { OARColor } from './util/constants';
+import EmbeddedMapUnauthorized from './components/EmbeddedMapUnauthorized';
 
 import './App.css';
 
-function App({ embed, contributor, getEmbedConfig, config }) {
+function App({
+    embed,
+    contributor,
+    getEmbedConfig,
+    config,
+    embedError,
+    embedLoading,
+}) {
     const contributorId = contributor?.value;
     useEffect(() => {
         if (embed && contributorId) {
@@ -33,6 +41,14 @@ function App({ embed, contributor, getEmbedConfig, config }) {
         [config],
     );
 
+    if (embed && embedLoading) {
+        return null;
+    }
+
+    if (embed && embedError) {
+        return <EmbeddedMapUnauthorized error={embedError} />;
+    }
+
     return (
         <MuiThemeProvider theme={theme}>
             <Routes />
@@ -40,11 +56,16 @@ function App({ embed, contributor, getEmbedConfig, config }) {
     );
 }
 
-function mapStateToProps({ embeddedMap: { embed, config }, filters }) {
+function mapStateToProps({
+    embeddedMap: { embed, config, error, loading },
+    filters,
+}) {
     return {
         embed: !!embed,
         contributor: filters?.contributors[0],
         config,
+        embedError: error,
+        embedLoading: loading,
     };
 }
 

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -77,7 +77,7 @@ function EmbeddedMapConfig({
     errors,
     timestamp,
 }) {
-    if (!user.embed_level) return <EmbeddedMapUnauthorized />;
+    if (!user.embed_level) return <EmbeddedMapUnauthorized isSettings />;
 
     const updateEmbedConfig = field => value =>
         setEmbedConfig(config => ({

--- a/src/app/src/components/EmbeddedMapUnauthorized.jsx
+++ b/src/app/src/components/EmbeddedMapUnauthorized.jsx
@@ -34,8 +34,8 @@ function EmbeddedMapUnauthorized({ isSettings, error = [] }) {
             </Typography>
             {isSettings && (
                 <Typography paragraph>
-                    Once you have activated it, your OAR Embedded Map Settings
-                    will appear on this tab.
+                    Once Embedded Map has been activated for your account, your
+                    OAR Embedded Map Settings will appear on this tab.
                 </Typography>
             )}
         </AppGrid>

--- a/src/app/src/components/EmbeddedMapUnauthorized.jsx
+++ b/src/app/src/components/EmbeddedMapUnauthorized.jsx
@@ -7,15 +7,23 @@ const styles = {
     container: {
         marginBottom: '200px',
     },
+    text: {
+        width: '100%',
+    },
 };
 
-function EmbeddedMapUnauthorized() {
+function EmbeddedMapUnauthorized({ isSettings, error = [] }) {
     return (
         <AppGrid style={styles.container} title="">
+            {error.map(e => (
+                <Typography style={styles.text} paragraph key={e}>
+                    <strong>Error:</strong> {e}
+                </Typography>
+            ))}
             <Typography paragraph>
                 Looking to display your supplier data on your website?
             </Typography>
-            <Typography paragraph style={{ width: '100%' }}>
+            <Typography paragraph style={styles.text}>
                 The Open Apparel registry offers an easy-to-use embedded map
                 option for your website.
             </Typography>
@@ -24,10 +32,12 @@ function EmbeddedMapUnauthorized() {
                 <a href={EmbeddedMapInfoLink}>OAR Embedded Map</a> page on our
                 website for packages and pricing options.
             </Typography>
-            <Typography paragraph>
-                Once you have activated it, your OAR Embedded Map Settings will
-                appear on this tab.
-            </Typography>
+            {isSettings && (
+                <Typography paragraph>
+                    Once you have activated it, your OAR Embedded Map Settings
+                    will appear on this tab.
+                </Typography>
+            )}
         </AppGrid>
     );
 }

--- a/src/app/src/reducers/EmbeddedMapReducer.js
+++ b/src/app/src/reducers/EmbeddedMapReducer.js
@@ -32,16 +32,19 @@ export default createReducer(
             update(state, {
                 loading: { $set: true },
                 config: { $set: initialConfig },
+                error: { $set: initialState.error },
             }),
         [completeFetchEmbedConfig]: (state, config) =>
             update(state, {
                 loading: { $set: false },
                 config: { $set: config },
+                error: { $set: initialState.error },
             }),
-        [failFetchEmbedConfig]: state =>
+        [failFetchEmbedConfig]: (state, error) =>
             update(state, {
-                loading: { $set: true },
+                loading: { $set: false },
                 config: { $set: initialConfig },
+                error: { $set: error },
             }),
         [completeSubmitLogOut]: () => initialState,
     },

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -422,6 +422,10 @@ def contributor_embed_config(request, pk=None):
     """
     try:
         contributor = Contributor.objects.get(id=pk)
+        if contributor.embed_level is None:
+            raise PermissionDenied(
+                'Embedded map is not configured for provided contributor.'
+            )
         embed_config = EmbedConfigSerializer(contributor.embed_config).data
         return Response(embed_config)
     except Contributor.DoesNotExist:


### PR DESCRIPTION
## Overview

When in embed mode, if the provided contributor has a `null` embed
level or if the provided contributor is not found, an error message and information regarding embedded map
access are displayed.

Connects #1368 

## Demo

<img width="1341" alt="Screen Shot 2021-06-01 at 12 43 31 PM" src="https://user-images.githubusercontent.com/21046714/120367268-aa435600-c2de-11eb-9380-1d9e65bf3f5a.png">

<img width="1353" alt="Screen Shot 2021-06-01 at 12 44 18 PM" src="https://user-images.githubusercontent.com/21046714/120367294-b0393700-c2de-11eb-9e58-b1945c97aa9d.png">

## Testing Instructions

* Run `./scripts/server`
* Attempt to access the embedded map using a contributor with a `null` embed_level
     - [ ] An error message should be displayed.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
