### PR TITLE
Redirect to alias for deleted facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add Geocoding Dashboard [#1469](https://github.com/open-apparel-registry/open-apparel-registry/pull/1469)
+- Redirect to alias for deleted facilities [#1473](https://github.com/open-apparel-registry/open-apparel-registry/pull/1473)
 
 ### Changed
 

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Redirect } from 'react-router';
 import { connect } from 'react-redux';
 import { arrayOf, bool, func, shape, string } from 'prop-types';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -155,6 +156,13 @@ class FacilityDetailSidebar extends Component {
             embed,
             classes,
         } = this.props;
+
+        if (data?.id && data?.id !== oarID) {
+            // When redirecting to a facility alias from a deleted facility,
+            // the OAR ID in the url will not match the facility data id;
+            // redirect to the appropriate facility URL.
+            return <Redirect to={`/facilities/${data.id}`} />;
+        }
 
         if (fetching) {
             return (


### PR DESCRIPTION
## Overview

If a user attempts to access a facility which has been deleted, in some cases the facility might have been moved to a new OAR ID or might have been deleted because it was a duplicate of a different facility, and users should be rerouted to the correct facility. When a facility is not found, determines if any aliases exist for the given OAR ID, then redirects to the first alias found, only returning a 404 if no aliases exist. 

Connects #623 

## Demo

![Sep-23-2021 11-41-22](https://user-images.githubusercontent.com/21046714/134539406-e38a5822-e79c-4766-bb88-2e8b06912484.gif)

## Notes

Redirects sent by servers are handled automatically by the browser, without giving the clientside app access to interfere in the process. Specifically, the browser receives the redirect and sends a GET request to the API for the alias facility - sending a request to the server for the desired frontend URL causes an error, since the API can't handle the request - eg the 302 is in response to the request for data, so the redirect must result in the app returning the correct data, not in the app returning a different webpage. Although redirecting to request the alias facility data correctly returns the desired facility, we then have a mismatch between the URL OAR ID and the actual displayed facility. 

The most common instance of this situation I found online was wanting to redirect unauthorized users to a login page. The suggested method was to send a 401 response instead of a 302, in order to allow the app to handle redirecting to the login page. However, a 401 response in our situation would be inaccurate. 

Instead, what we needed was two redirects - one to redirect to fetch the correct data, and one to redirect to the correct webpage. In order to manage this, we check in the facility details component to see if the provided OAR ID and the returned data id match. If there is a mismatch, we return a redirect to go to the appropriate URL. Because we check on component mount if the data is already loaded for the provided OAR ID parameter, this doesn't cause a second fetch of the data. Syntactically, this makes sense (we are in fact making two separate redirected requests - for the data and for the page), and experientially it looks to the user as if the page has loaded as usual without any disruption. 

## Testing Instructions

* Run `./scripts/server`. Get the URL for a facility details page. Create a FacilityAlias for the facility, and then delete the facility. 
* Attempt to access the URL for the facility details page of the deleted facility. You should be redirected to the facility alias' details page. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
