### PR TITLE
Add cumulative versions of reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add new admin reports [#1391](https://github.com/open-apparel-registry/open-apparel-registry/pull/1391)
 - Reorder contributor fields [#1398](https://github.com/open-apparel-registry/open-apparel-registry/pull/1398)
 - Add additional new admin reports [#1399](https://github.com/open-apparel-registry/open-apparel-registry/pull/1399)
+- Add cumulative versions of reports [#1405](https://github.com/open-apparel-registry/open-apparel-registry/pull/1405)
 
 ### Changed
 

--- a/src/django/api/reports/industry_data_vs_oar_data_cumulative.sql
+++ b/src/django/api/reports/industry_data_vs_oar_data_cumulative.sql
@@ -1,5 +1,5 @@
 SELECT
-  fm.month,
+  z.month,
   ROUND(CAST(
             (COUNT(CASE WHEN fm.is_public_list THEN 1 ELSE NULL END)*100)
         as decimal)/COUNT(*), 2) AS oar_data,
@@ -11,7 +11,8 @@ SELECT
   FROM (
       SELECT
           MIN(to_char(m.created_at, 'YYYY-MM')) AS month,
-          u.email LIKE '%openapparel.org%' AS is_public_list
+          u.email LIKE '%openapparel.org%' AS is_public_list,
+          m.facility_id
       FROM api_facilitymatch m
           JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
           JOIN api_source s on i.source_id = s.id
@@ -20,5 +21,10 @@ SELECT
       WHERE m.status NOT IN ('REJECTED', 'PENDING')
       GROUP BY m.facility_id, u.email
   ) as fm
- GROUP BY fm.month
- ORDER BY fm.month
+  JOIN (
+      SELECT to_char(m.created_at, 'YYYY-MM') AS month
+      FROM api_facilitymatch m
+      GROUP BY month
+  ) z on fm.month <= z.month
+ GROUP BY z.month
+ ORDER BY z.month;

--- a/src/django/api/reports/percent_data_by_contributor_type.sql
+++ b/src/django/api/reports/percent_data_by_contributor_type.sql
@@ -1,7 +1,9 @@
 SELECT
     match.month,
     contrib_type,
-    ROUND(CAST((COUNT(*)*100) as decimal)/total, 2) as percent_of_data
+    ROUND(CAST((COUNT(*)*100) as decimal)/total, 2) as percent_of_data,
+    COUNT(*) as type_count,
+    total
 FROM (
     SELECT
         MIN(to_char(m.created_at, 'YYYY-MM')) AS month,
@@ -32,4 +34,5 @@ JOIN (
     GROUP BY month
     ORDER BY month
 ) t ON t.month = match.month
-GROUP BY match.month, contrib_type, total;
+GROUP BY match.month, contrib_type, total
+ORDER BY month;

--- a/src/django/api/reports/percent_data_by_contributor_type_cumulative.sql
+++ b/src/django/api/reports/percent_data_by_contributor_type_cumulative.sql
@@ -1,0 +1,52 @@
+SELECT
+    c.month,
+    contrib_type,
+    ROUND(CAST((type_count*100) as decimal)/total, 2) as percent_of_data,
+    type_count,
+    total
+FROM (
+    SELECT z.month, contrib_type, count(*) as type_count
+    FROM (
+        SELECT
+            MIN(to_char(m.created_at, 'YYYY-MM')) AS month,
+            contrib_type
+        FROM api_facilitymatch m
+            JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+            JOIN api_source s on i.source_id = s.id
+            JOIN api_contributor c ON s.contributor_id = c.id
+            JOIN api_user u ON u.id = c.admin_id
+        WHERE m.status NOT IN ('REJECTED', 'PENDING')
+        AND u.email NOT LIKE '%openapparel.org%'
+        GROUP BY m.facility_id, u.email, c.contrib_type
+    ) as match
+    JOIN (
+        SELECT to_char(m.created_at, 'YYYY-MM') AS month
+        FROM api_facilitymatch m
+        GROUP BY month
+    ) z on match.month <= z.month
+    GROUP BY z.month, contrib_type
+) c
+JOIN (
+    SELECT z.month, count(*) as total
+    FROM (
+        SELECT
+            MIN(to_char(m.created_at, 'YYYY-MM')) AS month
+        FROM api_facilitymatch m
+            JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
+            JOIN api_source s on i.source_id = s.id
+            JOIN api_contributor c ON s.contributor_id = c.id
+            JOIN api_user u ON u.id = c.admin_id
+        WHERE m.status NOT IN ('REJECTED', 'PENDING')
+        AND u.email NOT LIKE '%openapparel.org%'
+        GROUP BY m.facility_id, u.email
+    ) as fm
+    JOIN (
+        SELECT to_char(m.created_at, 'YYYY-MM') AS month
+        FROM api_facilitymatch m
+        GROUP BY month
+    ) z on fm.month <= z.month
+    GROUP BY z.month
+    ORDER BY z.month
+) t on c.month = t.month
+GROUP BY c.month, contrib_type, type_count, total
+ORDER BY c.month;


### PR DESCRIPTION
## Overview

Adds cumulative versions of the Industry Data vs. OAR Data report
and the Percent Data by Contributor Type report. In addition, adds
columns for the counts used to calculate the percents, for added
clarity. 

Connects #1404 

## Demo

<img width="652" alt="Screen Shot 2021-06-17 at 3 56 11 PM" src="https://user-images.githubusercontent.com/21046714/122466132-e89b6f00-cf86-11eb-84ac-94c38ccea66d.png">
<img width="685" alt="Screen Shot 2021-06-17 at 3 56 26 PM" src="https://user-images.githubusercontent.com/21046714/122466152-edf8b980-cf86-11eb-908f-a52e2d56ba0d.png">

<img width="459" alt="Screen Shot 2021-06-17 at 3 56 34 PM" src="https://user-images.githubusercontent.com/21046714/122466188-fa7d1200-cf86-11eb-9b8c-09877bf8ce45.png">
<img width="605" alt="Screen Shot 2021-06-17 at 3 58 20 PM" src="https://user-images.githubusercontent.com/21046714/122466193-fbae3f00-cf86-11eb-9b8e-16fc770f972f.png">

## Testing Instructions

* Run `./scripts/server`
* In order to confirm the reports work locally, you will need to have matches submitted by a user with an openapparel.org email and also matches which were created in different months. I replicated this by changing the email of a user with already-submitted matches and by postdating a large number of matches using `./scripts/manage dbshell`.
* Visit [percent data by contributor type](http://localhost:8081/admin/reports/percent-data-by-contributor-type/) and note the count and total for a contributor type across different months. 
* Visit [percent data by contributor type cumulative](http://localhost:8081/admin/reports/percent-data-by-contributor-type-cumulative/) and confirm if you add the counts and totals for the contributor type it adds up to the cumulative amounts given. 
* Repeat with [industry data vs oar data](http://localhost:8081/admin/reports/industry-data-vs-oar-data/) and [industry data vs oar data cumulative](http://localhost:8081/admin/reports/industry-data-vs-oar-data-cumulative/)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
