### PR TITLE
Filter by extended fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Filter by extended fields [#1696](https://github.com/open-apparel-registry/open-apparel-registry/pull/1696)
+
 ### Changed
 
 ### Deprecated

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -35,6 +35,12 @@ class FacilitiesQueryParams:
     BOUNDARY = 'boundary'
     PPE = 'ppe'
     EMBED = 'embed'
+    PARENT_COMPANY = 'parent_company'
+    FACILITY_TYPE = 'facility_type'
+    PROCESSING_TYPE = 'processing_type'
+    PRODUCT_TYPE = 'product_type'
+    NUMBER_OF_WORKERS = 'number_of_workers'
+    NATIVE_LANGUAGE_NAME = 'native_language_name'
 
 
 class FacilityListQueryParams:

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1253,6 +1253,10 @@ class FacilityManager(models.Manager):
 
         product_types = params.getlist(FacilitiesQueryParams.PRODUCT_TYPE)
 
+        number_of_workers = params.getlist(
+            FacilitiesQueryParams.NUMBER_OF_WORKERS
+        )
+
         facilities_qs = FacilityIndex.objects.all()
 
         if free_text_query is not None:
@@ -1343,6 +1347,11 @@ class FacilityManager(models.Manager):
                 clean_product_types.append(clean(product_type))
             facilities_qs = facilities_qs.filter(
                 product_type__overlap=clean_product_types
+            )
+
+        if len(number_of_workers):
+            facilities_qs = facilities_qs.filter(
+                number_of_workers__overlap=number_of_workers
             )
 
         facility_ids = facilities_qs.values_list('id', flat=True)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1257,6 +1257,10 @@ class FacilityManager(models.Manager):
             FacilitiesQueryParams.NUMBER_OF_WORKERS
         )
 
+        native_language_name = params.get(
+            FacilitiesQueryParams.NATIVE_LANGUAGE_NAME, None
+        )
+
         facilities_qs = FacilityIndex.objects.all()
 
         if free_text_query is not None:
@@ -1352,6 +1356,12 @@ class FacilityManager(models.Manager):
         if len(number_of_workers):
             facilities_qs = facilities_qs.filter(
                 number_of_workers__overlap=number_of_workers
+            )
+
+        if native_language_name is not None:
+            unidecode_name = unidecode(native_language_name)
+            facilities_qs = facilities_qs.filter(
+                native_language_name__icontains=unidecode_name
             )
 
         facility_ids = facilities_qs.values_list('id', flat=True)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1251,6 +1251,8 @@ class FacilityManager(models.Manager):
             FacilitiesQueryParams.PROCESSING_TYPE
         )
 
+        product_types = params.getlist(FacilitiesQueryParams.PRODUCT_TYPE)
+
         facilities_qs = FacilityIndex.objects.all()
 
         if free_text_query is not None:
@@ -1333,6 +1335,14 @@ class FacilityManager(models.Manager):
                     standard_processing_types.append(standard_type[3])
             facilities_qs = facilities_qs.filter(
                 processing_type__overlap=standard_processing_types
+            )
+
+        if len(product_types):
+            clean_product_types = []
+            for product_type in product_types:
+                clean_product_types.append(clean(product_type))
+            facilities_qs = facilities_qs.filter(
+                product_type__overlap=clean_product_types
             )
 
         facility_ids = facilities_qs.values_list('id', flat=True)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -8407,3 +8407,32 @@ class NumberOfWorkersAPITest(FacilityAPITestCaseBase):
         )
         data = json.loads(response.content)
         self.assertEquals(data['count'], 0)
+
+
+class NativeLanguageNameAPITest(FacilityAPITestCaseBase):
+    def setUp(self):
+        super(NativeLanguageNameAPITest, self).setUp()
+        self.url = reverse('facility-list')
+        self.long_name = '杭州湾开发区兴慈二路与滨海二路叉口恒元工业园区A3'
+
+    @patch('api.geocoding.requests.get')
+    def test_search(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'native_language_name': self.long_name
+        }), content_type='application/json')
+
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(
+            self.url + '?native_language_name={}'.format(self.long_name)
+        )
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -8220,6 +8220,46 @@ class FacilityAndProcessingTypeAPITest(FacilityAPITestCaseBase):
         self.assertEqual(0, ExtendedField.objects.all().count())
         self.assertEqual(response.status_code, 400)
 
+    @patch('api.geocoding.requests.get')
+    def test_search_by_processing_type(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'processing_type': ['cutting']
+        }), content_type='application/json')
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(self.url + '?processing_type=cutting')
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
+    @patch('api.geocoding.requests.get')
+    def test_search_by_facility_type(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'facility_type': ['office hq', 'final product assembly']
+        }), content_type='application/json')
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(
+            self.url + '?facility_type=final%20product%20assembly'
+        )
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
 
 class NumberOfWorkersAPITest(FacilityAPITestCaseBase):
     def setUp(self):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -8124,6 +8124,26 @@ class ProductTypeTestCase(FacilityAPITestCaseBase):
         self.assertEqual(MAX_PRODUCT_TYPE_COUNT,
                          len(facility_index.product_type))
 
