### PR TITLE
Disable claim a facility in embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show messages when the embed config is incomplete [#1376](https://github.com/open-apparel-registry/open-apparel-registry/pull/1376)
 - Download and map changes for embed mode [#1378](https://github.com/open-apparel-registry/open-apparel-registry/pull/1378)
 - Use contributor ID rather than user ID when building embed code [#1380](https://github.com/open-apparel-registry/open-apparel-registry/pull/1380)
+- Disable claim a facility in embed mode [#1382](https://github.com/open-apparel-registry/open-apparel-registry/pull/1382)
 
 ### Changed
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -665,7 +665,7 @@ export const addProtocolToWebsiteURLIfMissing = url => {
 
 // OAR requested that the PPE features be disabled when in embedded mode
 export const filterFlagsIfAppIsEmbeded = (flags, isEmbeded) =>
-    filter(flags, f => !isEmbeded || f !== 'ppe');
+    filter(flags, f => !isEmbeded || (f !== 'ppe' && f !== 'claim_a_facility'));
 
 export const convertFeatureFlagsObjectToListOfActiveFlags = featureFlags =>
     keys(pickBy(featureFlags, identity));


### PR DESCRIPTION


## Overview

Similar to hiding PPE fields we do not want to allow any facility claiming UI to be shown in embed mode.

Connects #1381

## Demo

<img width="1307" alt="Screen Shot 2021-06-02 at 5 16 22 PM" src="https://user-images.githubusercontent.com/17363/120567335-5f9d0900-c3c6-11eb-8bff-1055b6fa92c9.png">

## Testing Instructions

* View facility detail in embed mode and verify that the claim button is hidden

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
