### PR TITLE
Add extended field handling to facility details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add extended field handling to facility details [#1593](https://github.com/open-apparel-registry/open-apparel-registry/pull/1593)
+
 ### Changed
 
 - Identify exact matches pre-dedupe [#1568](https://github.com/open-apparel-registry/open-apparel-registry/pull/1568)

--- a/src/app/src/components/FacilityDetailSidebarContributors.jsx
+++ b/src/app/src/components/FacilityDetailSidebarContributors.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
 
-import FacilityDetailSidebarDetail from './FacilityDetailSidebarDetail';
+import ShowOnly from './ShowOnly';
+import BadgeVerified from './BadgeVerified';
 
 import { makeProfileRouteLink } from '../util/util';
 
@@ -18,6 +20,9 @@ const detailsSidebarStyles = theme =>
             textTransform: 'uppercase',
             fontWeight: theme.typography.fontWeightMedium,
         },
+        primaryText: {
+            wordWrap: 'break-word',
+        },
         secondaryText: {
             color: 'rgba(0, 0, 0, 0.54)',
             display: 'flex',
@@ -25,8 +30,14 @@ const detailsSidebarStyles = theme =>
             fontSize: '12px',
             justify: 'flex-end',
         },
-        divider: {
-            backgroundColor: 'rgba(0, 0, 0, 0.06)',
+        icon: {
+            color: 'rgb(106, 106, 106)',
+            fontSize: '24px',
+            fontWeight: 300,
+            textAlign: 'center',
+        },
+        contributor: {
+            boxShadow: '0px -1px 0px 0px rgb(240, 240, 240)',
         },
     });
 
