### PR TITLE
Close all facilities on a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Integrate Mailchimp signup [#1412](https://github.com/open-apparel-registry/open-apparel-registry/pull/1412)
+- Close all facilities on a list [#1429](https://github.com/open-apparel-registry/open-apparel-registry/pull/1429)
 
 ### Changed
 

--- a/src/django/api/close_list.py
+++ b/src/django/api/close_list.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from django.utils import timezone
+
+from django.db import transaction
+
+from api.models import (Facility, FacilityActivityReport, Contributor, User)
+
+
+@transaction.atomic
+def close_list(list_id, user_id):
+    user = User.objects.get(id=user_id)
+    contributor = Contributor.objects.get(admin=user)
+    now = datetime.now(tz=timezone.utc)
+    reason = "Closed via bulk list closure"
+    facilities = Facility.objects.filter(
+        facilitylistitem__source__facility_list_id=list_id)
+    for facility in facilities:
+        facility.is_closed = True
+        facility.save()
+        FacilityActivityReport.objects.create(
+            facility=facility,
+            reported_by_user=user,
+            reported_by_contributor=contributor,
+            reason_for_report=reason,
+            closure_state="CLOSED",
+            approved_at=now,
+            status=FacilityActivityReport.CONFIRMED,
+            status_change_reason=reason,
+            status_change_by=user,
+            status_change_date=now,
+        )

--- a/src/django/api/management/commands/close_list.py
+++ b/src/django/api/management/commands/close_list.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+
+from api.close_list import close_list
+
+
+class Command(BaseCommand):
+    help = 'Closes all the facilities in a list.'
+
+    def add_arguments(self, parser):
+        # Create a group of arguments explicitly labeled as required,
+        # because by default named arguments are considered optional.
+        group = parser.add_argument_group('required arguments')
+        group.add_argument('-l', '--list-id',
+                           required=True,
+                           help='The id of the facility list to close.')
+        group.add_argument('-u', '--user-id',
+                           required=True,
+                           help='The id of the user to record as responsible' +
+                           ' for the closures.')
+
+    def handle(self, *args, **options):
+        list_id = options['list_id']
+        user_id = options['user_id']
+        close_list(list_id, user_id)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -31,7 +31,8 @@ from api.models import (Facility, FacilityList, FacilityListItem,
                         FacilityMatch, FacilityAlias, Contributor, User,
                         RequestLog, DownloadLog, FacilityLocation, Source,
                         ApiLimit, ApiBlock, ContributorNotifications,
-                        EmbedConfig, EmbedField, NonstandardField)
+                        EmbedConfig, EmbedField, NonstandardField,
+                        FacilityActivityReport)
 from api.oar_id import make_oar_id, validate_oar_id
 from api.matching import match_facility_list_items, GazetteerCache
 from api.processing import (parse_facility_list_item,
@@ -47,6 +48,7 @@ from api.serializers import (ApprovedFacilityClaimSerializer,
                              FacilityCreateBodySerializer,
                              FacilityListSerializer)
 from api.limits import check_api_limits, get_end_of_year
+from api.close_list import close_list
 
 
 class FacilityListCreateTest(APITestCase):
@@ -6604,6 +6606,105 @@ class ApiLimitTest(TestCase):
                      contributor=self.contrib_two)
         self.assertEqual(notice_two.api_limit_exceeded_sent_on,
                          self.notification_time)
+
+
+class CloseListTest(TestCase):
+    def setUp(self):
+        self.country_code = 'US'
+
+        self.user = User.objects.create(email='one@example.com')
+
+        self.contrib = Contributor \
+            .objects \
+            .create(admin=self.user,
+                    name='contributor',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        self.list_one = FacilityList \
+            .objects \
+            .create(header="header",
+                    file_name="one",
+                    name='list 1')
+
+        self.source_one = Source \
+            .objects \
+            .create(source_type=Source.LIST,
+                    facility_list=self.list_one,
+                    contributor=self.contrib)
+
+        self.list_item_one = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_one,
+                    status=FacilityListItem.MATCHED)
+
+        self.facility_one = Facility.objects.create(
+            country_code=self.country_code,
+            created_from=self.list_item_one,
+            facilitylistitem=self.list_item_one,
+            location=Point(0, 0),
+            is_closed=False,
+        )
+        self.list_item_one.facility = self.facility_one
+        self.list_item_one.save()
+
+        self.list_item_one_b = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_one,
+                    status=FacilityListItem.MATCHED)
+
+        self.facility_one_b = Facility.objects.create(
+            country_code=self.country_code,
+            created_from=self.list_item_one_b,
+            facilitylistitem=self.list_item_one_b,
+            location=Point(0, 0),
+            is_closed=False,
+        )
+        self.list_item_one_b.facility = self.facility_one_b
+        self.list_item_one_b.save()
+
+        self.list_two = FacilityList \
+            .objects \
+            .create(header="header",
+                    file_name="one-b",
+                    name='list 2')
+
+        self.source_two = Source \
+            .objects \
+            .create(source_type=Source.LIST,
+                    facility_list=self.list_two,
+                    contributor=self.contrib)
+
+        self.list_item_two = FacilityListItem \
+            .objects \
+            .create(row_index=0,
+                    source=self.source_two,
+                    status=FacilityListItem.MATCHED)
+
+        self.facility_two = Facility.objects.create(
+            country_code=self.country_code,
+            created_from=self.list_item_two,
+            facilitylistitem=self.list_item_two,
+            location=Point(0, 0),
+            is_closed=False,
+        )
+        self.list_item_two.facility = self.facility_two
+        self.list_item_two.save()
+
+    def test_closes_list(self):
+        close_list(self.list_one.id, self.user.id)
+
+        f_one = Facility.objects.get(id=self.facility_one.id)
+        f_one_b = Facility.objects.get(id=self.facility_one_b.id)
+        f_two = Facility.objects.get(id=self.facility_two.id)
+
+        self.assertTrue(f_one.is_closed)
+        self.assertTrue(f_one_b.is_closed)
+        self.assertFalse(f_two.is_closed)
+
+        activity = FacilityActivityReport.objects.all().count()
+        self.assertEquals(2, activity)
 
 
 class NonstandardFieldsApiTest(APITestCase):


### PR DESCRIPTION
## Overview

Adds the management command 'close_list', which closes all facilities
from a particular list and creates the appropriate activity reports. 
Users must provide the list id of the list to
be closed, and the id of the user who should be recorded as having
requested and approved the closures.

Connects [Client #33](https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/33)

## Demo

<img width="332" alt="Screen Shot 2021-07-20 at 8 43 43 AM" src="https://user-images.githubusercontent.com/21046714/126327327-58ed56fa-5f21-40ae-9260-d5f2abfc0fee.png">
<img width="343" alt="Screen Shot 2021-07-20 at 8 43 34 AM" src="https://user-images.githubusercontent.com/21046714/126327336-c38f2299-bd0d-420a-96fa-b2300f8893de.png">

## Notes

We initially wrote a sequel script to perform the closures. However, while this did mark the facilities as closed, it didn't create the necessary related FacilityActivityReports, which are required to correctly present the facility status in its details. 

## Testing Instructions

* Run `./scripts/test` and confirm all tests are passing. 
* Run `./scripts/manage close_list -l 3 -u 2`. 
* Run `./scripts/server` and navigate to [list 3](http://localhost:6543/?lists=3). Confirm that all items on the list are closed. 
* In the facility details for items in the list, confirm that the closure banner is present and that the activity reports are correct. 
* Navigate to the full list of facilities and confirm that only the items from list 3 have been closed. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
