### PR TITLE
Provide access to info endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Update header, footer, and font [#1495](https://github.com/open-apparel-registry/open-apparel-registry/pull/1495)
+- Provide access to info endpoints [#1499](https://github.com/open-apparel-registry/open-apparel-registry/pull/1499)
 
 ### Deprecated
 

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -32,6 +32,9 @@ class IsAuthenticatedOrWebClient(permissions.BasePermission):
         if settings.OAR_CLIENT_KEY == '':
             return True
 
+        if request.path.startswith("/api/info"):
+            return True
+
         client_key = request.META.get('HTTP_X_OAR_CLIENT_KEY')
         if client_key == settings.OAR_CLIENT_KEY:
             host = referring_host(request)

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -14,6 +14,7 @@ import os
 import requests
 
 from django.core.exceptions import ImproperlyConfigured
+from corsheaders.defaults import default_headers
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -44,7 +45,7 @@ GIT_COMMIT = os.getenv('GIT_COMMIT', 'UNKNOWN')
 DEBUG = (ENVIRONMENT == 'Development')
 
 ALLOWED_HOSTS = [
-    '.openapparel.org'
+    '.openapparel.org',
 ]
 
 if ENVIRONMENT == 'Development':
@@ -81,6 +82,7 @@ if ENVIRONMENT in ['Production', 'Staging'] and BATCH_MODE == '':
 # Application definition
 
 INSTALLED_APPS = [
+    'corsheaders',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -159,6 +161,7 @@ SWAGGER_SETTINGS = {
 }
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -365,6 +368,7 @@ if not DEBUG:
     rollbar.init(**ROLLBAR)
 
 OAR_CLIENT_KEY = os.getenv('OAR_CLIENT_KEY')
+
 if OAR_CLIENT_KEY is None:
     raise ImproperlyConfigured(
         'Invalid OAR_CLIENT_KEY provided, must be set')
@@ -372,3 +376,24 @@ if OAR_CLIENT_KEY is None:
 # Mailchimp settings
 MAILCHIMP_API_KEY = os.getenv('MAILCHIMP_API_KEY')
 MAILCHIMP_LIST_ID = os.getenv('MAILCHIMP_LIST_ID')
+
+# CORS
+# Regex defining which endpoints enable CORS
+CORS_URLS_REGEX = r"^/api/info/.*$"
+# allows X-OAR-Client-Key to be sent as a header on CORS requests
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'X-OAR-Client-Key',
+]
+# methods that can be used at CORS-enabled endpoints
+CORS_ALLOW_METHODS = [
+    "GET",
+    "OPTIONS",
+]
+# origins that are authorized to make cross-site HTTP
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://\w+\.openapparel\.org$",
+    r"^https://oar\.niceandserious\.com$",
+    r"^http://localhost",
+    r"http://127.0.0.1",
+]
+CORS_REPLACE_HTTPS_REFERER = True

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -61,6 +61,16 @@ public_apis = [
     url(r'^api/log-download/', views.log_download, name='log_download'),
 ]
 
+info_apis = [
+    url(r'^api/info/contributors/', views.active_contributors_count,
+        name='active_contributors_count'),
+    url(r'^api/info/countries/', views.active_countries_count,
+        name='active_countries_count'),
+    url(r'^api/info/facilities/',
+        views.FacilitiesViewSet.as_view({'get': 'count'}),
+        name='facilities_count'),
+]
+
 schema_view = get_swagger_view(title='Open Apparel Registry API Documentation',
                                patterns=public_apis)
 
@@ -92,4 +102,4 @@ internal_apis = [
     url(r'^api/geocoder/', views.get_geocoding, name='get_geocoding'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
-urlpatterns = public_apis + internal_apis
+urlpatterns = public_apis + internal_apis + info_apis

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -25,3 +25,4 @@ requests==2.21.0
 rollbar==0.14.6
 Unidecode==1.0.23
 xlrd==1.2.0
+django-cors-headers==3.10.0


### PR DESCRIPTION
## Overview

The info website needs to be able to access the `count` endpoints in
the backend, but a combination of CORS and general permissions has been
blocking its access. Enables CORS for GET requests to /api/info
endpoints from certain origins, and allows those endpoints to be
accessed without the ordinary protections.

We used the middleware [django-cors-headers](https://github.com/adamchainz/django-cors-headers) to enable CORS access. This allowed us to apply several protections to the cross-site access, including limiting it to specific endpoints, limiting it to GET and OPTIONS requests, and limiting it to requests from specific origins. 

Connects #1476

## Demo

<img width="1346" alt="Screen Shot 2021-10-22 at 2 29 02 PM" src="https://user-images.githubusercontent.com/21046714/138505207-91435fdc-cf38-403b-88f8-f549ef769557.png">

## Testing Instructions

* Run `./scripts/update` then `./scripts/server`
* Serve [this html file](https://drive.google.com/file/d/1Ky0ngyTJLpVtTDzZtYjHdc1MEB-Y6n86/view?usp=sharing) as a webpage locally and visit it. Note that it must be served on one of the allowed origins from settings.py. 
* The page should load the counts in the "results" div. 
* Visit other pages of the app in the browser, and confirm that the non-info websites work as before. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
