### PR TITLE
Handle create=false when exact matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Split clean field migration in two and handle real world data [#1571](https://github.com/open-apparel-registry/open-apparel-registry/pull/1571)
 - Fix the Percent Data by Source Type report [#1575](https://github.com/open-apparel-registry/open-apparel-registry/pull/1575)
+- Handle create=false when exact matching [#1594](https://github.com/open-apparel-registry/open-apparel-registry/pull/1594)
 
 ### Security
 

--- a/src/django/api/matching.py
+++ b/src/django/api/matching.py
@@ -116,7 +116,8 @@ def exact_match_items(messy, contributor):
 
     matched_items = FacilityListItem.objects \
         .filter(status__in=[FacilityListItem.MATCHED,
-                            FacilityListItem.CONFIRMED_MATCH])
+                            FacilityListItem.CONFIRMED_MATCH]) \
+        .exclude(facility_id=None)
     active_item_ids = FacilityMatch.objects \
         .filter(status__in=[FacilityMatch.AUTOMATIC,
                             FacilityMatch.CONFIRMED,

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -6026,6 +6026,14 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
         self.assertEquals(1, len(fields))
         self.assertIn('extra_1', fields)
 
+    def test_exact_matches_with_create_false(self):
+        self.join_group_and_login()
+        url_with_query = '{}?create=false&public=true'.format(self.url)
+        response = self.client.post(url_with_query, self.valid_facility)
+        self.assertEqual(response.status_code, 200)
+        response_two = self.client.post(url_with_query, self.valid_facility)
+        self.assertEqual(response_two.status_code, 200)
+
 
 class FacilityCreateBodySerializerTest(TestCase):
     def test_valid_data(self):


### PR DESCRIPTION
## Overview

When a facility list item is submitted with `create=false` and there is
no match found, a `FacilityListItem` is created with `facility_id=None`.
When another facility list item is submitted which exact matches that
`FacilityListItem`, an error was being thrown. Instead, we now filter
out `FacilityListItems` where the `facility_id=None`, allowing us to match
to the next best option (if one exists) or pass the `FacilityListItem`
on to the dedupe process.

Connects #1580 

## Testing Instructions

* Not on this branch, browse /api/docs/#!/facilities/facilities_create authorize with an API token
* Submit a facility with `create=false` twice. The second submission should result in ERROR_MATCHING
```
{
    "country": "Turkey",
    "name": "BAŞARI TEKSTİL",
    "address": "Merkezefendi"
}
```
* Switch to this branch and resubmit the facility. The submission should not throw an error. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
