### PR TITLE
Hide inactive contributor associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Hide inactive contributor associations [#1712](https://github.com/open-apparel-registry/open-apparel-registry/pull/1712)
+
 ### Security
 
 ## [60] - 2022-03-03


### PR DESCRIPTION
## Overview

The ExtendedField serializer was incorrectly returning non-anonymized
contributor names and ids for contributors who had deactivated the
list through which they contributed the fields.

Deactivating a list or match will now result in the contributor's
details being anonymized in the extended field serializer.

Connects #1711 

## Demo

<img width="314" alt="Screen Shot 2022-03-15 at 2 12 41 PM" src="https://user-images.githubusercontent.com/21046714/158451648-3bbef4d0-1236-46bc-9e35-51c5876da9b6.png">
<img width="302" alt="Screen Shot 2022-03-15 at 2 12 49 PM" src="https://user-images.githubusercontent.com/21046714/158451660-02134cbd-9382-428e-ba2c-a9e1d23baf98.png">

## Notes

My initial thought about this bug was that it was related to issue #1691, and possibly also extended field indexing. 
However, we handle anonymization of association displays in the serializers, not in the indexer, so this bug was unrelated to search or indexing.

## Testing Instructions

* Run `vagrant ssh` and `./scripts/server`
* Login as c2@example.com and submit [ExtendedFieldsTestListA.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8256370/ExtendedFieldsTestListA.csv). Fully process the list with `./tools/batch_process {list_id}`
* Open both facilities from the list in a new tab and confirm that they both display Service Provider A for all their fields and under contributors.
* Replace ExtendedFieldsTestListA with [ExtendedFieldsTestListB.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8256372/ExtendedFieldsTestListB.csv) (via submission form) and fully process the list with `./tools/batch_process {list_id}`.
* Refresh both facilities. 'Kept Facility' should still display Service Provider A for its contributor data. 'Deleted Facility' should now show 'a Service Provider' (an anonymized value) for the contributor details.

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
