### PR TITLE
Fix mobile header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix mobile header [#1454](https://github.com/open-apparel-registry/open-apparel-registry/pull/1454)
+
 ### Security
 
 ## [45] 2021-07-21

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -635,9 +635,17 @@ hr {
   justify-content: middle;
 }
 
+.logo {
+    height: 35px;
+}
+
 @media (min-width: 600px) {
   .mobileMenuToggle {
     display: none;
+  }
+
+  .logo {
+      height: 60px;
   }
 }
 

--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -218,11 +218,7 @@ function Navbar({ openGDPR }) {
                             href="/"
                             style={{ display: 'inline-flex' }}
                         >
-                            <img
-                                src={logo}
-                                style={{ height: '60px' }}
-                                alt="logo"
-                            />
+                            <img src={logo} className="logo" alt="logo" />
                         </Link>
                     </div>
                     {mainNavigation}


### PR DESCRIPTION
## Overview

The updated logo was pushing some buttons out of alignment on mobile.
A media query now adjusts the logo size as needed.

Connects #1453 

## Demo

Before
<img width="394" alt="Screen Shot 2021-08-16 at 10 09 20 AM" src="https://user-images.githubusercontent.com/21046714/129583437-942a4fd8-39f2-4a7d-afcc-1101d845732e.png">

After
<img width="387" alt="Screen Shot 2021-08-16 at 10 16 49 AM" src="https://user-images.githubusercontent.com/21046714/129583454-268332d0-15f2-4c43-abd9-dfb08621f65c.png">
<img width="1181" alt="Screen Shot 2021-08-16 at 10 17 00 AM" src="https://user-images.githubusercontent.com/21046714/129583465-1a4c4533-bc50-4b40-a58b-e9e2615be598.png">

## Testing Instructions

* Run `./scripts/server`
* View the app at various screen sizes, particularly mobile, and confirm the navigation buttons are aligned. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
