### PR TITLE
Update My Lists link/copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Update copy [#1515](https://github.com/open-apparel-registry/open-apparel-registry/pull/1515)
+- Update My Lists link/copy [#1516](https://github.com/open-apparel-registry/open-apparel-registry/pull/1516)
 
 ### Deprecated
 

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -23,9 +23,9 @@ import {
     OARFont,
     listsRoute,
     facilityListItemsRoute,
-    aboutProcessingRoute,
     authLoginFormRoute,
     dashboardListsRoute,
+    InfoLink,
 } from '../util/constants';
 
 import { facilityListPropType } from '../util/propTypes';
@@ -207,11 +207,15 @@ class FacilityListItems extends Component {
                             </div>
                         </div>
                         <div style={facilityListItemsStyles.subheadStyles}>
-                            Read about how your facility lists are processed and
-                            matched in this&nbsp;
-                            <a href={aboutProcessingRoute} target="">
-                                guide
+                            Read about how your facility data is{' '}
+                            <a
+                                href={`${InfoLink}/how-the-oar-improves-data-quality`}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                processed and matched
                             </a>
+                            .
                         </div>
                         {list.item_count ? (
                             <Route


### PR DESCRIPTION
## Overview

When looking at a list in the My Lists section of the OAR, there is
introductory text above the list. This has been updated to, 'Read about
how your facility data is processed and matched.' and the link has been
updated to the new info site link.

Connects #1511

## Demo

<img width="1424" alt="MyLists" src="https://user-images.githubusercontent.com/21046714/139703730-e9111692-9eda-4916-9e0d-9bfce2f6d845.png">

## Testing Instructions

* Run `./scripts/server`
* Open one of your [lists](http://localhost:6543/lists) and confirm the text at the top matches the copy in #1511 
* Click the link. It should open the data quality page in a new tab.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
