### PR TITLE
Extend geocoding report results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix facility detail header [#1419](https://github.com/open-apparel-registry/open-apparel-registry/pull/1419)
 - Fix facility history bug [#1421](https://github.com/open-apparel-registry/open-apparel-registry/pull/1421)
 - Block users without contributors [#1426](https://github.com/open-apparel-registry/open-apparel-registry/pull/1426)
+- Extend geocoding report results [#1428](https://github.com/open-apparel-registry/open-apparel-registry/pull/1428)
 
 ### Security
 


### PR DESCRIPTION
## Overview

The OAR team needs to see the geocoding times for the entire quarter.
Extends results to include all items in the past four months, and not
just the 1000 most recent items.

Connects #1423 

## Demo

<img width="725" alt="Screen Shot 2021-07-19 at 12 01 46 PM" src="https://user-images.githubusercontent.com/21046714/126191212-b962e464-e89c-4a1b-9b1b-a050559a8f57.png">
<img width="666" alt="Screen Shot 2021-07-19 at 12 01 35 PM" src="https://user-images.githubusercontent.com/21046714/126191217-5aa449b4-2807-4050-aa81-b77217bc659e.png">
<img width="694" alt="Screen Shot 2021-07-19 at 12 01 59 PM" src="https://user-images.githubusercontent.com/21046714/126191228-1e518033-830b-4841-ab91-6884274c23c8.png">
<img width="707" alt="Screen Shot 2021-07-19 at 12 02 11 PM" src="https://user-images.githubusercontent.com/21046714/126191235-11948e62-4a02-4b2b-94be-2f2a123bd516.png">

## Notes

This PR needs to be tested on Staging, because there are concerns that with the four-month window the request might time out. It does appear to be working as expected, and within reasonable timeframes, on Staging. 

## Testing Instructions

* Open https://staging.openapparel.org/admin/reports/recent_monthly_geocoding_time_with_queue
* Open https://staging.openapparel.org/admin/reports/recent_monthly_geocoding_time_without_queue
* Open https://staging.openapparel.org/admin/reports/recent_weekly_geocoding_time_with_queue
* Open https://staging.openapparel.org/admin/reports/recent_weekly_geocoding_time_without_queue

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
