### PR TITLE
Fix CSV download when Extended Profile switch is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Hide inactive contributor associations [#1712](https://github.com/open-apparel-registry/open-apparel-registry/pull/1712)
+- Fix CSV download when extended profile switch is off [#1720](https://github.com/open-apparel-registry/open-apparel-registry/pull/1720)
 
 ### Security
 

--- a/src/app/src/util/util.facilitiesCSV.js
+++ b/src/app/src/util/util.facilitiesCSV.js
@@ -214,7 +214,7 @@ export const makeFacilityReducer = options => (acc, next) =>
 
 const getContributorFieldHeaders = (facilities, options) => {
     let fields = get(facilities, '[0].properties.contributor_fields', []);
-    if (options && options.isEmbedded) {
+    if (options && options.includeExtendedFields) {
         fields = fields.filter(
             field => !extendedFieldHeaders.includes(field.fieldName),
         );


### PR DESCRIPTION
## Overview

When the extended profile switch is turned off, we were filtering out
extended field headers from the embedded map download but ttill
showing the extended field values, causing a mismatch between the
header and rows.

Elsewhere in the embedded map, we treat the extended fields as custom
contributor fields if extended profile is turned off. We now handle both
extended field headers and values as custom contributor fields in the
embedded map facilities download.

Connects #1700 

## Demo

Embedded map download when the extended profile flag is on:
[ExtendedProfileDownload.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8289918/ExtendedProfileDownload.csv)

Embedded map download when the extended profile flag is off:
[NoExtendedProfileDownload.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8289922/NoExtendedProfileDownload.csv)

## Testing Instructions

* Run `vagrant ssh` and `./scripts/server`
* As user c2@example.com, upload and process a list with both extended fields and custom fields. 
* Navigate to http://localhost:8081/admin/ as c1@example.com and turn off the extended profile switch. 
* Navigate to http://localhost:6543/settings as c2@example.com and search for the list you just uploaded in the embedded map preview. Download the list as a csv. The list should display the extended map fields as contributor fields. 
* Navigate to http://localhost:8081/admin/ as c1@example.com and turn on the extended profile switch. 
* Navigate to http://localhost:6543/settings as c2@example.com and search for the list you just uploaded in the embedded map preview. Download the list as a csv. The list should display the extended map fields as extended fields. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
