### PR TITLE
Remove state flag from useUpdateLeafletMapImperatively to avoid loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Remove state flag from useUpdateLeafletMapImperatively to avoid loop [#1393](https://github.com/open-apparel-registry/open-apparel-registry/pull/1393)
+
 ### Security
 
 ## [42] - 2021-06-02

--- a/src/app/src/util/hooks.js
+++ b/src/app/src/util/hooks.js
@@ -111,55 +111,34 @@ export default function useUpdateLeafletMapImperatively(
         }
     }, [data, shouldSetViewOnReceivingData, setShouldSetViewOnReceivingData]);
 
-    // Set the map view to center on the facility at zoom level 15 if
-    // the user has clicked on a facility list item in the sidebar for a
-    // facility that is currently off-screen or when the vector tile map
-    // is zoomed out a level low enough to show the grid layer.
-    const [
-        panMapOnGettingFacilityData,
-        setPanMapOnGettingFacilityData,
-    ] = useState(shouldPanMapToFacilityDetails);
-
     useEffect(() => {
-        if (shouldPanMapToFacilityDetails && !panMapOnGettingFacilityData) {
-            setPanMapOnGettingFacilityData(true);
-        } else if (data && panMapOnGettingFacilityData) {
-            const leafletMap = get(mapRef, 'current.leafletElement', null);
+        const leafletMap = get(mapRef, 'current.leafletElement', null);
 
-            const facilityLocation = get(data, 'geometry.coordinates', null);
+        const facilityLocation = get(data, 'geometry.coordinates', null);
 
-            if (leafletMap && facilityLocation) {
-                const facilityLatLng = {
-                    lng: head(facilityLocation),
-                    lat: last(facilityLocation),
-                };
+        if (leafletMap && facilityLocation) {
+            const facilityLatLng = {
+                lng: head(facilityLocation),
+                lat: last(facilityLocation),
+            };
 
-                const mapBoundsContainsFacility = leafletMap
-                    .getBounds()
-                    .contains(facilityLatLng);
+            const mapBoundsContainsFacility = leafletMap
+                .getBounds()
+                .contains(facilityLatLng);
 
-                const currentMapZoomLevel = leafletMap.getZoom();
+            const currentMapZoomLevel = leafletMap.getZoom();
 
-                const shouldSetMapView =
-                    (isVectorTileMap &&
-                        currentMapZoomLevel <
-                            maxVectorTileFacilitiesGridZoom + 1) ||
-                    !mapBoundsContainsFacility;
+            const shouldSetMapView =
+                (isVectorTileMap &&
+                    currentMapZoomLevel <
+                        maxVectorTileFacilitiesGridZoom + 1) ||
+                !mapBoundsContainsFacility;
 
-                if (shouldSetMapView) {
-                    leafletMap.setView(facilityLatLng, detailsZoomLevel);
-                }
+            if (shouldSetMapView) {
+                leafletMap.setView(facilityLatLng, detailsZoomLevel);
             }
-
-            setPanMapOnGettingFacilityData(false);
         }
-    }, [
-        data,
-        shouldPanMapToFacilityDetails,
-        panMapOnGettingFacilityData,
-        setPanMapOnGettingFacilityData,
-        isVectorTileMap,
-    ]);
+    }, [data, shouldPanMapToFacilityDetails, isVectorTileMap]);
 
     return mapRef;
 }


### PR DESCRIPTION
## Overview

When navigating from the facility search results list to the facility details view the final `useEffect` block in `useUpdateLeafletMapImperatively` was triggering a render loop. Removing the state flag used within that `useEffect` block eliminated the rendering loop without breaking any desired map pan and zoom functionality.

Connects #1297 
Connects #1392

## Demo

![2021-06-10 13 38 51](https://user-images.githubusercontent.com/17363/121594915-8b397800-c9f2-11eb-9e72-a49e0b951091.gif)

## Notes

I checked that the behaviors described in #799 are not affected.

- If the user clicks on a facility marker, do not pan & zoom to the
facility
- If the user arrives at the map directly from a URL containing an OAR
ID, set the map view on the facility location, zoomed to level 15
- If the user clicks on a facility in the sidebar and the selected
facility is outside of the bbox OR the zoom level is
within the range in which the facilities grid layer is shown, pan to the
facility and set the zoom level at 15. This ensures that the facility
details marker will be visible even if the map was at grid-layer zoom
levels before


While testing that this also fixes #1392 we saw that there was an error logged to the console and shown in the WDS overlay error viewer when navigating from the map page to a page without the map. It looks like this may be the result of some react-leaflet code trying to operate on the map related DOM elements that are no longer on the page. 

<img width="1356" alt="Screen Shot 2021-06-10 at 1 49 18 PM" src="https://user-images.githubusercontent.com/17363/121595251-f2efc300-c9f2-11eb-8df1-a44181bb2ad1.png">

This error does not appear to affect functionality

## Testing Instructions

* Open the console, browse http://localhost:6543/, click the Facilities tab, select a facility, and verify that no error is logged.
* Use the in-app back button to return to the facility list, select another facility, and verify that it also works.
* Log in as c2@example.com
* On the facility details page, click the "Claim this Facility" link and verify that the claim page loads (you may run into a non-blocking error when running in development. see note above. this error overlay can be dismissed using the X in the upper right.
 
## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
