### PR TITLE
Handle country code geocoding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Handle country code geocoding errors [#1619](https://github.com/open-apparel-registry/open-apparel-registry/pull/1619)
+
 ### Security
 
 ## [55] 2022-01-27

--- a/src/django/api/geocoding.py
+++ b/src/django/api/geocoding.py
@@ -15,11 +15,11 @@ def create_geocoding_params(address, country_code):
     }
 
 
-def format_geocoded_address_data(data):
-    first_result, *_ = data["results"]
-
-    geocoded_point = first_result["geometry"]["location"]
-    geocoded_address = first_result["formatted_address"]
+def format_geocoded_address_data(data, result=None):
+    if result is None:
+        result = data['results'][0]
+    geocoded_point = result["geometry"]["location"]
+    geocoded_address = result["formatted_address"]
 
     return {
         "result_count": len(data["results"]),
@@ -38,12 +38,41 @@ def format_no_geocode_results(data):
     }
 
 
-def validate_country_code(data, country_code):
-    address_components = data["results"][0]['address_components']
-    for component in address_components:
-        if component['short_name'] == country_code:
-            return True
-    raise ValueError("Geocoding results did not match provided country code.")
+# Results are valid if they contain a matching country-code.
+# If no results with matching country codes are found,
+# a result with no country-code will be accepted.
+# If all results contain non-matching country codes, throw an error.
+def find_valid_country_code(data, country_code):
+    first_inexact_result = None
+    country_codes = list()
+
+    for result in data["results"]:
+        address_components = result['address_components']
+        is_inexact = True
+        for component in address_components:
+            short_name = component.get('short_name', '')
+            # If a result with a matching country code is found
+            if short_name == country_code:
+                return result
+            # If the component is a non-matching country code
+            if 'country' in component.get('types', []):
+                country_codes.append(short_name)
+                is_inexact = False
+        # Save the first result with no country code
+        if first_inexact_result is None and is_inexact:
+            first_inexact_result = result
+
+    # If there were no results with matching country codes
+    # but there is a result with no country code, return it
+    if first_inexact_result is not None:
+        return first_inexact_result
+
+    # There were no results matching country codes
+    # and no results with no country code; throw an error
+    error = "Geocoding results of " + \
+            "{} did not match provided country code of {}.".format(
+                ', '.join(country_codes), country_code)
+    raise ValueError(error)
 
 
 def geocode_address(address, country_code):
@@ -59,6 +88,6 @@ def geocode_address(address, country_code):
     if data["status"] == ZERO_RESULTS or len(data["results"]) == 0:
         return format_no_geocode_results(data)
 
-    validate_country_code(data, country_code)
+    valid_result = find_valid_country_code(data, country_code)
 
-    return format_geocoded_address_data(data)
+    return format_geocoded_address_data(data, valid_result)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -540,8 +540,9 @@ class GeocodingUtilsTest(TestCase):
         )
 
     def test_geocoded_address_data_is_formatted_correctly(self):
+        data = parsed_city_hall_data['full_response']
         formatted_data = format_geocoded_address_data(
-            parsed_city_hall_data['full_response'])
+            data, data['results'][0])
         self.assertEqual(formatted_data, parsed_city_hall_data)
 
 
