### PR TITLE
Split clean field migration in two and handle real world data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Split clean field migration in two and handle real world data [#1571](https://github.com/open-apparel-registry/open-apparel-registry/pull/1571)
+
 ### Security
 
 ## [54] 2022-01-05

--- a/src/django/api/migrations/0075_add_clean_name_and_address.py
+++ b/src/django/api/migrations/0075_add_clean_name_and_address.py
@@ -4,18 +4,6 @@ from django.db import migrations, models
 from api.matching import clean
 
 
-def populate_cleaned_fields(apps, schema_editor):
-    FacilityListItem = apps.get_model('api', 'FacilityListItem')
-    for list_item in FacilityListItem.objects.all():
-        list_item.clean_name = clean(list_item.name)
-        list_item.clean_address = clean(list_item.address)
-        list_item.save()
-
-
-def do_nothing_on_reverse(apps, schema_editor):
-    pass
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -26,16 +14,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='facilitylistitem',
             name='clean_address',
-            field=models.CharField(default='', help_text='The cleaned address of the facility.', max_length=200),
+            field=models.CharField(default='', help_text='The cleaned address of the facility.', max_length=2000),
         ),
         migrations.AddField(
             model_name='facilitylistitem',
             name='clean_name',
-            field=models.CharField(default='', help_text='The cleaned name of the facility.', max_length=200),
+            field=models.CharField(default='', help_text='The cleaned name of the facility.', max_length=2000),
         ),
         migrations.AddIndex(
             model_name='facilitylistitem',
             index=models.Index(fields=['country_code', 'clean_name', 'clean_address'], name='api_fli_match_fields_idx'),
-        ),
-        migrations.RunPython(populate_cleaned_fields, do_nothing_on_reverse)
+        )
     ]

