### PR TITLE
Index custom text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add facility/processing type taxonomy and look-up function [#1601](https://github.com/open-apparel-registry/open-apparel-registry/pull/1601)
+- Index custom text [#1607](https://github.com/open-apparel-registry/open-apparel-registry/pull/1607)
 
 ### Changed
 

--- a/src/django/api/helpers.py
+++ b/src/django/api/helpers.py
@@ -1,4 +1,6 @@
 import re
+import csv
+import json
 
 CONSONANT_SOUND = re.compile(r'''
 one(![ir])
@@ -20,3 +22,42 @@ def prefix_a_an(value):
     if not CONSONANT_SOUND.match(value) and VOWEL_SOUND.match(value):
         return 'An {}'.format(value)
     return 'A {}'.format(value)
+
+
+def parse_raw_data(data):
+    try:
+        # try to parse as json
+        return json.loads(data)
+    except json.decoder.JSONDecodeError:
+        try:
+            # try to parse as stringified object
+            return json.loads(data.replace("'", '"'))
+        except json.decoder.JSONDecodeError:
+            return {}
+
+
+def get_csv_values(csv_data):
+    values = []
+    csvreader = csv.reader(csv_data.split('\n'), delimiter=',')
+    for row in csvreader:
+        values = values + row
+    return values
+
+
+def get_single_contributor_field_values(item, fields):
+    data = parse_raw_data(item.raw_data)
+    for f in fields:
+        value = data.get(f['column_name'], None)
+        if value is not None:
+            f['value'] = value
+    return fields
+
+
+def get_list_contributor_field_values(item, fields):
+    data_values = get_csv_values(item.raw_data)
+    list_fields = get_csv_values(item.source.facility_list.header)
+    for f in fields:
+        if f['column_name'] in list_fields:
+            index = list_fields.index(f['column_name'])
+            f['value'] = data_values[index]
+    return fields

--- a/src/django/api/management/commands/index_custom_text.py
+++ b/src/django/api/management/commands/index_custom_text.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+
+from api.models import index_custom_text
+
+
+class Command(BaseCommand):
+    help = 'Adds custom text to the index table based on the provided id(s).'
+
+    def add_arguments(self, parser):
+        parser.add_argument('facility_ids', type=str, nargs='*')
+
+    def handle(self, *args, **options):
+        facility_ids = options.get('facility_ids', [])
+        index_custom_text(facility_ids)

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1,6 +1,4 @@
 from itertools import chain
-import csv
-import json
 from collections import defaultdict
 
 from django.conf import settings
@@ -46,7 +44,9 @@ from api.models import (FacilityList,
                         ExtendedField)
 from api.countries import COUNTRY_NAMES, COUNTRY_CHOICES
 from api.processing import get_country_code
-from api.helpers import prefix_a_an
+from api.helpers import (prefix_a_an,
+                         get_single_contributor_field_values,
+                         get_list_contributor_field_values)
 from waffle import switch_is_active
 
 
@@ -629,45 +629,6 @@ class FacilitySerializer(GeoFeatureModelSerializer):
                 facilitymatch__is_active=True).order_by('-created_at').first()
 
         return assign_contributor_field_values(list_item, fields)
-
-
-def parse_raw_data(data):
-    try:
-        # try to parse as json
-        return json.loads(data)
-    except json.decoder.JSONDecodeError:
-        try:
-            # try to parse as stringified object
-            return json.loads(data.replace("'", '"'))
-        except json.decoder.JSONDecodeError:
-            return {}
-
-
-def get_csv_values(csv_data):
-    values = []
-    csvreader = csv.reader(csv_data.split('\n'), delimiter=',')
-    for row in csvreader:
-        values = values + row
-    return values
-
-
-def get_single_contributor_field_values(item, fields):
-    data = parse_raw_data(item.raw_data)
-    for f in fields:
-        value = data.get(f['column_name'], None)
-        if value is not None:
-            f['value'] = value
-    return fields
-
-
-def get_list_contributor_field_values(item, fields):
-    data_values = get_csv_values(item.raw_data)
-    list_fields = get_csv_values(item.source.facility_list.header)
-    for f in fields:
-        if f['column_name'] in list_fields:
-            index = list_fields.index(f['column_name'])
-            f['value'] = data_values[index]
-    return fields
 
 
 def assign_contributor_field_values(list_item, fields):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -92,7 +92,8 @@ from api.models import (FacilityList,
                         EmbedField,
                         NonstandardField,
                         FacilityIndex,
-                        ExtendedField)
+                        ExtendedField,
+                        index_custom_text)
 from api.processing import (parse_csv_line,
                             parse_csv,
                             parse_excel,
@@ -3825,6 +3826,14 @@ def create_embed_fields(fields_data, embed_config):
 
     for field_data in fields_data:
         EmbedField.objects.create(embed_config=embed_config, **field_data)
+
+    contributor = embed_config.contributor
+    f_ids = FacilityListItem.objects \
+        .filter(source__contributor=contributor, facility__isnull=False) \
+        .values_list('facility__id', flat=True)
+
+    if len(f_ids) > 0:
+        index_custom_text(f_ids)
 
 
 def get_contributor(request):


### PR DESCRIPTION
## Overview

Contributors want to mark specific contributor fields / embed fields to
be included in the text which is searched by the facilities query.
This adds the function to update the `custom_text` field in the
FacilityIndex, which will allow those custom fields to be included in
the facilities search.

Whenever the FacilityIndex is updated, and in post_save for
FacilityListItems, and when updating a user's embed config, the
index_custom_text function is passed an array of facility ids to
update.

We get a list of contributors who have searchable embed configs,
and for each of the facilities in the facility_ids list, find the most
recent FacilityListItem submitted for that facility by each contributor,
if one exists. Then we grab any fields from the `raw_data` of that
facility which are included in the submitting contributor's searchable
fields, and concatenate them into a single text value. Finally, we
update each facility's `custom_text` to the calculated combined text
value.

Connects #1535 

## Notes

The `custom_text_field` is reevaluated for effected facilities whenever the FacilityIndex is updated, but also in two other cases: 
- When a FacilityListItem is updated (because the facility's core data might not change and so not trigger the FacilityIndex, but we want to look at each contributor's most recent active data)
- When an EmbedField is updated. I initially tried putting a `post_save` trigger on the EmbedField model; however, we delete and recreate ALL of the embed fields for a contributor each time the config is updated, caused half a dozen instances of the index_custom_text method to run when it really should only run once. I also tried adding a `post_save` trigger to the EmbedConfig model, but because we first update the EmbedConfig and THEN update the EmbedFields, this caused the indexing to occur before the updates to the fields occurred. I ended up adding the reindexing as the final step in the `create_embed_fields` function, which we use both when creating and when updating (ie deleting and recreating) the EmbedFields, which causes the reindexing to occur once on each config update after the fields have updated. 

I applied several methods to attempt to keep time / overhead of the method lower, due to the relatively large amount of data processing required. 
- Using a dictionary to track contributor fields (allowing us to query for searchable contributor fields just once each time the index is run). 
- Using an `iterator` for the potentially larger queries which are used for loops
- Django's querying superpowers to cut number of FacilityListItems to loop through to a minimum (see code comments)

## Testing Instructions

* These directions assume you have run `./scripts/resetdb`
* In an incognito browser, navigate to [http://localhost:8081/admin/api/contributor/2/change/](the admin) log in as `c1@example.com` 
* Update Service Provider A to have deluxe embed permissions
* In another window, login as c2@example.com
* Contribute [oar-extra-fields.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7961425/oar-extra-fields.csv)
* Fully process the list
```
./scripts/manage batch_process --list-id 16 --action parse
./scripts/manage batch_process --list-id 16 --action geocode
./scripts/manage batch_process --list-id 16 --action match
```
* Make ‘custom_field_2’ visible and searchable in the embed config settings
* In a new terminal tab (keep the server running), run `./scripts/manage shell_plus` then run the following. You should receive 905 for the total FacilityIndex count and 0 for the filled `custom_text` count.
```
FacilityIndex.objects.count()
FacilityIndex.objects.filter(custom_text__isnull=False).exclude(custom_text=‘’).count()
```
* Setup the Embed Config (including height and width) and mark `custom_field` and `custom_field_2` visible (but NOT searchable) for c2@example.com in the embed config.
* The field values should appear in the Extra Fields List facilities in their details in the embed preview.
* Run the following in the shell. You should still see 0 filled `custom_text` values.
```
FacilityIndex.objects.filter(custom_text__isnull=False).exclude(custom_text=‘’).count()
```
* Mark `custom_field` searchable in the embed config.
* Run the following in the shell. 
```
FacilityIndex.objects.filter(custom_text__isnull=False).exclude(custom_text='').values('custom_text', 'name')
```
* This should return the following. Note that the custom text for the selected field is listed for each facility.
`<QuerySet [{'custom_text': 'Test Value!', 'name': 'Harts Are You'}, {'custom_text': 'Test Field Value', 'name': 'Hats Are Us'}]>`
* Mark `custom_field_2` searchable in the config settings. 
* Run the same command in the shell. 
```
FacilityIndex.objects.filter(custom_text__isnull=False).exclude(custom_text='').values('custom_text', 'name')
```
* This should return the following. Note the combined text value of the two searchable fields.
`<QuerySet [{'custom_text': 'Test Value!', 'name': 'Harts Are You'}, {'custom_text': 'Test Value 2Test Field Value', 'name': 'Hats Are Us'}]>`
* Mark `custom_field` NOT searchable and confirm it was successfully removed from the index using the same shell command.
* Navigate to http://localhost:8081/api/docs/#!/facilities/facilities_create and authenticate as c2@example.com
* Submit:
```
{
"country": "US",
"name": "Hats Are Us",
"address": "140 Simpson Ave Ardmore PA 19003",
"custom_field": "New API value"
}
```
* Run the same shell command again. The custom text should for Hats Are Us should be updated to 'Hats Are Us' (using the newest facility list item for the values). 
* Login as c3@example.com and submit [oar-extra-fields-2.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7961489/oar-extra-fields-2.csv)
* Fully process the list:
```
./scripts/manage batch_process --list-id 17 --action parse
./scripts/manage batch_process --list-id 17 --action geocode
./scripts/manage batch_process --list-id 17 --action match
```
* Create an embed config for c3@example.com but leave the fields NOT searchable
* Confirm that the custom text values for the facilities have not changed.
* Make the fields searchable for c3@example.com, then view the indexes again.
`<QuerySet [{'custom_text': 'Test Value!C3 Custom 2', 'name': 'Harts Are You'}, {'custom_text': 'New API valueC3 CustomC3 Other', 'name': 'Hats Are Us'}]>`
* Confirm that the custom text now includes the other contributor’s text. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
