### PR TITLE
Correctly position and size embed footer badge

### DIFF
--- a/src/app/src/Routes.jsx
+++ b/src/app/src/Routes.jsx
@@ -97,7 +97,7 @@ class Routes extends Component {
     render() {
         const { fetchingFeatureFlags, embed, classes } = this.props;
 
-        const mainPanelStyle = embed ? { top: 0 } : {};
+        const mainPanelStyle = embed ? { top: 0, bottom: '64px' } : {};
 
         return (
             <ErrorBoundary>

--- a/src/app/src/components/EmbeddedFooter.jsx
+++ b/src/app/src/components/EmbeddedFooter.jsx
@@ -3,13 +3,18 @@ import logo from '../styles/images/OAR_PoweredBy_white.svg';
 import { InfoLink } from '../util/constants';
 
 const EmbeddedFooter = () => (
-    <footer className="footerContainerEmbedded results-height-subtract" xs={12}>
+    <footer
+        className="footerContainerEmbedded results-height-subtract"
+        xs={12}
+        style={{ position: 'absolute', bottom: 0 }}
+    >
         <a href={`${InfoLink}`} target="_blank" rel="noopener noreferrer">
             <img
                 className="footer-image"
                 src={logo}
                 alt="Powered by Open Apparel Registry"
-                style={{ paddingLeft: '10px' }}
+                width="150"
+                style={{ margin: '8px' }}
             />
         </a>
     </footer>


### PR DESCRIPTION
## Overview

Set the size and position of the embed footer badge, and adjust embed map height to make room for it. This fixes two issues:

#1528 where the embed badge was appearing at a huge size before the map loads and then disappearing after the map loads
#1529 where the embed list height did not use up the available space

Connects #1528 
Connects #1529 

## Demo

![image](https://user-images.githubusercontent.com/128699/144494560-0c66bc7e-b291-44da-ad96-d51c84a81290.png)


## Notes

In troubleshooting this, I noticed significant CSS debt throughout the app, which made it quite challenging to fix, even though the final fix is quite short. Recommend rearchitecting the (layout, if not additional) CSS when possible.

## Testing Instructions

* `./scripts/server`
* Login as a user with an embed plan (might require some admin mojo)
* Settings > Embed
* Ensure OAR badge appears at correct size below map
* Adjust embed width or height to force it to rerender. Ensure badge doesn't appear huge before map appears.
* Switch to Facilities tab. Ensure results list uses up entire available height of sidebar.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
