### PR TITLE
Allow users to transfer matches between facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Allow users to transfer matches between facilities [#1464](https://github.com/open-apparel-registry/open-apparel-registry/pull/1464)
+
 ### Changed
 
 ### Deprecated

--- a/src/app/src/actions/adjustFacilityMatches.js
+++ b/src/app/src/actions/adjustFacilityMatches.js
@@ -6,6 +6,7 @@ import {
     logErrorAndDispatchFailure,
     makeSplitFacilityAPIURL,
     makePromoteFacilityMatchAPIURL,
+    makeTransferFacilityAPIURL,
 } from '../util/util';
 
 export const startFetchFacilityToAdjust = createAction(
@@ -48,6 +49,37 @@ export function fetchFacilityToAdjust() {
                         err,
                         'An error prevented fetching that facility',
                         failFetchFacilityToAdjust,
+                    ),
+                ),
+            );
+    };
+}
+
+export const startFetchFacilityToTransfer = createAction(
+    'START_FETCH_FACILITY_TO_TRANSFER',
+);
+export const failFetchFacilityToTransfer = createAction(
+    'FAIL_FETCH_FACILITY_TO_TRANSFER',
+);
+export const completeFetchFacilityToTransfer = createAction(
+    'COMPLETE_FETCH_FACILITY_TO_TRANSFER',
+);
+export const clearFacilityToTransfer = createAction(
+    'CLEAR_FACILITY_TO_TRANSFER',
+);
+export function fetchFacilityToTransfer(oarID) {
+    return dispatch => {
+        dispatch(startFetchFacilityToTransfer());
+
+        return apiRequest
+            .get(makeSplitFacilityAPIURL(oarID))
+            .then(({ data }) => dispatch(completeFetchFacilityToTransfer(data)))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented fetching that facility',
+                        failFetchFacilityToTransfer,
                     ),
                 ),
             );
@@ -124,6 +156,43 @@ export function promoteFacilityMatch(matchID) {
                         err,
                         'An error prevented promoting that facility match',
                         failPromoteFacilityMatch,
+                    ),
+                ),
+            );
+    };
+}
+
+export const startTransferFacilityMatch = createAction(
+    'START_TRANSFER_FACILITY_MATCH',
+);
+export const failTransferFacilityMatch = createAction(
+    'FAIL_TRANSFER_FACILITY_MATCH',
+);
+export const completeTransferFacilityMatch = createAction(
+    'COMPLETE_TRANSFER_FACILITY_MATCH',
+);
+
+export function transferFacilityMatch({ matchID, oarID }) {
+    return dispatch => {
+        if (!oarID || !matchID) {
+            return null;
+        }
+
+        dispatch(startTransferFacilityMatch());
+
+        return apiRequest
+            .post(makeTransferFacilityAPIURL(oarID), { match_id: matchID })
+            .then(({ data }) => {
+                dispatch(completeTransferFacilityMatch(data));
+                // Refresh facility to show match is no longer present
+                dispatch(fetchFacilityToAdjust());
+            })
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented moving that facility match',
+                        failTransferFacilityMatch,
                     ),
                 ),
             );

--- a/src/app/src/components/DashboardAdjustMatchCard.jsx
+++ b/src/app/src/components/DashboardAdjustMatchCard.jsx
@@ -15,6 +15,8 @@ import find from 'lodash/find';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
+import MoveMatchDialog from './MoveMatchDialog';
+
 import { makeFacilityDetailLink } from '../util/util';
 
 import { facilityDetailsPropType } from '../util/propTypes';
