### PR TITLE
Move exact_match sorting to server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Hide inactive contributor associations [#1712](https://github.com/open-apparel-registry/open-apparel-registry/pull/1712)
+- Move exact_match sorting to server [#1716](https://github.com/open-apparel-registry/open-apparel-registry/pull/1716)
 
 ### Security
 


### PR DESCRIPTION
## Overview

When a pending facility list item has multiple exact matches in the
database, we choose the match to automatically pair with via sorting
the matches and choosing the top result. We prefer active items, then
items which were submitted by the current contributor, then by the
most recent submission.

Previously, we sorted exact_matches using Django annotations and
order_by. This included a CPU-intensive nested subquery to collect a
list of active list item ids.

Moving the sorting to a server-side
sort allows us to perform the subquery only once, outside of the main
query, reducing the time taken by the query.

## Demo

I uploaded a large list three times using the old query. On the third time, once there were multiple matches for each item, I recorded the length of time taken by the full exact_match_items function and found it took 12.731543 seconds for matching all items. I also ran EXPLAIN ANALYZE in the dbshell and found that the execution time would be 5.394 ms for just the query (per item).

I then uploaded the same list again using the new query. The full exact_match_items function took 3.633751 seconds for matching all items in the list. EXPLAIN ANALYZE estimated that the execution time would be 0.123 ms for just the query (per item). 

OLD query:
```
                                                                                                                                                              QUERY PLAN                                    
                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=1503.05..1503.06 rows=1 width=2201) (actual time=5.348..5.350 rows=2 loops=1)
   Sort Key: ((hashed SubPlan 1)) DESC, ((api_source.contributor_id = 1)) DESC, api_facilitylistitem.updated_at
   Sort Method: quicksort  Memory: 29kB
   ->  Nested Loop  (cost=1486.72..1503.04 rows=1 width=2201) (actual time=5.315..5.336 rows=2 loops=1)
         ->  Index Scan using api_fli_match_fields_idx on api_facilitylistitem  (cost=0.28..8.32 rows=1 width=2199) (actual time=0.016..0.022 rows=2 loops=1)
               Index Cond: (((country_code)::text = 'VN'::text) AND (clean_name IS NOT NULL) AND (clean_name IS NOT NULL) AND ((clean_name)::text = 'tng investment and trading jsc padding factory branch':
:text) AND ((clean_address)::text = 'area b song cong industrial zone bach quang ward song cong city thai nguyen'::text))
               Filter: ((facility_id IS NOT NULL) AND ((status)::text = ANY ('{MATCHED,CONFIRMED_MATCH}'::text[])))
               Rows Removed by Filter: 1
         ->  Index Scan using api_source_pkey on api_source  (cost=0.15..8.17 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=2)
               Index Cond: (id = api_facilitylistitem.source_id)
         SubPlan 1
           ->  Hash Join  (cost=353.17..1479.02 rows=2907 width=4) (actual time=1.458..5.023 rows=924 loops=1)
                 Hash Cond: (u1.id = u0.facility_list_item_id)
                 ->  Hash Join  (cost=25.11..1095.17 rows=3563 width=4) (actual time=0.014..3.333 rows=2633 loops=1)
                       Hash Cond: (u1.source_id = u2.id)
                       ->  Seq Scan on api_facilitylistitem u1  (cost=0.00..1051.26 rows=7126 width=8) (actual time=0.004..2.844 rows=6050 loops=1)
                       ->  Hash  (cost=19.30..19.30 rows=465 width=4) (actual time=0.006..0.006 rows=18 loops=1)
                             Buckets: 1024  Batches: 1  Memory Usage: 9kB
                             ->  Seq Scan on api_source u2  (cost=0.00..19.30 rows=465 width=4) (actual time=0.002..0.004 rows=18 loops=1)
                                   Filter: is_active
                                   Rows Removed by Filter: 4
                 ->  Hash  (cost=255.38..255.38 rows=5814 width=4) (actual time=1.425..1.426 rows=4319 loops=1)
                       Buckets: 8192  Batches: 1  Memory Usage: 216kB
                       ->  Seq Scan on api_facilitymatch u0  (cost=0.00..255.38 rows=5814 width=4) (actual time=0.003..1.014 rows=4319 loops=1)
                             Filter: (is_active AND ((status)::text = ANY ('{AUTOMATIC,CONFIRMED,MERGED}'::text[])))
                             Rows Removed by Filter: 24
 Planning Time: 0.826 ms
 Execution Time: 5.394 ms
(28 rows)
```

NEW query: 

```
                                                                                                                                                         QUERY PLAN                                
                                                                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------------------------------
 Index Scan using api_fli_match_fields_idx on api_facilitylistitem  (cost=0.28..8.57 rows=1 width=2193) (actual time=0.094..0.104 rows=4 loops=1)
   Index Cond: (((country_code)::text = 'VN'::text) AND (clean_name IS NOT NULL) AND ((clean_name)::text = 'tng investment and trading jsc padding factory branch'::text) AND (clean_address IS NOT
 NULL) AND ((clean_address)::text = 'area b song cong industrial zone bach quang ward song cong city thai nguyen'::text))
   Filter: ((facility_id IS NOT NULL) AND ((status)::text = ANY ('{MATCHED,CONFIRMED_MATCH}'::text[])))
 Planning Time: 0.235 ms
 Execution Time: 0.123 ms
(5 rows)
```

## Testing Instructions

ON DEVELOP:
* Run `./scripts/server` and upload 
[1569-nodupes-latlng.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8274806/1569-nodupes-latlng.csv). This list contains lat and lng columns, which allows us to skip the geocoding process. 
* Run `./tools/batch_process {list_id}`.
* Re-upload and process the list several times. Note the timing of the match step.

ON THIS BRANCH:
* Re-upload and process the list several times. Note the timing of the match step.
* Confirm there is no functionality regression by completing the tests from https://github.com/open-apparel-registry/open-apparel-registry/pull/1568 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
