### PR TITLE
Align logout button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Conditionally hide remove button [#1417](https://github.com/open-apparel-registry/open-apparel-registry/pull/1417)
+- Align logout button [#1420](https://github.com/open-apparel-registry/open-apparel-registry/pull/1420)
 
 ### Deprecated
 

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -58,6 +58,12 @@ li.dropdown-list-item button {
   text-transform: none;
 }
 
+li.dropdown-list-item button.logout {
+    padding-left: 0 !important;
+    margin-left: -5px;
+    border: none;
+}
+
 li.dropdown-list-item a:hover,
 li.dropdown-list-item button:hover {
   background: none !important;

--- a/src/app/src/components/NavbarDropdown.jsx
+++ b/src/app/src/components/NavbarDropdown.jsx
@@ -58,7 +58,7 @@ const itemMap = item => {
                 <Button
                     color="primary"
                     onClick={item.action}
-                    style={{ border: 'none' }}
+                    className="logout"
                 >
                     {item.text}
                 </Button>


### PR DESCRIPTION
## Overview

The button for the navigation dropdown for logged-in users was out of
line with the links, but is now aligned. Logout, unlike the other items
in the navigation, is a button instead of an anchor, because it doesn't
navigate the user but rather performs an action in response to a click.
This requires it to have different styles, which need to be set using
higher specifity CSS classes in order to override the '!important' tags
on other CSS classes for nav dropdowns.

Connects #1411 

## Demo

<img width="162" alt="Screen Shot 2021-07-12 at 12 26 44 PM" src="https://user-images.githubusercontent.com/21046714/125327177-d526be00-e310-11eb-9184-94617c2335f6.png">

## Testing Instructions

* Run `./scripts/server`, login as any user, and click the user name in the upper right-hand corner to view the log out button. Confirm it is aligned properly at various screen sizes. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
