### PR TITLE
Fix contributor id bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Use newer version of terraform container to avoid CI error [#1566](https://github.com/open-apparel-registry/open-apparel-registry/pull/1566)
 - Add contributor fields to facility downloads [#1565](https://github.com/open-apparel-registry/open-apparel-registry/pull/1565)
+- Fix contributor id bug [#1567](https://github.com/open-apparel-registry/open-apparel-registry/pull/1567)
 
 ### Security
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -80,7 +80,7 @@ def get_embed_contributor_id(serializer):
 
     contributor = request.query_params.get('contributor', None)
     if contributor is None:
-        contributors = request.query_params.get('contributors', [])
+        contributors = request.query_params.getlist('contributors', [])
         if contributors is not None and len(contributors) > 0:
             contributor = contributors[0]
 


### PR DESCRIPTION
## Overview

When getting the contributor id for the facilities list from the
request params `contributors`, we were incorrectly grabbing it as a
string instead of a list. Then, when accessing the first item, the
first digit of the contributor's id was selected instead of the first
contributor id. This resulted in the wrong contributor being selected
when the contributor had a multi-digit id. Now we parse the param as
a list.

This bug impacts both the prefer_contributor_name setting and the contributor fields download. 

## Testing Instructions

* Give a contributor with a multi-digit id embed permissions. 
* Using that contributor, submit facilities with extra fields. Use fields / values not belonging to other contributors in your system.
* In the settings, set up their embedded map and view the preview. Confirm that the downloaded values (from the CSV /XLSX) match the ones submitted for this contributor
* Update a facility match for the contributor to use a different name from the currently set facility name. Set prefer_contributor_name to true and view the embedded map preview. The custom name should be shown. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
