### PR TITLE
Fix custom text processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Handle country code geocoding errors [#1619](https://github.com/open-apparel-registry/open-apparel-registry/pull/1619)
+- Fix custom text processing [#1631](https://github.com/open-apparel-registry/open-apparel-registry/pull/1631)
 
 ### Security
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -2410,7 +2410,7 @@ def index_custom_text(facility_ids=list):
         # Add the values to the dictionary entry for the item's facility
         custom_fields[item.facility.id] += item_fields_string
 
-    facilities = FacilityIndex.objects.filter(id__in=custom_fields.keys()) \
+    facilities = FacilityIndex.objects.filter(id__in=facility_ids) \
                                       .iterator()
     for facility in facilities:
         facility.custom_text = custom_fields.get(facility.id, '')


### PR DESCRIPTION
## Overview

The custom text field was not being updated to empty when all of the
fields for that facility had been marked un-searchable. We now
correct remove the custom_text for the facility in that case.

## Testing Instructions

* On the branch `eh/custom_text_in_embedded_map`, upload custom text fields for a facility, and mark them searchable. 
* Search for the facility by the custom fields and note that it is found. 
* Mark the custom texts to be NOT searchable, then search for the facility again and note that it is still found. 
* Switch to this branch and update the fields' searchability again by making them searchable and then unsearchable. 
* The facility should now NOT be found when searching. 
* Mark the field searchable again and confirm that the field is now found. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
