### PR TITLE
Download and map changes for embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow IFrames [#1367](https://github.com/open-apparel-registry/open-apparel-registry/pull/1367)
 - Prevent embedded map use without authorization [#1370](https://github.com/open-apparel-registry/open-apparel-registry/pull/1370)
 - Show messages when the embed config is incomplete [#1376](https://github.com/open-apparel-registry/open-apparel-registry/pull/1376)
+- Download and map changes for embed mode [#1378](https://github.com/open-apparel-registry/open-apparel-registry/pull/1378)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.facilitiesCSV.tests.js
+++ b/src/app/src/__tests__/utils.facilitiesCSV.tests.js
@@ -82,7 +82,7 @@ it('creates a 2-d array including headers for exporting as a CSV', () => {
     ];
 
     const expected2DArray = [
-        csvHeaders,
+        csvHeaders.concat(['contributors']),
         [
             'oar_id',
             'name',
@@ -127,7 +127,7 @@ it('creates a 2-d array including PPE headers', () => {
         },
     ];
 
-    const expectedHeader = csvHeaders.concat(PPE_FIELD_NAMES);
+    const expectedHeader = csvHeaders.concat(['contributors']).concat(PPE_FIELD_NAMES);
     const expectedRow = [
         'oar_id',
         'name',
@@ -182,6 +182,7 @@ it('creates a 2-d array including PPE headers and values', () => {
 
     const expected2DArray = [
         csvHeaders.concat([
+            'contributors',
             'ppe_product_types',
             'ppe_contact_phone',
             'ppe_contact_email',
@@ -260,6 +261,7 @@ it('creates a 2-d array including closure headers and values', () => {
 
     const expected2DArray = [
         csvHeaders.concat([
+            'contributors',
             'is_closed',
         ]),
         [

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -16,12 +16,14 @@ export const startLogDownload = createAction('START_LOG_DOWNLOAD');
 export const failLogDownload = createAction('FAIL_LOG_DOWNLOAD');
 export const completeLogDownload = createAction('COMPLETE_LOG_DOWNLOAD');
 
-export function logDownload(format) {
+export function logDownload(format, options) {
     return async (dispatch, getState) => {
         dispatch(startLogDownload());
 
         const downloadFacilities =
             format === 'csv' ? downloadFacilitiesCSV : downloadFacilitiesXLSX;
+
+        const isEmbedded = options?.isEmbedded || false;
 
         try {
             const {
@@ -34,49 +36,23 @@ export function logDownload(format) {
                 featureFlags,
             } = getState();
 
-            const vectorTileFlagIsActive = get(
-                featureFlags,
-                'flags.vector_tile',
-                false,
-            );
-            const ppeIsActive = get(featureFlags, 'flags.ppe', false);
-            const reportsAreActive = get(
-                featureFlags,
-                'flags.report_a_facility',
-                false,
-            );
+            const ppeIsActive =
+                get(featureFlags, 'flags.ppe', false) && !isEmbedded;
+            const reportsAreActive =
+                get(featureFlags, 'flags.report_a_facility', false) &&
+                !isEmbedded;
 
             const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 
-            if (!vectorTileFlagIsActive) {
-                const recordCount = facilities ? facilities.length : 0;
-
-                return apiRequest
-                    .post(makeLogDownloadUrl(path, recordCount))
-                    .then(() =>
-                        downloadFacilities(facilities, {
-                            includePPEFields: ppeIsActive,
-                            includeClosureFields: reportsAreActive,
-                        }),
-                    )
-                    .then(() => dispatch(completeLogDownload()))
-                    .catch(err =>
-                        dispatch(
-                            logErrorAndDispatchFailure(
-                                err,
-                                'An error prevented the download',
-                                failLogDownload,
-                            ),
-                        ),
-                    );
+            if (!isEmbedded) {
+                await apiRequest.post(makeLogDownloadUrl(path, count));
             }
-
-            await apiRequest.post(makeLogDownloadUrl(path, count));
 
             if (!nextPageURL) {
                 downloadFacilities(facilities, {
                     includePPEFields: ppeIsActive,
                     includeClosureFields: reportsAreActive,
+                    isEmbedded,
                 });
             } else {
                 let nextFacilitiesSetURL = nextPageURL;
@@ -118,6 +94,7 @@ export function logDownload(format) {
                 downloadFacilities(features, {
                     includePPEFields: ppeIsActive,
                     includeClosureFields: reportsAreActive,
+                    isEmbedded,
                 });
             }
 

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { arrayOf, func, string } from 'prop-types';
+import { arrayOf, string } from 'prop-types';
 import { connect } from 'react-redux';
 import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
@@ -17,9 +17,12 @@ const downloadFacilitiesStyles = Object.freeze({
 });
 
 function DownloadFacilitiesButton({
+    /* from state */
+    dispatch,
+    isEmbedded,
     logDownloadError,
     user,
-    handleDownload,
+    /* from props */
     setLoginRequiredDialogIsOpen,
 }) {
     const [requestedDownload, setRequestedDownload] = useState(false);
@@ -35,8 +38,11 @@ function DownloadFacilitiesButton({
     const handleClick = event => setAnchorEl(event.currentTarget);
     const handleClose = () => setAnchorEl(null);
 
+    const handleDownload = format =>
+        dispatch(logDownload(format, { isEmbedded }));
+
     const selectFormatAndDownload = format => {
-        if (user) {
+        if (user || isEmbedded) {
             setRequestedDownload(true);
             handleDownload(format);
         } else {
@@ -80,7 +86,6 @@ DownloadFacilitiesButton.defaultProps = {
 
 DownloadFacilitiesButton.propTypes = {
     logDownloadError: arrayOf(string),
-    handleDownload: func.isRequired,
 };
 
 function mapStateToProps({
@@ -88,20 +93,13 @@ function mapStateToProps({
         user: { user },
     },
     logDownload: { error: logDownloadError },
+    embeddedMap: { embed: isEmbedded },
 }) {
     return {
         user,
         logDownloadError,
+        isEmbedded,
     };
 }
 
-function mapDispatchToProps(dispatch) {
-    return {
-        handleDownload: format => dispatch(logDownload(format)),
-    };
-}
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(DownloadFacilitiesButton);
+export default connect(mapStateToProps)(DownloadFacilitiesButton);

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -63,6 +63,7 @@ function VectorTileFacilitiesMap({
     zoomToSearch,
     drawFilterActive,
     boundary,
+    isEmbedded,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
@@ -146,18 +147,20 @@ function VectorTileFacilitiesMap({
                     gridColorRamp={gridColorRamp}
                 />
             </Control>
-            <Control position="topright">
-                <CopyToClipboard
-                    text={getLocationWithoutEmbedParam()}
-                    onCopy={() => toast('Copied search to clipboard')}
-                >
-                    <Button
-                        text="Share This Search"
-                        onClick={noop}
-                        style={mapComponentStyles.copySearchButtonStyle}
-                    />
-                </CopyToClipboard>
-            </Control>
+            {isEmbedded ? null : (
+                <Control position="topright">
+                    <CopyToClipboard
+                        text={getLocationWithoutEmbedParam()}
+                        onCopy={() => toast('Copied search to clipboard')}
+                    >
+                        <Button
+                            text="Share This Search"
+                            onClick={noop}
+                            style={mapComponentStyles.copySearchButtonStyle}
+                        />
+                    </CopyToClipboard>
+                </Control>
+            )}
             <ZoomControl position="bottomright" />
             <VectorTileFacilitiesLayer
                 handleMarkerClick={handleMarkerClick}
@@ -225,6 +228,7 @@ function mapStateToProps({
     },
     vectorTileLayer: { gridColorRamp },
     filters: { boundary },
+    embeddedMap: { embed: isEmbedded },
 }) {
     return {
         resetButtonClickCount,
@@ -236,6 +240,7 @@ function mapStateToProps({
         zoomToSearch,
         drawFilterActive,
         boundary,
+        isEmbedded,
     };
 }
 

--- a/src/app/src/util/util.facilitiesCSV.js
+++ b/src/app/src/util/util.facilitiesCSV.js
@@ -12,7 +12,6 @@ export const csvHeaders = Object.freeze([
     'country_name',
     'lat',
     'lng',
-    'contributors',
 ]);
 
 export const createFacilityRowFromFeature = (feature, options) => {
@@ -31,6 +30,10 @@ export const createFacilityRowFromFeature = (feature, options) => {
         },
     } = feature;
 
+    const contributorFields =
+        options && options.isEmbedded
+            ? []
+            : [contributors ? contributors.map(c => c.name).join('|') : ''];
     const ppeFields =
         options && options.includePPEFields
             ? PPE_FIELD_NAMES.map(f =>
@@ -47,16 +50,8 @@ export const createFacilityRowFromFeature = (feature, options) => {
             : [];
 
     return Object.freeze(
-        [
-            oar_id,
-            name,
-            address,
-            country_code,
-            country_name,
-            lat,
-            lng,
-            contributors ? contributors.map(c => c.name).join('|') : '',
-        ]
+        [oar_id, name, address, country_code, country_name, lat, lng]
+            .concat(contributorFields)
             .concat(ppeFields)
             .concat(closureFields),
     );
@@ -67,6 +62,9 @@ export const makeFacilityReducer = options => (acc, next) =>
 
 export const makeHeaderRow = options => {
     let headerRow = csvHeaders;
+    if (!options || !options.isEmbedded) {
+        headerRow = headerRow.concat(['contributors']);
+    }
     if (options && options.includePPEFields) {
         headerRow = headerRow.concat(PPE_FIELD_NAMES);
     }


### PR DESCRIPTION
## Overview

When displaying the home page in embed mode modify the download button to work correctly and remove the "share this search" map control.

Connects #1374
Connects #1377

## Testing Instructions

* Using the preview function on the embed settings page, verify both CSV and Excel downloads work
* Verify that files downloaded in embed mode do not have PPE columns or a contributors column.
* Verify that the files downloaded from the regular mode have all columns
* Verify that in embed mode, the map no longer has a "Share this search" map control in the upper right.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
