### PR TITLE
Fix broken geocoding test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix broken geocoding test [#1546](https://github.com/open-apparel-registry/open-apparel-registry/pull/1546)
+
 ### Security
 
 ## [52] 2021-11-10


### PR DESCRIPTION
## Overview

When geocoding a facility, if the country code returned by Google Maps
is different from the country code provided by the user, we throw a
ValueError.

We’re testing this code with an address that previously was getting
mapped by Google Maps to China, and testing that we threw an error
because the user had entered it as India. Google is now returning that
address as being in India, which means that a value error was
(correctly, but breaking the test) not raised.

The test now mocks the API response so that we are testing only our
own code, and not third-party responses.

Connects #1545 

## Demo

Broken test:
<img width="634" alt="Screen Shot 2021-12-02 at 11 24 17 AM" src="https://user-images.githubusercontent.com/21046714/144461926-afafb2f3-20db-431d-85d0-9e57b873a362.png">

Passing tests:
<img width="513" alt="Screen Shot 2021-12-02 at 11 24 57 AM" src="https://user-images.githubusercontent.com/21046714/144461998-a02e5be5-5312-4f4e-a355-7c94228dcbc5.png">

## Notes

Only one of the three geocoding tests were breaking, but I switched to the mock for all three. 

## Testing Instructions

* Run the tests and confirm they are all passing. 
* Visually confirm the mocked responses are reasonable given the tests' purposes. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
