### PR TITLE
Fix custom text handling when not in embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix handling of numeric cells in Excel workbooks [#1663](https://github.com/open-apparel-registry/open-apparel-registry/pull/1663)
+- Fix custom text handling when not in embed mode [#1673](https://github.com/open-apparel-registry/open-apparel-registry/pull/1673)
 
 ### Security
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1254,7 +1254,10 @@ class FacilityManager(models.Manager):
         facilities_qs = FacilityIndex.objects.all()
 
         if free_text_query is not None:
-            custom_text = format_custom_text(contributors[0], free_text_query)
+            custom_text = (
+                format_custom_text(contributors[0], free_text_query)
+                if contributors
+                else free_text_query)
             if switch_is_active('ppe'):
                 if embed is not None:
                     facilities_qs = facilities_qs \


### PR DESCRIPTION

## Overview

When not in embed mode just searching for free text was raising an exception because `contributors` was None in `filter_by_query_params`.

Connects #1652
Connects #1672 

## Testing Instructions

* Check out `develop`
* Search for `test` and verify that an exception prevents the search from working
* Check out this branch, run the same search, and verify that it works.
* Verify that text search in embed mode still works

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
