### PR TITLE
Temporarily Fix Google Basemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [Temporarily fix Google basemap](https://github.com/open-apparel-registry/open-apparel-registry/pull/1658)
+
 ### Security
 
 - Bump follow-redirects from 1.14.3 to 1.14.8 in /src/app [#1645](https://github.com/open-apparel-registry/open-apparel-registry/pull/1645)

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -136,7 +136,7 @@ function VectorTileFacilitiesMap({
                 googleMapsLoaderConf={{
                     KEY: GOOGLE_CLIENT_SIDE_API_KEY,
                     REGION: countryCode,
-                    VERSION: 3.37,
+                    VERSION: 3.47,
                 }}
                 type="roadmap"
                 styles={mapStyle === 'silver' ? SILVER_MAP_STYLE : null}


### PR DESCRIPTION
## Overview

The API version to which we have manually set our Google basemap
has been deprecated for some time. When the requested version is
unavailable, the API defaults to returning the most current version
(currently, '3.48.1a', which can be seen by entering
'google.maps.version' in the app console).

The Google basemap is currently not loading in staging or production.
Although release notes for 4.8 have not been released, it was scheduled
to release around this time, so it seems likely that the release of
4.8 has some breaking change effecting our basemap.

Manually setting the version to 4.7 (a previous but still-available
version) results in the basemap loading as expected.

Version 4.7 should be available for at least the next quarter (per
https://developers.google.com/maps/documentation/javascript/versions,
it should be available for 3-6 months), which will give us time to
update our code to fix the basemap on current versions.

Connects #1657 

## Demo

Develop (temporarily fixed):
<img width="1408" alt="Screen Shot 2022-02-17 at 9 09 32 AM" src="https://user-images.githubusercontent.com/21046714/154498897-ab7da6a6-4d77-4fd4-8f2d-e05f43636ad6.png">

Production (broken):
<img width="1407" alt="Screen Shot 2022-02-17 at 9 07 27 AM" src="https://user-images.githubusercontent.com/21046714/154498380-5d91ddc6-3d1b-4958-9ab0-d20132668741.png">

## Testing Instructions

* On `develop`, run `./scripts/server` and note that the basemap is not displayed. There are multiple errors in the console. Enter `google.maps.version` and note the version number is 4.8.
* On this branch, run `./scripts/server` and note that the errors are gone and the basemap loads. Enter `google.maps.version` and note the version number is `4.7`.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
