### PR TITLE
Update copy on list pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow submitting non-taxonomy facility type and processing type [#1705](https://github.com/open-apparel-registry/open-apparel-registry/pull/1705)
 - Update email copy for list completion [#1709](https://github.com/open-apparel-registry/open-apparel-registry/pull/1709)
 - Remove the redundant workers suffix when showing value [#1715](https://github.com/open-apparel-registry/open-apparel-registry/pull/1715/files)
+- Update copy on list pages [#1719](https://github.com/open-apparel-registry/open-apparel-registry/pull/1719)
 
 ### Deprecated
 

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -216,7 +216,12 @@ class FacilityListItems extends Component {
                             >
                                 processed and matched
                             </a>
-                            .
+                            . Data points submitted beyond facility name and
+                            address are processing, even if they do not appear
+                            on this page. Once your list has processed, you will
+                            be able to view and search these data points on
+                            facility profiles, as well as in downloads from the
+                            platform.
                         </div>
                         {list.item_count ? (
                             <Route

--- a/src/app/src/components/FacilityLists.jsx
+++ b/src/app/src/components/FacilityLists.jsx
@@ -90,6 +90,12 @@ class FacilityLists extends Component {
                             View my facilities
                         </Link>
                     </ShowOnly>
+                    <p>
+                        The processing time may be longer for lists that include
+                        additional data points beyond facility name and address.
+                        You will receive an email when your list has finished
+                        processing.
+                    </p>
                     {tableComponent}
                 </AppGrid>
             </AppOverflow>


### PR DESCRIPTION
## Overview

In anticipation of user confusion / feedback about list processing
times and EP data points not showing up on the individual list page, we
have updated the copy at the top of the list pages to include
additional informational text.

Connects #1704 

## Demo

<img width="1360" alt="Screen Shot 2022-03-17 at 1 47 15 PM" src="https://user-images.githubusercontent.com/21046714/158864851-966f8d68-36dd-4e96-bf45-367d256aa6c7.png">
<img width="1358" alt="Screen Shot 2022-03-17 at 1 47 33 PM" src="https://user-images.githubusercontent.com/21046714/158864861-03a14c8e-de23-4f97-a2c6-d3a517147ff6.png">

## Testing Instructions

* Run `vagrant ssh` and `./scripts/server`
* Login as a user with existing lists.
* Navigate to http://localhost:6543/lists and confirm the text above the list of lists matches the copy provided in the issue.
* Select a list to view its individual list page. Confirm the text above the list matches the copy provided in the issue.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
