### PR TITLE
Fix handling of numeric cells in Excel workbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix handling of numeric cells in Excel workbooks [#1663](https://github.com/open-apparel-registry/open-apparel-registry/pull/1663)
+
 ### Security
 
 - Bump follow-redirects from 1.14.3 to 1.14.8 in /src/app [#1645](https://github.com/open-apparel-registry/open-apparel-registry/pull/1645)

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -7,9 +7,14 @@ from api.facility_type_processing_type import (
 )
 
 
-def extract_range_value(value):
-    values = [int(x) for x
-              in re.findall(r'([0-9]+)', str(value).replace(',', ''))]
+def extract_int_range_value(value):
+    """
+    Excel workbooks mat contain decimal values for number_of_workers. Matching
+    the decimal in the regex then using int(float(x)) ensures that a plain
+    integer is extracted.
+    """
+    values = [int(float(x)) for x
+              in re.findall(r'([0-9.]+)', str(value).replace(',', ''))]
     return {"min": min(values, default=0), "max": max(values, default=0)}
 
 
@@ -78,7 +83,7 @@ def get_product_type_extendedfield_value(field_value):
 def create_extendedfield(field, field_value, item, contributor):
     if field_value is not None and field_value != "":
         if field == ExtendedField.NUMBER_OF_WORKERS:
-            field_value = extract_range_value(field_value)
+            field_value = extract_int_range_value(field_value)
         elif field == ExtendedField.PARENT_COMPANY:
             field_value = get_parent_company_extendedfield_value(field_value)
         elif field == ExtendedField.PRODUCT_TYPE:
@@ -179,7 +184,7 @@ def create_extendedfields_for_claim(claim):
         field_value = getattr(claim, claim_field)
         if field_value is not None and field_value != "":
             if extended_field == ExtendedField.NUMBER_OF_WORKERS:
-                field_value = extract_range_value(field_value)
+                field_value = extract_int_range_value(field_value)
             elif extended_field == ExtendedField.PARENT_COMPANY:
                 field_value = get_parent_company_extendedfield_value(
                     field_value.name

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -53,7 +53,10 @@ def parse_excel(file, request):
         sheet = get_excel_sheet(file, request)
 
         header = ','.join(sheet.row_values(0))
-        rows = ['"{}"'.format('","'.join(sheet.row_values(idx)))
+        # Use use `str(x)` here since numbers in an Excel column will be
+        # returns as a Python number type
+        rows = ['"{}"'.format(
+            '","'.join([str(x) for x in sheet.row_values(idx)]))
                 for idx in range(1, sheet.nrows)]
 
         return header, rows


### PR DESCRIPTION

## Overview

With the introduction of number_of_workers we now have a column that can have a numeric value. This presented 2 challenges to the existing Python code.

- Excel parsing library returns these as numeric types, but the code was expecting a string.
- A value that appears as 130 in the workbook can appear as a float 130.0 after parsing.

This commit attempts to fix both of these issues by first manually casing cell values to strings when parsing the workbook, then using an `int(parse(x))` nested cast in the `extract_int_range_value` function to ensure that the decimal portion is removed. 

Connects #1638

## Testing Instructions

* Check out `develop`, log in as c2@example.com, submit 
[extended-template-test.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8110687/extended-template-test.xlsx). Verify that an error blocks submission.
* Check out `bugfix/jvw/handle-numeric-excel-cells` and attempt to submit the file again. Verify that it succeeds and that `./tools/batch_prcess {is}` completes successfully.


## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
