### PR TITLE
Fix 'More' Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix 'More' Links [#1505](https://github.com/open-apparel-registry/open-apparel-registry/pull/1505)
+
 ### Security
 
 ## [49] 2021-10-27

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -535,10 +535,7 @@ export const EmbeddedMapInfoLink = 'https://info.openapparel.org/embedded-map';
 // when the width is set to 100%
 export const minimum100PercentWidthEmbedHeight = '500px';
 
-export const InfoLink =
-    process.env.NODE_ENV === 'development'
-        ? 'https://oar.niceandserious.com'
-        : 'https://info.openapparel.org';
+export const InfoLink = 'https://info.openapparel.org';
 
 export const SubmenuLinks = {
     'How It Works': [
@@ -582,12 +579,12 @@ export const SubmenuLinks = {
             button: true,
         },
         {
-            href: `${InfoLink}/privacy-policy`,
+            url: 'privacy-policy',
             text: 'Privacy policy',
             external: true,
         },
         {
-            href: `${InfoLink}/terms-of-use`,
+            url: 'terms-of-use',
             text: 'Terms of use',
             external: true,
         },


### PR DESCRIPTION
## Overview

Fixes the links in the 'more' menu, which were incorrectly stored in the
links configuration object, causing 'undefined' routes to be created. 

Updates the development info site links to lead to the production info site. 

## Demo

<img width="494" alt="Screen Shot 2021-10-27 at 3 26 55 PM" src="https://user-images.githubusercontent.com/21046714/139133566-a303429b-3c39-44af-8bc2-73be582d13d2.png">
<img width="494" alt="Screen Shot 2021-10-27 at 3 27 06 PM" src="https://user-images.githubusercontent.com/21046714/139133576-c7810519-09ba-4523-802e-ac03c6a05a29.png">

## Testing Instructions

* Run `./scripts/server`
* In Mobile view, test each link in the 'more' navigation. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
