### PR TITLE
Create parent company extended fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add extended field handling to facility details [#1593](https://github.com/open-apparel-registry/open-apparel-registry/pull/1593)
 - Add searchability to embed config [#1598](https://github.com/open-apparel-registry/open-apparel-registry/pull/1598)
+- Create parent company extended fields [#1602](https://github.com/open-apparel-registry/open-apparel-registry/pull/1602)
 
 ### Changed
 

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -720,7 +720,7 @@ export const EXTENDED_FIELD_TYPES = [
     {
         label: 'Parent Company',
         fieldName: 'parent_company',
-        formatValue: v => v,
+        formatValue: v => v.contributor_name || v.name || v.raw_value,
     },
     {
         label: 'Facility Type',

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -1,5 +1,5 @@
 import re
-from api.models import ExtendedField
+from api.models import Contributor, ExtendedField
 
 
 def extract_range_value(value):
@@ -12,6 +12,19 @@ def create_extendedfield(field, field_value, item, contributor):
     if field_value is not None and field_value != "":
         if field == ExtendedField.NUMBER_OF_WORKERS:
             field_value = extract_range_value(field_value)
+        elif field == ExtendedField.PARENT_COMPANY:
+            matches = Contributor.objects.filter_by_name(field_value)
+            if matches.exists():
+                field_value = {
+                    'raw_value': field_value,
+                    'contributor_name': matches[0].name,
+                    'contributor_id': matches[0].id
+                }
+            else:
+                field_value = {
+                    'raw_value': field_value,
+                    'name': field_value
+                }
         ExtendedField.objects.create(
             contributor=contributor,
             facility_list_item=item,
@@ -21,7 +34,8 @@ def create_extendedfield(field, field_value, item, contributor):
 
 
 RAW_DATA_FIELDS = (ExtendedField.NUMBER_OF_WORKERS,
-                   ExtendedField.NATIVE_LANGUAGE_NAME)
+                   ExtendedField.NATIVE_LANGUAGE_NAME,
+                   ExtendedField.PARENT_COMPANY)
 
 
 def create_extendedfields_for_single_item(item, raw_data):

--- a/src/django/api/migrations/0076_fill_clean_name_and_address.py
+++ b/src/django/api/migrations/0076_fill_clean_name_and_address.py
@@ -3,8 +3,6 @@ from api.matching import clean
 
 
 def populate_cleaned_fields(apps, schema_editor):
-    print('')
-    print('Started filling clean name and address')
     count = 0
     FacilityListItem = apps.get_model('api', 'FacilityListItem')
     for list_item in FacilityListItem.objects.exclude(name='', address='').iterator():
@@ -14,7 +12,6 @@ def populate_cleaned_fields(apps, schema_editor):
         count += 1
         if count % 1000 == 0:
             print('Filled ' + str(count))
-    print('Finished filling clean name and address')
 
 
 def do_nothing_on_reverse(apps, schema_editor):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -33,7 +33,8 @@ from api.models import (Facility, FacilityList, FacilityListItem,
                         RequestLog, DownloadLog, FacilityLocation, Source,
                         ApiLimit, ApiBlock, ContributorNotifications,
                         EmbedConfig, EmbedField, NonstandardField,
-                        FacilityActivityReport, ExtendedField)
+                        FacilityActivityReport, ExtendedField,
+                        ContributorManager)
 from api.oar_id import make_oar_id, validate_oar_id
 from api.matching import match_facility_list_items, GazetteerCache
 from api.processing import (parse_facility_list_item,
@@ -7273,3 +7274,106 @@ class ContributorFieldsApiTest(APITestCase):
         self.assertEquals(None, field['value'])
         self.assertEquals('ExtraTwo', field_two['label'])
         self.assertEquals(None, field_two['value'])
+
+
+class ContributorManagerTest(TestCase):
+    fixtures = ['users', 'contributors']
+
+    def test_filter_by_name(self):
+        matches = Contributor.objects.filter_by_name('factory a')
+        self.assertGreater(matches.count(), 0)
+        self.assertEquals(1.0, matches[0].similarity)
+
+        matches = Contributor.objects.filter_by_name('factory')
+        self.assertGreater(matches.count(), 0)
+        self.assertLess(matches[0].similarity, 1.0)
+        self.assertGreater(matches[0].similarity,
+                           ContributorManager.TRIGRAM_SIMILARITY_THRESHOLD)
+
+    def test_filter_by_name_verified(self):
+        user1 = User.objects.create(email='test1@test.com')
+        user2 = User.objects.create(email='test2@test.com')
+        c1 = Contributor \
+            .objects \
+            .create(admin=user1,
+                    name='TESTING',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+        c2 = Contributor \
+            .objects \
+            .create(admin=user2,
+                    name='TESTING',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        matches = Contributor.objects.filter_by_name('TESTING')
+        self.assertEqual(2, matches.count())
+        # When the names are the same and neither is verified than the second
+        # contributor happens to sort first
+        self.assertEqual(c2, matches[0])
+
+        c1.is_verified = True
+        c1.save()
+        matches = Contributor.objects.filter_by_name('TESTING')
+        self.assertEqual(2, matches.count())
+        # Marking c1 as verified forces it to sort first
+        self.assertEqual(c1, matches[0])
+
+    def test_filter_by_name_source(self):
+        user1 = User.objects.create(email='test1@test.com')
+        user2 = User.objects.create(email='test2@test.com')
+        c1 = Contributor \
+            .objects \
+            .create(admin=user1,
+                    name='TESTING',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+        c2 = Contributor \
+            .objects \
+            .create(admin=user2,
+                    name='TESTING',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        matches = Contributor.objects.filter_by_name('TESTING')
+        self.assertEqual(2, matches.count())
+        # When the names are the same and neither is verified than the second
+        # contributor happens to sort first
+        self.assertEqual(c2, matches[0])
+
+        Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    is_active=True,
+                    is_public=True,
+                    contributor=c1)
+
+        matches = Contributor.objects.filter_by_name('TESTING')
+        self.assertEqual(2, matches.count())
+        # An active source forces it to sort first
+        self.assertEqual(c1, matches[0])
+
+    def test_filter_by_name_verified_and_source(self):
+        user1 = User.objects.create(email='test1@test.com')
+        user2 = User.objects.create(email='test2@test.com')
+        c1 = Contributor \
+            .objects \
+            .create(admin=user1,
+                    name='TESTING',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+        c2 = Contributor \
+            .objects \
+            .create(admin=user2,
+                    name='TESTING',
+                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+
+        Source \
+            .objects \
+            .create(source_type=Source.SINGLE,
+                    is_active=True,
+                    is_public=True,
+                    contributor=c1)
+
+        c2.is_verified = True
+        c2.save()
+
+        matches = Contributor.objects.filter_by_name('TESTING')
+        self.assertEqual(2, matches.count())
+        # A verified contributor sorts before one with a source
+        self.assertEqual(c2, matches[0])


### PR DESCRIPTION
## Overview

Create parent company extended fields when a contributor includes a `parent_company` in their CSV or API submission. Use a trigram search of existing contributor names to try an link the submitted value to a known contributor.

Connects #1584

## Demo

<img width="285" alt="Screen Shot 2022-01-26 at 4 12 21 PM" src="https://user-images.githubusercontent.com/17363/151263177-584314d5-8890-4a4e-af2a-be60b1647b17.png">


<img width="461" alt="Screen Shot 2022-01-26 at 4 13 27 PM" src="https://user-images.githubusercontent.com/17363/151263183-0bb2fc19-979b-47de-8626-34768520baab.png">


## Testing Instructions

These instruction assume `./scripts/resetdb` has been run.

* Browse http://localhost:8081/api/docs/#!/facilities/facilities_create and authenticate with `Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051`
* Submit this JSON
```
{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, 5th Floor Philadelphia, PA 19123",
  "parent_company": "A non matching value"
}
```
* Browse the facility and verify that the extended field value is displayed in the sidebar
* In a separate browser session browse http://localhost:8081/admin/api/extendedfield/1/change/ , log in as `c1@example.com` and verify that the extended field created includes but the raw value and a `name` key set to the same value.
* Log in as `c3@example.com` and contribute [parent-company.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7946025/parent-company.csv)
* Fully process the list
```
./scripts/manage batch_process --list-id 16 --action parse
./scripts/manage batch_process --list-id 16 --action geocode
./scripts/manage batch_process --list-id 16 --action match
```
* Browse the new facility and verify that the parent company was fuzzy matched to an existing contributor and that contributor is displayed in the sidebar. 
* In a the admin browser session browse http://localhost:8081/admin/api/extendedfield/2/ and verify that the extended field created includes the raw value and matched contributor details.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
