### PR TITLE
Fix facility history bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Anonymize other_locations contributors [#1415](https://github.com/open-apparel-registry/open-apparel-registry/pull/1415)
 - Fix facility detail header [#1419](https://github.com/open-apparel-registry/open-apparel-registry/pull/1419)
+- Fix facility history bug [#1421](https://github.com/open-apparel-registry/open-apparel-registry/pull/1421)
 
 ### Security
 

--- a/src/django/api/facility_history.py
+++ b/src/django/api/facility_history.py
@@ -1,4 +1,5 @@
 from django.db.models import F
+from django.core.exceptions import ObjectDoesNotExist
 
 from api.constants import ProcessingAction, FacilityHistoryActions
 from api.models import (FacilityMatch,
@@ -292,6 +293,13 @@ def create_facility_claim_entry(claim):
     return None
 
 
+def is_claim_for_facility(c, facility_id):
+    try:
+        return c.facility.id == facility_id
+    except ObjectDoesNotExist:
+        return False
+
+
 def create_facility_history_list(entries, facility_id, user=None):
     if user is not None and not user.is_anonymous:
         user_can_see_detail = user.can_view_full_contrib_details
@@ -376,7 +384,7 @@ def create_facility_history_list(entries, facility_id, user=None):
             FacilityClaim.APPROVED,
             FacilityClaim.REVOKED,
         ])
-        if c.facility.id == facility_id
+        if is_claim_for_facility(c, facility_id)
         if create_facility_claim_entry(c) is not None
     ]
 


### PR DESCRIPTION
## Overview

There are cases where a facility claim history object references
a facility which has been deleted. When fetching the facility history,
a ObjectDoesNotExist exception was being thrown. We now catch this
exception and exclude the broken objects.

Connects #1310 

## Demo

Test showing error prior to updating `facility_history.py`:
<img width="635" alt="Screen Shot 2021-07-13 at 10 03 44 AM" src="https://user-images.githubusercontent.com/21046714/125486610-2be17d79-af25-4ff4-a494-244633c85e6e.png">

## Notes

In most cases we would use `facility is not None` instead of
catching an exception. In this situation, most likely because of a
`history` related quirk, that doesn't resolve the error.

## Testing Instructions

* Run `./scripts/test` and confirm all tests pass
* Run `./scripts/server` and confirm that the history API is working as before

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
