### PR TITLE
Remove counts from contributor type dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
+- Remove contribute type counts from dropdown [#1732](https://github.com/open-apparel-registry/open-apparel-registry/pull/1732)
+
 ### Fixed
 
 ### Security

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -6925,7 +6925,7 @@ class ContributorTypesTest(FacilityAPITestCaseBase):
         response = self.get_contributor_types()
         data = json.loads(response.content)
         for (id, label) in data:
-            self.assertEqual(f'{id} [0]', label)
+            self.assertEqual(id, label)
 
     def test_all_types_are_returned(self):
         response = self.get_contributor_types()

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -13,7 +13,7 @@ from functools import reduce
 from django.core.files.uploadedfile import (InMemoryUploadedFile,
                                             TemporaryUploadedFile)
 from django.db import transaction
-from django.db.models import F, Q, Count
+from django.db.models import F, Q
 from django.core import exceptions as core_exceptions
 from django.core.validators import validate_email
 from django.contrib.auth import (authenticate, login, logout)
@@ -516,31 +516,18 @@ def getContributorTypeCount(value, counts):
 def all_contributor_types(request):
     """
     Returns a list of contributor type choices as tuples of values and display
-    names with appended count of contributors per type.
+    names.
 
     ## Sample Response
 
         [
-            ["Auditor", "Auditor [10]"],
-            ["Brand/Retailer", "Brand/Retailer [12]"],
-            ["Civil Society Organization", "Civil Society Organization [0]"],
-            ["Factory / Facility", "Factory / Facility [1]"]
+            ["Auditor", "Auditor"],
+            ["Brand/Retailer", "Brand/Retailer"],
+            ["Civil Society Organization", "Civil Society Organization"],
+            ["Factory / Facility", "Factory / Facility"]
         ]
     """
-    active_contrib_ids = Source.objects.filter(
-        is_active=True, is_public=True,
-        facilitylistitem__status__in=FacilityListItem.COMPLETE_STATUSES
-    ).values('contributor_id')
-    counts = Contributor.objects.filter(id__in=active_contrib_ids).values(
-        'contrib_type').annotate(num_type=Count('contrib_type'))
-
-    types = [
-        (t[0], f'{t[1]} [{getContributorTypeCount(t[0], counts)}]')
-        for t
-        in Contributor.CONTRIB_TYPE_CHOICES
-    ]
-
-    return Response(types)
+    return Response(Contributor.CONTRIB_TYPE_CHOICES)
 
 
 @api_view(['GET'])


### PR DESCRIPTION
## Overview

This should speed up this APIs response considerably.

Connects #1728 

### Demo

![image](https://user-images.githubusercontent.com/1430060/159124274-22c0c19f-437a-477f-bf7d-ac7cd9b62f65.png)

## Testing Instructions

* Load the home page
* Ensure there's no counts in the contributor types in the dropdown, and that the API is faster

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
