### PR TITLE
Remove the redundant workers suffix when showing value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Allow submitting non-taxonomy facility type and processing type [#1705](https://github.com/open-apparel-registry/open-apparel-registry/pull/1705)
 - Update email copy for list completion [#1709](https://github.com/open-apparel-registry/open-apparel-registry/pull/1709)
+- Remove the redundant workers suffix when showing value [#1715](https://github.com/open-apparel-registry/open-apparel-registry/pull/1715/files)
 
 ### Deprecated
 

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -756,7 +756,7 @@ export const EXTENDED_FIELD_TYPES = [
         label: 'Number of Workers',
         fieldName: 'number_of_workers',
         formatValue: ({ min, max }) =>
-            max === min ? `${max} workers` : `${min}-${max} workers`,
+            max === min ? `${max}` : `${min}-${max}`,
     },
     {
         label: 'Native Language Name',


### PR DESCRIPTION


## Overview

The label above the field already says "Number of workers" so the OAR team asked to remove the redundant suffix, making "1000 wokers" into "1000."

Connects #1694

## Demo

<img width="329" alt="Screen Shot 2022-03-15 at 5 58 28 PM" src="https://user-images.githubusercontent.com/17363/158496276-823d50c9-8fd3-440c-bd9c-8ecb9162cdcf.png">


## Testing Instructions

* Log in as c2@example.com
* Upload [Extended-WorkersTest.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8258153/Extended-WorkersTest.xlsx) and use `./tools/batch_process {list id}` to process it
* Browse both facilities and verify that the worker count does not have a suffix



## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
