### PR TITLE
Edit search label in embed config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add extended field handling to facility details [#1593](https://github.com/open-apparel-registry/open-apparel-registry/pull/1593)
 - Add searchability to embed config [#1598](https://github.com/open-apparel-registry/open-apparel-registry/pull/1598)
 - Create parent company extended fields [#1602](https://github.com/open-apparel-registry/open-apparel-registry/pull/1602)
+- Edit search label in embed config [#1604](https://github.com/open-apparel-registry/open-apparel-registry/pull/1604)
 
 ### Changed
 

--- a/src/app/src/components/ControlledTextInput.jsx
+++ b/src/app/src/components/ControlledTextInput.jsx
@@ -14,6 +14,7 @@ export default function ControlledTextInput({
     disabled,
     submitFormOnEnterKeyPress,
     autoFocus,
+    onBlur,
 }) {
     return (
         <Fragment>
@@ -28,6 +29,7 @@ export default function ControlledTextInput({
                 placeholder={placeholder}
                 disabled={disabled}
                 onKeyPress={submitFormOnEnterKeyPress}
+                onBlur={onBlur}
             />
         </Fragment>
     );

--- a/src/app/src/components/EmbeddedMapConfig.jsx
+++ b/src/app/src/components/EmbeddedMapConfig.jsx
@@ -87,6 +87,7 @@ function EmbeddedMapConfig({
         font,
         width,
         fullWidth,
+        textSearchLabel,
         height,
         preferContributorName,
     },
@@ -173,9 +174,17 @@ function EmbeddedMapConfig({
                             setPreferContributorName={updateEmbedConfig(
                                 'preferContributorName',
                             )}
+                            textSearchLabel={textSearchLabel}
+                            setTextSearchLabel={updateEmbedConfig(
+                                'textSearchLabel',
+                            )}
+                            anyFieldSearchable={fields.some(
+                                field => field.searchable,
+                            )}
                             errors={errors}
                         />
                     ) : null}
+
                     <EmbeddedMapThemeConfig
                         color={color}
                         setColor={updateEmbedConfig('color')}
@@ -225,6 +234,7 @@ EmbeddedMapConfig.propTypes = {
         width: string.isRequired,
         height: string.isRequired,
         fullWidth: bool.isRequired,
+        textSearchLabel: string.isRequired,
     }).isRequired,
     setEmbedConfig: func.isRequired,
     setFields: func.isRequired,

--- a/src/app/src/components/EmbeddedMapConfigWrapper.jsx
+++ b/src/app/src/components/EmbeddedMapConfigWrapper.jsx
@@ -108,7 +108,7 @@ function EmbeddedMapConfigWrapper({ user }) {
             } else {
                 createConfig();
             }
-        }, 500);
+        }, 1000);
 
         return () => {
             clearTimeout(handler);

--- a/src/app/src/components/EmbeddedMapFieldsConfig.jsx
+++ b/src/app/src/components/EmbeddedMapFieldsConfig.jsx
@@ -15,10 +15,15 @@ import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import { withStyles } from '@material-ui/core/styles';
 
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import EmbeddedMapSearchLabelConfig from './EmbeddedMapTextSearchLabelConfig';
 
 const styles = {
     section: {
         marginTop: '20px',
+    },
+    sectionDisabled: {
+        marginTop: '20px',
+        opacity: '30%',
     },
     sectionHeader: {
         color: 'rgb(0, 0, 0)',
@@ -104,6 +109,9 @@ function EmbeddedMapFieldsConfig({
     setPreferContributorName,
     classes,
     errors,
+    textSearchLabel,
+    setTextSearchLabel,
+    anyFieldSearchable,
 }) {
     const updateItem = item => {
         const index = fields.findIndex(f => f.columnName === item.columnName);
@@ -380,6 +388,19 @@ function EmbeddedMapFieldsConfig({
                         }
                         label="Use my facility name"
                         classes={{ label: classes.listText }}
+                    />
+                </div>
+                <div
+                    style={
+                        anyFieldSearchable
+                            ? styles.section
+                            : styles.sectionDisabled
+                    }
+                >
+                    <EmbeddedMapSearchLabelConfig
+                        anyFieldSearchable={anyFieldSearchable}
+                        textSearchLabel={textSearchLabel}
+                        setTextSearchLabel={setTextSearchLabel}
                     />
                 </div>
             </div>

--- a/src/app/src/components/EmbeddedMapTextSearchLabelConfig.jsx
+++ b/src/app/src/components/EmbeddedMapTextSearchLabelConfig.jsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+import ControlledTextInput from './ControlledTextInput';
+import { DEFAULT_SEARCH_TEXT } from '../util/constants';
+
+const styles = {
+    subsectionHeader: {
+        color: 'rgb(0, 0, 0)',
+        fontSize: '15px',
+        fontWeight: 'bold',
+        margin: '10px 0',
+    },
+    reset: {
+        background: 'none',
+        border: 'none',
+        padding: '0',
+        cursor: 'pointer',
+        textDecoration: 'underline',
+    },
+};
+
+function EmbeddedMapTextSearchLabelConfig({
+    textSearchLabel,
+    setTextSearchLabel,
+    anyFieldSearchable,
+}) {
+    const [textInputValue, setTextInputValue] = useState(textSearchLabel);
+    const buttonRef = useRef(null);
+
+    const saveTextValue = value => {
+        setTextInputValue(value);
+        setTextSearchLabel(value);
+    };
+
+    const setTextOnBlur = () => {
+        if (textInputValue.trim()) {
+            saveTextValue(textInputValue);
+        } else {
+            saveTextValue(DEFAULT_SEARCH_TEXT);
+        }
+    };
+
+    const setTextOnChange = value => {
+        if (value.trim()) {
+            saveTextValue(value);
+        } else {
+            setTextInputValue(value);
+        }
+    };
+    const onReset = e => {
+        e.preventDefault();
+        saveTextValue(DEFAULT_SEARCH_TEXT);
+    };
+
+    useEffect(() => {
+        if (!anyFieldSearchable) {
+            saveTextValue(DEFAULT_SEARCH_TEXT);
+        }
+    }, [anyFieldSearchable]);
+
+    useEffect(() => {
+        if (textInputValue === DEFAULT_SEARCH_TEXT) {
+            buttonRef.current.style.display = 'none';
+        } else {
+            buttonRef.current.style.display = '';
+        }
+    }, [textInputValue]);
+
+    return (
+        <div>
+            <Typography style={styles.subsectionHeader}>
+                Search box label
+            </Typography>
+            <Typography>
+                If you&apos;ve made any of your custom fields searchable, you
+                can write your own custom label for the search box, so users
+                know what they can search for&nbsp;&nbsp;&nbsp;&nbsp;
+                <button
+                    ref={buttonRef}
+                    onClick={onReset}
+                    type="button"
+                    style={styles.reset}
+                    className="inline-link"
+                >
+                    Reset to default
+                </button>
+            </Typography>
+            <ControlledTextInput
+                id="text-search-label"
+                value={textInputValue}
+                onChange={e => {
+                    setTextOnChange(e.target.value);
+                }}
+                disabled={!anyFieldSearchable}
+                onBlur={setTextOnBlur}
+            />
+        </div>
+    );
+}
+
+export default withStyles(styles)(EmbeddedMapTextSearchLabelConfig);

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -47,7 +47,10 @@ import {
     makeSubmitFormOnEnterKeyPressFunction,
 } from '../util/util';
 
-import { FACILITIES_REQUEST_PAGE_SIZE } from '../util/constants';
+import {
+    FACILITIES_REQUEST_PAGE_SIZE,
+    DEFAULT_SEARCH_TEXT,
+} from '../util/constants';
 
 const filterSidebarSearchTabStyles = theme =>
     Object.freeze({
@@ -110,6 +113,7 @@ function FilterSidebarSearchTab({
     updateList,
     lists,
     classes,
+    textSearchLabel,
 }) {
     const [
         contributorPopoverAnchorEl,
@@ -235,14 +239,20 @@ function FilterSidebarSearchTab({
                     <InputLabel htmlFor={FACILITIES} className="form__label">
                         <FeatureFlag
                             flag="ppe"
-                            alternative="Search a Facility Name or OAR ID"
+                            alternative={
+                                embed ? textSearchLabel : DEFAULT_SEARCH_TEXT
+                            }
                         >
                             Search a Facility Name, OAR ID, or PPE Product Type
                         </FeatureFlag>
                     </InputLabel>
                     <TextField
                         id={FACILITIES}
-                        placeholder="Facility Name or OAR ID"
+                        placeholder={
+                            embed && textSearchLabel !== DEFAULT_SEARCH_TEXT
+                                ? textSearchLabel
+                                : 'Facility Name or OAR ID'
+                        }
                         className="full-width margin-bottom-16 form__text-input"
                         value={facilityFreeTextQuery}
                         onChange={updateFacilityFreeTextQuery}
@@ -558,7 +568,7 @@ function mapStateToProps({
         facilities: { data: facilities, fetching: fetchingFacilities },
     },
     featureFlags,
-    embeddedMap: { embed },
+    embeddedMap: { embed, config },
 }) {
     const vectorTileFlagIsActive = get(
         featureFlags,
@@ -588,6 +598,7 @@ function mapStateToProps({
             fetchingCountries,
         embed: !!embed,
         fetchingLists,
+        textSearchLabel: config.text_search_label,
     };
 }
 

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -466,6 +466,7 @@ export const PPE = 'ppe';
 export const REPORT_A_FACILITY = 'report_a_facility';
 export const EMBEDDED_MAP_FLAG = 'embedded_map';
 export const EXTENDED_PROFILE_FLAG = 'extended_profile';
+export const DEFAULT_SEARCH_TEXT = 'Search a Facility Name or OAR ID';
 
 export const COUNTRY_CODES = Object.freeze({
     default: 'IE',

--- a/src/app/src/util/embeddedMap.js
+++ b/src/app/src/util/embeddedMap.js
@@ -1,6 +1,6 @@
 import sortBy from 'lodash/sortBy';
 
-import { OARFont } from './constants';
+import { OARFont, DEFAULT_SEARCH_TEXT } from './constants';
 
 export const DEFAULT_WIDTH = '1000';
 export const DEFAULT_HEIGHT = '800';
@@ -31,7 +31,9 @@ export const formatExistingConfig = embedConfig => {
         font: embedConfig.font ? embedConfig.font : OARFont,
         height: getHeight(embedConfig),
         preferContributorName: embedConfig.prefer_contributor_name,
-        textSearchLabel: embedConfig.text_search_label,
+        textSearchLabel: embedConfig.text_search_label
+            ? embedConfig.text_search_label
+            : DEFAULT_SEARCH_TEXT,
     };
 };
 


### PR DESCRIPTION
## Overview

Update embedded map UI to add a "Text search label" and search sidebar UI to show custom label which is set on the `EmbedConfig`

Connects #1534

## Demo

### Embed Config page
![2022-01-27 16 47 41](https://user-images.githubusercontent.com/60887686/151449315-fa1aadd3-6824-40d7-b5d5-91f5bd448bd3.gif)

### Embedded Map
![image](https://user-images.githubusercontent.com/60887686/151449260-0fa92a74-768f-4535-a099-37da0b0d04f5.png)

## Testing Instructions

* Run `./scripts/server` and log in as any users with embed permissions (e.g. c2@example.com)
* Go to the Setting - Embed page to set the search label config
    - [x] The info text is descriptive enough for users
    - [x] When no fields are marked searchable, the custom search box is reset to the default text and disabled.
    - [x] No lag during typing
    - [x] If the text search label is blank, it is replaced with the default text
* Go to preview and embed mode map
    - [x] The search label changes accordingly

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
