### PR TITLE
Use contributor ID rather than user ID when building embed code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Prevent embedded map use without authorization [#1370](https://github.com/open-apparel-registry/open-apparel-registry/pull/1370)
 - Show messages when the embed config is incomplete [#1376](https://github.com/open-apparel-registry/open-apparel-registry/pull/1376)
 - Download and map changes for embed mode [#1378](https://github.com/open-apparel-registry/open-apparel-registry/pull/1378)
+- Use contributor ID rather than user ID when building embed code [#1380](https://github.com/open-apparel-registry/open-apparel-registry/pull/1380)
 
 ### Changed
 

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -90,7 +90,7 @@ function EmbeddedMapConfig({
         width,
         height,
         fullWidth,
-        contributor: [user?.id],
+        contributor: [user?.contributor_id],
         timestamp,
         minimumConfigurationIsComplete,
     };


### PR DESCRIPTION
## Overview

This should have always been `contributor_id` but was masked by the fact that user IDs and contributor IDs match in development.

Connects #1379

## Demo

![2021-06-02 16 43 02](https://user-images.githubusercontent.com/17363/120565471-f915ec00-c3c1-11eb-8218-dae60f57220f.gif)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
