### PR TITLE
Display processing and facility type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Index custom text [#1607](https://github.com/open-apparel-registry/open-apparel-registry/pull/1607)
 - Create extended field values for processing/facility type [#1616](https://github.com/open-apparel-registry/open-apparel-registry/pull/1616)
 - Add batch_process tool [#1625](https://github.com/open-apparel-registry/open-apparel-registry/pull/1625)
+- Display processing and facility type [#1624](https://github.com/open-apparel-registry/open-apparel-registry/pull/1624)
 
 ### Changed
 

--- a/src/app/src/components/FacilityDetailSidebarExtended.jsx
+++ b/src/app/src/components/FacilityDetailSidebarExtended.jsx
@@ -84,8 +84,8 @@ const detailsSidebarStyles = theme =>
 const formatAttribution = (createdAt, contributor) =>
     `${moment(createdAt).format('LL')} by ${contributor}`;
 
-const formatIfList = value =>
-    Array.isArray(value) ? value.map(v => <li>{v}</li>) : value;
+const formatIfListAndRemoveDuplicates = value =>
+    Array.isArray(value) ? [...new Set(value)].map(v => <li>{v}</li>) : value;
 
 /* eslint-disable camelcase */
 const formatExtendedField = ({
@@ -96,7 +96,7 @@ const formatExtendedField = ({
     id,
     formatValue = v => v,
 }) => ({
-    primary: formatIfList(formatValue(value)),
+    primary: formatIfListAndRemoveDuplicates(formatValue(value)),
     secondary: formatAttribution(updated_at, contributor_name),
     verified,
     key: id,

--- a/src/app/src/components/FacilityDetailSidebarItem.jsx
+++ b/src/app/src/components/FacilityDetailSidebarItem.jsx
@@ -50,11 +50,6 @@ const FacilityDetailSidebarItem = ({
     const hasAdditionalContent = !embed && !!additionalContent?.length;
     const additionalContentCount = additionalContent?.length;
 
-    // Temporary, until these field types can be handled
-    if (label === 'Processing Type' || label === 'Facility Type') {
-        return null;
-    }
-
     return (
         <div className={classes.item}>
             <ListItem

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -724,19 +724,19 @@ export const EXTENDED_FIELD_TYPES = [
         formatValue: v => v.contributor_name || v.name || v.raw_value,
     },
     {
+        label: 'Processing Type',
+        fieldName: 'processing_type',
+        formatValue: v => v.matched_values.map(val => val[3]),
+    },
+    {
         label: 'Facility Type',
         fieldName: 'facility_type',
-        formatValue: v => v,
+        formatValue: v => v.matched_values.map(val => val[2]),
     },
     {
         label: 'Product Type',
         fieldName: 'product_type',
         formatValue: v => v.raw_values,
-    },
-    {
-        label: 'Processing Type',
-        fieldName: 'processing_type',
-        formatValue: v => v,
     },
     {
         label: 'Number of Workers',


### PR DESCRIPTION
## Overview

Show the processing type(s) and facility type(s) for a facility in the facility details sidebar.

Also, reorder the extended fields in the sidebar so that processing type and facility type are next to each other.

Connects #1618

## Demo

![Screen Shot 2022-02-03 at 1 07 39 PM](https://user-images.githubusercontent.com/1042475/152403460-a457081c-65a5-4275-936f-566bfee23ed7.png)

## Testing Instructions

 - If you don't already have some locations with facility and processing types assigned, follow the instructions in #1616.
 - Select a facility on the map, and verify that the facility and processing types are displayed correctly.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
