### PR TITLE
Search custom_text in embedded map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Create extended field values for processing/facility type [#1616](https://github.com/open-apparel-registry/open-apparel-registry/pull/1616)
 - Add batch_process tool [#1625](https://github.com/open-apparel-registry/open-apparel-registry/pull/1625)
 - Display processing and facility type [#1624](https://github.com/open-apparel-registry/open-apparel-registry/pull/1624)
+- Search custom_text in embedded map [#1629](https://github.com/open-apparel-registry/open-apparel-registry/pull/1629)
 
 ### Changed
 

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -363,9 +363,9 @@ function mapStateToProps({
         facilitiesSidebarTabSearch: { resetButtonClickCount },
     },
     vectorTileLayer: { key },
-    embeddedMap: { config },
+    embeddedMap: { config, embed },
 }) {
-    const querystring = createQueryStringFromSearchFilters(filters);
+    const querystring = createQueryStringFromSearchFilters(filters, embed);
     const tileCacheKey = createTileCacheKeyWithEncodedFilters(filters, key);
     const tileURL = createTileURLWithQueryString(
         querystring,

--- a/src/app/src/components/VectorTileFacilityGridLayer.jsx
+++ b/src/app/src/components/VectorTileFacilityGridLayer.jsx
@@ -145,8 +145,9 @@ function mapStateToProps({
         facilitiesSidebarTabSearch: { resetButtonClickCount },
     },
     vectorTileLayer: { key, gridColorRamp },
+    embeddedMap: { embed },
 }) {
-    const querystring = createQueryStringFromSearchFilters(filters);
+    const querystring = createQueryStringFromSearchFilters(filters, embed);
     const tileCacheKey = createTileCacheKeyWithEncodedFilters(filters, key);
     const tileURL = createTileURLWithQueryString(querystring, tileCacheKey);
 

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -34,6 +34,7 @@ class FacilitiesQueryParams:
     COMBINE_CONTRIBUTORS = 'combine_contributors'
     BOUNDARY = 'boundary'
     PPE = 'ppe'
+    EMBED = 'embed'
 
 
 class FacilityListQueryParams:

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1234,6 +1234,10 @@ class FacilityManager(models.Manager):
             FacilitiesQueryParams.BOUNDARY, None
         )
 
+        embed = params.get(
+            FacilitiesQueryParams.EMBED, None
+        )
+
         # The `ppe` query argument is defined as an optional boolean at the
         # swagger level which is the built in field type option that most
         # closely matches our desired behavior. Our intended use of the
@@ -1247,14 +1251,27 @@ class FacilityManager(models.Manager):
 
         if free_text_query is not None:
             if switch_is_active('ppe'):
-                facilities_qs = facilities_qs \
-                    .filter(Q(name__icontains=free_text_query) |
-                            Q(id__icontains=free_text_query) |
-                            Q(ppe__icontains=free_text_query))
+                if embed is not None:
+                    facilities_qs = facilities_qs \
+                        .filter(Q(name__icontains=free_text_query) |
+                                Q(id__icontains=free_text_query) |
+                                Q(ppe__icontains=free_text_query) |
+                                Q(custom_text__icontains=free_text_query))
+                else:
+                    facilities_qs = facilities_qs \
+                        .filter(Q(name__icontains=free_text_query) |
+                                Q(id__icontains=free_text_query) |
+                                Q(ppe__icontains=free_text_query))
             else:
-                facilities_qs = facilities_qs \
-                    .filter(Q(name__icontains=free_text_query) |
-                            Q(id__icontains=free_text_query))
+                if embed is not None:
+                    facilities_qs = facilities_qs \
+                        .filter(Q(name__icontains=free_text_query) |
+                                Q(id__icontains=free_text_query) |
+                                Q(custom_text__icontains=free_text_query))
+                else:
+                    facilities_qs = facilities_qs \
+                        .filter(Q(name__icontains=free_text_query) |
+                                Q(id__icontains=free_text_query))
 
         # `name` is deprecated in favor of `q`. We keep `name` available for
         # backward compatibility.


### PR DESCRIPTION
## Overview

Allows free text search on an embedded map in the custom_text field

Connects #1536

## Demo

![2022-02-07 16 50 46](https://user-images.githubusercontent.com/60887686/152878097-1c426aa1-a769-4f6b-9bc9-a73af5ba91d9.gif)

## Notes

- `embed` is passed to `VectorTileFacilitiesLayer` and `VectorTileFacilityGridLayer` to make sure that the facility markers are shown individually at both high zoom level and in the hex grid clustering at lower zoom level
- The custom text field was not being correctly updated to empty when all of the fields for that facility had been marked un-searchable. We now correct remove the custom_text for the facility in that case in #1631.



## Testing Instructions

* Checkout this branch and run `./scripts/server`
* In an incognito browser, navigate to [the admin](http://localhost:8081/admin/api/contributor/2/change/) log in as c1@example.com
* Update Service Provider A to have deluxe embed permissions
* In another window, login as [c2@example.com](mailto:c2@example.com)
* Contribute [oar-custom-text.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8006223/oar-custom-text.csv)
* Fully process the list with: `./tools/batch_process {list-id}` (the ID is 17 for me)
* Go to embed config settings, make ‘custom_field’ and ‘custom_field_2’ visible and searchable
* Navigate to [embedded map](http://localhost:6543/contributors=2&embed=1) and search "test" for custom field
    - [x] Search "test" for custom field and get two results - Hamster Home and Guinea Garden
    - [x] Search "Home" and "Garden" for the name field and should get one result respectively
* Navigate to [OAR search page](http://localhost:6543/)
    - [x] Search "test" for custom field and get zero results since custom text search is disabled for non-embedded mode
    - [x] Search "Home" and "Garden" for the name field and should get one result respectively

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
