### PR TITLE
Use newer version of terraform container to avoid CI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Use newer version of terraform container to avoid CI error [#1566](https://github.com/open-apparel-registry/open-apparel-registry/pull/1566)
+
 ### Security
 
 ## [53] 2021-12-09

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,7 +4,7 @@ services:
     image: "openapparelregistry:${GIT_COMMIT:-latest}"
 
   terraform:
-    image: quay.io/azavea/terraform:0.11.14
+    image: quay.io/azavea/terraform:0.11.15
     volumes:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro


### PR DESCRIPTION
## Overview

CI was failing to deploy the develop branch to staging. The following command

```
docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```

failed with

```
Error installing provider "aws": openpgp: signature made by unknown entity.
```

A newer patch release of terraform has updated key references to avoid this
issue.

Connects #1564

## Demo

<img width="886" alt="Screen Shot 2021-12-22 at 10 28 42 AM" src="https://user-images.githubusercontent.com/17363/147132186-ad720f4a-afbb-4931-b75c-1e8de5597755.png">


## Testing Instructions

* Verify that this PR branch was successfully deployed to staging

## Checklist

- [ ] Drop the testing commit
- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
