### PR TITLE
Fix the Percent Data by Source Type report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Split clean field migration in two and handle real world data [#1571](https://github.com/open-apparel-registry/open-apparel-registry/pull/1571)
+- Fix the Percent Data by Source Type report [#1575](https://github.com/open-apparel-registry/open-apparel-registry/pull/1575)
 
 ### Security
 

--- a/src/django/api/reports/percent_data_by_source_type.sql
+++ b/src/django/api/reports/percent_data_by_source_type.sql
@@ -1,3 +1,6 @@
+-- Calculate the percentage of facilities submitted via API or List each month.
+-- Only count the first instance of each unique combination of facility/contributor/source_type.
+
 SELECT
     match.month,
     source_type,
@@ -9,9 +12,8 @@ FROM (
     FROM api_facilitymatch m
         JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
         JOIN api_source s on i.source_id = s.id
-        JOIN api_contributor c ON s.contributor_id = c.id
     WHERE m.status NOT IN ('REJECTED', 'PENDING')
-    GROUP BY m.facility_id, c.id, s.source_type
+    GROUP BY m.facility_id, s.contributor_id, s.source_type
 ) as match
 JOIN (
     SELECT month, count(*) as total
@@ -21,9 +23,8 @@ JOIN (
         FROM api_facilitymatch m
             JOIN api_facilitylistitem i on m.facility_list_item_id = i.id
             JOIN api_source s on i.source_id = s.id
-            JOIN api_contributor c ON s.contributor_id = c.id
         WHERE m.status NOT IN ('REJECTED', 'PENDING')
-        GROUP BY m.facility_id, c.id
+        GROUP BY m.facility_id, s.contributor_id, s.source_type
     ) as fm
     GROUP BY month
     ORDER BY month


### PR DESCRIPTION
## Overview

The Percent Data by Source Type report was using a different method
to count the total number of submissions per month (only counting the
first instance of each unique contributor/facility combination) than
the method used to count the number of submissions per source type
(only counting the first instance of each unique contributor/facility/
source_type combination), resulting in invalid percentages. Adjusts
the query to use the first instance of each unique contributor/facility/
source_type combination for both sub-calculations for consistency.

Connects #1554 

## Demo

<img width="563" alt="Screen Shot 2022-01-10 at 12 35 27 PM" src="https://user-images.githubusercontent.com/21046714/148812723-ae1c8c4b-f890-4aed-9294-80e53be2389b.png">

## Notes

Please see the more detailed write-up describing the bug in [the original issue](https://github.com/open-apparel-registry/open-apparel-registry/issues/1554#issuecomment-1009175227).

## Testing Instructions

* Run `./scripts/server` and confirm [the report](http://localhost:8081/admin/reports/percent-data-by-source-type/) appears correct.
* View the manually pulled report in the management channel in Slack (or manually pull the report yourself on Production) to confirm that the real data appears correct. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
