### PR TITLE
Create product type extended field 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add facility/processing type taxonomy and look-up function [#1601](https://github.com/open-apparel-registry/open-apparel-registry/pull/1601)
+- Create product type extended field [#1605](https://github.com/open-apparel-registry/open-apparel-registry/pull/1605)
 
 ### Changed
 

--- a/src/app/src/components/FacilityDetailSidebarExtended.jsx
+++ b/src/app/src/components/FacilityDetailSidebarExtended.jsx
@@ -84,6 +84,9 @@ const detailsSidebarStyles = theme =>
 const formatAttribution = (createdAt, contributor) =>
     `${moment(createdAt).format('LL')} by ${contributor}`;
 
+const formatIfList = value =>
+    Array.isArray(value) ? value.map(v => <li>{v}</li>) : value;
+
 /* eslint-disable camelcase */
 const formatExtendedField = ({
     value,
@@ -93,7 +96,7 @@ const formatExtendedField = ({
     id,
     formatValue = v => v,
 }) => ({
-    primary: formatValue(value),
+    primary: formatIfList(formatValue(value)),
     secondary: formatAttribution(updated_at, contributor_name),
     verified,
     key: id,

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -730,7 +730,7 @@ export const EXTENDED_FIELD_TYPES = [
     {
         label: 'Product Type',
         fieldName: 'product_type',
-        formatValue: v => v,
+        formatValue: v => v.raw_values,
     },
     {
         label: 'Processing Type',

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -59,6 +59,7 @@ from api.facility_type_processing_type import (
     WET_ROLLER_PRINTING,
     get_facility_and_processing_type
 )
+from api.extended_fields import MAX_PRODUCT_TYPE_COUNT
 
 
 class FacilityListCreateTest(APITestCase):
@@ -4435,6 +4436,16 @@ class FacilityAPITestCaseBase(APITestCase):
         self.list_item.facility = self.facility
         self.list_item.save()
 
+    def join_group_and_login(self):
+        self.client.logout()
+        group = auth.models.Group.objects.get(
+            name=FeatureGroups.CAN_SUBMIT_FACILITY,
+        )
+        self.user.groups.set([group.id])
+        self.user.save()
+        self.client.login(email=self.user_email,
+                          password=self.user_password)
+
 
 class SearchByList(APITestCase):
     def setUp(self):
@@ -5972,16 +5983,6 @@ class FacilitySubmitTest(FacilityAPITestCaseBase):
             'extra_1': 'Extra data'
         }
 
-    def join_group_and_login(self):
-        self.client.logout()
-        group = auth.models.Group.objects.get(
-            name=FeatureGroups.CAN_SUBMIT_FACILITY,
-        )
-        self.user.groups.set([group.id])
-        self.user.save()
-        self.client.login(email=self.user_email,
-                          password=self.user_password)
-
     def test_unauthenticated_receives_401(self):
         self.client.logout()
         response = self.client.post(self.url)
@@ -7454,16 +7455,6 @@ class ParentCompanyTestCase(FacilityAPITestCaseBase):
         super(ParentCompanyTestCase, self).setUp()
         self.url = reverse('facility-list')
 
-    def join_group_and_login(self):
-        self.client.logout()
-        group = auth.models.Group.objects.get(
-            name=FeatureGroups.CAN_SUBMIT_FACILITY,
-        )
-        self.user.groups.set([group.id])
-        self.user.save()
-        self.client.login(email=self.user_email,
-                          password=self.user_password)
-
     def test_submit_parent_company_no_match(self):
         self.join_group_and_login()
         self.client.post(self.url, {
@@ -7496,3 +7487,69 @@ class ParentCompanyTestCase(FacilityAPITestCaseBase):
             'contributor_name': self.contributor.name,
             'contributor_id': self.contributor.id
         }, ef.value)
+
+
+class ProductTypeTestCase(FacilityAPITestCaseBase):
+    def setUp(self):
+        super(ProductTypeTestCase, self).setUp()
+        self.url = reverse('facility-list')
+
+    def test_array(self):
+        self.join_group_and_login()
+        self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'product_type': ['a', 'b']
+        }), content_type='application/json')
+        self.assertEqual(1, ExtendedField.objects.all().count())
+        ef = ExtendedField.objects.first()
+        self.assertEqual(ExtendedField.PRODUCT_TYPE, ef.field_name)
+        self.assertEqual({
+            'raw_values': ['a', 'b']
+        }, ef.value)
+
+    def test_string(self):
+        self.join_group_and_login()
+        self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'product_type': 'a|b'
+        }), content_type='application/json')
+        self.assertEqual(1, ExtendedField.objects.all().count())
+        ef = ExtendedField.objects.first()
+        self.assertEqual(ExtendedField.PRODUCT_TYPE, ef.field_name)
+        self.assertEqual({
+            'raw_values': ['a', 'b']
+        }, ef.value)
+
+    def test_list_validation(self):
+        self.join_group_and_login()
+        response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'product_type': {}
+        }), content_type='application/json')
+        self.assertEqual(0, ExtendedField.objects.all().count())
+        self.assertEqual(response.status_code, 400)
+
+    def test_max_count(self):
+        self.join_group_and_login()
+        response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'product_type': [str(a) for a in range(MAX_PRODUCT_TYPE_COUNT)]
+        }), content_type='application/json')
+        self.assertEqual(1, ExtendedField.objects.all().count())
+
+        response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'product_type': [str(a) for a in range(MAX_PRODUCT_TYPE_COUNT + 1)]
+        }), content_type='application/json')
+        self.assertEqual(1, ExtendedField.objects.all().count())
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Overview

