### PR TITLE
Include extended fields in CSV/Excel download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Include extended fields in CSV/Excel downloads [#1683](https://github.com/open-apparel-registry/open-apparel-registry/pull/1683)
+
 ### Changed
 
 ### Deprecated

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -42,6 +42,12 @@ export function logDownload(format, options) {
                 get(featureFlags, 'flags.report_a_facility', false) &&
                 !isEmbedded;
 
+            const extendedFieldsAreActive = get(
+                featureFlags,
+                'flags.extended_profile',
+                false,
+            );
+
             const path = `${window.location.pathname}${window.location.search}${window.location.hash}`;
 
             if (!isEmbedded) {
@@ -52,6 +58,7 @@ export function logDownload(format, options) {
                 downloadFacilities(facilities, {
                     includePPEFields: ppeIsActive,
                     includeClosureFields: reportsAreActive,
+                    includeExtendedFields: extendedFieldsAreActive,
                     isEmbedded,
                 });
             } else {
@@ -94,6 +101,7 @@ export function logDownload(format, options) {
                 downloadFacilities(features, {
                     includePPEFields: ppeIsActive,
                     includeClosureFields: reportsAreActive,
+                    includeExtendedFields: extendedFieldsAreActive,
                     isEmbedded,
                 });
             }

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -554,6 +554,7 @@ class FacilitySerializer(GeoFeatureModelSerializer):
     contributors = SerializerMethodField()
     name = SerializerMethodField()
     contributor_fields = SerializerMethodField()
+    extended_fields = SerializerMethodField()
 
     class Meta:
         model = Facility
@@ -561,7 +562,7 @@ class FacilitySerializer(GeoFeatureModelSerializer):
                   'oar_id', 'country_name', 'contributors',
                   'ppe_product_types', 'ppe_contact_phone',
                   'ppe_contact_email', 'ppe_website', 'is_closed',
-                  'contributor_fields')
+                  'contributor_fields', 'extended_fields')
         geo_field = 'location'
 
     # Added to ensure including the OAR ID in the geojson properties map
@@ -642,6 +643,61 @@ class FacilitySerializer(GeoFeatureModelSerializer):
                 facilitymatch__is_active=True).order_by('-created_at').first()
 
         return assign_contributor_field_values(list_item, fields)
+
+    def get_extended_fields(self, facility):
+        request = self.context.get('request') \
+            if self.context is not None else None
+        embed = request.query_params.get('embed') \
+            if request is not None else None
+        contributor_id = request.query_params.get('contributor', None) \
+            if request is not None and embed == '1' else None
+        if contributor_id is None and request is not None and embed == '1':
+            contributor_ids = request.query_params.getlist('contributors', [])
+            if len(contributor_ids):
+                contributor_id = contributor_ids[0]
+
+        fields = facility.extended_fields(contributor_id=contributor_id)
+        user_can_see_detail = can_user_see_detail(self)
+        embed_mode_active = is_embed_mode_active(self)
+
+        grouped_data = defaultdict(list)
+
+        def sort_order(k):
+            return (k.get('verified_count', 0), k.get('is_from_claim', False),
+                    k.get('value_count', 1), k.get('updated_at', None))
+
+        for field_name, _ in ExtendedField.FIELD_CHOICES:
+            serializer = ExtendedFieldListSerializer(
+                        fields.filter(field_name=field_name),
+                        many=True,
+                        context={'user_can_see_detail': user_can_see_detail,
+                                 'embed_mode_active': embed_mode_active}
+                    )
+
+            if field_name == ExtendedField.NAME and not embed_mode_active:
+                unsorted_data = serializer.data
+                for item in get_facility_names(facility):
+                    if item.name is not None and len(item.name) != 0:
+                        unsorted_data.append(
+                            create_name_field(item.name,
+                                              item.source.contributor,
+                                              user_can_see_detail))
+                data = sorted(unsorted_data, key=sort_order, reverse=True)
+            elif field_name == ExtendedField.ADDRESS and not embed_mode_active:
+                unsorted_data = serializer.data
+                for item in get_facility_addresses(facility):
+                    if item.address is not None and len(item.address) != 0:
+                        unsorted_data.append(
+                            create_address_field(item.address,
+                                                 item.source.contributor,
+                                                 user_can_see_detail))
+                data = sorted(unsorted_data, key=sort_order, reverse=True)
+            else:
+                data = sorted(serializer.data, key=sort_order, reverse=True)
+
+            grouped_data[field_name] = data
+
+        return grouped_data
 
 
 def assign_contributor_field_values(list_item, fields):
@@ -924,57 +980,6 @@ class FacilityDetailsSerializer(FacilitySerializer):
                 facilitymatch__is_active=True).order_by('-created_at').first()
 
         return assign_contributor_field_values(list_item, fields)
