### PR TITLE
Allow searching contributors by name and admin email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add selecting silver map style to embed config [#1637](https://github.com/open-apparel-registry/open-apparel-registry/pull/1637)
 - Integrate facility/processing type taxonomy into facility claims [#1639](https://github.com/open-apparel-registry/open-apparel-registry/pull/1639)
 - Index extended fields [#1651](https://github.com/open-apparel-registry/open-apparel-registry/pull/1651)
+- Allow searching contributors by name and admin email [#1668](https://github.com/open-apparel-registry/open-apparel-registry/pull/1668)
 
 ### Changed
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -92,6 +92,7 @@ class FacilityMatchAdmin(SimpleHistoryAdmin):
 
 class ContributorAdmin(SimpleHistoryAdmin):
     history_list_display = ('is_verified', 'verification_notes')
+    search_fields = ('name', 'admin__email')
 
 
 class FacilityClaimAdmin(SimpleHistoryAdmin):


### PR DESCRIPTION
## Overview

Granting API access and other administrative tasks often depends on finding the proper contributor account given an email address.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/76

## Demo

<img width="548" alt="Screen Shot 2022-02-22 at 2 43 02 PM" src="https://user-images.githubusercontent.com/17363/155224575-74283e4e-e83d-4681-a77f-974e0d4fd97f.png">
ots, `curl` examples, etc.

## Testing Instructions

* Browse http://localhost:8081/admin/api/contributor/ and verify that you can search for partial and full contributor names and admin email addresses.
 
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