+    @patch('api.geocoding.requests.get')
+    def test_search_by_product_type(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'product_type': ['a', 'b']
+        }), content_type='application/json')
+
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(self.url + '?product_type=A')
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
 
 class FacilityAndProcessingTypeAPITest(FacilityAPITestCaseBase):
     def setUp(self):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -7968,6 +7968,71 @@ class ParentCompanyTestCase(FacilityAPITestCaseBase):
         self.assertIn(self.contributor.id, facility_index.parent_company_id)
         self.assertEqual(1, len(facility_index.parent_company_id))
 
+    @patch('api.geocoding.requests.get')
+    def test_search_by_name(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, {
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'parent_company': 'TEST CNTRIBUTOR'
+        })
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(
+            self.url + '?parent_company={}'.format(self.contributor.id)
+        )
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
+    @patch('api.geocoding.requests.get')
+    def test_search_by_id(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, {
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'parent_company': 'TEST CNTRIBUTOR'
+        })
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(
+            self.url + '?parent_company={}'.format(self.contributor.name)
+        )
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
+    @patch('api.geocoding.requests.get')
+    def test_search_by_multiple(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, {
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'parent_company': 'TEST CNTRIBUTOR'
+        })
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(
+            self.url + '?parent_company={}?parent_company={}'.format(
+                self.contributor.name, self.contributor.id
+            )
+        )
+        data = json.loads(response.content)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
 
 class ProductTypeTestCase(FacilityAPITestCaseBase):
     def setUp(self):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -671,22 +671,56 @@ class FacilitiesAPIFilterBackend(BaseFilterBackend):
                         'Pass a GeoJSON geometry to filter by '
                         'facilities within the boundaries of that geometry.')
                 ),
+                coreapi.Field(
+                    name='parent_company',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description=(
+                        'Pass a Contributor ID or Contributor name to filter '
+                        'by facilities with that Parent Company.')
+                ),
+                coreapi.Field(
+                    name='facility_type',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description='Facility type',
+                ),
+                coreapi.Field(
+                    name='processing_type',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description='Processing type',
+                ),
+                coreapi.Field(
+                    name='product_type',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description='Product type',
+                ),
+                coreapi.Field(
+                    name='number_of_workers',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description=(
+                        'Submit one of several standardized ranges to filter '
+                        'by facilities with a number_of_workers matching '
+                        'those values. Options are: "Less than 1000", '
+                        '"1001-5000", "5001-10000", or "More than 10000".'
+                    ),
+                ),
+                coreapi.Field(
+                    name='native_language_name',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description='The native language name of the facility',
+                ),
             ]
-
-            if switch_is_active('ppe'):
-                fields.append(
-                    coreapi.Field(
-                        name='ppe',
-                        location='query',
-                        type='boolean',
-                        required=False,
-                        description=(
-                            'If "true" only facilities with PPE '
-                            'production details or PPE-specific contact '
-                            'information will be returned. Any other value '
-                            'will return all facilities.'),
-                    )
-                )
 
             return fields
 


### PR DESCRIPTION
## Overview

Allows users to search for facilities by extended fields. 

- `parent_company`: Users can pass one or more parent_company params to the search query. Values can be numeric, which will match with parent_company_ids, or strings, which will match with parent_company_names. Any facility which contains a matching parent_company_id or a matching parent_company_name will be returned.
- `facility_type`: Allows users to send one or more facility_type strings. These are converted into the standardized facility types. Facilities which contain any matching facility_type are returned.
- `processing_type`: See `facility_type`
- `product_type`: The product_type strings are run through the `clean` function, and then any facilities which have any matching product_type are returned.
- `number_of_workers`: We store the number_of_workers value in the index using the standard ranges 'Less than 1000', '1001-5000', '5001-10000', 'More than 10000'. Users can pass one or more standard ranges as strings to the 'number_of_workers' param. Facilities are returned which have ranges that overlap with the provided values.
- `native_language_name`: We use unidecode on the query value and do a substring match to the native_language_name column and return any matching facilities.

Adds the new params to the Swagger API. 

To simplify some of the search functionality, removes PPE fields from the search query and Swagger API. 

Connects #1562 

## Demo

<img width="965" alt="Screen Shot 2022-03-04 at 1 39 28 PM" src="https://user-images.githubusercontent.com/21046714/156822644-782612be-240d-42d9-b1af-3d8259e988a7.png">

## Testing Instructions

* Run `./scripts/server`
* Upload and process the 
[ExtendedFieldsTestList.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8188113/ExtendedFieldsTestList.csv)
* In [the Swagger API](http://localhost:8081/api/docs/#!/facilities/facilities_list), search by various parameters and confirm that they return the below facilities. Confirm that any additional facilities returned from the search contain the expected extended fields.
      - parent_company: Factory A -> Ahmed Ahmed Abbas for Readymade Garments
      - parent_company: 2 -> Ahmed Ahmed Abbas for Readymade Garments
      - facility_type: Final Product Assembly -> All Wells International Co., Ltd
      - processing_type: Doubling -> A.Schmied s.r.o.
      - product_type: Blazers -> 4teams - Advertising & Merchandising, Lda.
      - number_of_workers: 1001-5000 -> BAOJI HAWK IND. & TRADE CO. LTD
      - native_language_name: 杭州湾开发区兴慈二路与滨海二路叉口恒元工业园区A3 -> BAOJI HAWK IND. & TRADE CO. LTD

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
