### PR TITLE
Enable remote Django debugging in Visual Studio Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Django",
+            "type": "python",
+            "request": "attach",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/src/django",
+                    "remoteRoot": "/usr/local/src"
+                }
+            ],
+            "port": 3000,
+            "host": "localhost",
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Open Apparel Registry (OAR) is a tool to identify every apparel facility wor
   - [Google Maps Platform](#google-maps-platform)
 - [Development](#development)
   - [Hot Reloading 🔥](#hot-reloading-)
+  - [Debugging Django](#debugging-django)
   - [Ports](#ports)
 - [Scripts 🧰](#scripts-)
 
@@ -75,6 +76,24 @@ vagrant@vagrant:/vagrant$ ./scripts/server
 The frontend uses [Create React App](https://github.com/facebook/create-react-app/). When running `server`, the page will automatically [reload](https://github.com/facebook/create-react-app/#whats-included) if you make changes to the code.
 
 The [Django](https://www.djangoproject.com) app runs inside a [Gunicorn](https://www.gunicorn.org) worker. The worker will [restart](https://docs.gunicorn.org/en/stable/settings.html#reload) if you make changes to the code.
+
+### Debugging Django
+
+Breakpoint debugging of the Python back-end is available via Visual Studio Code. To get started, run the Django development server by passing the `--debug` flag to the `server` script. Note that you have to run the application in Docker for Mac directly and not within Vagrant to be able to debug.
+
+```
+./scripts/server --debug
+```
+
+In Visual Studio Code, select the "Run and Debug" view from the sidebar. At the top of the "Run and Debug" pane, click the green arrow next to the "Debug Django" menu item.
+
+<img width="288" alt="image" src="https://user-images.githubusercontent.com/1042475/153924321-3c60a9de-b528-4dad-92b3-8eb8184987fc.png">
+
+If Visual Studio Code can connect, you should see a play/pause/next menu bar in the top right of the window.
+
+Set a breakpoint by clicking in the column next to the line numbers for a `.py` file. A red dot should appear. Now, if the breakpoint is hit when you visit a page of the app in the browser (note that you must access the site via the React development server port), Visual Studio Code should highlight the line in the file, the "Run and Debug" window should be populated with information about currently set variables, and execution of the code should be paused.
+
+Note that, due to the way static files are managed for the normal development environment, the Django server at 8081 is not available when running the `server` script with the `--debug` flag.
 
 ### Ports
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,16 @@
+version: "2.4"
+services:
+  django:
+    entrypoint:
+      - "python"
+    command:
+      - "manage.py"
+      - "runserver"
+      - "0.0.0.0:8081"
+      - "--noreload"
+      - "--nothreading"
+    environment:
+      - PYTHONUNBUFFERED=1
+    ports:
+      - "8081:8081"
+      - "3000:3000"

--- a/scripts/server
+++ b/scripts/server
@@ -17,6 +17,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        docker-compose up
+        if [ "${1:-}" = "--debug" ]; then
+            docker-compose -f docker-compose.yml -f docker-compose.debug.yml up
+        else
+            docker-compose up
+        fi
     fi
 fi

--- a/src/django/manage.py
+++ b/src/django/manage.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 import os
 import sys
+import debugpy
 
 if __name__ == "__main__":
+    debugpy.listen(('0.0.0.0', 3000))
+    print('Ready for debugging!')
+
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "oar.settings")
     try:
         from django.core.management import execute_from_command_line

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -27,3 +27,4 @@ thefuzz==0.19.0
 Unidecode==1.0.23
 xlrd==1.2.0
 django-cors-headers==3.10.0
+debugpy==1.5.1


### PR DESCRIPTION
## Overview

Allow developers to debug the Python back-end by using Visual Studio Code's debugging capabilities along with the [debugpy](https://github.com/microsoft/debugpy) library.

## Demo

![Screen Shot 2022-02-14 at 1 04 52 PM](https://user-images.githubusercontent.com/1042475/153931710-fe401b6f-da4f-467f-a994-cfba5f0e5b0a.png)

## Notes

- I tried to get this to work using the Gnuicorn server, but I was unable to. I think it has to do with they way Gnuicorn does multi-threading. I wasn't able to find many examples of people using Gnuicorn in development, let alone with debugpy. 
- This does not work if you are running the app within Vagrant. I was hoping forwarding the port would be enough, but that was not the case. Other attempted fixes also did not work.

## Testing Instructions

- Follow the instructions in the README and see if you can successfully trigger a breakpoint. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
