### PR TITLE
Fix delete facility endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix delete facility endpoint [#1472](https://github.com/open-apparel-registry/open-apparel-registry/pull/1472)
+
 ### Security
 
 ## [47] 2021-09-14

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1395,7 +1395,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                 best_match = max(
                     other_matches.filter(
                         status__in=(FacilityMatch.AUTOMATIC,
-                                    FacilityMatch.CONFIRMED)),
+                                    FacilityMatch.CONFIRMED)).exclude(
+                        facility_list_item__geocoded_point__isnull=True),
                     key=lambda m: m.confidence)
             except ValueError:
                 # Raised when there are no AUTOMATIC or CONFIRMED matches


### PR DESCRIPTION
## Overview

When deleting a facility with multiple confirmed or automatic matches,
we attempt to split off and create a new facility from the top match.
In the case that the match was missing a location, this caused a null
location error, preventing the facility from being deleted.

Matches without locations are now filtered out when searching for valid
matches to use to create a new facility during the deletion process.

Connects [Client #49](https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/49)

## Notes

If the match without a location is the only automatic/confirmed match other than the primary facility match, no new facility will be created when deleting a facility. Potentially, we could instead send a descriptive error message to the user in this case, to allow them to choose to move the match before deleting; but this has the downside of preventing them from deleting the facility at all unless they transfer the match, forcing their hand, which seems like very undesired behavior. 

See [here](https://rollbar.com/OpenApparelRegistry/OpenApparelRegistry/items/908/) for the Rollbar error that occurs when attempting to delete the facility indicated in the issue. It is the same error as previously occurred in the `split` API when users attempted to split a match with no location. 

## Testing Instructions

* On `develop`, run `./scripts/server` and identify a facility with a confirmed or automatic match in addition to the primary match. 
* Set the geocoded_point for the match's facilitylistitem to null using `./scripts/manage shell_plus`. 
* Attempt to delete the facility via the [facility deletion tool](http://localhost:6543/dashboard/deletefacility). It should throw an error matching the one that occurred in production, related to a null location value. 
* Checkout this branch and attempt to delete the same facility. It should delete without an issue. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
