### PR TITLE
Add closure status to extended sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add closure status to extended profile [#1635](https://github.com/open-apparel-registry/open-apparel-registry/pull/1635)
+
 ### Changed
 
 ### Deprecated

--- a/src/app/src/components/DashboardActivityReportToast.jsx
+++ b/src/app/src/components/DashboardActivityReportToast.jsx
@@ -13,6 +13,7 @@ const gradient =
 const styles = {
     message: {
         bottom: '75px',
+        left: 0,
     },
     messageGradient: {
         minWidth: '368px',

--- a/src/app/src/components/FacilityDetailSidebarClosureStatus.jsx
+++ b/src/app/src/components/FacilityDetailSidebarClosureStatus.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import get from 'lodash/get';
+import Typography from '@material-ui/core/Typography';
+import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/core/styles';
+
+import FeatureFlag from './FeatureFlag';
+import { REPORT_A_FACILITY } from '../util/constants';
+import { makeFacilityDetailLink } from '../util/util';
+
+const styles = () =>
+    Object.freeze({
+        status: {
+            background: 'rgb(40, 39, 39)',
+            borderRadius: 0,
+            display: 'flex',
+            padding: '8px 16px',
+            alignItems: 'center',
+            margin: '24px 24px 0 24px',
+        },
+        icon: {
+            fontSize: '24px',
+            fontWeight: 'normal',
+            padding: '8px 16px 8px 0',
+        },
+        textBox: {
+            display: 'flex',
+            flexDirection: 'column',
+        },
+        text: {
+            color: 'rgb(255, 255, 255)',
+        },
+    });
+
+const FacilityDetailClosureStatus = ({ data, clearFacility, classes }) => {
+    const report = get(data, 'properties.activity_reports[0]');
+    const newOarId = get(data, 'properties.new_oar_id');
+    const isClosed = get(data, 'properties.is_closed');
+    const isPending = report?.status === 'PENDING';
+
+    if (!report || (!isPending && !isClosed)) return null;
+
+    let primaryText = null;
+    if (isPending) {
+        primaryText = (
+            <Typography className={classes.text} variant="subheading">
+                This facility may be {report.closure_state.toLowerCase()}
+            </Typography>
+        );
+    } else if (isClosed && !!newOarId) {
+        primaryText = (
+            <Typography className={classes.text} variant="subheading">
+                This facility has moved to{' '}
+                <Link
+                    to={{
+                        pathname: makeFacilityDetailLink(newOarId),
+                        state: {
+                            panMapToFacilityDetails: true,
+                        },
+                    }}
+                    className={classes.text}
+                    onClick={() => clearFacility()}
+                >
+                    {newOarId}
+                </Link>
+            </Typography>
+        );
+    } else if (isClosed) {
+        primaryText = (
+            <Typography className={classes.text} variant="subheading">
+                This facility is closed
+            </Typography>
+        );
+    }
+
+    return (
+        <FeatureFlag flag={REPORT_A_FACILITY}>
+            <div className={classes.status}>
+                <i
+                    className={`${classes.text} ${classes.icon} far fa-fw fa-store-slash`}
+                />
+                <div className={classes.textBox}>
+                    {primaryText}
+                    {isPending && (
+                        <Typography className={classes.text} variant="body1">
+                            Status pending
+                        </Typography>
+                    )}
+                </div>
+            </div>
+        </FeatureFlag>
+    );
+};
+
+export default withStyles(styles)(FacilityDetailClosureStatus);

--- a/src/app/src/components/FacilityDetailSidebarHeader.jsx
+++ b/src/app/src/components/FacilityDetailSidebarHeader.jsx
@@ -104,8 +104,9 @@ const FacilityDetailSidebarHeader = ({
     claimantName,
     embedContributor,
     fetching,
-    push,
     oarId,
+    onBack,
+    push,
 }) => {
     const content = getContent({
         isEmbed,
@@ -121,7 +122,10 @@ const FacilityDetailSidebarHeader = ({
                 <IconButton
                     aria-label="Back"
                     disabled={fetching}
-                    onClick={() => push(facilitiesRoute)}
+                    onClick={() => {
+                        onBack();
+                        push(facilitiesRoute);
+                    }}
                 >
                     <ListItemIcon>
                         <ArrowBackIcon className={classes.backArrow} />

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -207,11 +207,11 @@ const findFacilitiesAtSamePointFromVectorTile = (data, tileLayerRef = null) => {
 const VectorTileFacilitiesLayer = ({
     tileURL,
     handleMarkerClick,
+    handleFacilityClick,
     fetching,
     resetButtonClickCount,
     tileCacheKey,
     oarID,
-    pushRoute,
     minZoom,
     maxZoom,
     iconColor,
@@ -239,8 +239,9 @@ const VectorTileFacilitiesLayer = ({
         closeMultipleFacilitiesPopup,
     );
 
-    const selectFacilityOnClick = facilityID =>
-        pushRoute(`/facilities/${facilityID}`);
+    const selectFacilityOnClick = facilityID => {
+        handleFacilityClick(facilityID);
+    };
 
     const vectorTileLayerRef = useUpdateTileLayerWithMarkerForSelectedOARID(
         oarID,
@@ -351,7 +352,6 @@ VectorTileFacilitiesLayer.propTypes = {
     fetching: bool.isRequired,
     resetButtonClickCount: number.isRequired,
     oarID: string,
-    pushRoute: func.isRequired,
 };
 
 function mapStateToProps({

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -54,6 +54,7 @@ function VectorTileFacilitiesMap({
     clientInfoFetched,
     countryCode,
     handleMarkerClick,
+    handleFacilityClick,
     match: {
         params: { oarID },
     },
@@ -167,6 +168,7 @@ function VectorTileFacilitiesMap({
             <ZoomControl position="bottomright" />
             <VectorTileFacilitiesLayer
                 handleMarkerClick={handleMarkerClick}
+                handleFacilityClick={handleFacilityClick}
                 oarID={oarID}
                 pushRoute={push}
                 minZoom={maxVectorTileFacilitiesGridZoom + 1}
@@ -247,18 +249,24 @@ function mapStateToProps({
     };
 }
 
-function mapDispatchToProps(dispatch, { history: { push } }) {
+function mapDispatchToProps(
+    dispatch,
+    { history: { push }, match: { params } },
+) {
+    const visitFacility = oarID => {
+        if (oarID && oarID !== params?.oarID) {
+            dispatch(resetSingleFacility());
+            return push(makeFacilityDetailLink(oarID));
+        }
+
+        return noop();
+    };
     return {
         handleMarkerClick: e => {
             const oarID = get(e, 'layer.properties.id', null);
-
-            if (oarID) {
-                dispatch(resetSingleFacility());
-                return push(makeFacilityDetailLink(oarID));
-            }
-
-            return noop();
+            visitFacility(oarID);
         },
+        handleFacilityClick: visitFacility,
     };
 }
 


### PR DESCRIPTION
## Overview

Adds the facility closure status ribbon (including the 'moved facility'
link) and the closure status history to the new extended field
sidebar.

Working with the 'moved facility' link resurfaced a bug that we've been 
experiencing elsewhere in the app related to stale state in the facility details,
which has now been resolved for the new sidebar. 

When navigating away from a facility, we need to clear the facility
currently in state, or the facility redirect process identifies the
stale facility ID as an alternate id and redirects to the stale
facility. This can result in an infinite loop.

The same issue was causing a redirect loop when navigating to alternate
facilities by clicking on the map while in the facility details.

We were also not correctly clearing the facility and refetching the
search results when navigating away from the facility and back to the
facilities list. 

Connects #1541, #1507

## Demo

<img width="359" alt="Screen Shot 2022-02-09 at 2 45 43 PM" src="https://user-images.githubusercontent.com/21046714/153461704-7b6c8d23-d77e-4395-b256-82f282e76d01.png">

<img width="364" alt="Screen Shot 2022-02-09 at 2 46 40 PM" src="https://user-images.githubusercontent.com/21046714/153461726-c81ea178-3db2-4b66-95a2-18c937382d82.png">

<img width="513" alt="Screen Shot 2022-02-09 at 3 21 48 PM" src="https://user-images.githubusercontent.com/21046714/153461748-44fdc3f6-8fcb-46e3-a760-439d81296d79.png">

## Testing Instructions

These instructions assume that `./scripts/resetdb` has been run. 

- Login as c2@example.com
- Navigate to [contributor 7](http://localhost:6543/facilities/?contributors=7)
- Select Chaohu Galaxy Vegas Textile in the list. 
    - [x] There should be no facility status ribbon at the top of the facility.
    - [x] There should be no ‘Status’ section at the bottom of the facility. 
- Report the facility as closed. 
    - [x] There should be a popup with a success notice.
    - [x] There should be a ‘status’ section noting that the facility was reported closed by Service Provider A.
    - [x] There should be a closure ribbon with ‘Status pending’
- In an incognito browser, login as [c1@example.com](mailto:c1@example.com).
- Confirm the [closure report](http://localhost:6543/dashboard/activityreports).
- Refresh Chaohu Galaxy Vegas Textile. 
    - [x] The closure ribbon should say the facility is closed
    - [x] The top item in the ‘status’ section should say ‘Verified closed’ and list no contributor name. 
    - [x] The reported closed status with Service Provider A should appear in the expanded view. 
- Report the facility as reopened.
    - [x] The first status should say ‘reported open’
    - [x] There should be a ‘status pending’ ribbon
- Confirm the reopening report and refresh the facility. 
    - [x] There should be no closure ribbon.
    - [x] The reopening status report should be listed under ‘status’
- Report the facility as closed and confirm. 
- Navigate back to the facility list. Note that the filter by ‘contributors=7’ should be maintained and the search results should all appear (not just Chaos Galaxy Vegas Textile)
- Select Chung Tai Garment Factory and copy its facility id. 
- In the Django Admin, set the ‘New oar id’ for Chaohu Galaxy Vegas Textile to the ID for Chung Tai Garment Factory. 
- Return to the details for Chaohu Galaxy Vegas Textile.
    - [x] The ID for Chung Tai Garment Factory should appear in the ribbon as a link.
- Follow the link for Chung Tai Garment Factory. 
    - [x] The facility details should load and not redirect back to Chaohu Galaxy Vegas Textile.
    - [x] The map should show Chung Tai Garment Factory. 
- Clear the search filters and zoom in until you have two facility markers on screen. Click one and then the other. 
    - [x] The facilities should load without looping.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
