### PR TITLE
Add Custom Marker Colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add custom marker colors [#1445](https://github.com/open-apparel-registry/open-apparel-registry/pull/1445)
+
 ### Changed
 
 - Disable scrolling in embed mode (#1437)[https://github.com/open-apparel-registry/open-apparel-registry/pull/1437]


### PR DESCRIPTION
## Overview

Replaces the current icons with SVG icons, utilizing data-urls.
Unselected marker icons are set to grey, and selected marker icons are
set to the OAR color or (in embed mode) the embed config color.

Connects #806 

## Demo

<img width="1333" alt="Screen Shot 2021-08-02 at 11 12 12 AM" src="https://user-images.githubusercontent.com/21046714/127890568-bd9fcfd5-f92c-4980-b967-ba8dc4161d6e.png">
<img width="1338" alt="Screen Shot 2021-08-02 at 11 51 36 AM" src="https://user-images.githubusercontent.com/21046714/127890573-fca6a656-6a07-4ae7-9425-6558ef61258e.png">

## Testing Instructions

* Run `./scripts/server` and navigate to the map. Confirm that markers appear as expected, and are grey until selected, then appear as an appropriate color. 
* Login as a user with embed permissions and set the custom color to something noticeable. Visit the map and confirm that selected markers are now the new color. 
* Navigate around and click on various facilities to ensure that the dynamic markers don't cause any rendering bugs. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
