### PR TITLE
Remove native language name from filter sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update email copy for list completion [#1709](https://github.com/open-apparel-registry/open-apparel-registry/pull/1709)
 - Remove the redundant workers suffix when showing value [#1715](https://github.com/open-apparel-registry/open-apparel-registry/pull/1715/files)
 - Update copy on list pages [#1719](https://github.com/open-apparel-registry/open-apparel-registry/pull/1719)
+- Remove native language name from filter sidebar [#1722](https://github.com/open-apparel-registry/open-apparel-registry/pull/1722)
 
 ### Deprecated
 

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -114,7 +114,6 @@ const FACILITY_TYPE = 'FACILITY_TYPE';
 const PROCESSING_TYPE = 'PROCESSING_TYPE';
 const PRODUCT_TYPE = 'PRODUCT_TYPE';
 const NUMBER_OF_WORKERS = 'NUMBER_OF_WORKERS';
-const NATIVE_LANGUAGE_NAME = 'NATIVE_LANGUAGE_NAME';
 
 const mapFacilityTypeOptions = (fPTypes, pTypes) => {
     let fTypes = [];
@@ -181,8 +180,6 @@ function FilterSidebarSearchTab({
     updateProductType,
     numberOfWorkers,
     updateNumberOfWorkers,
-    nativeLanguageName,
-    updateNativeLanguageName,
     combineContributors,
     updateCombineContributors,
     fetchingFacilities,
@@ -210,7 +207,6 @@ function FilterSidebarSearchTab({
         processingType,
         productType,
         numberOfWorkers,
-        nativeLanguageName,
     ];
 
     const allFields = extendedFields.concat([
@@ -767,25 +763,6 @@ function FilterSidebarSearchTab({
                             disabled={fetchingOptions || fetchingFacilities}
                         />
                     </div>
-                    <div
-                        className="form__field"
-                        style={{ marginBottom: '10px' }}
-                    >
-                        <InputLabel
-                            htmlFor={NATIVE_LANGUAGE_NAME}
-                            className="form__label"
-                        >
-                            Native Language Name
-                        </InputLabel>
-                        <TextField
-                            id={NATIVE_LANGUAGE_NAME}
-                            placeholder="Native Language Facility Name"
-                            className="full-width margin-bottom-16 form__text-input"
-                            value={nativeLanguageName}
-                            onChange={updateNativeLanguageName}
-                            onKeyPress={submitFormOnEnterKeyPress}
-                        />
-                    </div>
                 </ShowOnly>
                 <div className="form__action">{searchResetButtonGroup()}</div>
                 <div className="form__field">
@@ -849,7 +826,6 @@ FilterSidebarSearchTab.propTypes = {
     processingType: processingTypeOptionsPropType.isRequired,
     productType: productTypeOptionsPropType.isRequired,
     numberOfWorkers: numberOfWorkerOptionsPropType.isRequired,
-    nativeLanguageName: string.isRequired,
     combineContributors: string.isRequired,
     ppe: string.isRequired,
     fetchingFacilities: bool.isRequired,


### PR DESCRIPTION
## Overview

Remove the native language name free text field from the filter sidebar while keeping the searching ability upon OAR request

Connects #1717 

## Demo

![image](https://user-images.githubusercontent.com/60887686/158892330-ab5c6af0-e2bd-4cb6-9db9-29d8e90cc43b.png)

## Testing Instructions

* Checkout this branch and run `server`
* Contribute [ExtendedFieldsTestList.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8291884/ExtendedFieldsTestList.csv) and fully process it
* Expand the filter sidebar to show extended fields
    - [x] Make sure "Native Language Name" is not there
    - [x] All other extended field searches work as intended
    - [x] Open `http://localhost:6543/facilities?native_language_name=工业` and _BAOJI HAWK IND. & TRADE CO. LTD_ should be found.



## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
