### PR TITLE
Handle error when splitting match w/o location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Conditionally hide remove button [#1417](https://github.com/open-apparel-registry/open-apparel-registry/pull/1417)
 - Align logout button [#1420](https://github.com/open-apparel-registry/open-apparel-registry/pull/1420)
 - Use contractual limit tracking [#1418](https://github.com/open-apparel-registry/open-apparel-registry/pull/1418)
+- Handle error when splitting match w/o location [#1424](https://github.com/open-apparel-registry/open-apparel-registry/pull/1424)
 
 ### Deprecated
 

--- a/src/app/src/components/DashboardAdjustMatchCard.jsx
+++ b/src/app/src/components/DashboardAdjustMatchCard.jsx
@@ -305,7 +305,7 @@ export default function DashboardAdjustMatchCard({
                 </Typography>
                 {errorAdjusting && (
                     <Typography style={adjustMatchCardStyles.errorStyles}>
-                        An error prevented adjusting that facility match
+                        {errorAdjusting[0]}
                     </Typography>
                 )}
                 <CardContent style={adjustMatchCardStyles.contentStyles}>

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1819,6 +1819,10 @@ class FacilitiesViewSet(mixins.ListModelMixin,
 
             list_item_for_match = match_for_new_facility.facility_list_item
 
+            if list_item_for_match.geocoded_point is None:
+                raise ValidationError('The match can not be split because '
+                                      'it does not have a location.')
+
             facility_qs = Facility.objects.filter(
                 created_from=list_item_for_match)
             if facility_qs.exists():


### PR DESCRIPTION
## Overview

Show an informational error message when a match can not be split out into its own facility because it does not have a geocoded location.

Connects to https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/38

## Demo

<img width="500" alt="Screen Shot 2021-07-14 at 12 13 59 PM" src="https://user-images.githubusercontent.com/1042475/125656721-d264fa61-1e9d-40db-98e9-1cee8b65cfbc.png">

## Testing Instructions

- Create a new facility via the API or CSV upload
- Create a second facility with a similar name and the same address as the first facility. Ensure it is matched to the first facility.
- Visit the admin, view the list of `FacilityListItems`, and note the id of the matched facility.
- Open the shell (`./scripts/manage shell_plus`).
- Find the matched item `foo = FacilityListItem.objects.get(pk=XXX)`
- Set the location to `None` `foo.geocoded_point = None`
- Save the item `foo.save()`
- Go to the Adjust Facility Matches dashboard page.
- Find the Facility ID of the first facility you created and enter it on the dashboard page.
- Attempt to remove the matched item. You should see an error message about the match not having a location.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
