### PR TITLE
Fix invalid country/address combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix delete facility endpoint [#1472](https://github.com/open-apparel-registry/open-apparel-registry/pull/1472)
 - Allow blank new_oar_ids [#1485](https://github.com/open-apparel-registry/open-apparel-registry/pull/1485)
+- Fix invalid country/address combinations [#1482](https://github.com/open-apparel-registry/open-apparel-registry/pull/1482)
 
 ### Security
 

--- a/src/django/api/geocoding.py
+++ b/src/django/api/geocoding.py
@@ -38,6 +38,14 @@ def format_no_geocode_results(data):
     }
 
 
+def validate_country_code(data, country_code):
+    address_components = data["results"][0]['address_components']
+    for component in address_components:
+        if component['short_name'] == country_code:
+            return True
+    raise ValueError("Geocoding results did not match provided country code.")
+
+
 def geocode_address(address, country_code):
     params = create_geocoding_params(address, country_code)
     r = requests.get(GEOCODING_URL, params=params)
@@ -50,5 +58,7 @@ def geocode_address(address, country_code):
 
     if data["status"] == ZERO_RESULTS or len(data["results"]) == 0:
         return format_no_geocode_results(data)
+
+    validate_country_code(data, country_code)
 
     return format_geocoded_address_data(data)


### PR DESCRIPTION
## Overview

Three facilities contributed to the OAR have addresses in China but,
erroneously, have India listed as the country in the data upload.
These facilities have plotted on the map in China, but appear in India
country searches because of their assigned country code.

Reviewing the raw data for the associated facility
list items, it appears that the submitted country code was for India,
although the addresses appear to be in China. This seems like an error
in the submitted data.

To prevent similar invalid facilities from being inserted into the
database in the future, we now raise a geocoding error when the geocoded
location's country code doesn't match the provided country code. 

Connects #1092 

## Demo

<img width="1216" alt="Screen Shot 2021-10-06 at 2 09 17 PM" src="https://user-images.githubusercontent.com/21046714/136278368-68ddceee-0534-4678-a134-67675d9a3ff3.png">

## Testing Instructions

* Run `./scripts/server`
* Upload a new facility list using the raw data from the invalid facilities. Note the list id. 
https://openapparel.org/facilities/IN2020217JJAJW1?contributors=139&countries=IN
https://openapparel.org/facilities/IN2020217A108YP
https://openapparel.org/facilities/IN202022057W0HR
* Run `./scripts/manage batch_process --list-id {id} --action parse` and confirm all three facilities parse. 
* Run `./scripts/manage batch_process --list-id {id} --action geocode` and confirm that all three facilities fail. 
* View the list in the application and confirm that the three list items all show appropriate geocoding errors. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
