### PR TITLE
Delay loading search field dropdown data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Delay loading search field dropdown data [#1731](https://github.com/open-apparel-registry/open-apparel-registry/pull/1731)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -244,10 +244,9 @@ export function fetchNumberOfWorkersOptions() {
     };
 }
 
-export function fetchAllFilterOptions() {
+export function fetchAllPrimaryFilterOptions() {
     return dispatch => {
         dispatch(fetchContributorOptions());
-        dispatch(fetchContributorTypeOptions());
         dispatch(fetchCountryOptions());
         dispatch(fetchListOptions());
     };

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -30,21 +30,13 @@ import {
 import {
     fetchContributorOptions,
     fetchListOptions,
-    fetchContributorTypeOptions,
     fetchCountryOptions,
-    fetchFacilityProcessingTypeOptions,
-    fetchProductTypeOptions,
-    fetchNumberOfWorkersOptions,
-    fetchAllFilterOptions,
+    fetchAllPrimaryFilterOptions,
 } from '../actions/filterOptions';
 
 import {
     contributorOptionsPropType,
-    contributorTypeOptionsPropType,
     countryOptionsPropType,
-    facilityProcessingTypeOptionsPropType,
-    productTypeOptionsPropType,
-    numberOfWorkerOptionsPropType,
 } from '../util/propTypes';
 
 import { allListsAreEmpty } from '../util/util';
@@ -67,32 +59,15 @@ class FilterSidebar extends Component {
     componentDidMount() {
         const {
             contributorsData,
-            contributorTypesData,
             countriesData,
-            facilityProcessingTypeData,
-            productTypeData,
-            numberOfWorkersData,
             fetchFilterOptions,
             fetchContributors,
             fetchLists,
-            fetchContributorTypes,
             fetchCountries,
-            fetchFacilityProcessingType,
-            fetchProductType,
-            fetchNumberOfWorkers,
             contributors,
         } = this.props;
 
-        if (
-            allListsAreEmpty(
-                contributorsData,
-                contributorTypesData,
-                countriesData,
-                facilityProcessingTypeData,
-                productTypeData,
-                numberOfWorkersData,
-            )
-        ) {
+        if (allListsAreEmpty(contributorsData, countriesData)) {
             return fetchFilterOptions();
         }
 
@@ -100,24 +75,8 @@ class FilterSidebar extends Component {
             fetchContributors();
         }
 
-        if (!contributorTypesData.length) {
-            fetchContributorTypes();
-        }
-
         if (!countriesData.length) {
             fetchCountries();
-        }
-
-        if (!facilityProcessingTypeData.length) {
-            fetchFacilityProcessingType();
-        }
-
-        if (!productTypeData.length) {
-            fetchProductType();
-        }
-
-        if (!numberOfWorkersData.length) {
-            fetchNumberOfWorkers();
         }
 
         if (contributors && contributors.length) {
@@ -266,18 +225,9 @@ FilterSidebar.propTypes = {
     makeFacilitiesTabActive: func.isRequired,
     fetchFilterOptions: func.isRequired,
     fetchContributors: func.isRequired,
-    fetchContributorTypes: func.isRequired,
     fetchCountries: func.isRequired,
-    fetchFacilityProcessingType: func.isRequired,
-    fetchProductType: func.isRequired,
-    fetchNumberOfWorkers: func.isRequired,
     contributorsData: contributorOptionsPropType.isRequired,
-    contributorTypesData: contributorTypeOptionsPropType.isRequired,
     countriesData: countryOptionsPropType.isRequired,
-    facilityProcessingTypeData:
-        facilityProcessingTypeOptionsPropType.isRequired,
-    productTypeData: productTypeOptionsPropType.isRequired,
-    numberOfWorkersData: numberOfWorkerOptionsPropType.isRequired,
     vectorTileFeatureIsActive: bool.isRequired,
     fetchingFeatureFlags: bool.isRequired,
 };
@@ -287,11 +237,7 @@ function mapStateToProps({
     filterOptions: {
         contributors: { data: contributorsData },
         lists: { data: listsData },
-        contributorTypes: { data: contributorTypesData },
         countries: { data: countriesData },
-        facilityProcessingType: { data: facilityProcessingTypeData },
-        productType: { data: productTypeData },
-        numberOfWorkers: { data: numberOfWorkersData },
     },
     featureFlags: { flags, fetching: fetchingFeatureFlags },
     embeddedMap: { embed },
@@ -303,11 +249,7 @@ function mapStateToProps({
     return {
         activeFilterSidebarTab,
         contributorsData,
-        contributorTypesData,
         countriesData,
-        facilityProcessingTypeData,
-        productTypeData,
-        numberOfWorkersData,
         listsData,
         vectorTileFeatureIsActive: get(flags, 'vector_tile', false),
         fetchingFeatureFlags,
@@ -323,15 +265,10 @@ function mapDispatchToProps(dispatch) {
         makeSearchTabActive: () => dispatch(makeSidebarSearchTabActive()),
         makeFacilitiesTabActive: () =>
             dispatch(makeSidebarFacilitiesTabActive()),
-        fetchFilterOptions: () => dispatch(fetchAllFilterOptions()),
+        fetchFilterOptions: () => dispatch(fetchAllPrimaryFilterOptions()),
         fetchContributors: () => dispatch(fetchContributorOptions()),
         fetchLists: () => dispatch(fetchListOptions()),
-        fetchContributorTypes: () => dispatch(fetchContributorTypeOptions()),
         fetchCountries: () => dispatch(fetchCountryOptions()),
-        fetchFacilityProcessingType: () =>
-            dispatch(fetchFacilityProcessingTypeOptions()),
-        fetchProductType: () => dispatch(fetchProductTypeOptions()),
-        fetchNumberOfWorkers: () => dispatch(fetchNumberOfWorkersOptions()),
     };
 }
 

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -51,12 +51,8 @@ import {
     mapDjangoChoiceTuplesValueToSelectOptions,
 } from '../util/util';
 
-const filterSidebarSearchTabStyles = theme =>
+const filterSidebarExtendedSearchStyles = theme =>
     Object.freeze({
-        formStyle: Object.freeze({
-            width: '100%',
-            marginBottom: '32px',
-        }),
         inputLabelStyle: Object.freeze({
             fontFamily: theme.typography.fontFamily,
             fontSize: '16px',
@@ -65,24 +61,11 @@ const filterSidebarSearchTabStyles = theme =>
             transform: 'translate(0, -8px) scale(1)',
             paddingBottom: '0.5rem',
         }),
-        helpSubheadStyle: Object.freeze({
-            fontFamily: theme.typography.fontFamily,
-            ontSize: '12px',
-            fontWeight: 500,
-            color: '#000',
-            paddingTop: '0.5rem',
-            paddingBottom: '0.5rem',
-        }),
         selectStyle: Object.freeze({
             fontFamily: theme.typography.fontFamily,
         }),
         font: Object.freeze({
             fontFamily: `${theme.typography.fontFamily} !important`,
-        }),
-        reset: Object.freeze({
-            marginLeft: '16px',
-            minWidth: '36px',
-            minHeight: '36px',
         }),
         ...filterSidebarStyles,
     });
@@ -473,4 +456,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withStyles(filterSidebarSearchTabStyles)(FilterSidebarSearchTab));
+)(withStyles(filterSidebarExtendedSearchStyles)(FilterSidebarSearchTab));

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -1,0 +1,476 @@
+import React, { useEffect } from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
+import InputLabel from '@material-ui/core/InputLabel';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import ReactSelect from 'react-select';
+import Creatable from 'react-select/creatable';
+import Divider from '@material-ui/core/Divider';
+import { withStyles } from '@material-ui/core/styles';
+import uniq from 'lodash/uniq';
+
+import ShowOnly from './ShowOnly';
+
+import {
+    updateContributorTypeFilter,
+    updateParentCompanyFilter,
+    updateFacilityTypeFilter,
+    updateProcessingTypeFilter,
+    updateProductTypeFilter,
+    updateNumberofWorkersFilter,
+    updateNativeLanguageNameFilter,
+    updateBoundaryFilter,
+} from '../actions/filters';
+
+import {
+    fetchContributorTypeOptions,
+    fetchFacilityProcessingTypeOptions,
+    fetchProductTypeOptions,
+    fetchNumberOfWorkersOptions,
+} from '../actions/filterOptions';
+
+import { fetchFacilities } from '../actions/facilities';
+
+import { showDrawFilter } from '../actions/ui';
+
+import {
+    contributorOptionsPropType,
+    contributorTypeOptionsPropType,
+    facilityTypeOptionsPropType,
+    processingTypeOptionsPropType,
+    facilityProcessingTypeOptionsPropType,
+    productTypeOptionsPropType,
+    numberOfWorkerOptionsPropType,
+} from '../util/propTypes';
+
+import { filterSidebarStyles } from '../util/styles';
+
+import {
+    getValueFromEvent,
+    mapDjangoChoiceTuplesValueToSelectOptions,
+} from '../util/util';
+
+const filterSidebarSearchTabStyles = theme =>
+    Object.freeze({
+        formStyle: Object.freeze({
+            width: '100%',
+            marginBottom: '32px',
+        }),
+        inputLabelStyle: Object.freeze({
+            fontFamily: theme.typography.fontFamily,
+            fontSize: '16px',
+            fontWeight: 500,
+            color: '#000',
+            transform: 'translate(0, -8px) scale(1)',
+            paddingBottom: '0.5rem',
+        }),
+        helpSubheadStyle: Object.freeze({
+            fontFamily: theme.typography.fontFamily,
+            ontSize: '12px',
+            fontWeight: 500,
+            color: '#000',
+            paddingTop: '0.5rem',
+            paddingBottom: '0.5rem',
+        }),
+        selectStyle: Object.freeze({
+            fontFamily: theme.typography.fontFamily,
+        }),
+        font: Object.freeze({
+            fontFamily: `${theme.typography.fontFamily} !important`,
+        }),
+        reset: Object.freeze({
+            marginLeft: '16px',
+            minWidth: '36px',
+            minHeight: '36px',
+        }),
+        ...filterSidebarStyles,
+    });
+
+const CONTRIBUTORS = 'CONTRIBUTORS';
+const CONTRIBUTOR_TYPES = 'CONTRIBUTOR_TYPES';
+const PARENT_COMPANY = 'PARENT_COMPANY';
+const FACILITY_TYPE = 'FACILITY_TYPE';
+const PROCESSING_TYPE = 'PROCESSING_TYPE';
+const PRODUCT_TYPE = 'PRODUCT_TYPE';
+const NUMBER_OF_WORKERS = 'NUMBER_OF_WORKERS';
+
+const mapFacilityTypeOptions = (fPTypes, pTypes) => {
+    let fTypes = [];
+    if (pTypes.length === 0) {
+        fTypes = fPTypes.map(type => type.facilityType);
+    } else {
+        // When there are processing types, only return the
+        // facility types that have those processing types
+        pTypes.forEach(pType => {
+            fPTypes.forEach(fPType => {
+                if (fPType.processingTypes.includes(pType.value)) {
+                    fTypes = fTypes.concat(fPType.facilityType);
+                }
+            });
+        });
+    }
+    return mapDjangoChoiceTuplesValueToSelectOptions(uniq(fTypes.sort()));
+};
+
+const mapProcessingTypeOptions = (fPTypes, fTypes) => {
+    let pTypes = [];
+    if (fTypes.length === 0) {
+        pTypes = fPTypes.map(type => type.processingTypes).flat();
+    } else {
+        // When there are facility types, only return the
+        // processing types that are under those facility types
+        fTypes.forEach(fType => {
+            fPTypes.forEach(fPType => {
+                if (fType.value === fPType.facilityType) {
+                    pTypes = pTypes.concat(fPType.processingTypes);
+                }
+            });
+        });
+    }
+    return mapDjangoChoiceTuplesValueToSelectOptions(uniq(pTypes.sort()));
+};
+
+function FilterSidebarSearchTab({
+    contributorOptions,
+    contributorTypeOptions,
+    facilityProcessingTypeOptions,
+    productTypeOptions,
+    numberOfWorkersOptions,
+    contributorTypes,
+    updateContributorType,
+    parentCompany,
+    updateParentCompany,
+    facilityType,
+    updateFacilityType,
+    processingType,
+    updateProcessingType,
+    productType,
+    updateProductType,
+    numberOfWorkers,
+    updateNumberOfWorkers,
+    fetchingFacilities,
+    fetchingExtendedOptions,
+    activateDrawFilter,
+    clearDrawFilter,
+    boundary,
+    embed,
+    classes,
+    fetchContributorTypes,
+    fetchFacilityProcessingType,
+    fetchProductType,
+    fetchNumberOfWorkers,
+}) {
+    useEffect(() => {
+        if (!contributorTypeOptions.length) {
+            fetchContributorTypes();
+        }
+
+        if (!facilityProcessingTypeOptions.length) {
+            fetchFacilityProcessingType();
+        }
+
+        if (!productTypeOptions.length) {
+            fetchProductType();
+        }
+
+        if (!numberOfWorkersOptions.length) {
+            fetchNumberOfWorkers();
+        }
+    }, []);
+
+    if (fetchingExtendedOptions) {
+        return (
+            <div className="control-panel__content">
+                <CircularProgress />
+            </div>
+        );
+    }
+
+    const boundaryButton =
+        boundary == null ? (
+            <Button
+                variant="outlined"
+                onClick={activateDrawFilter}
+                disableRipple
+                color="primary"
+                fullWidth
+            >
+                DRAW AREA
+            </Button>
+        ) : (
+            <Button
+                variant="outlined"
+                onClick={clearDrawFilter}
+                disableRipple
+                color="primary"
+                fullWidth
+            >
+                REMOVE AREA
+            </Button>
+        );
+
+    return (
+        <>
+            <div className="form__field">
+                <ShowOnly when={!embed}>
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={CONTRIBUTOR_TYPES}
+                        className={classes.inputLabelStyle}
+                    >
+                        Contributor Type
+                    </InputLabel>
+                    <ReactSelect
+                        isMulti
+                        id={CONTRIBUTOR_TYPES}
+                        name="contributorTypes"
+                        className={`basic-multi-select notranslate ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        options={contributorTypeOptions}
+                        value={contributorTypes}
+                        onChange={updateContributorType}
+                        disabled={fetchingExtendedOptions || fetchingFacilities}
+                    />
+                </ShowOnly>
+            </div>
+            <div className="form__field">
+                <InputLabel
+                    shrink={false}
+                    htmlFor={CONTRIBUTORS}
+                    className={classes.inputLabelStyle}
+                >
+                    Area
+                </InputLabel>
+                {boundaryButton}
+            </div>
+            <div className="form__field">
+                <Divider />
+                <div
+                    className="form__info"
+                    style={{ color: 'rgba(0, 0, 0, 0.8)' }}
+                >
+                    The following filters are new to the OAR and may not return
+                    complete results until we have more data
+                </div>
+            </div>
+            <div className="form__field">
+                <InputLabel
+                    shrink={false}
+                    htmlFor={PARENT_COMPANY}
+                    className={classes.inputLabelStyle}
+                >
+                    Parent Company
+                </InputLabel>
+                <Creatable
+                    isMulti
+                    id={PARENT_COMPANY}
+                    name={PARENT_COMPANY}
+                    className={`basic-multi-select ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    options={contributorOptions}
+                    value={parentCompany}
+                    onChange={updateParentCompany}
+                    disabled={fetchingExtendedOptions || fetchingFacilities}
+                />
+            </div>
+            <div className="form__field">
+                <InputLabel
+                    shrink={false}
+                    htmlFor={FACILITY_TYPE}
+                    className={classes.inputLabelStyle}
+                >
+                    Facility Type
+                </InputLabel>
+                <ReactSelect
+                    isMulti
+                    id={FACILITY_TYPE}
+                    name={FACILITY_TYPE}
+                    className={`basic-multi-select ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    options={mapFacilityTypeOptions(
+                        facilityProcessingTypeOptions,
+                        processingType,
+                    )}
+                    value={facilityType}
+                    onChange={updateFacilityType}
+                    disabled={fetchingExtendedOptions || fetchingFacilities}
+                />
+            </div>
+            <div className="form__field">
+                <InputLabel
+                    shrink={false}
+                    htmlFor={PROCESSING_TYPE}
+                    className={classes.inputLabelStyle}
+                >
+                    Processing Type
+                </InputLabel>
+                <ReactSelect
+                    isMulti
+                    id={PROCESSING_TYPE}
+                    name={PROCESSING_TYPE}
+                    className={`basic-multi-select ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    options={mapProcessingTypeOptions(
+                        facilityProcessingTypeOptions,
+                        facilityType,
+                    )}
+                    value={processingType}
+                    onChange={updateProcessingType}
+                    disabled={fetchingExtendedOptions || fetchingFacilities}
+                />
+            </div>
+            <div className="form__field">
+                <InputLabel
+                    shrink={false}
+                    htmlFor={PRODUCT_TYPE}
+                    className={classes.inputLabelStyle}
+                >
+                    Product Type
+                </InputLabel>
+                <Creatable
+                    isMulti
+                    id={PRODUCT_TYPE}
+                    name={PRODUCT_TYPE}
+                    className={`basic-multi-select ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    options={productTypeOptions}
+                    value={productType}
+                    onChange={updateProductType}
+                    disabled={fetchingExtendedOptions || fetchingFacilities}
+                />
+            </div>
+            <div className="form__field">
+                <InputLabel
+                    shrink={false}
+                    htmlFor={NUMBER_OF_WORKERS}
+                    className={classes.inputLabelStyle}
+                >
+                    Number of Workers
+                </InputLabel>
+                <ReactSelect
+                    isMulti
+                    id={NUMBER_OF_WORKERS}
+                    name={NUMBER_OF_WORKERS}
+                    className={`basic-multi-select ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    options={numberOfWorkersOptions}
+                    value={numberOfWorkers}
+                    onChange={updateNumberOfWorkers}
+                    disabled={fetchingExtendedOptions || fetchingFacilities}
+                />
+            </div>
+        </>
+    );
+}
+
+FilterSidebarSearchTab.propTypes = {
+    contributorOptions: contributorOptionsPropType.isRequired,
+    contributorTypeOptions: contributorTypeOptionsPropType.isRequired,
+    facilityProcessingTypeOptions:
+        facilityProcessingTypeOptionsPropType.isRequired,
+    productTypeOptions: productTypeOptionsPropType.isRequired,
+    numberOfWorkersOptions: numberOfWorkerOptionsPropType.isRequired,
+    updateContributorType: func.isRequired,
+    contributorTypes: contributorTypeOptionsPropType.isRequired,
+    parentCompany: contributorOptionsPropType.isRequired,
+    facilityType: facilityTypeOptionsPropType.isRequired,
+    processingType: processingTypeOptionsPropType.isRequired,
+    productType: productTypeOptionsPropType.isRequired,
+    numberOfWorkers: numberOfWorkerOptionsPropType.isRequired,
+    fetchingFacilities: bool.isRequired,
+    fetchingExtendedOptions: bool.isRequired,
+};
+
+function mapStateToProps({
+    filterOptions: {
+        contributors: {
+            data: contributorOptions,
+            fetching: fetchingContributors,
+        },
+        contributorTypes: {
+            data: contributorTypeOptions,
+            fetching: fetchingContributorTypes,
+        },
+        facilityProcessingType: {
+            data: facilityProcessingTypeOptions,
+            fetching: fetchingFacilityProcessingType,
+        },
+        productType: {
+            data: productTypeOptions,
+            fetching: fetchingProductType,
+        },
+        numberOfWorkers: {
+            data: numberOfWorkersOptions,
+            fetching: fetchingNumberofWorkers,
+        },
+    },
+    filters: {
+        contributorTypes,
+        parentCompany,
+        facilityType,
+        processingType,
+        productType,
+        numberOfWorkers,
+        nativeLanguageName,
+        boundary,
+    },
+    facilities: {
+        facilities: { data: facilities, fetching: fetchingFacilities },
+    },
+    embeddedMap: { embed },
+}) {
+    return {
+        contributorOptions,
+        contributorTypeOptions,
+        facilityProcessingTypeOptions,
+        productTypeOptions,
+        numberOfWorkersOptions,
+        contributorTypes,
+        parentCompany,
+        facilityType,
+        processingType,
+        productType,
+        numberOfWorkers,
+        nativeLanguageName,
+        fetchingFacilities,
+        facilities,
+        boundary,
+        fetchingExtendedOptions:
+            fetchingContributors ||
+            fetchingContributorTypes ||
+            fetchingFacilityProcessingType ||
+            fetchingProductType ||
+            fetchingNumberofWorkers,
+        embed: !!embed,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        updateContributorType: v => dispatch(updateContributorTypeFilter(v)),
+        updateParentCompany: v => dispatch(updateParentCompanyFilter(v)),
+        updateFacilityType: v => dispatch(updateFacilityTypeFilter(v)),
+        updateProcessingType: v => dispatch(updateProcessingTypeFilter(v)),
+        updateProductType: v => dispatch(updateProductTypeFilter(v)),
+        updateNumberOfWorkers: v => dispatch(updateNumberofWorkersFilter(v)),
+        updateNativeLanguageName: e =>
+            dispatch(updateNativeLanguageNameFilter(getValueFromEvent(e))),
+        activateDrawFilter: () => dispatch(showDrawFilter(true)),
+        clearDrawFilter: () => {
+            dispatch(showDrawFilter(false));
+            dispatch(updateBoundaryFilter(null));
+            return dispatch(fetchFacilities({}));
+        },
+        fetchContributorTypes: () => dispatch(fetchContributorTypeOptions()),
+        fetchFacilityProcessingType: () =>
+            dispatch(fetchFacilityProcessingTypeOptions()),
+        fetchProductType: () => dispatch(fetchProductTypeOptions()),
+        fetchNumberOfWorkers: () => dispatch(fetchNumberOfWorkersOptions()),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(filterSidebarSearchTabStyles)(FilterSidebarSearchTab));

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -148,19 +148,25 @@ function FilterSidebarExtendedSearch({
         if (!contributorTypeOptions.length) {
             fetchContributorTypes();
         }
+    }, [contributorTypeOptions, fetchContributorTypes]);
 
+    useEffect(() => {
         if (!facilityProcessingTypeOptions.length) {
             fetchFacilityProcessingType();
         }
+    }, [facilityProcessingTypeOptions, fetchFacilityProcessingType]);
 
+    useEffect(() => {
         if (!productTypeOptions.length) {
             fetchProductType();
         }
+    }, [productTypeOptions, fetchProductType]);
 
+    useEffect(() => {
         if (!numberOfWorkersOptions.length) {
             fetchNumberOfWorkers();
         }
-    }, []);
+    }, [numberOfWorkersOptions, fetchNumberOfWorkers]);
 
     if (fetchingExtendedOptions) {
         return (

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -114,7 +114,7 @@ const mapProcessingTypeOptions = (fPTypes, fTypes) => {
     return mapDjangoChoiceTuplesValueToSelectOptions(uniq(pTypes.sort()));
 };
 
-function FilterSidebarSearchTab({
+function FilterSidebarExtendedSearch({
     contributorOptions,
     contributorTypeOptions,
     facilityProcessingTypeOptions,
@@ -347,7 +347,7 @@ function FilterSidebarSearchTab({
     );
 }
 
-FilterSidebarSearchTab.propTypes = {
+FilterSidebarExtendedSearch.propTypes = {
     contributorOptions: contributorOptionsPropType.isRequired,
     contributorTypeOptions: contributorTypeOptionsPropType.isRequired,
     facilityProcessingTypeOptions:
@@ -456,4 +456,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withStyles(filterSidebarExtendedSearchStyles)(FilterSidebarSearchTab));
+)(withStyles(filterSidebarExtendedSearchStyles)(FilterSidebarExtendedSearch));


### PR DESCRIPTION
## Overview

As part of our redesign of the sidebar to support extended fields we researched search behavior and hid list frequently used search fields. If the search fields are never shown, their dropdown list option do not need to be fetched.

Connects #1729

## Demo

![2022-03-19 10 04 11](https://user-images.githubusercontent.com/17363/159131051-b05297d0-c8f7-48a7-8e90-5ee7bdf66a21.gif)

## Notes

When refreshing the page after selection both a facility type and a processing type, the facility type options do not populate. This is not a regression and is a non-ideal behavior in the current implementation of filtering options based on the connection between facility type and processing type.  

## Testing Instructions

* Open the dev tools network tab and filter by XHR
* Browse http://localhost:6543/ and verify that API request are not made for
  * /api/contributor-types
  * /api/facility-processing-types
  * /api/product-types
  * /api/worker-ranges
* Click "More filters" and verify that fetches are now make and that all the dropdowns are populated
* Select items in all the extended field dropdowns then refresh the page, verify that the selections are restored

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
