### PR TITLE
Show messages when the embed config is incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable the default embed map custom fields by default [#1365](https://github.com/open-apparel-registry/open-apparel-registry/pull/1365)
 - Allow IFrames [#1367](https://github.com/open-apparel-registry/open-apparel-registry/pull/1367)
 - Prevent embedded map use without authorization [#1370](https://github.com/open-apparel-registry/open-apparel-registry/pull/1370)
+- Show messages when the embed config is incomplete [#1376](https://github.com/open-apparel-registry/open-apparel-registry/pull/1376)
 
 ### Changed
 

--- a/src/app/src/components/EmbeddedMapCode.jsx
+++ b/src/app/src/components/EmbeddedMapCode.jsx
@@ -46,7 +46,13 @@ const styles = {
     },
 };
 
-function EmbeddedMapCode({ width, height, fullWidth, contributor }) {
+function EmbeddedMapCode({
+    width,
+    height,
+    fullWidth,
+    contributor,
+    minimumConfigurationIsComplete,
+}) {
     const mapSettings = {
         width,
         height,
@@ -59,21 +65,30 @@ function EmbeddedMapCode({ width, height, fullWidth, contributor }) {
             <Typography style={styles.sectionHeader}>
                 Embed code for your website
             </Typography>
-            <Typography style={styles.embedTextBox}>
-                {createIFrameHTML(mapSettings)}
-            </Typography>
-            <CopyToClipboard
-                text={createIFrameHTML(mapSettings)}
-                onCopy={() => toast('Copied code to clipboard')}
-            >
-                <Button
-                    variant="contained"
-                    style={styles.embedButton}
-                    onClick={noop}
-                >
-                    Copy to clipboard
-                </Button>
-            </CopyToClipboard>
+            {minimumConfigurationIsComplete ? (
+                <>
+                    <Typography style={styles.embedTextBox}>
+                        {createIFrameHTML(mapSettings)}
+                    </Typography>
+                    <CopyToClipboard
+                        text={createIFrameHTML(mapSettings)}
+                        onCopy={() => toast('Copied code to clipboard')}
+                    >
+                        <Button
+                            variant="contained"
+                            style={styles.embedButton}
+                            onClick={noop}
+                        >
+                            Copy to clipboard
+                        </Button>
+                    </CopyToClipboard>
+                </>
+            ) : (
+                <Typography paragraph>
+                    Choose a color and enter a width and height to view the
+                    embed code.
+                </Typography>
+            )}
         </div>
     );
 }

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -84,12 +84,15 @@ function EmbeddedMapConfig({
             [field]: value,
         }));
 
+    const minimumConfigurationIsComplete = !!(width && height && color);
+
     const mapSettings = {
         width,
         height,
         fullWidth,
         contributor: [user?.id],
         timestamp,
+        minimumConfigurationIsComplete,
     };
 
     return (
@@ -167,7 +170,14 @@ function EmbeddedMapConfig({
                 style={{ ...styles.section, minHeight: '500px' }}
             >
                 <Typography style={styles.previewHeader}>Preview</Typography>
-                {renderEmbeddedMap({ fullWidth, mapSettings, height, width })}
+                {minimumConfigurationIsComplete ? (
+                    renderEmbeddedMap({ fullWidth, mapSettings, height, width })
+                ) : (
+                    <Typography paragraph>
+                        Choose a color and enter a width and height to see a
+                        preview.
+                    </Typography>
+                )}
             </Grid>
         </AppGrid>
     );

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -158,7 +158,6 @@ function EmbeddedMapConfig({
                     setHeight={updateEmbedConfig('height')}
                     fullWidth={fullWidth}
                     setFullWidth={updateEmbedConfig('fullWidth')}
-                    errors={errors}
                 />
             </Grid>
             <Grid item xs={6} style={styles.code}>

--- a/src/app/src/components/EmbeddedMapSizeConfig.jsx
+++ b/src/app/src/components/EmbeddedMapSizeConfig.jsx
@@ -51,7 +51,6 @@ function EmbeddedMapSizeConfig({
     setHeight,
     fullWidth,
     setFullWidth,
-    errors,
 }) {
     const updateFullWidth = isFullWidth => {
         if (isFullWidth) {
@@ -77,16 +76,6 @@ function EmbeddedMapSizeConfig({
                 fills to whatever width is available on your website, with the
                 height automatically adjusting from there.
             </Typography>
-            {errors?.width && (
-                <Typography style={{ color: 'red' }}>
-                    Error: {errors.width.join(', ')}
-                </Typography>
-            )}
-            {errors?.height && (
-                <Typography style={{ color: 'red' }}>
-                    Error: {errors.height.join(', ')}
-                </Typography>
-            )}
             <div style={styles.contentContainer}>
                 <div style={styles.widthContainer}>
                     {!fullWidth && (


### PR DESCRIPTION


## Overview

The embed preview and code do not render properly unless a size is selected. To handle that we show informational messages rather than content until the minimum required configuration has been entered.

Connects #1371

## Demo

<img width="1116" alt="Screen Shot 2021-06-02 at 1 23 28 PM" src="https://user-images.githubusercontent.com/17363/120548013-b4308c00-c3a6-11eb-8ca7-52c4616b53d6.png">

## Testing Instructions

* Enable embed for a contributor who has never used it
* Browse config and verify that content is hidden until color, width, and height are selected.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