--- a/src/django/api/migrations/0076_fill_clean_name_and_address.py
+++ b/src/django/api/migrations/0076_fill_clean_name_and_address.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+from api.matching import clean
+
+
+def populate_cleaned_fields(apps, schema_editor):
+    print('')
+    print('Started filling clean name and address')
+    count = 0
+    FacilityListItem = apps.get_model('api', 'FacilityListItem')
+    for list_item in FacilityListItem.objects.exclude(name='', address='').iterator():
+        list_item.clean_name = clean(list_item.name) or ''
+        list_item.clean_address = clean(list_item.address) or ''
+        list_item.save()
+        count += 1
+        if count % 1000 == 0:
+            print('Filled ' + str(count))
+    print('Finished filling clean name and address')
+
+
+def do_nothing_on_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0075_add_clean_name_and_address'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_cleaned_fields, do_nothing_on_reverse),
+    ]

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -625,13 +625,13 @@ class FacilityListItem(PPEMixin):
                    'previously existing facility to which this list '
                    'item was matched.'))
     clean_name = models.CharField(
-        max_length=200,
+        max_length=2000,
         null=False,
         blank=False,
         default='',
         help_text='The cleaned name of the facility.')
     clean_address = models.CharField(
-        max_length=200,
+        max_length=2000,
         null=False,
         blank=False,
         default='',


### PR DESCRIPTION
## Overview

We ran into multiple, overlapping issues when trying to run the first version of
the 0075 migration in our staging environment.

- Items in the `UPLOADED` or `ERROR_PARSING` status will have empty name and
  address fields. We address this by excluding rows where both the name and
  address are empty strings.
- The `clean` function returns None if all characters are removed, but the
  clean_* fields mush be set to an empty string, not None. We address this by
  adding `or ''` when setting values.
- The "fill" operation talks a long time to run though 300k+ rows. During this
  time the application will crash because the new model fields do not exist in
  the database until the migration is complete. We address this by splitting the
  migration into 2, a structural change followed by the "fill" operation.
- By default running a `for` loop over QuerySet will cache all of the records
  before starting the iteration. This creates a process that is slow to start
  and requires a large memory footprint. We address this by using
  `QueySet.iterator()`
- The `clean` operation uses the unidecode library to convert unicode characters
  to ascii by replacing them with transliterations which can result in the clean
  strings being longer than the original. We address this by making the clean
  fields 10x longer than the originals, because we did not identify any
  transliterations more than 9 characters long.

To make the debugging process easier we added print statements to show the
progress of the fill operation over time.

Connects #1549

## Demo

```
Operations to perform:
  Apply all migrations: account, admin, api, auth, authtoken, contenttypes, sessions, sites, socialaccount, waffle
Running migrations:
  Applying api.0075_add_clean_name_and_address... OK
  Applying api.0076_fill_clean_name_and_address...
Started filling clean name and address
Filled 1000
Filled 2000
Filled 3000
Filled 4000
Filled 5000
Filled 6000
Filled 7000
Filled 8000
Filled 9000
Filled 10000
Filled 11000
Filled 12000
Filled 13000
Filled 14000
Filled 15000
Filled 16000
Filled 17000
Filled 18000
Filled 19000
Filled 20000
Filled 21000
Filled 22000
Filled 23000
Filled 24000
Filled 25000
Filled 26000
Filled 27000
Filled 28000
Filled 29000
Filled 30000
Filled 31000
Filled 32000
Filled 33000
Filled 34000
Filled 35000
Filled 36000
Filled 37000
Filled 38000
Filled 39000
Filled 40000
Filled 41000
Filled 42000
Filled 43000
Filled 44000
Filled 45000
Filled 46000
Filled 47000
Filled 48000
Filled 49000
Filled 50000
Filled 51000
Filled 52000
Filled 53000
Filled 54000
Filled 55000
Filled 56000
Filled 57000
Filled 58000
Filled 59000
Filled 60000
Filled 61000
Filled 62000
Filled 63000
Filled 64000
Filled 65000
Filled 66000
Filled 67000
Filled 68000
Filled 69000
Filled 70000
Filled 71000
Filled 72000
Filled 73000
Filled 74000
Filled 75000
Filled 76000
Filled 77000
Filled 78000
Filled 79000
Filled 80000
Filled 81000
Filled 82000
Filled 83000
Filled 84000
Filled 85000
Filled 86000
Filled 87000
Filled 88000
Filled 89000
Filled 90000
Filled 91000
Filled 92000
Filled 93000
Filled 94000
Filled 95000
Filled 96000
Filled 97000
Filled 98000
Filled 99000
Filled 100000
Filled 101000
Filled 102000
Filled 103000
Filled 104000
Filled 105000
Filled 106000
Filled 107000
Filled 108000
Filled 109000
Filled 110000
Filled 111000
Filled 112000
Filled 113000
Filled 114000
Filled 115000
Filled 116000
Filled 117000
Filled 118000
Filled 119000
Filled 120000
Filled 121000
Filled 122000
Filled 123000
Filled 124000
Filled 125000
Filled 126000
Filled 127000
Filled 128000
Filled 129000
Filled 130000
Filled 131000
Filled 132000
Filled 133000
Filled 134000
Filled 135000
Filled 136000
Filled 137000
Filled 138000
Filled 139000
Filled 140000
Filled 141000
Filled 142000
Filled 143000
Filled 144000
Filled 145000
Filled 146000
Filled 147000
Filled 148000
Filled 149000
Filled 150000
Filled 151000
Filled 152000
Filled 153000
Filled 154000
Filled 155000
Filled 156000
Filled 157000
Filled 158000
Filled 159000
Filled 160000
Filled 161000
Filled 162000
Filled 163000
Filled 164000
Filled 165000
Filled 166000
Filled 167000
Filled 168000
Filled 169000
Filled 170000
Filled 171000
Filled 172000
Filled 173000
Filled 174000
Filled 175000
Filled 176000
Filled 177000
Filled 178000
Filled 179000
Filled 180000
Filled 181000
Filled 182000
Filled 183000
Filled 184000
Filled 185000
Filled 186000
Filled 187000
Filled 188000
Filled 189000
Filled 190000
Filled 191000
Filled 192000
Filled 193000
Filled 194000
Filled 195000
Filled 196000
Filled 197000
Filled 198000
Filled 199000
Filled 200000
Filled 201000
Filled 202000
Filled 203000
Filled 204000
Filled 205000
Filled 206000
Filled 207000
Filled 208000
Filled 209000
Filled 210000
Filled 211000
Filled 212000
Filled 213000
Filled 214000
Filled 215000
Filled 216000
Filled 217000
Filled 218000
Filled 219000
Filled 220000
Filled 221000
Filled 222000
Filled 223000
Filled 224000
Filled 225000
Filled 226000
Filled 227000
Filled 228000
Filled 229000
Filled 230000
Filled 231000
Filled 232000
Filled 233000
Filled 234000
Filled 235000
Filled 236000
Filled 237000
Filled 238000
Filled 239000
Filled 240000
Filled 241000
Filled 242000
Filled 243000
Filled 244000
Filled 245000
Filled 246000
Filled 247000
Filled 248000
Filled 249000
Filled 250000
Filled 251000
Filled 252000
Filled 253000
Filled 254000
Filled 255000
Filled 256000
Filled 257000
Filled 258000
Filled 259000
Filled 260000
Filled 261000
Filled 262000
Filled 263000
Filled 264000
Filled 265000
Filled 266000
Filled 267000
Filled 268000
Filled 269000
Filled 270000
Filled 271000
Filled 272000
Filled 273000
Filled 274000
Filled 275000
Filled 276000
Filled 277000
Filled 278000
Filled 279000
Filled 280000
Filled 281000
Filled 282000
Filled 283000
Filled 284000
Filled 285000
Filled 286000
Filled 287000
Filled 288000
Filled 289000
Filled 290000
Filled 291000
Filled 292000
Filled 293000
Filled 294000
Filled 295000
Filled 296000
Filled 297000
Filled 298000
Filled 299000
Filled 300000
Filled 301000
Filled 302000
Filled 303000
Filled 304000
Filled 305000
Filled 306000
Filled 307000
Filled 308000
Filled 309000
Filled 310000
Filled 311000
Filled 312000
Filled 313000
Filled 314000
Filled 315000
Filled 316000
Filled 317000
Filled 318000
Filled 319000
Filled 320000
Filled 321000
Filled 322000
Filled 323000
Filled 324000
Filled 325000
Filled 326000
Filled 327000
Filled 328000
Filled 329000
Filled 330000
Filled 331000
Filled 332000
Filled 333000
Filled 334000
Filled 335000
Filled 336000
Filled 337000
Filled 338000
Filled 339000
Filled 340000
Filled 341000
Filled 342000
Filled 343000
Filled 344000
Filled 345000
Filled 346000
Finished filling clean name and address
 OK
```

## Testing Instructions

*  Checkout `develop`
* Unapply the previous 0075 migration with `./scripts/manage migrate api 0074`
* Check out this PR branch
* `./scripts/manage migrate` and verify that is succeeds


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
