### PR TITLE
Fix Facility Detail Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Anonymize other_locations contributors [#1415](https://github.com/open-apparel-registry/open-apparel-registry/pull/1415)
+- Fix facility detail header [#1419](https://github.com/open-apparel-registry/open-apparel-registry/pull/1419)
 
 ### Security
 

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -32,7 +32,6 @@
   background: linear-gradient(135deg, #003de5 0%,#7964ff 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#003de5', endColorstr='#7964ff',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
   padding: 20px 16px;
-  max-height: 110px;
 }
 
 .panel-header__title {


### PR DESCRIPTION
## Overview

The bottom line of the address was getting cut off for long names and
addresses. Removing the maximum height for the header resolves this.

Connects #1413 

## Demo

<img width="358" alt="Screen Shot 2021-07-12 at 9 37 02 AM" src="https://user-images.githubusercontent.com/21046714/125297717-7d2e8e00-e2f5-11eb-88a0-dd0b7951b665.png">

## Testing Instructions

* On `develop`, view a facility with a particularly long name and address, such as 'An Phat Invest Joint Stock Company - Zone A ( Unit 2, 3, 4)'. Note that the address is hidden below the bottom of the header. 
* On this branch, view the same facility and confirm that the name and address are visible. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
