### PR TITLE
Fix ExtendedField admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Split clean field migration in two and handle real world data [#1571](https://github.com/open-apparel-registry/open-apparel-registry/pull/1571)
 - Fix the Percent Data by Source Type report [#1575](https://github.com/open-apparel-registry/open-apparel-registry/pull/1575)
 - Handle create=false when exact matching [#1594](https://github.com/open-apparel-registry/open-apparel-registry/pull/1594)
+- Fix ExtendedField admin [#1596](https://github.com/open-apparel-registry/open-apparel-registry/pull/1596)
 
 ### Security
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -146,11 +146,16 @@ class ApiLimitAdmin(admin.ModelAdmin):
             return []
 
 
+class ExtendedFieldAdmin(admin.ModelAdmin):
+    readonly_fields = ('contributor', 'facility', 'facility_list_item',
+                       'facility_claim')
+
+
 admin_site.register(models.Version)
 admin_site.register(models.User, OarUserAdmin)
 admin_site.register(models.Contributor, ContributorAdmin)
 admin_site.register(models.FacilityList)
-admin_site.register(models.ExtendedField)
+admin_site.register(models.ExtendedField, ExtendedFieldAdmin)
 admin_site.register(models.Source, SourceAdmin)
 admin_site.register(models.FacilityListItem, FacilityListItemAdmin)
 admin_site.register(models.Facility, FacilityHistoryAdmin)


### PR DESCRIPTION
## Overview

Loading an individual ExtendedField in the Django admin on staging
causes a server timeout. It seems likely that this is due to the
automatic setup of the admin, which creates dropdown lists for
contributor, facility, facility claim, and facility list item, some of
which include thousands of items. Because we are unlikely to want to
update these fields in the admin (rather, we would create a new
extended field), I have updated them to be readonly, which prevents the
fetching of so much data and should resolve the timeout errors.

## Demo

<img width="1139" alt="Screen Shot 2022-01-20 at 10 06 02 AM" src="https://user-images.githubusercontent.com/21046714/150365947-44e6822b-828b-477f-b446-06ed060edb2b.png">

## Notes

A second option, if we do think we will want to allow updating any of these fields in the admin, could be to use a raw id field as described [here](https://books.agiliq.com/projects/django-admin-cookbook/en/latest/many_fks.html).

## Testing Instructions

* Run `./scripts/server`
* Visit an ExtendedField in the Django admin and confirm that it loads quickly and without fetching large amounts of related data. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
