### PR TITLE
Conditionally change split operation to revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Conditionally change split operation to revert [#1386](https://github.com/open-apparel-registry/open-apparel-registry/pull/1386)
+
 ### Changed
 
 ### Deprecated

--- a/src/app/src/components/DashboardAdjustMatchCard.jsx
+++ b/src/app/src/components/DashboardAdjustMatchCard.jsx
@@ -131,10 +131,15 @@ export default function DashboardAdjustMatchCard({
         promoteMatch(matchToPromote.match_id);
     };
 
+    const successfulSplitMessage = match =>
+        match.facility_created_by_item
+            ? 'Reverted match to original facility'
+            : 'New facility was created';
+
     useEffect(() => {
         if (!adjusting && loading) {
             const toastMessage = matchToSplit
-                ? 'New facility was created'
+                ? successfulSplitMessage(matchToSplit)
                 : 'Match was promoted';
 
             setMatchToSplit(null);
@@ -188,7 +193,7 @@ export default function DashboardAdjustMatchCard({
                     }
                     style={adjustMatchCardStyles.buttonStyles}
                 >
-                    Split
+                    {match.facility_created_by_item ? 'Revert' : 'Split'}
                 </Button>
                 <Button
                     variant="contained"
@@ -222,15 +227,21 @@ export default function DashboardAdjustMatchCard({
             action,
         } = matchToSplit
             ? {
-                  title: `Create a new facility from Match ${get(
-                      matchToSplit,
-                      'match_id',
-                      '',
-                  )}?`,
-                  subtitle: 'This will create a new facility from:',
+                  title: matchToSplit.facility_created_by_item
+                      ? `Revert match to original facility ${matchToSplit.facility_created_by_item}`
+                      : `Create a new facility from Match ${get(
+                            matchToSplit,
+                            'match_id',
+                            '',
+                        )}?`,
+                  subtitle: matchToSplit.facility_created_by_item
+                      ? 'This will connect the item to the original facility'
+                      : 'This will create a new facility from:',
                   name: get(matchToSplit, 'name', ''),
                   address: get(matchToSplit, 'address', ''),
-                  actionLabel: 'Create facility',
+                  actionLabel: matchToSplit.facility_created_by_item
+                      ? 'Revert match'
+                      : 'Create facility',
                   action: handleSplitMatch,
               }
             : {


### PR DESCRIPTION
## Overview

Conditionally change the split operation on the dashboard to revert in cases when the list item was previously used to create a new facility.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/26

## Demo

<img width="1088" alt="Screen Shot 2021-06-09 at 7 12 44 AM" src="https://user-images.githubusercontent.com/17363/121399357-3242e480-c90b-11eb-89ed-c4368e545a93.png">

## Notes

In production we encountered a situation where a list item was used to create a facility but then through some sequence of moderation activities was matched to a different facility. Attempts to use split function in the dashboard failed because attempting to create a new facility from the list item violated the uniqueness constraint on `Facility.created_from`.

To work around this problem we now include `facility_created_by_item` in the data used to populate the dashboard split tool and conditionally offer a "revert" option in place of split and mirror that change in the API view to connect the match to the originally created facility rather than attempting to make a new facility record.## Testing Instructions

## Testing

These instructions assume that you have run `./scripts/resetdb`

* Log in as c8@example.com, browse http://localhost:6543/lists/8, and confirm the pending matches.
  * Copy the OAR ID for "Nantong Jackbeanie Headwear..."
* Log in as c1@example.com and browse http://localhost:6543/dashboard/adjustfacilitymatches.
* Search for the "Nantong Jackbeanie Headwear..." OAR ID and save the match ID in the right hand column for later. Verify that an action button is labeled "SPLIT"
* Run `./scripts/manage shell_plus` and set up the test condition
```
m = FacilityMatch.objects.get(id={{the match ID}})
f = Facility()
f.country_code = m.facility_list_item.country_code
f.name = m.facility_list_item.name
f.address = m.facility_list_item.address
f.created_from = m.facility_list_item
f.location = m.facility_list_item.geocoded_point
f.save()
f.id
```
* Note the OAR id printed after the last command and save it for later
* On http://localhost:6543/dashboard/adjustfacilitymatches search for the OAR ID again and verify that the "SPLIT" button is now labeled "REVERT"
* Click "REVERT" and verify that the confirmation modal has a title that includes the OAR ID. Verify that it is the same OAR ID as the facility created through `shell_plus`.
* Confirm the revert and verify that it completes successfully.


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
