### PR TITLE
Add new admin reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add new admin reports [#1391](https://github.com/open-apparel-registry/open-apparel-registry/pull/1391)
+
 ### Changed
 
 - Consolidate contributor type options [#1395](https://github.com/open-apparel-registry/open-apparel-registry/pull/1395)

--- a/src/django/api/reports.py
+++ b/src/django/api/reports.py
@@ -4,15 +4,37 @@ from glob import glob
 from urllib.parse import quote
 
 from django.db import connection
-
+from api.models import HistoricalFacility
 
 _root = os.path.abspath(os.path.dirname(__file__))
+
+
+def monthly_promoted_name_and_address():
+    data = dict()
+    historical_facilities = HistoricalFacility.objects \
+        .exclude(created_from_id__isnull=True) \
+        .order_by('id', 'history_date') \
+        .values_list('id', 'history_date', 'created_from_id')
+    for i, h in enumerate(historical_facilities):
+            if i != 0:
+                prev = historical_facilities[i - 1]
+                if prev[0] == h[0] and h[2] != prev[2]:
+                    month = h[1].strftime('%Y-%m')
+                    data[month] = data.get(month, 0) + 1
+    return [['month', 'facilities promoted'],
+            sorted(data.items(), key=lambda x: x[0])]
+
+
+NON_SQL_REPORTS = {
+    'monthly_promoted_name_and_address': monthly_promoted_name_and_address
+}
 
 
 def get_report_names():
     file_paths = glob(os.path.join(_root, 'reports', '*.sql'))
     files = [os.path.basename(f) for f in file_paths]
     names = [os.path.splitext(f)[0].replace('_', '-') for f in files]
+    names += NON_SQL_REPORTS.keys()
     names.sort()
     return names
 
@@ -27,6 +49,31 @@ def quote_val(val):
 
 
 def run_report(name):
+    if name in NON_SQL_REPORTS.keys():
+        return run_non_sql_report(name)
+    else:
+        return run_sql_report(name)
+
+
+def create_csv_data(columns, rows):
+    csv_rows = [','.join([quote_val(c) for c in r]) for r in rows]
+    csv_lines = [','.join([quote_val(c) for c in columns])] + csv_rows
+    return quote('\n'.join(csv_lines))
+
+
+def run_non_sql_report(name):
+    columns, rows = NON_SQL_REPORTS[name]()
+    csv_data = create_csv_data(columns, rows)
+    return {
+        'name': name,
+        'sql': 'N/A: Custom Report',
+        'columns': columns,
+        'rows': rows,
+        'csv_data': csv_data,
+    }
+
+
+def run_sql_report(name):
     report_filename = os.path.join(
         _root, 'reports', '{}.sql'.format(name.replace('-', '_')))
     with open(report_filename, 'r') as report_file:
@@ -35,9 +82,8 @@ def run_report(name):
             cursor.execute(report_sql)
             columns = [col[0] for col in cursor.description]
             rows = cursor.fetchall()
-            csv_rows = [','.join([quote_val(c) for c in r]) for r in rows]
-            csv_lines = [','.join([quote_val(c) for c in columns])] + csv_rows
-            csv_data = quote('\n'.join(csv_lines))
+            csv_data = create_csv_data(columns, rows)
+
             return {
                 'name': name,
                 'sql': report_sql,

--- a/src/django/api/reports/duplicates_merged.sql
+++ b/src/django/api/reports/duplicates_merged.sql
@@ -1,0 +1,5 @@
+SELECT to_char(a.created_at, 'YYYY-MM') as month, COUNT(*) as duplicates_merged
+FROM api_facilityalias a
+WHERE reason = 'MERGE'
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/facilities_marked_closed.sql
+++ b/src/django/api/reports/facilities_marked_closed.sql
@@ -1,0 +1,5 @@
+SELECT to_char(approved_at, 'YYYY-MM') as month, COUNT(*) as facilities_closed_in_month
+FROM api_HistoricalFacilityActivityReport
+WHERE status = 'CONFIRMED' AND closure_state = 'CLOSED'
+GROUP BY month
+ORDER BY month;

--- a/src/django/api/reports/percent_facilities_claimed.sql
+++ b/src/django/api/reports/percent_facilities_claimed.sql
@@ -1,0 +1,33 @@
+SELECT c.zmonth as month,
+    c.approved_claims,
+    t.total_facilities,
+    ROUND(CAST((c.approved_claims*100) as decimal)/t.total_facilities, 2) as percent_of_facilities_claimed
+FROM (
+    SELECT
+        COUNT(f.id) as approved_claims,
+        z.month as zmonth,
+        status
+    FROM api_facility f
+    JOIN (
+        SELECT to_char(m.created_at, 'YYYY-MM') as month
+        FROM api_facility m group by month
+    ) z ON to_char(f.created_at, 'YYYY-MM') <= z.month
+    LEFT JOIN (
+        SELECT status, status_change_date, facility_id
+        FROM api_facilityclaim
+    ) as fc on f.id = fc.facility_id and to_char(status_change_date, 'YYYY-MM') <= z.month
+    WHERE status = 'APPROVED'
+    GROUP BY zmonth, status
+) as c
+JOIN (
+    SELECT
+        COUNT(f.id) as total_facilities,
+        z.month as zmonth
+    FROM api_facility f
+    JOIN (
+        SELECT to_char(m.created_at, 'YYYY-MM') as month
+        FROM api_facility m group by month
+    ) z ON to_char(f.created_at, 'YYYY-MM') <= z.month
+    GROUP BY zmonth
+) as t on t.zmonth = c.zmonth
+WHERE status = 'APPROVED';


### PR DESCRIPTION
## Overview

Adds new administrative reports for:
- Percent of facilities claimed (monthly)
- Duplicates merged per month
- Facilities marked as closed per month
- Names and addresses promoted per month

Some reports have proven difficult or inefficient to create using pure SQL, so the names and addresses promoted per month report introduces a new method of running reports which uses a custom Python function on a per-report basis. 

Connects #1346 

## Demo

<img width="540" alt="Screen Shot 2021-06-08 at 11 37 39 AM" src="https://user-images.githubusercontent.com/21046714/121532527-6aaaf700-c9cd-11eb-8d43-d6a3ec44d03b.png">
<img width="703" alt="Screen Shot 2021-06-10 at 9 23 30 AM" src="https://user-images.githubusercontent.com/21046714/121532641-8910f280-c9cd-11eb-8360-6d923f381012.png">
<img width="749" alt="Screen Shot 2021-06-10 at 9 24 15 AM" src="https://user-images.githubusercontent.com/21046714/121532751-a5149400-c9cd-11eb-90b6-fa8e7f963409.png">
<img width="651" alt="Screen Shot 2021-06-10 at 8 35 07 AM" src="https://user-images.githubusercontent.com/21046714/121532774-a9d94800-c9cd-11eb-83f7-7e459be5984d.png">

## Testing Instructions

* Run `./scripts/server`
* Claim a facility
* Merge two facilities
* Mark a facility as closed
* Promote a facility address
* Confirm that each report's logic appears sound 
* Confirm that the facility actions you have taken show in the reports
* Confirm that the downloaded CSV files are correct

## Checklist

- [x] **DROP** any commits that change Jenkinsfile
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
