### PR TITLE
Add embed_level to development contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Include extended fields in CSV/Excel downloads [#1683](https://github.com/open-apparel-registry/open-apparel-registry/pull/1683)
+- Add embed_level to development contributors [#1681](https://github.com/open-apparel-registry/open-apparel-registry/pull/1681)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Set a breakpoint by clicking in the column next to the line numbers for a `.py` 
 
 Note that, due to the way static files are managed for the normal development environment, the Django server at 8081 is not available when running the `server` script with the `--debug` flag.
 
+### Embedded Maps
+
+Three users in development have embedded map access by default. User c2@example.com has Embed Deluxe / Custom Embed permissions, the highest level; user c3@example.com has Embed+ permissions; and user c4@example.com has general Embed permissions, the lowest level.
+
+In order to access the embedded map for a user with permissions, you must go to their Settings
+page and set up the basic map configuration, including height and width. A preview will then
+be available on their page, or you can visit http://localhost:6543/?embed=1&contributors=id where 'id' is the contributor's id. 
+
 ### Ports
 
 | Service                    | Port                            |

--- a/src/django/api/fixtures/contributors.json
+++ b/src/django/api/fixtures/contributors.json
@@ -10,7 +10,8 @@
             "contrib_type": "Service Provider",
             "other_contrib_type": null,
             "created_at": "2020-03-09T14:25:18+00:00",
-            "updated_at": "2020-03-13T17:47:08.934203+00:00"
+            "updated_at": "2020-03-13T17:47:08.934203+00:00",
+            "embed_level": 3
         }
     },
     {
@@ -24,7 +25,8 @@
             "contrib_type": "Factory / Facility",
             "other_contrib_type": null,
             "created_at": "2020-03-08T18:27:40+00:00",
-            "updated_at": "2020-03-13T17:47:08.839090+00:00"
+            "updated_at": "2020-03-13T17:47:08.839090+00:00",
+            "embed_level": 2
         }
     },
     {
@@ -38,7 +40,8 @@
             "contrib_type": "Brand/Retailer",
             "other_contrib_type": null,
             "created_at": "2020-03-09T14:34:09+00:00",
-            "updated_at": "2020-03-13T17:47:08.847584+00:00"
+            "updated_at": "2020-03-13T17:47:08.847584+00:00",
+            "embed_level": 1
         }
     },
     {


### PR DESCRIPTION
## Overview

We frequently need to test embedded map settings and embedded map mode.
If `resetdb` has been run, this requires logging in as an admin and
giving embed permissions to one of the development contributors.

Adds a default embed_level of 3 to c2@example.com, 2 to c3@example.com,
and 1 to c4@example.com to avoid needing to manually set these
permissions.

Adds notes to the Readme about embedded map use. 

## Testing Instructions

* Run `./scripts/resetdb`
* Login as c2@example.com, c3@example.com, and c4@example.com in turn and confirm that they have embed level 3, 2, and 1 respectively. 
* Review the new readme section for clarity/correctness. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
