### PR TITLE
Update extended fields when matches are adjusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Update extended fields when matches are adjusted [#1544](https://github.com/open-apparel-registry/open-apparel-registry/pull/1544)
+
 ### Changed
 
 ### Deprecated

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -89,7 +89,8 @@ from api.models import (FacilityList,
                         EmbedConfig,
                         EmbedField,
                         NonstandardField,
-                        FacilityIndex)
+                        FacilityIndex,
+                        ExtendedField)
 from api.processing import (parse_csv_line,
                             parse_csv,
                             parse_excel,
@@ -1786,6 +1787,10 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     'Merging {} into {}'.format(merge.id, target.id)
             claim.save()
 
+        for field in ExtendedField.objects.filter(facility=merge):
+            field.facility = target
+            field.save()
+
         for alias in FacilityAlias.objects.filter(facility=merge):
             oar_id = alias.oar_id
             alias.changeReason = 'Merging {} into {}'.format(
@@ -1929,6 +1934,12 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             if old_facility.revert_ppe(list_item_for_match):
                 old_facility.save()
 
+            fields = ExtendedField.objects.filter(
+                facility_list_item=list_item_for_match)
+            for field in fields:
+                field.facility = new_facility
+                field.save()
+
             return Response({
                 'match_id': match_for_new_facility.id,
                 'new_oar_id': new_facility.id,
@@ -1981,6 +1992,12 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             })
 
             list_item_for_match.save()
+
+            fields = ExtendedField.objects.filter(
+                facility_list_item=list_item_for_match)
+            for field in fields:
+                field.facility = new_facility
+                field.save()
 
             return Response({
                 'match_id': match.id,


### PR DESCRIPTION
## Overview

When merging two facilities, splitting a facility list item into its
own facility, or transferring a list item from one facility to another,
the list items in question are adjusted to point to a new facility.

ExtendedFields which are created from a list item contain both a
reference to the list item and a reference to the facility. In order to
keep the fields and list item in sync, we now update the ExtendedFields
when the list item's facility is changed.

Connects #1537 

## Testing Instructions

* Run `./scripts/server`
* Create extended fields from at least two separate list items (Item A and Item B). Note the ids of the matched / created facilities (Facility A, Facility B). 
* Merge Facility B into Facility A. The extended fields for Item B should point to Facility A and Item B. The fields for Item A should still point to Facility A and Item A. 
* Split Item B away from Facility A. The extended fields from Item B should no longer point to Facility A. 
* Transfer / move Item B to a new facility. The extended fields for Item B should now point to the new facility. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
