### PR TITLE
Correct info site routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Correct info site routes [#1520](https://github.com/open-apparel-registry/open-apparel-registry/pull/1520)
+
 ### Security
 
 ## [51] 2021-11-04

--- a/src/app/src/components/Contribute.jsx
+++ b/src/app/src/components/Contribute.jsx
@@ -10,7 +10,12 @@ import AppGrid from './AppGrid';
 import AppOverflow from './AppOverflow';
 import ContributeForm from './ContributeForm';
 
-import { listsRoute, authLoginFormRoute, InfoLink } from '../util/constants';
+import {
+    listsRoute,
+    authLoginFormRoute,
+    InfoLink,
+    InfoPaths,
+} from '../util/constants';
 
 function ContributeList({ userHasSignedIn, fetchingSessionSignIn }) {
     if (fetchingSessionSignIn) {
@@ -51,7 +56,7 @@ function ContributeList({ userHasSignedIn, fetchingSessionSignIn }) {
 
                         <p>
                             <a
-                                href={`${InfoLink}/resources/how-to-contribute-data-to-the-oar`}
+                                href={`${InfoLink}/${InfoPaths.contribute}`}
                                 target="_blank"
                                 rel="noreferrer"
                             >
@@ -84,7 +89,7 @@ function ContributeList({ userHasSignedIn, fetchingSessionSignIn }) {
                                     uploaded, you will receive an email letting
                                     you know{' '}
                                     <a
-                                        href={`${InfoLink}/how-the-oar-improves-data-quality`}
+                                        href={`${InfoLink}/${InfoPaths.dataQuality}`}
                                         target="_blank"
                                         rel="noreferrer"
                                     >

--- a/src/app/src/components/CookiePreferencesText.jsx
+++ b/src/app/src/components/CookiePreferencesText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InfoLink } from '../util/constants';
+import { InfoLink, InfoPaths } from '../util/constants';
 
 const CookiePreferencesText = () => (
     <div>
@@ -7,11 +7,19 @@ const CookiePreferencesText = () => (
         performance and usage. By clicking the Accept button, you agree to allow
         us to place cookies and share information with Google Analytics. For
         more information, please visit our{' '}
-        <a href={`${InfoLink}/terms-of-use`} target="_blank" rel="noreferrer">
+        <a
+            href={`${InfoLink}/${InfoPaths.termsOfUse}`}
+            target="_blank"
+            rel="noreferrer"
+        >
             Terms of Use
         </a>{' '}
         and{' '}
-        <a href={`${InfoLink}/privacy-policy`} target="_blank" rel="noreferrer">
+        <a
+            href={`${InfoLink}/${InfoPaths.privacyPolicy}`}
+            target="_blank"
+            rel="noreferrer"
+        >
             Privacy Policy
         </a>
         .

--- a/src/app/src/components/EmbeddedFooter.jsx
+++ b/src/app/src/components/EmbeddedFooter.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import logo from '../styles/images/OAR_PoweredBy_white.svg';
+import { InfoLink } from '../util/constants';
 
 const EmbeddedFooter = () => (
     <footer className="footerContainerEmbedded results-height-subtract" xs={12}>
-        <a
-            href="https://info.openapparel.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-        >
+        <a href={`${InfoLink}`} target="_blank" rel="noopener noreferrer">
             <img
                 className="footer-image"
                 src={logo}

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -138,7 +138,12 @@ function EmbeddedMapConfig({
             </Typography>
             <Typography paragraph style={{ width: '100%' }}>
                 <strong>Have questions?</strong> Check out the FAQs on our{' '}
-                <a href={EmbeddedMapInfoLink} className="inline-link">
+                <a
+                    href={EmbeddedMapInfoLink}
+                    className="inline-link"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     Embedded Map info page
                 </a>{' '}
                 or email{' '}

--- a/src/app/src/components/EmbeddedMapUnauthorized.jsx
+++ b/src/app/src/components/EmbeddedMapUnauthorized.jsx
@@ -29,8 +29,10 @@ function EmbeddedMapUnauthorized({ isSettings, error = [] }) {
             </Typography>
             <Typography paragraph>
                 To activate this paid-for feature, check out the{' '}
-                <a href={EmbeddedMapInfoLink}>OAR Embedded Map</a> page on our
-                website for packages and pricing options.
+                <a href={EmbeddedMapInfoLink} target="_blank" rel="noreferrer">
+                    OAR Embedded Map
+                </a>{' '}
+                page on our website for packages and pricing options.
             </Typography>
             {isSettings && (
                 <Typography paragraph>

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -26,6 +26,7 @@ import {
     authLoginFormRoute,
     dashboardListsRoute,
     InfoLink,
+    InfoPaths,
 } from '../util/constants';
 
 import { facilityListPropType } from '../util/propTypes';
@@ -209,7 +210,7 @@ class FacilityListItems extends Component {
                         <div style={facilityListItemsStyles.subheadStyles}>
                             Read about how your facility data is{' '}
                             <a
-                                href={`${InfoLink}/how-the-oar-improves-data-quality`}
+                                href={`${InfoLink}/${InfoPaths.dataQuality}`}
                                 target="_blank"
                                 rel="noreferrer"
                             >

--- a/src/app/src/components/FilterSidebarGuideTab.jsx
+++ b/src/app/src/components/FilterSidebarGuideTab.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { filterSidebarStyles } from '../util/styles';
-import { authRegisterFormRoute } from '../util/constants';
+import { authRegisterFormRoute, InfoLink, InfoPaths } from '../util/constants';
 
 export default function FilterSidebarGuideTab({ vectorTile }) {
     if (!vectorTile) {
@@ -36,7 +36,7 @@ export default function FilterSidebarGuideTab({ vectorTile }) {
                     are able to search the site without creating an account.
                 </p>
                 <a
-                    href="http://info.openapparel.org/about"
+                    href={`${InfoLink}/${InfoPaths.aboutUs}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="link-underline"
@@ -120,7 +120,7 @@ export default function FilterSidebarGuideTab({ vectorTile }) {
                 the OAR map.
             </p>
             <a
-                href="http://info.openapparel.org/about"
+                href={`${InfoLink}/${InfoPaths.aboutUs}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="link-underline"

--- a/src/app/src/components/Footer.jsx
+++ b/src/app/src/components/Footer.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import logo from '../styles/images/Creative-Commons-Attribution-ShareAlike-40-International-Public.png';
 
 import { setGDPROpen } from '../actions/ui';
-import { InfoLink } from '../util/constants';
+import { FooterLinks } from '../util/constants';
 
 const linkButtonStyle = {
     minHeight: 'auto',
@@ -17,54 +17,10 @@ const linkButtonStyle = {
     fontWeight: 700,
 };
 
-const links = [
-    {
-        href: 'https://www.azavea.com/',
-        prefix: 'Built by ',
-        text: 'Azavea',
-        external: true,
-        newTab: true,
-    },
-    {
-        text: 'Cookie Preferences',
-        button: true,
-    },
-    {
-        href: `${InfoLink}/contact`,
-        text: 'Contact us',
-        external: true,
-        newTab: true,
-    },
-    {
-        href: `${InfoLink}/work-with-us`,
-        text: 'Work with us',
-        external: true,
-        newTab: true,
-    },
-    {
-        href: `${InfoLink}/faqs`,
-        text: 'FAQs',
-        external: true,
-        newTab: true,
-    },
-    {
-        href: `${InfoLink}/privacy-policy`,
-        text: 'Privacy policy',
-        external: true,
-        newTab: true,
-    },
-    {
-        href: `${InfoLink}/terms-of-use`,
-        text: 'Terms of use',
-        external: true,
-        newTab: true,
-    },
-];
-
 const Footer = ({ openGDPR }) => (
     <footer className="results-height-subtract" xs={12}>
         <div className="simple-footer">
-            {links.map(l => {
+            {FooterLinks.map(l => {
                 if (l.external && 'prefix' in l) {
                     return (
                         <span

--- a/src/app/src/components/Navbar.jsx
+++ b/src/app/src/components/Navbar.jsx
@@ -10,7 +10,7 @@ import MainMobileNav from './Navbar/MainMobileNav';
 
 import '../styles/css/header.css';
 
-import { InfoLink } from '../util/constants';
+import { InfoLink, InfoPaths } from '../util/constants';
 
 function Navbar() {
     const [activeSubmenu, setActiveSubmenu] = useState(null);
@@ -37,7 +37,7 @@ function Navbar() {
                 />
                 <a
                     className="nav__link nav__link--level-1"
-                    href={`${InfoLink}/resources`}
+                    href={`${InfoLink}/${InfoPaths.storiesResources}`}
                     target="_blank"
                     rel="noreferrer"
                 >

--- a/src/app/src/components/Navbar/MainMobileNav.jsx
+++ b/src/app/src/components/Navbar/MainMobileNav.jsx
@@ -4,7 +4,11 @@ import MobileNavParent from './MobileNavParent';
 import BurgerButton from './BurgerButton';
 import MobileContributeButton from './MobileContributeButton';
 
-import { MOBILE_HEADER_HEIGHT, InfoLink } from '../../util/constants';
+import {
+    MOBILE_HEADER_HEIGHT,
+    InfoLink,
+    InfoPaths,
+} from '../../util/constants';
 
 const styles = {
     mobileNavActive: {
@@ -53,7 +57,7 @@ function MainMobileNav({
                 <div className="mobile-nav__item">
                     <a
                         className="mobile-nav__link"
-                        href={`${InfoLink}/resources`}
+                        href={`${InfoLink}/${InfoPaths.storiesResources}`}
                         target="_blank"
                         rel="noreferrer"
                         onClick={handleClose}

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -8,6 +8,28 @@ export const FACILITIES_REQUEST_PAGE_SIZE = 50;
 export const WEB_HEADER_HEIGHT = '80px';
 export const MOBILE_HEADER_HEIGHT = '68px';
 
+export const InfoLink = 'https://info.openapparel.org';
+
+export const InfoPaths = {
+    home: '',
+    gettingStarted: 'getting-started',
+    dataTechnology: 'data-technology',
+    api: 'api',
+    embeddedMap: 'embedded-map',
+    faqs: 'faqs',
+    aboutUs: 'about-us',
+    funding: 'funding',
+    press: 'press',
+    workWithUs: 'work-with-us',
+    contactUs: 'contact-us',
+    storiesResources: 'stories-resources',
+    privacyPolicy: 'privacy-policy',
+    termsOfUse: 'terms-of-use',
+    contribute: 'stories-resources/how-to-contribute-data-to-the-oar',
+    dataQuality: 'how-the-oar-improves-data-quality',
+    claimedFacilities: 'stories-resources/claim-a-facility',
+};
+
 // This choices must be kept in sync with the identical list
 // kept in the Django API's models.py file
 export const contributorTypeOptions = Object.freeze([
@@ -186,7 +208,7 @@ const accountTOSField = Object.freeze({
     label: 'Terms of Service',
     link: Object.freeze({
         prefixText: 'Agree to ',
-        url: 'https://info.openapparel.org/tos/',
+        url: `${InfoLink}/${InfoPaths.termsOfUse}`,
     }),
     required: true,
     modelFieldName: 'has_agreed_to_terms_of_service',
@@ -231,7 +253,7 @@ export const facilitiesRoute = '/facilities';
 export const facilityDetailsRoute = '/facilities/:oarID';
 export const claimFacilityRoute = '/facilities/:oarID/claim';
 export const profileRoute = '/profile/:id';
-export const aboutProcessingRoute = 'https://info.openapparel.org/processing';
+export const aboutProcessingRoute = `${InfoLink}/${InfoPaths.dataQuality}`;
 export const dashboardRoute = '/dashboard';
 export const dashboardListsRoute = '/dashboard/lists';
 export const dashboardApiBlocksRoute = '/dashboard/apiblocks';
@@ -249,8 +271,7 @@ export const dashboardGeocoderRoute = '/dashboard/geocoder';
 export const claimedFacilitiesRoute = '/claimed';
 export const claimedFacilitiesDetailRoute = '/claimed/:claimID';
 export const dashboardClaimsDetailsRoute = '/dashboard/claims/:claimID';
-export const aboutClaimedFacilitiesRoute =
-    'https://info.openapparel.org/claimed-facilities';
+export const aboutClaimedFacilitiesRoute = `${InfoLink}/${InfoPaths.claimedFacilities}`;
 
 export const contributeFieldsEnum = Object.freeze({
     name: 'name',
@@ -528,49 +549,47 @@ export const PPE_FIELD_NAMES = Object.freeze([
 export const OARFont = "'DM Sans',sans-serif";
 export const OARColor = '#0427a4';
 
-export const EmbeddedMapInfoLink = 'https://info.openapparel.org/embedded-map';
-
 // A CSS size value that is used to set a lower bound on the iframe height
 // when the width is set to 100%
 export const minimum100PercentWidthEmbedHeight = '500px';
 
-export const InfoLink = 'https://info.openapparel.org';
+export const EmbeddedMapInfoLink = `${InfoLink}/${InfoPaths.embeddedMap}`;
 
 export const SubmenuLinks = {
     'How It Works': [
         {
-            url: '',
+            url: InfoPaths.home,
             text: 'Home',
             external: true,
         },
         {
-            url: 'getting-started',
+            url: InfoPaths.gettingStarted,
             text: 'Getting Started',
             external: true,
         },
         {
-            url: 'data-technology',
+            url: InfoPaths.dataTechnology,
             text: 'Data & Technology',
             external: true,
         },
-        { url: 'api', text: 'API', external: true },
+        { url: InfoPaths.api, text: 'API', external: true },
         {
-            url: 'embedded-map',
+            url: InfoPaths.embeddedMap,
             text: 'Embedded Map',
             external: true,
         },
-        { url: 'faqs', text: 'FAQs', external: true },
+        { url: InfoPaths.faqs, text: 'FAQs', external: true },
     ],
     'About Us': [
-        { url: 'about', text: 'About Us', external: true },
-        { url: 'funding', text: 'Funding', external: true },
-        { url: 'press', text: 'Press', external: true },
+        { url: InfoPaths.aboutUs, text: 'About Us', external: true },
+        { url: InfoPaths.funding, text: 'Funding', external: true },
+        { url: InfoPaths.press, text: 'Press', external: true },
         {
-            url: 'work-with-us',
+            url: InfoPaths.workWithUs,
             text: 'Work With Us',
             external: true,
         },
-        { url: 'contact', text: 'Contact Us', external: true },
+        { url: InfoPaths.contactUs, text: 'Contact Us', external: true },
     ],
     More: [
         {
@@ -578,17 +597,61 @@ export const SubmenuLinks = {
             button: true,
         },
         {
-            url: 'privacy-policy',
+            url: InfoPaths.privacyPolicy,
             text: 'Privacy policy',
             external: true,
         },
         {
-            url: 'terms-of-use',
+            url: InfoPaths.termsOfUse,
             text: 'Terms of use',
             external: true,
         },
     ],
 };
+
+export const FooterLinks = [
+    {
+        href: 'https://www.azavea.com/',
+        prefix: 'Built by ',
+        text: 'Azavea',
+        external: true,
+        newTab: true,
+    },
+    {
+        text: 'Cookie Preferences',
+        button: true,
+    },
+    {
+        href: `${InfoLink}/${InfoPaths.contactUs}`,
+        text: 'Contact us',
+        external: true,
+        newTab: true,
+    },
+    {
+        href: `${InfoLink}/${InfoPaths.workWithUs}`,
+        text: 'Work with us',
+        external: true,
+        newTab: true,
+    },
+    {
+        href: `${InfoLink}/${InfoPaths.faqs}`,
+        text: 'FAQs',
+        external: true,
+        newTab: true,
+    },
+    {
+        href: `${InfoLink}/${InfoPaths.privacyPolicy}`,
+        text: 'Privacy policy',
+        external: true,
+        newTab: true,
+    },
+    {
+        href: `${InfoLink}/${InfoPaths.termsOfUse}`,
+        text: 'Terms of use',
+        external: true,
+        newTab: true,
+    },
+];
 
 export const createUserDropdownLinks = (
     user,


### PR DESCRIPTION
## Overview

Adds the info site routes as constants in the constants file,
instead of using their string value directly. This allows us to
update the links in one place in order to keep them consistent and
avoid outdated links around the site.

Updates the info links throughout the site to use the constant values.

Updates the info site routes to use the most current version of the
URLs.

Confirms the info site links open in a new tab. 

Connects #1512, #1510 

## Notes

Technically the issue only referenced the header and footer links, but it saves time to update the miscellaneous outdated info site links throughout the site at the same time instead of pushing them off to another issue. 

## Testing Instructions

* Run `./scripts/server`
* For each link in the header (in both web and mobile view) and footer, confirm that it matches the appropriate link in the issue and that it opens in a new tab. 
* Click the info site links on the contribute page, a list page, the cookie preferences text, the Guide tab, the and the embedded map config page and confirm they open in a new tab. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