-
-    def get_extended_fields(self, facility):
-        request = self.context.get('request') \
-            if self.context is not None else None
-        embed = request.query_params.get('embed') \
-            if request is not None else None
-        contributor_id = request.query_params.get('contributor', None) \
-            if request is not None and embed == '1' else None
-
-        fields = facility.extended_fields(contributor_id=contributor_id)
-        user_can_see_detail = can_user_see_detail(self)
-        embed_mode_active = is_embed_mode_active(self)
-
-        grouped_data = defaultdict(list)
-
-        def sort_order(k):
-            return (k.get('verified_count', 0), k.get('is_from_claim', False),
-                    k.get('value_count', 1), k.get('updated_at', None))
-
-        for field_name, _ in ExtendedField.FIELD_CHOICES:
-            serializer = ExtendedFieldListSerializer(
-                        fields.filter(field_name=field_name),
-                        many=True,
-                        context={'user_can_see_detail': user_can_see_detail,
-                                 'embed_mode_active': embed_mode_active}
-                    )
-
-            if field_name == ExtendedField.NAME and not embed_mode_active:
-                unsorted_data = serializer.data
-                for item in get_facility_names(facility):
-                    if item.name is not None and len(item.name) != 0:
-                        unsorted_data.append(
-                            create_name_field(item.name,
-                                              item.source.contributor,
-                                              user_can_see_detail))
-                data = sorted(unsorted_data, key=sort_order, reverse=True)
-            elif field_name == ExtendedField.ADDRESS and not embed_mode_active:
-                unsorted_data = serializer.data
-                for item in get_facility_addresses(facility):
-                    if item.address is not None and len(item.address) != 0:
-                        unsorted_data.append(
-                            create_address_field(item.address,
-                                                 item.source.contributor,
-                                                 user_can_see_detail))
-                data = sorted(unsorted_data, key=sort_order, reverse=True)
-            else:
-                data = sorted(serializer.data, key=sort_order, reverse=True)
-
-            grouped_data[field_name] = data
-
-        return grouped_data
 
     def get_created_from(self, facility):
         user_can_see_detail = can_user_see_detail(self)


### PR DESCRIPTION
## Overview

Adds extended fields values to the CSV/Excel downloads.

The fields are included as number_of_workers, parent_company,
facility_type, facility_type_raw, processing_type, processing_type_raw,
and product_type. Because the matched values might not be significantly
different from the submitted values for facility_type and
processing_type (due to aliasing), the raw values are included in the
download by client request.

Multiple values in a cell are combined by separating them with a
vertical bar, and each value include the contributor name and date:
Value (Contributor Name on Jun 1 2021).

In embed mode, the contributor name and the date are not included,
and only the values are shown. Values submitted by contributors
other than the owner of the embedded map are not included in the
download.

Connects #1591 

## Demo

Embed:
[embed-download.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8143579/embed-download.csv)

Regular:
[facilities-download.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8143580/facilities-download.csv)

## Testing Instructions

* Run `./scripts/server`
* Give embed permissions to c2@example.com and c15@example.com
* Login as c2@example.com and submit and fully process this list. 
[ExtendedFieldsTestList.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8143534/ExtendedFieldsTestList.csv)
* As c2@example.com, navigate to the embed preview in settings and download their facilities as CSV and as Excel. The extended fields should be included in the download; no contributor names or dates should be listed beside the values.
* As c15@example.com, navigate to the embed preview in settings and download their facilities as CSV and as Excel. The extended field cells should be empty (note that this list includes some of the same facilities as c2@example.com, but c2@example.com's values shouldn't be displayed). 
* Navigate to the main application view and download ExtendedFieldsTestList as CSV and as Excel. The extended field cells should include the contributor name and the date as well as the values. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
