### PR TITLE
Update email copy for list completion email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Allow submitting non-taxonomy facility type and processing type [#1705](https://github.com/open-apparel-registry/open-apparel-registry/pull/1705)
+- Update email copy for list completion [#1709](https://github.com/open-apparel-registry/open-apparel-registry/pull/1709)
 
 ### Deprecated
 

--- a/src/django/api/templates/mail/facility_list_complete_body.html
+++ b/src/django/api/templates/mail/facility_list_complete_body.html
@@ -13,17 +13,32 @@
             Thanks for submitting {{ list_name }} to the Open Apparel Registry. The list has now been processed by our system and the results are available here: <a href="{{ list_url }}">{{ list_url }}</a>.
         </p>
         <strong>What next?</strong>
-        <ul>
+        <strong>Reviewing your upload: </strong>
+        <ol>
             <li>
-                <strong> Review your list </strong> to see which facilities already exist in the OAR, access their unique OAR IDs and understand which other organisations share connections to the facilities you’re working with. What collaborations could you explore working on together? You’ll also see <strong> New Facilities </strong> in instances where you’ve added a new entry to the system, also allocated their own unique OAR IDs.
+                <strong> Check for and Resolve Errors:</strong> Some entries in your list may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. You can read the <a href="https://info.openapparel.org/faqs#processing-data-in-the-oar">Processing data in the OAR section of our FAQs</a> for more information on error types and how to resolve them. Once you have pin-pointed the cause of the error, update your facility information in your Excel/CSV file and re-upload your FULL list to the OAR again (uploading one facility at a time results in multiple lists that are harder to manage).
             </li>
             <li>
-                <strong> Confirm or Reject Potential Matches: </strong> In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool (for more on how the OAR processes data, read this technical blog). Here we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I supposed to do on the confirm / reject page?” section of our FAQ page.
+                <strong> Confirm or Reject Potential Matches: </strong> In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool. Once you have resolved any errors in your list, next we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I meant to do on the confirm / reject page?” question of our <a href="https://info.openapparel.org/faqs#uploading-to-the-oar">FAQ page</a>.
             </li>
             <li>
-                <strong> Resolve Errors: </strong> Some entries may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. Once you have pin-pointed the cause, you can re-upload a list of those facilities with cleaned data.
+                <strong> Data Points Beyond Name and Address: </strong> If you uploaded additional data points beyond facility name and address, you will now be able to see them by searching or downloading your contribution from the Open Apparel Registry.
             </li>
-        </ul>
+        </ol>
+        <strong>Once your list is uploaded and cleaned: </strong>
+        <ol>
+            <li>
+                <strong> See who else is connected with your facilities/suppliers: </strong>Once you have contributed to the OAR, check out your facility profiles to see which other companies and organizations are connected with the facilities you uploaded. What collaborations could you explore working on together?
+            </li>
+            <li>
+                <strong>Share your OAR contribution: </strong>Link directly to your facility/supplier data on the OAR from your website, so your users can easily search and navigate through your list. <a href="https://info.openapparel.org/stories-resources/assets-for-oar-stakeholders">These free graphics are available</a> for use to point users to your OAR contribution on your website, LinkedIn profile, and/or on social media. You can also display your facility/supplier data as an <a href="https://info.openapparel.org/embedded-map">interactive map, embedded on your website</a>.
+            </li>
+            <li>
+                <strong>Encourage your facilities/suppliers to claim their profiles or claim your facility, if you are the owner: </strong>By claiming their facilities on the OAR, facility owners or senior management can provide facility location data straight from the source, as well as add additional details to their profiles, including MOQs, lead times, certifications, and more.
+                <br/>
+                If you are a brand or organization uploading a facility list, you can find suggested text for <a href="https://info.openapparel.org/stories-resources/encourage-your-facilities-to-claim-their-profiles">a message to your suppliers here</a>, to encourage them to claim their profiles.</li>
+            </li>
+        </ol>
         <p>
             For any questions, feel free to reach out to the OAR team: <a href="mailto:info@openapparel.org">info@openapparel.org</a>
         </p>

--- a/src/django/api/templates/mail/facility_list_complete_body.txt
+++ b/src/django/api/templates/mail/facility_list_complete_body.txt
@@ -5,13 +5,25 @@ Thanks for submitting {{ list_name }} to the Open Apparel Registry. The list has
 
 What next?
 
-Review your list to see which facilities already exist in the OAR, access their unique OAR IDs and understand which other organisations share connections to the facilities you’re working with. What collaborations could you explore working on together? You’ll also see New Facilities in instances where you’ve added a new entry to the system, also allocated their own unique OAR IDs.
+Reviewing your upload:
 
-Confirm or Reject Potential Matches: In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool (for more on how the OAR processes data, read this technical blog). Here we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I supposed to do on the confirm / reject page?” section of our FAQ page.
+1. Check for and Resolve Errors: Some entries in your list may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. You can read the Processing data in the OAR section of our FAQs (https://info.openapparel.org/faqs#processing-data-in-the-oar) for more information on error types and how to resolve them. Once you have pin-pointed the cause of the error, update your facility information in your Excel/CSV file and re-upload your FULL list to the OAR again (uploading one facility at a time results in multiple lists that are harder to manage).
 
-Resolve Errors: Some entries may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. Once you have pin-pointed the cause, you can re-upload a list of those facilities with cleaned data.
+2. Confirm or Reject Potential Matches: In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool. Once you have resolved any errors in your list, next we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I meant to do on the confirm / reject page?” question of our FAQ page (https://info.openapparel.org/faqs#uploading-to-the-oar).
 
-For any questions, feel free to reach out to the OAR team: info@openapparel.org
+3. Data Points Beyond Name and Address: If you uploaded additional data points beyond facility name and address, you will now be able to see them by searching or downloading your contribution from the Open Apparel Registry.
+
+Once your list is uploaded and cleaned:
+
+1. See who else is connected with your facilities/suppliers: Once you have contributed to the OAR, check out your facility profiles to see which other companies and organizations are connected with the facilities you uploaded. What collaborations could you explore working on together?
+
+2. Share your OAR contribution: Link directly to your facility/supplier data on the OAR from your website, so your users can easily search and navigate through your list. These free graphics are available (https://info.openapparel.org/stories-resources/assets-for-oar-stakeholders) for use to point users to your OAR contribution on your website, LinkedIn profile, and/or on social media. You can also display your facility/supplier data as an interactive map, embedded on your website (https://info.openapparel.org/embedded-map).
+
+3. Encourage your facilities/suppliers to claim their profiles or claim your facility, if you are the owner: By claiming their facilities on the OAR, facility owners or senior management can provide facility location data straight from the source, as well as add additional details to their profiles, including MOQs, lead times, certifications, and more.
+
+If you are a brand or organization uploading a facility list, you can find suggested text for a message to your suppliers here (https://info.openapparel.org/stories-resources/encourage-your-facilities-to-claim-their-profiles), to encourage them to claim their profiles.
+
+For any questions, feel free to reach out to the OAR team: info@openapparel.org.
 
 All the best,
 


### PR DESCRIPTION
## Overview

Replaces current email copy sent when a list finishes processing with
[updated text](https://docs.google.com/document/d/1_1jP8NURMiRyjFRnBUfi3r8XbsIb0vPXYWtS1IM_rms/edit) provided by the OAR team.

Connects #1443 

## Demo

<img width="1211" alt="Screen Shot 2022-03-14 at 11 41 15 AM" src="https://user-images.githubusercontent.com/21046714/158246412-20f97006-cb07-4f9d-8184-77011034302f.png">

<img width="1090" alt="Screen Shot 2022-03-14 at 11 41 02 AM" src="https://user-images.githubusercontent.com/21046714/158246427-e8b8f305-f1f5-47ee-a6af-76dad08a038e.png">

## Testing Instructions

* Run `vagrant ssh` and ` ./scripts/manage batch_process -a notify_complete -l 15`
* Confirm that the email printed to the console matches the text and links provided in [the document](https://docs.google.com/document/d/1_1jP8NURMiRyjFRnBUfi3r8XbsIb0vPXYWtS1IM_rms/edit)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
