### PR TITLE
Use DEBUGPY env var to conditionally enable debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update final facility_type/processing_type taxonomy [#1644](https://github.com/open-apparel-registry/open-apparel-registry/pull/1644)
 - Modified custom_text handling [#1665](https://github.com/open-apparel-registry/open-apparel-registry/pull/1665)
 - Add two additional types to taxonomy [#1662](https://github.com/open-apparel-registry/open-apparel-registry/pull/1662)
+- Use DEBUGPY env var to conditionally enable debugging [#1675](https://github.com/open-apparel-registry/open-apparel-registry/pull/1675)
 
 ### Deprecated
 

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -11,6 +11,7 @@ services:
       - "--nothreading"
     environment:
       - PYTHONUNBUFFERED=1
+      - DEBUGPY=1
     ports:
       - "8081:8081"
       - "3000:3000"

--- a/src/django/manage.py
+++ b/src/django/manage.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 import os
 import sys
-import debugpy
 
 if __name__ == "__main__":
-    debugpy.listen(('0.0.0.0', 3000))
-    print('Ready for debugging!')
+    if os.getenv('DEBUGPY') is not None:
+        import debugpy
+        debugpy.listen(('0.0.0.0', 3000))
+        print('Ready for debugging!')
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "oar.settings")
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION


## Overview

Attempting to open the debug port for listening when running management commands in AWS Batch was raising exceptions because multiple processes were trying to listen to the same port.

Connects  #1670
Connects #1674

## Demo

### Running ./scripts/server

```
$ lsof -n -i4TCP:3000 | grep LISTEN
```

### Running ./scripts/server --debug

```
$ lsof -n -i4TCP:3000 | grep LISTEN
com.docke 3930 jwalgran  157u  IPv6 0x5ff8f6fc71b89b25
```

## Testing Instructions

* Run `./scripts/server` and in a separate shell rung `lsof -n -i4TCP:3000 | grep LISTEN` to verify that port 3000 is not bound
* Verify that running `./scripts/server --debug` and then running `lsof -n -i4TCP:3000 | grep LISTEN`  shows port 3000 is now bound.


## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
