### PR TITLE
Pass request as context to FacilitySerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Remove state flag from useUpdateLeafletMapImperatively to avoid loop [#1393](https://github.com/open-apparel-registry/open-apparel-registry/pull/1393)
+- Pass request as context to FacilitySerializer [#1396](https://github.com/open-apparel-registry/open-apparel-registry/pull/1396)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -786,13 +786,17 @@ class FacilitiesViewSet(mixins.ListModelMixin,
 
         extent = queryset.aggregate(Extent('location'))['location__extent']
 
+        context = {'request': request}
+
         if page_queryset is not None:
-            serializer = FacilitySerializer(page_queryset, many=True)
+            serializer = FacilitySerializer(page_queryset, many=True,
+                                            context=context)
             response = self.get_paginated_response(serializer.data)
             response.data['extent'] = extent
             return response
 
-        response_data = FacilitySerializer(queryset, many=True).data
+        response_data = FacilitySerializer(queryset, many=True,
+                                           context=context).data
         response_data['extent'] = extent
         return Response(response_data)
 


### PR DESCRIPTION
## Overview

Passing the request context ensures that the serialization can conditionally show information in the search results based on the authenticated user.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/35

## Demo

### Before
```
$ curl -X GET --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' 'http://localhost:6543/api/facilities/?pageSize=1' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   690  100   690    0     0   5847      0 --:--:-- --:--:-- --:--:--  5847
{
  "type": "FeatureCollection",
  "count": 904,
  "next": "http://localhost:6543/api/facilities/?page=2&pageSize=1",
  "previous": null,
  "features": [
    {
      "id": "US2021161ZZA8W1",
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          -81.3044164,
          28.7313374
        ]
      },
      "properties": {
        "name": "1v1 Fight Gear",
        "address": "5320 Tower Way, Sanford, 32773, Florida",
        "country_code": "US",
        "oar_id": "US2021161ZZA8W1",
        "country_name": "United States",
        "contributors": [
          {
            "id": 15,
            "name": "Manufacturing Group E (Winter 2019 Compliance List)",
            "is_verified": false
          }
        ],
        "ppe_product_types": null,
        "ppe_contact_phone": null,
        "ppe_contact_email": null,
        "ppe_website": null,
        "is_closed": null
      }
    }
  ],
  "extent": [
    -123.1036081,
    -43.9036876,
    174.9025665,
    56.2409907
  ]
}
```
### After

```
$ curl -X GET --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' 'http://localhost:6543/api/facilities/?pageSize=1' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   652  100   652    0     0    194      0  0:00:03  0:00:03 --:--:--   194
{
  "type": "FeatureCollection",
  "count": 904,
  "next": "http://localhost:6543/api/facilities/?page=2&pageSize=1",
  "previous": null,
  "features": [
    {
      "id": "US2021161ZZA8W1",
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          -81.3044164,
          28.7313374
        ]
      },
      "properties": {
        "name": "1v1 Fight Gear",
        "address": "5320 Tower Way, Sanford, 32773, Florida",
        "country_code": "US",
        "oar_id": "US2021161ZZA8W1",
        "country_name": "United States",
        "contributors": [
          {
            "name": "A Manufacturing Group / Supplier / Vendor"
          }
        ],
        "ppe_product_types": null,
        "ppe_contact_phone": null,
        "ppe_contact_email": null,
        "ppe_website": null,
        "is_closed": null
      }
    }
  ],
  "extent": [
    -123.1036081,
    -43.9036876,
    174.9025665,
    56.2409907
  ]
}
```

## Testing Instructions

* Check out `develop`
* Log in as c1@example.com
* Browse http://localhost:8081/admin/api/user/2/change, remove the `can_view_full_contrib_detail` permission and save
* Make the following request to facility search and note that the contributor name is incorrectly returned in the response
```
curl -X GET --header 'Accept: application/json' --header 'Authorization: Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051' 'http://localhost:6543/api/facilities/?pageSize=1'
```
* Check out this branch (`bugfix/jcw/pass-context-to-facility-serializer`) and make the same `curl` request. Verify that the contributor name is anonymized.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
