### PR TITLE
Set a minimum height when using a 100% width embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Correct contributor types [#1397](https://github.com/open-apparel-registry/open-apparel-registry/pull/1397)
+- Set a minimum height when using a 100% width embed [#1401](https://github.com/open-apparel-registry/open-apparel-registry/pull/1401)
 
 ### Security
 

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -5,7 +5,10 @@ import { func, shape, string, bool } from 'prop-types';
 
 import { userPropType } from '../util/propTypes';
 import { getEmbeddedMapSrc } from '../util/util';
-import { EmbeddedMapInfoLink } from '../util/constants';
+import {
+    EmbeddedMapInfoLink,
+    minimum100PercentWidthEmbedHeight,
+} from '../util/constants';
 
 import AppGrid from './AppGrid';
 import EmbeddedMapFieldsConfig from './EmbeddedMapFieldsConfig';
@@ -31,15 +34,24 @@ const styles = {
     },
 };
 
+// This must be kept in sync with createIFrameHTML in util.js
+// We use a separate function to avoid using dangerouslySetInnerHTML
 const renderEmbeddedMap = ({ fullWidth, mapSettings, height, width }) =>
     fullWidth ? (
         <div>
-            <div
-                style={{
-                    position: 'relative',
-                    paddingTop: `${height}%`,
-                }}
-            >
+            <style>
+                {`\
+                #oar-embed-0d4dc3a7-e3cd-4acc-88f0-422f5aeefa48 {\
+                    position: relative;\
+                    padding-top: ${height}%;\
+                }\
+                @media (max-width: 600px) { /* mobile breakpoint */\
+                    #oar-embed-0d4dc3a7-e3cd-4acc-88f0-422f5aeefa48 {\
+                        padding-top: ${minimum100PercentWidthEmbedHeight}\
+                    }\
+                }`}
+            </style>
+            <div id="oar-embed-0d4dc3a7-e3cd-4acc-88f0-422f5aeefa48">
                 <iframe
                     src={getEmbeddedMapSrc(mapSettings)}
                     frameBorder="0"

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -227,7 +227,7 @@ function FilterSidebarSearchTab({
         <div
             className={`control-panel__content ${classes.controlPanelContentStyles}`}
         >
-            <div>
+            <div style={{ marginBottom: '60px' }}>
                 <div className="form__field" style={{ marginBottom: '10px' }}>
                     <InputLabel htmlFor={FACILITIES} className="form__label">
                         <FeatureFlag

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -520,3 +520,7 @@ export const OARFont = 'ff-tisa-sans-web-pro,sans-serif';
 export const OARColor = '#0427a4';
 
 export const EmbeddedMapInfoLink = 'https://info.openapparel.org/embedded-map';
+
+// A CSS size value that is used to set a lower bound on the iframe height
+// when the width is set to 100%
+export const minimum100PercentWidthEmbedHeight = '500px';

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -49,6 +49,7 @@ import {
     facilityListItemStatusChoicesEnum,
     facilityListItemErrorStatuses,
     facilityListSummaryStatusMessages,
+    minimum100PercentWidthEmbedHeight,
 } from './constants';
 
 import { createListItemCSV } from './util.listItemCSV';
@@ -776,7 +777,7 @@ export const getEmbeddedMapSrc = ({ contributor, timestamp }) => {
 export const createIFrameHTML = ({ fullWidth, contributor, height, width }) =>
     fullWidth
         ? `<div>
-            <div style="position:relative;padding-top:${height}%;">
+            <div style="position:relative;padding-top:max(${height}%,${minimum100PercentWidthEmbedHeight});">
                 <iframe
                     src="${getEmbeddedMapSrc({
                         contributor,

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -774,6 +774,7 @@ export const getEmbeddedMapSrc = ({ contributor, timestamp }) => {
     return window.location.href.replace('settings', `?${qs}`);
 };
 
+// This must be kept in sync with renderEmbeddedMap in EmbeddedMapConfig.jsx
 export const createIFrameHTML = ({ fullWidth, contributor, height, width }) =>
     fullWidth
         ? `<div>

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -777,19 +777,30 @@ export const getEmbeddedMapSrc = ({ contributor, timestamp }) => {
 export const createIFrameHTML = ({ fullWidth, contributor, height, width }) =>
     fullWidth
         ? `<div>
-            <div style="position:relative;padding-top:max(${height}%,${minimum100PercentWidthEmbedHeight});">
-                <iframe
-                    src="${getEmbeddedMapSrc({
-                        contributor,
-                    })}"
-                    frameborder="0"
-                    allowfullscreen
-                    style="position:absolute;top:0;
-                           left:0;width:100%;height:100%;"
-                    title="embedded-map">
-                </iframe>
-              </div>
-            </div>`
+               <style>
+                   #oar-embed-0d4dc3a7-e3cd-4acc-88f0-422f5aeefa48 {
+                       position: relative;
+                       padding-top: ${height}%;
+                   }
+                   @media (max-width: 600px) { /* mobile breakpoint */
+                       #oar-embed-0d4dc3a7-e3cd-4acc-88f0-422f5aeefa48 {
+                           padding-top: ${minimum100PercentWidthEmbedHeight}
+                       }
+                   }
+               </style>
+               <div id="oar-embed-0d4dc3a7-e3cd-4acc-88f0-422f5aeefa48">
+                   <iframe
+                       src="${getEmbeddedMapSrc({
+                           contributor,
+                       })}"
+                       frameborder="0"
+                       allowfullscreen
+                       style="position:absolute;top:0;
+                              left:0;width:100%;height:100%;"
+                       title="embedded-map">
+                   </iframe>
+               </div>
+           </div>`
         : `<iframe
                 src="${getEmbeddedMapSrc({
                     contributor,


### PR DESCRIPTION
## Overview

When setting the embed height as a proportion of the page width, the narrow screen widths of mobile devices lead to an embed that is too sort to be functional.

To work around this we introduce additional styling of the embed that uses media query to override the percentage with a fixed, minimum height.

Connects #1400

## Demo
![2021-06-16 15 18 08](https://user-images.githubusercontent.com/17363/122302005-5c217b80-ceb6-11eb-89d5-ed97c120aac9.gif)

![2021-06-16 15 18 58](https://user-images.githubusercontent.com/17363/122302035-68a5d400-ceb6-11eb-94bf-476d22b41f6e.gif)


## Testing Instructions

I used this index.html page served wtih https://www.npmjs.com/package/http-server to test the embed codes generated by this PR

```
<!doctype html>

<html lang="en">
    <head>
        <meta charset="UTF-8"/>
        <meta name="viewport" content="width=device-width">
        <title>OAR Embed Demo</title>
    </head>
    <body>
        <h1>
            <div>
                My embedded map
            </div>
        </h1>
        <li>item one</li>
        <li>item b</li>
        <li>item the third</li>



        <!-- embed -->
        <!-- end -->

    </body>
</html>
```
* Test that the embed code generated for both fixed and full width embeds work and the full width embed works at phone width.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
