### PR TITLE
Add extended profile feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Create ExtendedFields [#1527](https://github.com/open-apparel-registry/open-apparel-registry/pull/1527)
 - Include ExtendedFields in Facility Details [#1530](https://github.com/open-apparel-registry/open-apparel-registry/pull/1530)
+- Add extended profile feature flag [#1542](https://github.com/open-apparel-registry/open-apparel-registry/pull/1542)
 
 ### Changed
 

--- a/scripts/resetdb
+++ b/scripts/resetdb
@@ -27,6 +27,7 @@ function enableswitches() {
     ./scripts/manage waffle_switch ppe on
     ./scripts/manage waffle_switch report_a_facility on
     ./scripts/manage waffle_switch embedded_map on
+    ./scripts/manage waffle_switch extended_profile on
 }
 
 function assigngroups() {

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -465,6 +465,7 @@ export const VECTOR_TILE = 'vector_tile';
 export const PPE = 'ppe';
 export const REPORT_A_FACILITY = 'report_a_facility';
 export const EMBEDDED_MAP_FLAG = 'embedded_map';
+export const EXTENDED_PROFILE_FLAG = 'extended_profile';
 
 export const COUNTRY_CODES = Object.freeze({
     default: 'IE',

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -26,6 +26,7 @@ import {
     PPE,
     REPORT_A_FACILITY,
     EMBEDDED_MAP_FLAG,
+    EXTENDED_PROFILE_FLAG,
     facilityClaimStatusChoicesEnum,
 } from './constants';
 
@@ -245,6 +246,7 @@ export const featureFlagPropType = oneOf([
     PPE,
     REPORT_A_FACILITY,
     EMBEDDED_MAP_FLAG,
+    EXTENDED_PROFILE_FLAG,
 ]);
 
 export const facilityClaimsListPropType = arrayOf(

--- a/src/django/api/migrations/0073_add_extended_profile_switch.py
+++ b/src/django/api/migrations/0073_add_extended_profile_switch.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def create_extended_profile_switch(apps, schema_editor):
+    Switch = apps.get_model('waffle', 'Switch')
+    Switch.objects.create(name='extended_profile', active=False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('api', '0072_make_extendedfield_facility_nullable'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_extended_profile_switch)
+    ]


### PR DESCRIPTION
## Overview

Extended profiles is a long-developing feature which which involve
large changes to the UI. In order to enable ongoing maintenance releases
during development of the new feature, we have added a feature flag to
allow us to hide the new components until we are ready to release them.

Connects #1538 

## Demo

<img width="1025" alt="Screen Shot 2021-11-30 at 12 38 29 PM" src="https://user-images.githubusercontent.com/21046714/144098995-54bfa46c-7b6a-4cdc-865b-860950ca1342.png">

## Testing Instructions

* Run `./scripts/manage migrate`.
* Run `./scripts/server` and confirm the new switch is present in the Django admin. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