Create product type extended fields when product type is submitted via CSV or API

Connects #1586

## Demo

<img width="365" alt="Screen Shot 2022-01-28 at 11 08 18 AM" src="https://user-images.githubusercontent.com/17363/151599270-adabcd76-54c9-4865-9e15-057cb5d172ff.png">

<img width="543" alt="Screen Shot 2022-01-28 at 11 15 17 AM" src="https://user-images.githubusercontent.com/17363/151600070-bdf2797f-84ab-458e-9ade-535acbdf4848.png">

## Testing Instructions

These instruction assume `./scripts/resetdb` has been run.

* Browse http://localhost:8081/api/docs/#!/facilities/facilities_create and authenticate with `Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051`
* Submit this JSON
```
{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, 5th Floor Philadelphia, PA 19123",
  "product_type": ["Hats", "Shoes", "Gloves"]
}
```
* Copy the OAER ID of the created facility from the API response and, In another tab, browse the facility and verify that the extended field value is displayed in the sidebar
* Back on the API page submit this JSON
```
{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, 5th Floor Philadelphia, PA 19123",
  "product_type": {}
}
```
* Verify that a 400 is returned with an error message
* Submit this JSON
```
[{
  "country": "US",
  "name": "Azavea",
  "address": "990 Spring Garden Street, 5th Floor Philadelphia, PA 19123",
  "product_type": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50"]
}]
```
* Verify that a 400 is returned with an error message
* In a separate browser session browse http://localhost:8081/admin/api/extendedfield/1/change/ , log in as `c1@example.com` and verify that the extended field created includes a `raw_values` key set to an array of values.
* Back in the original browser, log in as `c3@example.com`, browse http://localhost:6543/contribute and and submit [product-type.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7960914/product-type.csv)
* Use the terminal to full process the list
```
./scripts/manage batch_process --list-id 16 --action parse
./scripts/manage batch_process --list-id 16 --action geocode
./scripts/manage batch_process --list-id 16 --action match
```
* Refresh the browser and click the lock to navigate to the facility and verify that the the product types are displayed
* In a the admin browser session browse http://localhost:8081/admin/api/extendedfield/2/ and verify that the extended field created includes a `raw_values` key set to an array of values.

# Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
