### PR TITLE
Block users without contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Anonymize other_locations contributors [#1415](https://github.com/open-apparel-registry/open-apparel-registry/pull/1415)
 - Fix facility detail header [#1419](https://github.com/open-apparel-registry/open-apparel-registry/pull/1419)
 - Fix facility history bug [#1421](https://github.com/open-apparel-registry/open-apparel-registry/pull/1421)
+- Block users without contributors [#1426](https://github.com/open-apparel-registry/open-apparel-registry/pull/1426)
 
 ### Security
 

--- a/src/django/api/limits.py
+++ b/src/django/api/limits.py
@@ -33,7 +33,13 @@ def get_start_date(period_start_date):
 
 @transaction.atomic
 def check_contributor_api_limit(at_datetime, c):
-    contributor = Contributor.objects.get(id=c.get('contributor'))
+    try:
+        contributor = Contributor.objects.get(id=c.get('contributor'))
+    except Contributor.DoesNotExist:
+        # API Limits and Blocks are linked to contributors.
+        # Users without contributors are blocked from the system
+        # in middleware and don't need to be handled here.
+        return
     log_dates = c.get('log_dates')
     notification, created = ContributorNotifications \
         .objects \

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -350,7 +350,7 @@ class FacilityListCreateTest(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()), 1)
 
-    def test_upload_by_user_with_no_contributor_returns_400(self):
+    def test_upload_by_user_with_no_contributor_returns_402(self):
         Contributor.objects.all().delete()
         token = Token.objects.create(user=self.user)
         self.client.post('/user-logout/')
@@ -359,7 +359,7 @@ class FacilityListCreateTest(APITestCase):
                                     {'file': self.test_file},
                                     format='multipart',
                                     **header)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 402)
 
     def test_list_request_by_user_with_no_contributor_returns_400(self):
         Contributor.objects.all().delete()


### PR DESCRIPTION
## Overview

The `check_api_limits` management command was throwing an error when
attempting to process a user with no contributor (an invalid data
state). Because ApiBlocks are set on contributors, and not on individual
 users, we can't block a user with no contributor via ApiLimit under our
 current system. Instead, we now prevent these users from
 accessing the API entirely and return a clear error response.

Connects #1425 

## Demo

<img width="950" alt="Screen Shot 2021-07-15 at 2 58 46 PM" src="https://user-images.githubusercontent.com/21046714/125842485-48b87572-527c-4411-83d8-46a32fef86f0.png">

## Testing Instructions

* Run `./scripts/manage shell_plus` and delete a contributor. 
```
c = Contributor.objects.get(id=6)
c.delete()
```
* Run `./scripts/manage check_api_limits` and confirm it runs without error
* Run `./scripts/server` and login as the user whose contributor you deleted. Get the user's token and authenticate with the API, then send a request. You should see an error message. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
