### PR TITLE
Add an API to return suggested product type choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Filter by extended fields [#1696](https://github.com/open-apparel-registry/open-apparel-registry/pull/1696)
 - Add extended profile search APIs [#1697](https://github.com/open-apparel-registry/open-apparel-registry/pull/1697)
+- Add an API to return suggested product type choices [#1708](https://github.com/open-apparel-registry/open-apparel-registry/pull/1708)
 
 ### Changed
 

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -1,6 +1,6 @@
 import re
 from django.core import exceptions as core_exceptions
-from api.models import Contributor, ExtendedField
+from api.models import Contributor, ExtendedField, ProductType
 from api.facility_type_processing_type import (
     get_facility_and_processing_type,
     ALL_PROCESSING_TYPES
@@ -228,3 +228,17 @@ def create_extendedfields_for_claim(claim):
         else:
             ExtendedField.objects.filter(facility_claim=claim,
                                          field_name=extended_field).delete()
+
+
+def get_product_types():
+    product_types = list(ProductType.objects.all()
+                         .values_list('value', flat=True))
+    ef_values = (ExtendedField.objects.filter(field_name='product_type')
+                 .values_list('value__raw_values', flat=True))
+    flat_ef_value_titles = [item.title() for sublist in
+                            ef_values for item in sublist]
+    product_types.extend(flat_ef_value_titles)
+    # Converting to a set and back removes duplicates
+    product_types = list(set(product_types))
+    product_types.sort()
+    return product_types

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1,4 +1,3 @@
-from itertools import chain
 from collections import defaultdict
 
 from django.conf import settings
@@ -33,7 +32,6 @@ from api.models import (FacilityList,
                         FacilityClaimReviewNote,
                         User,
                         Contributor,
-                        ProductType,
                         Source,
                         ApiBlock,
                         FacilityActivityReport,
@@ -46,6 +44,7 @@ from api.processing import get_country_code
 from api.helpers import (prefix_a_an,
                          get_single_contributor_field_values,
                          get_list_contributor_field_values)
+from api.extended_fields import get_product_types
 from api.facility_type_processing_type import (
     ALL_FACILITY_TYPE_CHOICES,
     ALL_PROCESSING_TYPE_CHOICES
@@ -1172,33 +1171,10 @@ class ApprovedFacilityClaimSerializer(ModelSerializer):
         return FacilityClaim.CERTIFICATION_CHOICES
 
     def get_product_type_choices(self, claim):
-        seeds = [
-            seed
-            for seed
-            in ProductType.objects.all().values_list('value', flat=True)
-            or []
-        ]
-
-        new_values = FacilityClaim \
-            .objects \
-            .all() \
-            .values_list('facility_product_types', flat=True)
-
-        values = [
-            new_value
-            for new_value
-            in new_values if new_value is not None
-        ]
-
-        # Using `chain` flattens nested lists
-        union_of_seeds_and_values = list(
-            set(chain.from_iterable(values)).union(seeds))
-        union_of_seeds_and_values.sort()
-
         return [
             (choice, choice)
             for choice
-            in union_of_seeds_and_values
+            in get_product_types()
         ]
 
     def get_production_type_choices(self, claim):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4600,21 +4600,6 @@ class FacilityClaimSerializerTests(TestCase):
         self.assertIsNotNone(data['production_type_choices'])
         self.assertNotEqual([], data['production_type_choices'])
 
-    def test_product_and_production_values_from_claims_are_included(self):
-        self.claim.facility_product_types = ['A', 'B']
-        self.claim.facility_production_types = ['Blending', 'Bonding']
-        self.claim.save()
-        data = ApprovedFacilityClaimSerializer(self.claim).data
-
-        product_types = data['product_type_choices']
-        self.assertIn(('A', 'A'), product_types)
-        self.assertEqual(('A', 'A'), product_types[0])
-        self.assertIn(('B', 'B'), product_types)
-
-        production_types = data['production_type_choices']
-        self.assertIn(('blending', 'Blending'), production_types)
-        self.assertIn(('bonding', 'Bonding'), production_types)
-
 
 class LogDownloadTests(APITestCase):
     def setUp(self):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -145,7 +145,8 @@ from api.facility_history import (create_facility_history_list,
                                   create_dissociate_match_change_reason)
 from api.extended_fields import (create_extendedfields_for_single_item,
                                  update_extendedfields_for_list_item,
-                                 create_extendedfields_for_claim)
+                                 create_extendedfields_for_claim,
+                                 get_product_types)
 from api.facility_type_processing_type import (
     FACILITY_PROCESSING_TYPES_VALUES)
 
@@ -618,6 +619,24 @@ def facility_processing_types(request):
 
     """
     return Response(FACILITY_PROCESSING_TYPES_VALUES)
+
+
+@api_view(['GET'])
+def product_types(request):
+    """
+    Returns a list of suggested product types by combining standard types with
+    distinct values submitted by contributors.
+
+    ## Sample Response
+
+        [
+            "Accessories",
+            "Belts",
+            "Caps"
+        ]
+
+    """
+    return Response(get_product_types())
 
 
 @api_view(['GET'])

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -62,7 +62,9 @@ public_apis = [
     url(r'^api/workers-ranges/', views.number_of_workers_ranges,
         name='number_of_workers_ranges'),
     url(r'^api/facility-processing-types', views.facility_processing_types,
-        name='facility_processing_types')
+        name='facility_processing_types'),
+    url(r'^api/product-types', views.product_types,
+        name='prodcut_types'),
 ]
 
 info_apis = [


### PR DESCRIPTION


## Overview

We allow contributors to submit any value for product type but expect that by suggesting standard values and values that have already been submitted we will have more standardization in the collected data.

We use a helper function so we can share the logic with a public API and with the claim form serializer which was already pulling a list of values. Now that we have migrated claims to use extended fields we can replace the old logic used to look for product types used on other claims.

Connects #1706

## Demo

<img width="792" alt="Screen Shot 2022-03-11 at 1 34 46 PM" src="https://user-images.githubusercontent.com/17363/157958554-400f82ab-ccb1-42a1-99fb-000d37888e96.png">


## Testing Instructions

* Verify that the new product-types API is available at http://localhost:8081/api/docs/#!/product-types/product_types_list and that it returns a list of unique types.
* Log in as c2@example.com and submit a claim
* In a separate browser log in as c1@example.com, browse http://localhost:8081/dashboard/claims/  and approve the claim
* In the original session browse http://localhost:6543/claimed, edit the claim, and verify that the product types dropdown lists is filled with values.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
