### PR TITLE
Disable map scrolling in embedded map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Disable scrolling in embed mode (#1437)[https://github.com/open-apparel-registry/open-apparel-registry/pull/1437]
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -84,6 +84,7 @@ function FacilitiesMap({
     match: {
         params: { oarID },
     },
+    isEmbedded,
 }) {
     const mapRef = useRef(null);
 
@@ -247,6 +248,7 @@ function FacilitiesMap({
             center={initialCenter}
             zoom={initialZoom}
             minZoom={minimumZoom}
+            scrollWheelZoom={!isEmbedded}
             renderer={L.canvas()}
             style={mapComponentStyles.mapContainerStyles}
             zoomControl={false}
@@ -394,6 +396,7 @@ function mapStateToProps({
         facilitiesSidebarTabSearch: { resetButtonClickCount },
     },
     clientInfo: { fetched, countryCode },
+    embeddedMap: { embed: isEmbedded },
 }) {
     return {
         fetching,
@@ -402,6 +405,7 @@ function mapStateToProps({
         resetButtonClickCount,
         clientInfoFetched: fetched,
         countryCode: countryCode || COUNTRY_CODES.default,
+        isEmbedded,
     };
 }
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -116,6 +116,7 @@ function VectorTileFacilitiesMap({
             ref={mapRef}
             center={initialCenter}
             zoom={initialZoom}
+            scrollWheelZoom={!isEmbedded}
             minZoom={minimumZoom}
             renderer={L.canvas()}
             style={mapComponentStyles.mapContainerStyles}


### PR DESCRIPTION
## Overview

When the embed is 100%, the map scroll prevents users from scrolling
the page in which the map is embedded, so scrolling the map to zoom is
now disabled when in embed mode.

Connects #1431 

## Testing Instructions

* Run `./scripts/server`
* The main map should zoom on scroll as usual (in regular mode). 
* Login as a user with embedded map permissions and navigate to their map settings page. Confirm that the map does not scroll-zoom. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