@@ -107,6 +109,7 @@ export default function DashboardAdjustMatchCard({
     const [matchToSplit, setMatchToSplit] = useState(null);
     const [matchToPromote, setMatchToPromote] = useState(null);
     const [loading, setLoading] = useState(false);
+    const [matchToMove, setMatchToMove] = useState(null);
 
     const closeDialog = () => {
         setMatchToSplit(null);
@@ -183,17 +186,36 @@ export default function DashboardAdjustMatchCard({
         }
 
         return (
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                }}
+            >
+                {(match.facility_created_by_item || match.is_geocoded) && (
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        disabled={adjusting}
+                        onClick={() =>
+                            openDialogForMatchToAdjust(
+                                match,
+                                dialogTypesEnum.split,
+                            )
+                        }
+                        style={adjustMatchCardStyles.buttonStyles}
+                    >
+                        {match.facility_created_by_item ? 'Revert' : 'Split'}
+                    </Button>
+                )}
                 <Button
                     variant="contained"
                     color="primary"
                     disabled={adjusting}
-                    onClick={() =>
-                        openDialogForMatchToAdjust(match, dialogTypesEnum.split)
-                    }
+                    onClick={() => setMatchToMove(match)}
                     style={adjustMatchCardStyles.buttonStyles}
                 >
-                    {match.facility_created_by_item ? 'Revert' : 'Split'}
+                    Transfer to Alternate Facility
                 </Button>
                 <Button
                     variant="contained"
@@ -320,8 +342,8 @@ export default function DashboardAdjustMatchCard({
                                 <Typography variant="title">
                                     Match {match.match_id}
                                 </Typography>
-                                {createButtonControls(match)}
                             </div>
+                            <div>{createButtonControls(match)}</div>
                             <div style={adjustMatchCardStyles.nameRowStyles}>
                                 <MatchDetailItem
                                     label="Contributor Name"
@@ -354,6 +376,10 @@ export default function DashboardAdjustMatchCard({
             <Dialog open={Boolean(matchToSplit) || Boolean(matchToPromote)}>
                 {dialogContent}
             </Dialog>
+            <MoveMatchDialog
+                matchToMove={matchToMove}
+                handleClose={() => setMatchToMove(null)}
+            />
         </>
     );
 }

--- a/src/app/src/components/DashboardFacilityCard.jsx
+++ b/src/app/src/components/DashboardFacilityCard.jsx
@@ -2,16 +2,13 @@ import React from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
-import CardContent from '@material-ui/core/CardContent';
-import CircularProgress from '@material-ui/core/CircularProgress';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
-import get from 'lodash/get';
 
 import { facilityDetailsPropType } from '../util/propTypes';
 
-import FacilityDetailsStaticMap from './FacilityDetailsStaticMap';
+import DashboardFacilityCardDetails from './DashboardFacilityCardDetails';
 
 const dashboardFacilityCardStyles = Object.freeze({
     cardStyles: Object.freeze({
@@ -107,87 +104,6 @@ export default function DashboardFacilityCard({
         </>
     );
 
-    const cardContent = (() => {
-        if (fetching) {
-            return <CircularProgress />;
-        }
-
-        if (error && error.length) {
-            return (
-                <ul style={dashboardFacilityCardStyles.errorStyles}>
-                    {error.map(err => (
-                        <li key={err}>
-                            <span
-                                style={dashboardFacilityCardStyles.errorStyles}
-                            >
-                                {err}
-                            </span>
-                        </li>
-                    ))}
-                </ul>
-            );
-        }
-
-        if (!data) {
-            return null;
-        }
-
-        const contributorContent = get(data, 'properties.contributors', [])
-            .length && (
-            <ul style={dashboardFacilityCardStyles.listStyles}>
-                {data.properties.contributors.map(({ name }) => (
-                    <li key={name}>
-                        <Typography
-                            style={dashboardFacilityCardStyles.fieldStyles}
-                        >
-                            {name}
-                        </Typography>
-                    </li>
-                ))}
-            </ul>
-        );
-
-        return (
-            <>
-                <div style={dashboardFacilityCardStyles.mapStyles}>
-                    <FacilityDetailsStaticMap data={data} />
-                </div>
-                <div style={dashboardFacilityCardStyles.infoContainerStyles}>
-                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
-                        Name
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
-                        {get(data, 'properties.name', null)}
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
-                        Address
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
-                        {get(data, 'properties.address', null)}
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
-                        Country
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
-                        {get(data, 'properties.country_name', null)}
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
-                        Location
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
-                        {get(data, 'geometry.coordinates', []).join(', ')}
-                    </Typography>
-                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
-                        Contributors
-                    </Typography>
-                    <div style={dashboardFacilityCardStyles.fieldStyles}>
-                        {contributorContent}
-                    </div>
-                </div>
-            </>
-        );
-    })();
-
     return (
         <Card style={dashboardFacilityCardStyles.cardStyles}>
             <Typography
@@ -199,9 +115,11 @@ export default function DashboardFacilityCard({
             <CardActions style={dashboardFacilityCardStyles.cardActionsStyles}>
                 {cardActions}
             </CardActions>
-            <CardContent style={dashboardFacilityCardStyles.cardContentStyles}>
-                {cardContent}
-            </CardContent>
+            <DashboardFacilityCardDetails
+                data={data}
+                fetching={fetching}
+                error={error}
+            />
         </Card>
     );
 }

--- a/src/app/src/components/DashboardFacilityCardDetails.jsx
+++ b/src/app/src/components/DashboardFacilityCardDetails.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { arrayOf, bool, string } from 'prop-types';
+import CardContent from '@material-ui/core/CardContent';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+import get from 'lodash/get';
+
+import { facilityDetailsPropType } from '../util/propTypes';
+
+import FacilityDetailsStaticMap from './FacilityDetailsStaticMap';
+
+const dashboardFacilityCardStyles = Object.freeze({
+    cardContentStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '0 20px',
+    }),
+    labelStyles: Object.freeze({
+        fontSize: '16px',
+        fontWeight: '700',
+        padding: '5px 0 0',
+    }),
+    fieldStyles: Object.freeze({
+        fontSize: '16px',
+        padding: '0 0 5px',
+    }),
+    listStyles: Object.freeze({
+        margin: '0 5px',
+    }),
+    mapStyles: Object.freeze({
+        padding: '0',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+    }),
+    errorStyles: Object.freeze({
+        color: 'red',
+    }),
+    infoContainerStyles: Object.freeze({
+        marging: '10px 0',
+    }),
+});
+
+export default function DashboardFacilityCardDetails({
+    data,
+    fetching,
+    error,
+}) {
+    const cardContent = (() => {
+        if (fetching) {
+            return <CircularProgress />;
+        }
+
+        if (error && error.length) {
+            return (
+                <ul style={dashboardFacilityCardStyles.errorStyles}>
+                    {error.map(err => (
+                        <li key={err}>
+                            <span
+                                style={dashboardFacilityCardStyles.errorStyles}
+                            >
+                                {err}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            );
+        }
+
+        if (!data) {
+            return null;
+        }
+
+        const contributorContent = get(data, 'properties.contributors', [])
+            .length && (
+            <ul style={dashboardFacilityCardStyles.listStyles}>
+                {data.properties.contributors.map(({ name }) => (
+                    <li key={name}>
+                        <Typography
+                            style={dashboardFacilityCardStyles.fieldStyles}
+                        >
+                            {name}
+                        </Typography>
+                    </li>
+                ))}
+            </ul>
+        );
+
+        return (
+            <>
+                <div style={dashboardFacilityCardStyles.mapStyles}>
+                    <FacilityDetailsStaticMap data={data} />
+                </div>
+                <div style={dashboardFacilityCardStyles.infoContainerStyles}>
+                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
+                        Name
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
+                        {get(data, 'properties.name', null)}
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
+                        Address
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
+                        {get(data, 'properties.address', null)}
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
+                        Country
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
+                        {get(data, 'properties.country_name', null)}
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
+                        Location
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.fieldStyles}>
+                        {get(data, 'geometry.coordinates', []).join(', ')}
+                    </Typography>
+                    <Typography style={dashboardFacilityCardStyles.labelStyles}>
+                        Contributors
+                    </Typography>
+                    <div style={dashboardFacilityCardStyles.fieldStyles}>
+                        {contributorContent}
+                    </div>
+                </div>
+            </>
+        );
+    })();
+
+    return (
+        <CardContent style={dashboardFacilityCardStyles.cardContentStyles}>
+            {cardContent}
+        </CardContent>
+    );
+}
+
+DashboardFacilityCardDetails.defaultProps = {
+    data: null,
+    error: null,
+};
+
+DashboardFacilityCardDetails.propTypes = {
+    data: facilityDetailsPropType,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+};

--- a/src/app/src/components/MoveMatchDialog.jsx
+++ b/src/app/src/components/MoveMatchDialog.jsx
@@ -1,0 +1,183 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import Divider from '@material-ui/core/Divider';
+import CardActions from '@material-ui/core/CardActions';
+
+import DashboardFacilityCardDetails from './DashboardFacilityCardDetails';
+import {
+    fetchFacilityToTransfer,
+    clearFacilityToTransfer,
+    transferFacilityMatch,
+} from '../actions/adjustFacilityMatches';
+import { getValueFromEvent } from '../util/util';
+
+const styles = Object.freeze({
+    cardStyles: Object.freeze({
+        width: '45%',
+        margin: '0 20px',
+        padding: '10px',
+    }),
+    textSectionStyles: Object.freeze({
+        padding: '10px 20px',
+    }),
+    cardActionsStyles: Object.freeze({
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '10px 20px',
+    }),
+    cardContentStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '0 20px',
+    }),
+    labelStyles: Object.freeze({
+        fontSize: '16px',
+        fontWeight: '700',
+        padding: '5px 0 0',
+    }),
+    fieldStyles: Object.freeze({
+        fontSize: '16px',
+        padding: '0 0 5px',
+    }),
+    listStyles: Object.freeze({
+        margin: '0 5px',
+    }),
+    mapStyles: Object.freeze({
+        padding: '0',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '100%',
+    }),
+    oarIDStyles: Object.freeze({
+        fontSize: '18px',
+    }),
+    errorStyles: Object.freeze({
+        color: 'red',
+    }),
+    infoContainerStyles: Object.freeze({
+        margin: '10px 0',
+    }),
+    dialogStyle: Object.freeze({
+        margin: '25px',
+    }),
+    container: Object.freeze({
+        margin: '20px',
+    }),
+    contentsContainer: Object.freeze({
+        maxHeight: '300px',
+        overflow: 'scroll',
+    }),
+});
+
+function MoveMatchDialog({
+    matchToMove,
+    handleClose,
+    fetchFacility,
+    data,
+    fetching,
+    error,
+    clearFacility,
+    moveMatch,
+}) {
+    const [oarID, updateOARID] = useState('');
+    const onClose = () => {
+        updateOARID('');
+        clearFacility();
+        handleClose();
+    };
+
+    const handleFetchFacility = () => fetchFacility(oarID);
+    const handleMoveMatch = () => {
+        moveMatch({ oarID, matchID: matchToMove.match_id });
+        onClose();
+    };
+    const fetchOnEnter = ({ key }) => {
+        if (key === 'Enter') {
+            handleFetchFacility();
+        }
+    };
+
+    return (
+        <Dialog
+            open={Boolean(matchToMove)}
+            onClose={onClose}
+            aria-labelledby="move-dialog-title"
+            style={styles.dialogStyle}
+        >
+            <div style={styles.container}>
+                <Typography variant="title" style={styles.textSectionStyles}>
+                    Transfer match to alternate facility
+                </Typography>
+                <CardActions style={styles.cardActionsStyles}>
+                    <TextField
+                        variant="outlined"
+                        onChange={e => updateOARID(getValueFromEvent(e))}
+                        value={oarID}
+                        placeholder="Enter an OAR ID"
+                        onKeyPress={fetchOnEnter}
+                    />
+                    <Button
+                        onClick={handleFetchFacility}
+                        variant="contained"
+                        color="primary"
+                        disabled={fetching || !oarID}
+                    >
+                        Search
+                    </Button>
+                </CardActions>
+                {data && <Divider />}
+                <div style={styles.contentsContainer}>
+                    <DashboardFacilityCardDetails
+                        fetching={fetching}
+                        data={data}
+                        error={error}
+                    />
+                </div>
+                {data && <Divider />}
+                {data && (
+                    <CardActions style={styles.cardActionsStyles}>
+                        <Button onClick={onClose} variant="contained">
+                            Cancel
+                        </Button>
+                        <Button
+                            onClick={handleMoveMatch}
+                            variant="contained"
+                            color="primary"
+                        >
+                            Transfer Match
+                        </Button>
+                    </CardActions>
+                )}
+            </div>
+        </Dialog>
+    );
+}
+
+function mapStateToProps({
+    adjustFacilityMatches: {
+        transferFacility: { data, fetching, error },
+    },
+}) {
+    return {
+        data,
+        fetching,
+        error,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        fetchFacility: oarID => dispatch(fetchFacilityToTransfer(oarID)),
+        clearFacility: () => dispatch(clearFacilityToTransfer()),
+        moveMatch: ({ oarID, matchID }) =>
+            dispatch(transferFacilityMatch({ oarID, matchID })),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MoveMatchDialog);

--- a/src/app/src/reducers/AdjustFacilityMatchesReducer.js
+++ b/src/app/src/reducers/AdjustFacilityMatchesReducer.js
@@ -18,6 +18,10 @@ import {
     startPromoteFacilityMatch,
     failPromoteFacilityMatch,
     completePromoteFacilityMatch,
+    startFetchFacilityToTransfer,
+    failFetchFacilityToTransfer,
+    completeFetchFacilityToTransfer,
+    clearFacilityToTransfer,
 } from '../actions/adjustFacilityMatches';
 
 const initialState = Object.freeze({
@@ -29,6 +33,11 @@ const initialState = Object.freeze({
     }),
     adjustFacilities: Object.freeze({
         data: Object.freeze([]),
+        fetching: false,
+        error: null,
+    }),
+    transferFacility: Object.freeze({
+        data: null,
         fetching: false,
         error: null,
     }),
@@ -137,6 +146,31 @@ export default createReducer(
                 facility: {
                     data: { $set: data },
                 },
+            }),
+        [startFetchFacilityToTransfer]: state =>
+            update(state, {
+                transferFacility: {
+                    fetching: { $set: true },
+                    error: { $set: initialState.transferFacility.error },
+                },
+            }),
+        [failFetchFacilityToTransfer]: (state, error) =>
+            update(state, {
+                transferFacility: {
+                    fetching: { $set: initialState.transferFacility.fetching },
+                    error: { $set: error },
+                },
+            }),
+        [completeFetchFacilityToTransfer]: (state, data) =>
+            update(state, {
+                transferFacility: {
+                    data: { $set: data },
+                    fetching: { $set: initialState.transferFacility.fetching },
+                },
+            }),
+        [clearFacilityToTransfer]: state =>
+            update(state, {
+                transferFacility: { $set: initialState.transferFacility },
             }),
         [resetAdjustFacilityState]: constant(initialState),
     },

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -135,6 +135,8 @@ export const makeClaimFacilityAPIURL = oarId =>
     `/api/facilities/${oarId}/claim/`;
 export const makeSplitFacilityAPIURL = oarID =>
     `/api/facilities/${oarID}/split/`;
+export const makeTransferFacilityAPIURL = oarID =>
+    `/api/facilities/${oarID}/move/`;
 export const makePromoteFacilityMatchAPIURL = oarID =>
     `/api/facilities/${oarID}/promote/`;
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -20,6 +20,7 @@ class ProcessingAction:
     PROMOTE_MATCH = 'promote_match'
     MERGE_FACILITY = 'merge_facility'
     SPLIT_FACILITY = 'split_facility'
+    MOVE_FACILITY = 'move_facility'
     NOTIFY_COMPLETE = 'notify_complete'
 
 
@@ -68,6 +69,7 @@ class FacilityHistoryActions:
     DELETE = 'DELETE'
     MERGE = 'MERGE'
     SPLIT = 'SPLIT'
+    MOVE = 'MOVE'
     OTHER = 'OTHER'
     ASSOCIATE = 'ASSOCIATE'
     DISSOCIATE = 'DISSOCIATE'

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4799,6 +4799,45 @@ class FacilityHistoryEndpointTest(FacilityAPITestCaseBase):
         )
 
     @override_flag('can_get_facility_history', active=True)
+    def test_serializes_facility_match_move(self):
+        move_facility_url = '/api/facilities/{}/move/'.format(
+            self.facility.id)
+
+        move_facility_data = {
+            'match_id': self.match_two.id,
+        }
+
+        move_facility_response = self.client.post(
+            move_facility_url,
+            move_facility_data,
+        )
+
+        self.assertEqual(move_facility_response.status_code, 200)
+
+        self.match_two.refresh_from_db()
+
+        response = self.client.get(self.facility_two_history_url)
+        data = json.loads(response.content)
+
+        self.assertEqual(
+            data[0]['action'],
+            'MOVE',
+        )
+
+        self.assertEqual(
+            data[0]['detail'],
+            'Match {} was moved from {}'.format(
+                self.match_two.id,
+                self.facility_two.id,
+            )
+        )
+
+        self.assertEqual(
+            len(data),
+            3,
+        )
+
+    @override_flag('can_get_facility_history', active=True)
     def test_handles_request_for_invalid_facility_id(self):
         invalid_history_url = '/api/facilities/hello/history/'
         invalid_history_response = self.client.get(invalid_history_url)


### PR DESCRIPTION
## Overview

In some cases, list items have been incorrectly matched to a facility.
Currently, users will 'split' those list items away from the incorrect
facility. As a second step, they sometimes merge the match to a
different facility.

However, when the list items are not able to be geocoded, it's
impossible to use the 'split' functionality to create a new facility
from the match.

This adds the functionality to move or transfer a list item directly
from one existing facility to another existing facility, avoiding the
need to create a new, intermediate facility.

Connects #1459 

## Demo

<img width="1118" alt="Screen Shot 2021-09-09 at 2 41 58 PM" src="https://user-images.githubusercontent.com/21046714/132744319-3664f803-8294-480e-aa95-ab5f269b19ea.png">
<img width="503" alt="Screen Shot 2021-09-09 at 12 08 31 PM" src="https://user-images.githubusercontent.com/21046714/132737339-086c63ac-a55e-408e-a7eb-c66d6bd99557.png">
<img width="1036" alt="Screen Shot 2021-09-09 at 12 08 43 PM" src="https://user-images.githubusercontent.com/21046714/132737348-3ce8e085-a399-47cc-a1f6-498724cdd683.png">
<img width="993" alt="Screen Shot 2021-09-09 at 12 13 55 PM" src="https://user-images.githubusercontent.com/21046714/132737359-ed915351-9ea4-433c-b134-dbf50bed215d.png">

## Notes

Scott recommended using more descriptive / different titles for the buttons to clarify their purpose. I think to do this thoroughly will require a follow-up card to determine the most appropriate titles and do any refactoring / styling needed to improve the display. 

Part of the facility details card was pulled out into a separate component. Initially I hope to reuse the entire component, but the card is actually the basis of the full page, and its functionality is very tied to the data flow for the facility whose matches are being adjusted. Separating the main UI of the card allowed me to reuse just that portion in the transfer modal with a different facility from the rest of the page. 

## Testing Instructions

* Create a match by uploading two similar facility list items on separate lists. 
* Note the id of the facility (the source facility). Get the id of a different facility (the transfer facility) to which you will move the match. 
* Login as an admin and navigate to the [adjust facility match dashboard](http://localhost:6543/dashboard/adjustfacilitymatches).
* Search for the source facility by id. It should display in the card as before. 
* The match you created should appear in the right hand. If it was successfully geocoded, it should show the 'split' button in addition to the 'promote' and 'transfer' buttons. 
* Click 'transfer'. A modal should open. 
* Search for the transfer facility by id and it should render in the modal. 
* Select 'cancel' and the modal should close. The transfer should not occur. 
* Reopen the modal and search again. Press 'transfer'. The modal should close and the match should be transferred. 
* Search for the transfer facility in the adjust facilities dashboard and you should see the match attached to it. 
* Use the history API to get the history of the source facility. The match move should be listed. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