@@ -38,18 +49,30 @@ const FacilityDetailSidebarContributors = ({ classes, contributors, push }) => {
     return (
         <div className={classes.item}>
             <Typography className={classes.label}>Contributors</Typography>
-            <Divider className={classes.divider} />
-            {contributors.map(contributor => (
-                <FacilityDetailSidebarDetail
-                    primary={contributor.contributor_name}
-                    secondary={contributor.list_name}
-                    hasAdditionalContent={!!contributor.id}
-                    hideTopDivider
-                    additionalContentCount=""
-                    onClick={() => push(makeProfileRouteLink(contributor.id))}
-                    key={contributor.id}
-                    verified={contributor.is_verified}
-                />
+            {visibleContributors.map(contributor => (
+                <ListItem
+                    button={!!contributor.id}
+                    onClick={() => {
+                        if (!contributor.id) return;
+                        push(makeProfileRouteLink(contributor.id));
+                    }}
+                    key={`${contributor.id} ${contributor.list_name}`}
+                    className={classes.contributor}
+                >
+                    <ShowOnly when={contributor.is_verified}>
+                        <BadgeVerified />
+                    </ShowOnly>
+                    <ListItemText
+                        primary={contributor.contributor_name}
+                        secondary={contributor.list_name}
+                        classes={{ primary: classes.primaryText }}
+                    />
+                    <ShowOnly when={!!contributor.id}>
+                        <i
+                            className={`${classes.icon} far fa-fw fa-angle-right`}
+                        />
+                    </ShowOnly>
+                </ListItem>
             ))}
         </div>
     );

--- a/src/app/src/components/FacilityDetailSidebarDetail.jsx
+++ b/src/app/src/components/FacilityDetailSidebarDetail.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import Divider from '@material-ui/core/Divider';
-import ArrowForwardIcon from '@material-ui/icons/ChevronRight';
 
 import ShowOnly from './ShowOnly';
 import BadgeVerified from './BadgeVerified';
@@ -13,56 +11,27 @@ const detailsSidebarStyles = () =>
         primaryText: {
             wordWrap: 'break-word',
         },
-        secondaryText: {
-            color: 'rgba(0, 0, 0, 0.54)',
-            display: 'flex',
-            alignItems: 'center',
-            fontSize: '12px',
-            justify: 'flex-end',
-        },
-        divider: {
-            backgroundColor: 'rgba(0, 0, 0, 0.06)',
+        item: {
+            boxShadow: '0px -1px 0px 0px rgb(240, 240, 240)',
         },
     });
 
 const FacilityDetailSidebarDetail = ({
-    hasAdditionalContent,
-    additionalContentCount,
     primary,
     secondary,
-    onClick,
-    hideTopDivider,
     verified,
     classes,
 }) => (
-    <>
-        <ShowOnly when={!hideTopDivider}>
-            <Divider className={classes.divider} />
+    <ListItem className={classes.item}>
+        <ShowOnly when={verified}>
+            <BadgeVerified />
         </ShowOnly>
-        <ListItem
-            button={hasAdditionalContent}
-            onClick={() => {
-                if (!hasAdditionalContent) return;
-                onClick();
-            }}
-        >
-            <ShowOnly when={verified}>
-                <BadgeVerified />
-            </ShowOnly>
-            <ListItemText
-                primary={primary}
-                secondary={secondary}
-                classes={{ primary: classes.primaryText }}
-            />
-            <ShowOnly when={hasAdditionalContent}>
-                <div className={classes.secondaryText}>
-                    <ListItemText secondary={additionalContentCount} />
-                    <ArrowForwardIcon />
-                </div>
-            </ShowOnly>
-        </ListItem>
-        <Divider className={classes.divider} />
-    </>
+        <ListItemText
+            primary={primary}
+            secondary={secondary}
+            classes={{ primary: classes.primaryText }}
+        />
+    </ListItem>
 );
 
 export default withStyles(detailsSidebarStyles)(FacilityDetailSidebarDetail);

--- a/src/app/src/components/FacilityDetailSidebarHeader.jsx
+++ b/src/app/src/components/FacilityDetailSidebarHeader.jsx
@@ -90,7 +90,7 @@ const getContent = ({
         secondary: 'Claim this facility',
         icon: <BadgeUnclaimed />,
         style: {
-            background: 'rgb(9, 18, 50)',
+            background: 'rgb(61, 50, 138)',
             color: 'rgb(255, 255, 255)',
         },
     };

--- a/src/app/src/components/FacilityDetailSidebarItem.jsx
+++ b/src/app/src/components/FacilityDetailSidebarItem.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
 
 import FacilityDetailSidebarDetail from './FacilityDetailSidebarDetail';
+import ShowOnly from './ShowOnly';
 
 const detailsSidebarStyles = () =>
     Object.freeze({
@@ -10,10 +12,28 @@ const detailsSidebarStyles = () =>
             paddingTop: '16px',
         },
         label: {
-            padding: '12px 24px 4px 24px',
             fontSize: '0.75rem',
             textTransform: 'uppercase',
             fontWeight: 'bold',
+        },
+        primaryText: {
+            wordWrap: 'break-word',
+        },
+        secondaryText: {
+            color: 'rgba(0, 0, 0, 0.54)',
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: '12px',
+            justify: 'flex-end',
+        },
+        divider: {
+            backgroundColor: 'rgba(0, 0, 0, 0.06)',
+        },
+        icon: {
+            color: 'rgb(106, 106, 106)',
+            fontSize: '24px',
+            fontWeight: 300,
+            textAlign: 'center',
         },
     });
 
@@ -24,23 +44,45 @@ const FacilityDetailSidebarItem = ({
     secondary,
     classes,
     embed,
-    href,
-    link,
+    verified,
 }) => {
-    const hasAdditionalContent = !!additionalContent?.length;
+    const [isOpen, setIsOpen] = useState(false);
+    const hasAdditionalContent = !embed && !!additionalContent?.length;
+    const additionalContentCount = additionalContent?.length;
 
     return (
         <div className={classes.item}>
-            <Typography className={classes.label}>{label}</Typography>
+            <ListItem
+                button={hasAdditionalContent}
+                onClick={() => {
+                    if (!hasAdditionalContent) return;
+                    setIsOpen(!isOpen);
+                }}
+            >
+                <ListItemText
+                    primary={label}
+                    classes={{ primary: classes.label }}
+                />
+                <ShowOnly when={hasAdditionalContent}>
+                    <div className={classes.secondaryText}>
+                        <ListItemText secondary={additionalContentCount + 1} />
+                        <i
+                            className={`${classes.icon} far fa-fw fa-${
+                                isOpen ? 'angle-up' : 'angle-down'
+                            }`}
+                        />
+                    </div>
+                </ShowOnly>
+            </ListItem>
             <FacilityDetailSidebarDetail
-                hasAdditionalContent={!embed && hasAdditionalContent}
-                additionalContentCount={additionalContent?.length}
                 primary={primary}
                 secondary={secondary}
-                onClick={() => {}}
-                link={link}
-                href={href}
+                verified={verified}
             />
+            {isOpen &&
+                additionalContent.map(item => (
+                    <FacilityDetailSidebarDetail {...item} />
+                ))}
         </div>
     );
 };

--- a/src/app/src/components/FacilityDetailSidebarLocation.jsx
+++ b/src/app/src/components/FacilityDetailSidebarLocation.jsx
@@ -33,7 +33,12 @@ const FacilityDetailSidebarLocation = ({ data, embed }) => {
                 label="GPS"
                 primary={`${facilityLng}, ${facilityLat}`}
                 secondary={attribution}
-                additionalContent={otherLocationsData}
+                embed={embed}
+                additionalContent={otherLocationsData.map((item, i) => ({
+                    primary: `${item.lng}, ${item.lat}`,
+                    secondary: item.contributor_name,
+                    key: `${item.lng}, ${item.lat} - ${i}`,
+                }))}
             />
         </>
     );

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -715,3 +715,37 @@ export const facilitySidebarActions = {
     CLAIM_FACILITY: 'Claim this facility',
     VIEW_ON_OAR: 'View on the Open Apparel Registry',
 };
+
+export const EXTENDED_FIELD_TYPES = [
+    {
+        label: 'Parent Company',
+        fieldName: 'parent_company',
+        formatValue: v => v,
+    },
+    {
+        label: 'Facility Type',
+        fieldName: 'facility_type',
+        formatValue: v => v,
+    },
+    {
+        label: 'Product Type',
+        fieldName: 'product_type',
+        formatValue: v => v,
+    },
+    {
+        label: 'Processing Type',
+        fieldName: 'processing_type',
+        formatValue: v => v,
+    },
+    {
+        label: 'Number of Workers',
+        fieldName: 'number_of_workers',
+        formatValue: ({ min, max }) =>
+            max === min ? `${max} workers` : `${min}-${max} workers`,
+    },
+    {
+        label: 'Native Language Name',
+        fieldName: 'native_language_name',
+        formatValue: v => v,
+    },
+];


### PR DESCRIPTION
## Overview

Makes the facility details subsections expandable to show additional
content (details from other matches, claims, etc.) when not in embed
mode.

Adds extended field subsections (number of workers, native language
name, and so on) when values are present and the map is not in embed
mode.

Adds nonstandard/contributor field subsections when values are present
in embed mode.

Connects #1540 

## Demo

Closed items
<img width="359" alt="Screen Shot 2022-01-18 at 2 02 03 PM" src="https://user-images.githubusercontent.com/21046714/150004909-0cc9e4ea-fb8a-4d6c-bcc6-7dde5a053916.png">

Opened items
<img width="357" alt="Screen Shot 2022-01-18 at 2 02 12 PM" src="https://user-images.githubusercontent.com/21046714/150005005-6efcc0ae-4b41-4510-a547-6c4a8ebfc42f.png">

Extended fields
<img width="360" alt="Screen Shot 2022-01-18 at 2 02 59 PM" src="https://user-images.githubusercontent.com/21046714/150005021-dd5e0ded-3248-405f-b62c-7eac7d9c49c4.png">

Nonstandard / contributor fields (in embed)
<img width="272" alt="Screen Shot 2022-01-18 at 2 21 50 PM" src="https://user-images.githubusercontent.com/21046714/150005078-c5a3e7c3-03ca-4e0f-af47-88a0f8019d56.png">

## Notes

Anticipated extended fields have been included in the list of fields to attempt to render if available, in addition to the existing extended fields. However, because these are not yet present in the API response, some tweaking might be necessary once they are being returned from the API to ensure all formatting / etc are working as expected. 

Some changes have been made to the styling of the items and header based on the updated wireframes. 

## Testing Instructions

* Run `./scripts/server`
* View a facility with multiple matches and confirm that other names, addresses, and GPS coordinates are available when expanding the subsections. 
* Submit and approve a claim for the facility, then submit a claim name, address, and number of workers. 
* The new claim details should be displayed in the expandable lists of facility details. 
* Submit and setup nonstandard fields for the facility. 
* Open the facility details in the embedded map preview. No items should be expandable, the contributors sections and expanded fields should be hidden, and the nonstandard fields should be shown. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
