### PR TITLE
Add extended profile search APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Filter by extended fields [#1696](https://github.com/open-apparel-registry/open-apparel-registry/pull/1696)
+- Add extended profile search APIs [#1697](https://github.com/open-apparel-registry/open-apparel-registry/pull/1697)
 
 ### Changed
 

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -406,6 +406,12 @@ ALL_PROCESSING_TYPES_ALIAS = {
 }
 
 
+FACILITY_PROCESSING_TYPES_VALUES = [{
+    'facilityType': v,
+    'processingTypes': sorted(FACILITY_PROCESSING_TYPES[k].values())
+} for k, v in sorted(ALL_FACILITY_TYPES.items())]
+
+
 def get_facility_and_processing_type(facility_or_processing_type):
     """Attempts to match the input value to a facility or processing
     type via various methods.

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -66,7 +66,8 @@ from api.constants import (CsvHeaderField,
                            ProcessingAction,
                            LogDownloadQueryParams,
                            UpdateLocationParams,
-                           FeatureGroups)
+                           FeatureGroups,
+                           NumberOfWorkersRanges)
 from api.geocoding import geocode_address
 from api.matching import (match_item,
                           exact_match_item,
@@ -569,6 +570,26 @@ def active_countries_count(request):
                                  .distinct().count()
 
     return Response({"count": count})
+
+
+@api_view(['GET'])
+def number_of_workers_ranges(request):
+    """
+    Returns a list of standardized ranges for the number_of_workers extended
+    field.
+
+    ## Sample Response
+
+        [
+            "Less than 1000",
+            "1001-5000",
+            "5001-10000",
+            "More than 10000",
+        ]
+
+    """
+    return Response([r['label'] for r
+                     in NumberOfWorkersRanges.STANDARD_RANGES])
 
 
 @api_view(['GET'])

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -146,6 +146,8 @@ from api.facility_history import (create_facility_history_list,
 from api.extended_fields import (create_extendedfields_for_single_item,
                                  update_extendedfields_for_list_item,
                                  create_extendedfields_for_claim)
+from api.facility_type_processing_type import (
+    FACILITY_PROCESSING_TYPES_VALUES)
 
 
 def _report_facility_claim_email_error_to_rollbar(claim):
@@ -590,6 +592,32 @@ def number_of_workers_ranges(request):
     """
     return Response([r['label'] for r
                      in NumberOfWorkersRanges.STANDARD_RANGES])
+
+
+@api_view(['GET'])
+def facility_processing_types(request):
+    """
+    Returns a list of standardized ranges for the number_of_workers extended
+    field.
+
+    ## Sample Response
+
+        [{
+            "facilityType": "Final Product Assembly",
+            "processingTypes": [
+              "Assembly",
+              "Cut & Sew",
+              "Cutting",
+              "Embellishment",
+              "Embroidery",
+              ...
+            ]
+          },
+          ...
+         ]
+
+    """
+    return Response(FACILITY_PROCESSING_TYPES_VALUES)
 
 
 @api_view(['GET'])

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -59,6 +59,8 @@ public_apis = [
         views.ContributorFacilityListViewSet.as_view({'get': 'list'}),
         name='contributor_lists'),
     url(r'^api/log-download/', views.log_download, name='log_download'),
+    url(r'^api/workers-ranges/', views.number_of_workers_ranges,
+        name='number_of_workers_ranges')
 ]
 
 info_apis = [

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -60,7 +60,9 @@ public_apis = [
         name='contributor_lists'),
     url(r'^api/log-download/', views.log_download, name='log_download'),
     url(r'^api/workers-ranges/', views.number_of_workers_ranges,
-        name='number_of_workers_ranges')
+        name='number_of_workers_ranges'),
+    url(r'^api/facility-processing-types', views.facility_processing_types,
+        name='facility_processing_types')
 ]
 
 info_apis = [


### PR DESCRIPTION
## Overview

We will need access in the client to the standardized range values
for the number_of_workers extended profile field in order to populate
the select field.

- Adds an endpoint which returns a list of standard fields as strings.
- Adds an endpoint which returns a list of objects of the form
{ 'facilityType': value, 'processingTypes': [values] }

Connects #1588 

## Demo

<img width="993" alt="Screen Shot 2022-03-07 at 9 03 10 AM" src="https://user-images.githubusercontent.com/21046714/157053455-430fb00a-f7cd-41ab-9c9d-a394ca025141.png">

![Uploading Screen Shot 2022-03-07 at 9.03.30 AM.png…]()

## Testing Instructions

* Run `./scripts/server`
* Visit http://localhost:8081/api/docs/#!/facility-processing-types/facility_processing_types_list and click 'Try it out!'
     - The returned value should match the structure of the sample response and include the appropriate values. 
* Visit http://localhost:8081/api/docs/#!/workers-ranges/workers_ranges_list and click 'Try it out!'
     - The returned value should match the sample response and include the appropriate values. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
