### PR TITLE
Redirect to new info site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Redirect to new info site [#1523](https://github.com/open-apparel-registry/open-apparel-registry/pull/1523)
+
 ### Changed
 
 ### Deprecated

--- a/src/app/src/Routes.jsx
+++ b/src/app/src/Routes.jsx
@@ -30,6 +30,7 @@ import ClaimFacility from './components/ClaimFacility';
 import ClaimedFacilities from './components/ClaimedFacilities';
 import SurveyDialogNotification from './components/SurveyDialogNotification';
 import Settings from './components/Settings';
+import ExternalRedirect from './components/ExternalRedirect';
 
 import { sessionLogin } from './actions/auth';
 import { fetchFeatureFlags } from './actions/featureFlags';
@@ -56,6 +57,8 @@ import {
     settingsRoute,
     WEB_HEADER_HEIGHT,
     MOBILE_HEADER_HEIGHT,
+    InfoLink,
+    InfoPaths,
 } from './util/constants';
 
 const appStyles = theme =>
@@ -199,6 +202,21 @@ class Routes extends Component {
                                     path={settingsRoute}
                                     component={Settings}
                                 />
+                                <Route exact path="/about/processing">
+                                    <ExternalRedirect
+                                        to={`${InfoLink}/${InfoPaths.dataQuality}`}
+                                    />
+                                </Route>
+                                <Route exact path="/about/claimedfacilities">
+                                    <ExternalRedirect
+                                        to={`${InfoLink}/${InfoPaths.claimedFacilities}`}
+                                    />
+                                </Route>
+                                <Route exact path="/tos">
+                                    <ExternalRedirect
+                                        to={`${InfoLink}/${InfoPaths.termsOfUse}`}
+                                    />
+                                </Route>
                                 <Route
                                     exact
                                     path={mainRoute}

--- a/src/app/src/components/ExternalRedirect.jsx
+++ b/src/app/src/components/ExternalRedirect.jsx
@@ -1,0 +1,6 @@
+const ExternalRedirect = ({ to }) => {
+    window.location.replace(to);
+    return null;
+};
+
+export default ExternalRedirect;


### PR DESCRIPTION
## Overview

Some pages on the map site have been moved to the info site.
When users attempt to access the obsolete links, they are redirected
to the appropriate page on the info site.

Connects #1508 

## Notes

React-Router 'Redirects' don't work as expected for external routes (they add the new route as a path at the end of the url instead of rerouting), so a manual redirect was required. 

## Testing Instructions

* Run `./scripts/server`
* Attempt to access http://localhost:6543/about/processing. It should redirect to https://info.openapparel.org/how-the-oar-improves-data-quality and clicking the back button shouldn't return you to /about/processing.
* http://localhost:6543/about/claimedfacilities should redirect to https://info.openapparel.org/resources-stories/claim-a-facility
* http://localhost:6543/tos should redirect to https://info.openapparel.org/terms-of-use

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
