### PR TITLE
Conditionally hide remove button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Conditionally hide remove button [#1417](https://github.com/open-apparel-registry/open-apparel-registry/pull/1417)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/FacilityListItemsTableRow.jsx
+++ b/src/app/src/components/FacilityListItemsTableRow.jsx
@@ -12,6 +12,8 @@ import { listTableCellStyles } from '../util/styles';
 
 import { makeFacilityDetailLink } from '../util/util';
 
+import { facilityListItemErrorStatuses } from '../util/constants';
+
 const makeTableRowStyles = ({ handleSelectRow, isRemoved }) => ({
     cursor: isFunction(handleSelectRow) ? 'pointer' : 'auto',
     opacity: isRemoved ? '0.6' : '1.0',
@@ -101,15 +103,20 @@ const FacilityListItemsTableRow = ({
                         <span style={{ marginRight: '5px' }}>
                             {newFacility ? 'NEW_FACILITY' : status}
                         </span>
-                        <Button
-                            color="primary"
-                            onClick={handleRemoveItem}
-                            style={{ marginLeft: '5px', marginRight: '5px' }}
-                            disabled={removeButtonDisabled}
-                            id={removeButtonID}
-                        >
-                            Remove
-                        </Button>
+                        {!facilityListItemErrorStatuses.includes(status) && (
+                            <Button
+                                color="primary"
+                                onClick={handleRemoveItem}
+                                style={{
+                                    marginLeft: '5px',
+                                    marginRight: '5px',
+                                }}
+                                disabled={removeButtonDisabled}
+                                id={removeButtonID}
+                            >
+                                Remove
+                            </Button>
+                        )}
                     </div>
                 );
             })()}


### PR DESCRIPTION
## Overview

Because list items with errors never had matches/facilities created
for them, the remove button in the list dashboard will have no effect.
Hides the remove button for items in an error state.

Connects #1414 

## Demo

<img width="1316" alt="Screen Shot 2021-07-08 at 1 50 50 PM" src="https://user-images.githubusercontent.com/21046714/124971280-ff1d6f00-dff6-11eb-8aa1-e9c57b57e8d0.png">

## Testing Instructions

* Run `./scripts/server` login as a contributor. Set several items in a list belonging to that contributor to an error state. 
* View the list with error items. List items with an error status should not have 'remove' buttons. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