@@ -573,6 +574,142 @@ geocoding_data = {'results': [{'address_components': [
     'place_id': 'ChIJ8cV_ZH_IxokRA_ETpdB5R3Y',
     'types': ['premise']}],
     'status': 'OK'}
+
+geocoding_data_no_country = {
+   "results": [
+      {
+         "address_components": [
+            {
+               "long_name": "4WHM+QCX",
+               "short_name": "4WHM+QCX",
+               "types": ["plus_code"]
+            },
+            {
+               "long_name": "Famagusta",
+               "short_name": "Famagusta",
+               "types": ["locality", "political"]
+            },
+            {
+               "long_name": "99450",
+               "short_name": "99450",
+               "types": ["postal_code"]
+            }
+         ],
+         "formatted_address": "4WHM+QCX, Famagusta 99450",
+         "geometry": {
+            "location": {"lat": 35.1294866, "lng": 33.9336133},
+            "location_type": "GEOMETRIC_CENTER",
+            "viewport": {
+               "northeast": {
+                  "lat": 35.1308355802915,
+                  "lng": 33.9349622802915
+               },
+               "southwest": {
+                  "lat": 35.1281376197085,
+                  "lng": 33.9322643197085
+               }
+            }
+         },
+         "partial_match": True,
+         "place_id": "ChIJDzTqezLI3xQRW5kjGEGLRzA",
+         "types": ["establishment", "point_of_interest"]
+      }
+   ],
+   "status": "OK"
+}
+
+geocoding_data_second_country = {
+   "results": [
+      {
+         "address_components": [
+            {
+               "long_name": "Noor Bagh",
+               "short_name": "Noor Bagh",
+               "types": ["political", "sublocality", "sublocality_level_1"]
+            },
+            {
+               "long_name": "Srinagar",
+               "short_name": "Srinagar",
+               "types": ["locality", "political"]
+            },
+            {
+               "long_name": "190009",
+               "short_name": "190009",
+               "types": ["postal_code"]
+            }
+         ],
+         "formatted_address": "Noor Bagh, Srinagar 190009",
+         "geometry": {
+            "bounds": {
+               "northeast": {"lat": 34.07490560000001, "lng": 74.8043599},
+               "southwest": {"lat": 34.0734423, "lng": 74.8023449}
+            },
+            "location": {"lat": 34.0742387, "lng": 74.8035549},
+            "location_type": "APPROXIMATE",
+            "viewport": {
+               "northeast": {
+                  "lat": 34.07552293029151,
+                  "lng": 74.8047013802915
+               },
+               "southwest": {
+                  "lat": 34.07282496970851,
+                  "lng": 74.80200341970848
+               }
+            }
+         },
+         "partial_match": True,
+         "place_id": "ChIJmQlkN-2P4TgR6u3glWeOMTE",
+         "types": ["political", "sublocality", "sublocality_level_1"]
+      },
+      {
+         "address_components": [
+            {
+               "long_name": "Kaliakair",
+               "short_name": "Kaliakair",
+               "types": ["locality", "political"]
+            },
+            {
+               "long_name": "Gazipur District",
+               "short_name": "Gazipur District",
+               "types": ["administrative_area_level_2", "political"]
+            },
+            {
+               "long_name": "Dhaka Division",
+               "short_name": "Dhaka Division",
+               "types": ["administrative_area_level_1", "political"]
+            },
+            {
+               "long_name": "Bangladesh",
+               "short_name": "BD",
+               "types": ["country", "political"]
+            }
+         ],
+         "formatted_address": "Kaliakair, Bangladesh",
+         "geometry": {
+            "bounds": {
+               "northeast": {"lat": 24.0840819, "lng": 90.2365494},
+               "southwest": {"lat": 24.0535966, "lng": 90.2030754}
+            },
+            "location": {"lat": 24.0694528, "lng": 90.2221213},
+            "location_type": "APPROXIMATE",
+            "viewport": {
+               "northeast": {
+                  "lat": 24.0840819,
+                  "lng": 90.2365494
+               },
+               "southwest": {
+                  "lat": 24.0535966,
+                  "lng": 90.2030754
+               }
+            }
+         },
+         "partial_match":  True,
+         "place_id": "ChIJTfs3ierjVTcRysKYnbOKmZM",
+         "types": ["locality", "political"]
+      }
+   ],
+   "status": "OK"
+}
 
 
 class GeocodingTest(TestCase):
@@ -606,8 +743,38 @@ class GeocodingTest(TestCase):
 
         self.assertEqual(
             cm.exception.args,
-            ("Geocoding results did not match provided country code.",)
+            ("Geocoding results of US did not match " +
+             "provided country code of IN.",)
         )
+
+    @patch('api.geocoding.requests.get')
+    def test_accepts_inexact_address(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data_no_country
+
+        expected_result = geocoding_data_no_country['results'][0]
+        expected_point = expected_result["geometry"]["location"]
+        expected_address = expected_result["formatted_address"]
+
+        results = geocode_address('PortİSBİ Serbest Bölge Office:4, ' +
+                                  'Gazimağusa, North Cyprus, 99450',
+                                  'TR')
+        self.assertEqual(expected_point, results["geocoded_point"])
+        self.assertEqual(expected_address, results['geocoded_address'])
+
+    @patch('api.geocoding.requests.get')
+    def test_accepts_alternate_address(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data_second_country
+
+        expected_result = geocoding_data_second_country['results'][1]
+        expected_point = expected_result["geometry"]["location"]
+        expected_address = expected_result["formatted_address"]
+
+        results = geocode_address('Noorbagh, Kaliakoir Gazipur Dhaka 1704',
+                                  'BD')
+        self.assertEqual(expected_point, results["geocoded_point"])
+        self.assertEqual(expected_address, results['geocoded_address'])
 
 
 class FacilityAndProcessingTypeTest(TestCase):
@@ -672,6 +839,101 @@ class FacilityAndProcessingTypeTest(TestCase):
         self.assertEqual(output, expected_output)
 
 
+listitem_geocode_data = {
+   "results": [
+      {
+         "address_components": [
+            {
+               "long_name": "Linjiacunzhen",
+               "short_name": "Linjiacunzhen",
+               "types": ["political", "sublocality", "sublocality_level_2"]
+            },
+            {
+               "long_name": "Zhucheng",
+               "short_name": "Zhucheng",
+               "types": ["political", "sublocality", "sublocality_level_1"]
+            },
+            {
+               "long_name": "Weifang",
+               "short_name": "Weifang",
+               "types": ["locality", "political"]
+            },
+            {
+               "long_name": "Shandong",
+               "short_name": "Shandong",
+               "types": ["administrative_area_level_1", "political"]
+            },
+            {
+               "long_name": "China",
+               "short_name": "CN",
+               "types": ["country", "political"]
+            },
+            {
+               "long_name": "262232",
+               "short_name": "262232",
+               "types": ["postal_code"]
+            }
+         ],
+         "formatted_address": "Linjiacunzhen, Zhucheng, " +
+                              "Weifang, Shandong, China, 262232",
+         "geometry": {
+            "location": {"lat": 35.994813, "lng": 119.65418},
+            "location_type": "APPROXIMATE",
+            "viewport": {
+               "northeast": {"lat": 36.0038401, "lng": 119.6701874},
+               "southwest": {"lat": 35.9857849, "lng": 119.6381726}
+            }
+         },
+         "partial_match": True,
+         "place_id": "ChIJV5SPiTEkvjUR7ErhmnSRTR8",
+         "types": ["political", "sublocality", "sublocality_level_2"]
+      },
+      {
+         "address_components": [
+            {
+               "long_name": "396210",
+               "short_name": "396210",
+               "types": ["postal_code"]
+            },
+            {
+               "long_name": "Daman",
+               "short_name": "Daman",
+               "types": ["administrative_area_level_2", "political"]
+            },
+            {
+               "long_name": "Dadra and Nagar Haveli and Daman and Diu",
+               "short_name": "DH",
+               "types": ["administrative_area_level_1", "political"]
+            },
+            {
+               "long_name": "India",
+               "short_name": "IN",
+               "types": ["country", "political"]
+            }
+         ],
+         "formatted_address":  "Dadra and Nagar Haveli and Daman and " +
+                               "Diu 396210, India",
+         "geometry": {
+            "bounds": {
+               "northeast": {"lat": 20.4696847, "lng": 72.8751228},
+               "southwest": {"lat": 20.4051972, "lng": 72.82805549999999}
+            },
+            "location": {"lat": 20.4346424, "lng": 72.8456399},
+            "location_type": "APPROXIMATE",
+            "viewport": {
+               "northeast": {"lat": 20.4696847, "lng": 72.8751228},
+               "southwest": {"lat": 20.4051972, "lng": 72.82805549999999}
+            }
+         },
+         "partial_match": True,
+         "place_id": "ChIJ8d4EeIra4DsR3xkUSZh_-ng",
+         "types": ["postal_code"]
+      }
+   ],
+   "status": "OK"
+}
+
+
 class FacilityListItemGeocodingTest(ProcessingTestCase):
     def test_invalid_argument_raises_error(self):
         with self.assertRaises(ValueError) as cm:
@@ -699,7 +961,10 @@ class FacilityListItemGeocodingTest(ProcessingTestCase):
             ('Items to be geocoded must be in the PARSED status',),
         )
 
-    def test_incorrect_country_code_has_error_status(self):
+    @patch('api.geocoding.requests.get')
+    def test_nested_correct_country_code_succeeds(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = listitem_geocode_data
         facility_list = FacilityList.objects.create(
             header='address,country,name')
         source = Source.objects.create(
@@ -708,6 +973,30 @@ class FacilityListItemGeocodingTest(ProcessingTestCase):
         item = FacilityListItem(
             raw_data='"Linjiacun Town, Zhucheng City Weifang, Daman, ' +
                      'Daman, 396210",IN,Shirts!',
+            source=source
+        )
+        parse_facility_list_item(item)
+        geocode_facility_list_item(item)
+
+        expected_result = listitem_geocode_data['results'][1]
+        expected_address = expected_result['formatted_address']
+
+        self.assertEqual(item.status, FacilityListItem.GEOCODED)
+        self.assertEqual(item.geocoded_address, expected_address)
+        self.assertIsInstance(item.geocoded_point, Point)
+
+    @patch('api.geocoding.requests.get')
+    def test_incorrect_country_code_has_error_status(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = listitem_geocode_data
+        facility_list = FacilityList.objects.create(
+            header='address,country,name')
+        source = Source.objects.create(
+            source_type=Source.LIST,
+            facility_list=facility_list)
+        item = FacilityListItem(
+            raw_data='"Linjiacun Town, Zhucheng City Weifang, Daman, ' +
+                     'Daman, 396210",BD,Shirts!',
             source=source
         )
         parse_facility_list_item(item)


### PR DESCRIPTION
## Overview

Submitted facilities are frequently throwing the country code error,
which indicates that the geocoding process has returned a result that
doesn't contain the country which the contributor has submitted for the
facility.

There are two primary instances where this is occurring:

1) The returned geocoding result is imprecise and contains no country
code at all. In this case, we will now accept this as a valid result.

2) There are multiple results returned, and although the top result
has an invalid code, another result contains the correct country code.
In this case, we will now select the result with the correct country
code. (If there are both a result with a correct country code and an
inexact result, we prefer the correct country code.)

We will still return a geocoding error if all results include
non-matching country codes.

Connects [Client #62](https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/62)

## Notes

I added additional mock data for geocoding responses in the test suite. 

## Testing Instructions

* These directions assume that `./scripts/resetdb` has been run. 
* Run `./scripts/server` and upload facilities which previous threw geocoding errors.
[oar-country-geocode-errors.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/7989054/oar-country-geocode-errors.csv)
* Process the facilities.
```
./scripts/manage batch_process --list-id 16 --action parse
./scripts/manage batch_process --list-id 16 --action geocode
./scripts/manage batch_process --list-id 16 --action match
```
* Confirm that the facilities have been successfully geocoded.
* Submit one or more of the addresses (with new names) via the API. Confirm that they have been successfully geocoded. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
