### PR TITLE
Combine facility type and production type claim fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Change production type to Processing type in Django admin [#1679](https://github.com/open-apparel-registry/open-apparel-registry/pull/1679)
+- Combine facility type and production type claim fields [#1678](https://github.com/open-apparel-registry/open-apparel-registry/pull/1678/files)
 
 ### Deprecated
 

--- a/src/app/src/components/ClaimedFacilitiesDetails.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetails.jsx
@@ -48,7 +48,6 @@ import {
     updateClaimedFacilityDescription,
     updateClaimedFacilityMinimumOrder,
     updateClaimedFacilityAverageLeadTime,
-    updateClaimedFacilityFacilityTypes,
     updateClaimedFacilityContactPersonName,
     updateClaimedFacilityContactEmail,
     updateClaimedFacilityPointOfContactVisibility,
@@ -295,7 +294,6 @@ function ClaimedFacilitiesDetails({
     errorUpdating,
     updateParentCompany,
     contributorOptions,
-    updateFacilityType,
 }) {
     /* eslint-disable react-hooks/exhaustive-deps */
     // disabled because we want to use this as just
@@ -424,17 +422,6 @@ function ClaimedFacilitiesDetails({
                     </Typography>
                 </ShowOnly>
                 <InputSection
-                    label="Facility Type"
-                    value={get(data, 'facility_type', [])}
-                    onChange={updateFacilityType}
-                    disabled={updating}
-                    isSelect
-                    isMultiSelect
-                    selectOptions={mapDjangoChoiceTuplesToSelectOptions(
-                        data.facility_types,
-                    )}
-                />
-                <InputSection
                     label="Minimum order quantity"
                     value={data.facility_minimum_order_quantity}
                     onChange={updateFacilityMinimumOrder}
@@ -498,6 +485,17 @@ function ClaimedFacilitiesDetails({
                     )}
                 />
                 <InputSection
+                    label="Facility / Processing Types"
+                    value={get(data, 'facility_production_types', [])}
+                    onChange={updateFacilityProductionTypes}
+                    disabled={updating}
+                    isSelect
+                    isMultiSelect
+                    selectOptions={mapDjangoChoiceTuplesToSelectOptions(
+                        data.production_type_choices,
+                    )}
+                />
+                <InputSection
                     label="Product Types"
                     value={get(data, 'facility_product_types', [])}
                     onChange={updateFacilityProductTypes}
@@ -507,17 +505,6 @@ function ClaimedFacilitiesDetails({
                     isCreatable
                     selectOptions={mapDjangoChoiceTuplesToSelectOptions(
                         data.product_type_choices,
-                    )}
-                />
-                <InputSection
-                    label="Processing Types"
-                    value={get(data, 'facility_production_types', [])}
-                    onChange={updateFacilityProductionTypes}
-                    disabled={updating}
-                    isSelect
-                    isMultiSelect
-                    selectOptions={mapDjangoChoiceTuplesToSelectOptions(
-                        data.production_type_choices,
                     )}
                 />
                 <Typography
@@ -681,7 +668,6 @@ ClaimedFacilitiesDetails.propTypes = {
     updateContactVisibility: func.isRequired,
     updateOfficeVisibility: func.isRequired,
     contributorOptions: contributorOptionsPropType,
-    updateFacilityType: func.isRequired,
 };
 
 function mapStateToProps({
@@ -760,9 +746,6 @@ function mapDispatchToProps(
         ),
         updateFacilityDescription: makeDispatchValueFn(
             updateClaimedFacilityDescription,
-        ),
-        updateFacilityType: makeDispatchMultiSelectFn(
-            updateClaimedFacilityFacilityTypes,
         ),
         updateFacilityMinimumOrder: makeDispatchValueFn(
             updateClaimedFacilityMinimumOrder,

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -190,7 +190,13 @@ def create_extendedfields_for_claim(claim):
     f = claim.facility
 
     for claim_field, extended_field in CLAIM_FIELDS:
-        field_value = getattr(claim, claim_field)
+        if extended_field == ExtendedField.FACILITY_TYPE:
+            # We have unified the facility type and processing type in the UI
+            # into a single processing type field but we still want to create a
+            # facility type extended field based on processing types selected
+            field_value = getattr(claim, 'facility_production_types')
+        else:
+            field_value = getattr(claim, claim_field)
         if field_value is not None and field_value != "":
             if extended_field == ExtendedField.NUMBER_OF_WORKERS:
                 field_value = extract_int_range_value(field_value)


### PR DESCRIPTION
## Overview

In an effort to simplify the contribution process the OAR team has decided, in CSV/Excel file templates and the facility claim form, to unify the facility type and processing type fields. To accomplish this on the clame form we remove the facility type field from the UI and on the backend create extended fields for both facility type and processing type based on the values selected for processing type.

Connects #1649

## Demo

<img width="594" alt="Screen Shot 2022-02-24 at 4 05 17 PM" src="https://user-images.githubusercontent.com/17363/155622421-4759f6ed-ce40-4268-96db-f66a50f7e516.png">

## Testing Instructions

*  Log in a c2@example.com
* Browse any facility, click claim at the top of the sidebar, and complete the wizard
* In a separate browser session log in as c1@example.com, browse http://localhost:6543/dashboard/claims, select, and approve the claim.
* Back in the original session browse http://localhost:6543/claimed and open the approved claim
* Verify that the Facility Type field has been removed and there is a "Facility / Processing Types" field.
* Select some values for "Facility / Processing Types" and click save at the bottom of the form.
* Use the OAR ID link at the top right of the form to open the facility details page and verify that the appropriate values appear in the Facility Type and Processing Type extended fields.
* Edit the form, selecting different values for "Facility / Processing Types" and vierfy that saving them updated the extened fields correctly.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
