### PR TITLE
Add support for facility_type_processing_type meta extended field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Integrate facility/processing type taxonomy into facility claims [#1639](https://github.com/open-apparel-registry/open-apparel-registry/pull/1639)
 - Index extended fields [#1651](https://github.com/open-apparel-registry/open-apparel-registry/pull/1651)
 - Allow searching contributors by name and admin email [#1668](https://github.com/open-apparel-registry/open-apparel-registry/pull/1668)
+- Add support for facility_type_processing_type meta extended field [#1671](https://github.com/open-apparel-registry/open-apparel-registry/pull/1671)
 
 ### Changed
 

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -115,10 +115,19 @@ def create_extendedfields_for_single_item(item, raw_data):
         return False
     contributor = item.source.contributor
 
+    # facility_type_processing_type is a special "meta" field that attempts to
+    # simplify the submission process for contributors.
+    if (raw_data.get('facility_type_processing_type')):
+        if raw_data.get('facility_type') is None:
+            raw_data['facility_type'] = \
+                raw_data['facility_type_processing_type']
+        if raw_data.get('processing_type') is None:
+            raw_data['processing_type'] = \
+                raw_data['facility_type_processing_type']
     # Add a facility_type extended field if the user only
     # submitted a processing_type
-    if (raw_data.get('processing_type') and
-       raw_data.get('facility_type') is None):
+    elif (raw_data.get('processing_type') and
+          raw_data.get('facility_type') is None):
         raw_data['facility_type'] = raw_data['processing_type']
     # Add a processing_type extended field if the user only
     # submitted a facility_type

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -2403,6 +2403,10 @@ class ExtendedField(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     history = HistoricalRecords()
 
+    def __str__(self):
+        return "{} - {} - {} ({})".format(
+            self.field_name, self.facility_id, self.contributor.name, self.id)
+
     @staticmethod
     def post_save(sender, **kwargs):
         instance = kwargs.get('instance')

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -114,6 +114,19 @@ def parse_facility_list_item(item):
         fields = [f.lower()
                   for f in parse_csv_line(item.source.facility_list.header)]
         values = parse_csv_line(item.raw_data)
+
+        # facility_type_processing_type is a special "meta" field that attempts
+        # to simplify the submission process for contributors.
+        if 'facility_type_processing_type' in fields:
+            if 'facility_type' not in fields:
+                fields.append('facility_type')
+                values.append(
+                    values[fields.index('facility_type_processing_type')])
+            if 'processing_type' not in fields:
+                fields.append('processing_type')
+                values.append(
+                    values[fields.index('facility_type_processing_type')])
+
         if CsvHeaderField.COUNTRY in fields:
             item.country_code = get_country_code(
                 values[fields.index(CsvHeaderField.COUNTRY)])


### PR DESCRIPTION
## Overview

In an attempt to avoid confusion the data submission process we will be putting a single `facility_type_processing_type` column in our upload templates rather than separate `facility_type` and `processing_type` columns. Though we are unifying the fields in the template we still want to create separate extended fields for each field type. Supporting this is a simple change because our processing was designed to handle either value type in either field.

We also add __str__ to the ExtendedField model in an attempt to  make the list view in the Django admin more helpful.

Connects #1655 

## Demo

<img width="969" alt="Screen Shot 2022-02-23 at 11 14 35 AM" src="https://user-images.githubusercontent.com/17363/155381560-fde33248-baaf-4e6f-9c61-7dd78faa3005.png">

<img width="123" alt="Screen Shot 2022-02-23 at 11 15 39 AM" src="https://user-images.githubusercontent.com/17363/155381772-30140aaa-cfbf-4534-9a94-be17a79f6cdb.png">

<img width="516" alt="Screen Shot 2022-02-23 at 11 04 11 AM" src="https://user-images.githubusercontent.com/17363/155381476-ca89777b-c96c-491e-a5b6-01ed0c3b3090.png">

## Testing Instructions

* Log in as c2@example.com
* Upload [ETEST2combofield.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8126846/ETEST2combofield.xlsx) and run `./tools/batch_process {list id}`
* Refresh the list page to see the updated row and click the link to view the facility. Verify that all the extended fields are filled in.
* Brows http://localhost:8081/api/docs/#!/facilities/facilities_create and authenticate with `Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051`
* Submit this record browse the resulting record, and verify that all extended fields are created. 
```
{
    "country": "US",
    "name": "API Meta Field Testing",
    "address": "200 Main St Philadelphia PA",
    "number_of_workers": 123,
    "parent_company": "Yet another parenct co",
    "facility_type_processing_type": "cut|warehousing",
	"product_type": ["pants", "suits"]
}
```

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
