### PR TITLE
Add contributor fields to facility downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Use newer version of terraform container to avoid CI error [#1566](https://github.com/open-apparel-registry/open-apparel-registry/pull/1566)
+- Add contributor fields to facility downloads [#1565](https://github.com/open-apparel-registry/open-apparel-registry/pull/1565)
 
 ### Security
 


### PR DESCRIPTION
## Overview

When a user downloads CSV/Excel files from an Embedded Map,
we include the nonstandard embedded map contributor fields
to the download. The fields appear in the format and order
specified by the user in the embedded map config.

Connects #1559 

## Demo

CSV with contributor fields
<img width="887" alt="Screen Shot 2021-12-22 at 10 29 59 AM" src="https://user-images.githubusercontent.com/21046714/147125654-fc50bd87-31d7-4b34-8989-76206f20612e.png">

XLSX with contributor fields
<img width="807" alt="Screen Shot 2021-12-22 at 10 30 23 AM" src="https://user-images.githubusercontent.com/21046714/147125712-ef692425-31a7-4c2e-8e1d-9311746c8ed6.png">

## Testing Instructions

* Login as c1@example.com. Enable embedded map for user c3@example.com.
* Login as c3@example.com. Navigate to the embedded map settings. Set up a map size, and edit the default fields.
* In the map preview, download the list of facilities using both CSV and XLSX. Confirm that the fields selected above are present. 
* Upload and process a facility list with extra fields. [list_with_extra_fields.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7764001/OAR_Contributor_Template1.csv)
* Return to the settings page and add the extra fields to the contributor fields. 
* Download the CSV and XLSX from the preview again and confirm the new fields are present and have values where appropriate. 
* Navigate to the homepage, filtering by the c3@example.com. http://localhost:6543/?contributors=3
* Download the CSV and XLSX files again and confirm that the embedded map contributor fields are not present. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
