### PR TITLE
Prevent `clean_` field error when parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix the Percent Data by Source Type report [#1575](https://github.com/open-apparel-registry/open-apparel-registry/pull/1575)
 - Handle create=false when exact matching [#1594](https://github.com/open-apparel-registry/open-apparel-registry/pull/1594)
 - Fix ExtendedField admin [#1596](https://github.com/open-apparel-registry/open-apparel-registry/pull/1596)
+- Prevent 'clean' field error when parsing [#1600](https://github.com/open-apparel-registry/open-apparel-registry/pull/1600)
 
 ### Security
 

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -116,9 +116,13 @@ def parse_facility_list_item(item):
         if CsvHeaderField.NAME in fields:
             item.name = values[fields.index(CsvHeaderField.NAME)]
             item.clean_name = clean(item.name)
+            if item.clean_name is None:
+                item.clean_name = ''
         if CsvHeaderField.ADDRESS in fields:
             item.address = values[fields.index(CsvHeaderField.ADDRESS)]
             item.clean_address = clean(item.address)
+            if item.clean_address is None:
+                item.clean_address = ''
         if CsvHeaderField.LAT in fields and CsvHeaderField.LNG in fields:
             lat = float(values[fields.index(CsvHeaderField.LAT)])
             lng = float(values[fields.index(CsvHeaderField.LNG)])

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -6034,6 +6034,24 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
         response_two = self.client.post(url_with_query, self.valid_facility)
         self.assertEqual(response_two.status_code, 200)
 
+    def test_handles_exact_matches_with_empty_strings(self):
+        self.join_group_and_login()
+        url_with_query = '{}?public=true'.format(self.url)
+        response = self.client.post(url_with_query, {
+            'country': 'United States',
+            'name': ',',
+            'address': '123 Main St, Anywhereville, PA',
+            'extra_1': 'Extra data'
+        })
+        self.assertEqual(response.status_code, 400)
+        response_two = self.client.post(url_with_query, {
+            'country': 'United States',
+            'name': 'Pants Hut',
+            'address': ',,',
+            'extra_1': 'Extra data'
+        })
+        self.assertEqual(response_two.status_code, 400)
+
 
 class FacilityCreateBodySerializerTest(TestCase):
     def test_valid_data(self):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1165,6 +1165,23 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         body_serializer = FacilityCreateBodySerializer(data=request.data)
         body_serializer.is_valid(raise_exception=True)
 
+        clean_name = clean(body_serializer.validated_data.get('name'))
+        if clean_name is None:
+            clean_name = ''
+            raise ValidationError({
+              "clean_name": [
+                "This field may not be blank."
+              ]
+            })
+        clean_address = clean(body_serializer.validated_data.get('address'))
+        if clean_address is None:
+            clean_address = ''
+            raise ValidationError({
+              "clean_address": [
+                "This field may not be blank."
+              ]
+            })
+
         params_serializer = FacilityCreateQueryParamsSerializer(
             data=request.query_params)
         params_serializer.is_valid(raise_exception=True)
@@ -1209,9 +1226,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             raw_data=json.dumps(request.data),
             status=FacilityListItem.PARSED,
             name=name,
-            clean_name=clean(name),
+            clean_name=clean_name,
             address=address,
-            clean_address=clean(address),
+            clean_address=clean_address,
             country_code=country_code,
             ppe_product_types=ppe_product_types,
             ppe_contact_phone=ppe_contact_phone,


### PR DESCRIPTION
## Overview

When there is an error parsing a facility, we attempt to create a
list item with an 'ERROR PARSING' status. If this list item has an
empty address or name field, it threw an error due to the not-null
rule for clean_name and clean_address. If a `clean_` field would get
set to `None`, instead set them to an empty string.

Connects #1597 

## Demo

<img width="1321" alt="Screen Shot 2022-01-24 at 2 50 50 PM" src="https://user-images.githubusercontent.com/21046714/150865116-375b4cb4-9c9b-495c-a8ee-e1edbe5a0ec7.png">

## Testing Instructions

* Run `./scripts/server` and login as c2@example.com
* Contribute a list with empty fields and note the list id
[empty-fields.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7929020/empty-fields.csv)
* Process the list using the appropriate list-id
```
./scripts/manage batch_process --list-id 16 --action parse
./scripts/manage batch_process --list-id 16 --action geocode
./scripts/manage batch_process --list-id 16 --action match
```
* The list as a whole should not break, but there should be parse errors on fields with missing or invalid names or addresses
* Submit a facility via API with a missing name or address field and confirm that there is a validation error
* Submit a facility with a name or address that will `clean` to an empty string via API and confirm that there is a validation error
* Submit a valid facility via API and confirm that there is no error

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
