### PR TITLE
Remove product type dropdown from search and claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 - Remove contribute type counts from dropdown [#1732](https://github.com/open-apparel-registry/open-apparel-registry/pull/1732)
+- Remove product type dropdown from search and claim [#1734](https://github.com/open-apparel-registry/open-apparel-registry/pull/1734)
 
 ### Fixed
 

--- a/src/app/src/actions/claimedFacilityDetails.js
+++ b/src/app/src/actions/claimedFacilityDetails.js
@@ -87,7 +87,6 @@ export function submitClaimedFacilityDetailsUpdate(claimID) {
                 'facility_types',
                 'affiliation_choices',
                 'certification_choices',
-                'product_type_choices',
                 'production_type_choices',
             ]),
             {

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -10,7 +10,6 @@ import {
     makeGetContributorTypesURL,
     makeGetCountriesURL,
     makeGetFacilitiesTypeProcessingTypeURL,
-    makeGetProductTypeURL,
     makeGetNumberOfWorkersURL,
     mapDjangoChoiceTuplesToSelectOptions,
     mapDjangoChoiceTuplesValueToSelectOptions,
@@ -63,16 +62,6 @@ export const failFetchFacilityProcessingTypeOptions = createAction(
 );
 export const completeFetchFacilityProcessingTypeOptions = createAction(
     'COMPLETE_FETCH_FACILITY_PROCESSING_TYPE_OPTIONS',
-);
-
-export const startFetchProductTypeOptions = createAction(
-    'START_FETCH_PRODUCT_TYPE_OPTIONS',
-);
-export const failFetchProductTypeOptions = createAction(
-    'FAIL_FETCH_PRODUCT_TYPE_OPTIONS',
-);
-export const completeFetchProductTypeOptions = createAction(
-    'COMPLETE_FETCH_PRODUCT_TYPE_OPTIONS',
 );
 
 export const startFetchNumberOfWorkersOptions = createAction(
@@ -194,28 +183,6 @@ export function fetchFacilityProcessingTypeOptions() {
                         err,
                         'An error prevented fetching facility processing type options',
                         failFetchFacilityProcessingTypeOptions,
-                    ),
-                ),
-            );
-    };
-}
-
-export function fetchProductTypeOptions() {
-    return dispatch => {
-        dispatch(startFetchProductTypeOptions());
-
-        return apiRequest
-            .get(makeGetProductTypeURL())
-            .then(({ data }) => mapDjangoChoiceTuplesValueToSelectOptions(data))
-            .then(data => {
-                dispatch(completeFetchProductTypeOptions(data));
-            })
-            .catch(err =>
-                dispatch(
-                    logErrorAndDispatchFailure(
-                        err,
-                        'An error prevented fetching product type options',
-                        failFetchProductTypeOptions,
                     ),
                 ),
             );

--- a/src/app/src/components/ClaimedFacilitiesDetails.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetails.jsx
@@ -25,6 +25,7 @@ import { toast } from 'react-toastify';
 
 import ClaimedFacilitiesDetailsSidebar from './ClaimedFacilitiesDetailsSidebar';
 import ShowOnly from './ShowOnly';
+import CreatableInputOnly from './CreatableInputOnly';
 
 import COLOURS from '../util/COLOURS';
 
@@ -162,7 +163,10 @@ const InputSection = ({
     selectOptions = null,
     hasValidationErrorFn = stubFalse,
     aside = null,
+    selectPlaceholder = 'Select...',
 }) => {
+    let SelectComponent = null;
+
     const asideNode = (
         <ShowOnly when={!isNull(aside)}>
             <aside style={claimedFacilitiesDetailsStyles.asideStyles}>
@@ -194,7 +198,11 @@ const InputSection = ({
             };
         })();
 
-        const SelectComponent = isCreatable ? Creatable : Select;
+        if (isCreatable) {
+            SelectComponent = selectOptions ? Creatable : CreatableInputOnly;
+        } else {
+            SelectComponent = Select;
+        }
 
         return (
             <div style={claimedFacilitiesDetailsStyles.inputSectionStyles}>
@@ -213,6 +221,7 @@ const InputSection = ({
                     disabled={disabled}
                     styles={selectStyles}
                     isMulti={isMultiSelect}
+                    placeholder={selectPlaceholder}
                 />
             </div>
         );
@@ -503,9 +512,7 @@ function ClaimedFacilitiesDetails({
                     isSelect
                     isMultiSelect
                     isCreatable
-                    selectOptions={mapDjangoChoiceTuplesToSelectOptions(
-                        data.product_type_choices,
-                    )}
+                    selectPlaceholder="e.g. Jackets - Use <Enter> or <Tab> to add multiple values"
                 />
                 <Typography
                     variant="title"

--- a/src/app/src/components/CreatableInputOnly.jsx
+++ b/src/app/src/components/CreatableInputOnly.jsx
@@ -1,0 +1,63 @@
+// This was adapted from the TypeScript "Multi-selct text input" example from
+// https://react-select.com/creatable. We modified the state and change
+// notification to work like the other CreatableSelect components in use.
+
+import React, { Component } from 'react';
+
+import CreatableSelect from 'react-select/creatable';
+
+const components = {
+    DropdownIndicator: null,
+};
+
+const createOption = label => ({
+    label,
+    value: label,
+});
+
+export default class CreatableInputOnly extends Component {
+    state = {
+        inputValue: '',
+    };
+
+    handleChange = value => {
+        const { onChange } = this.props;
+        onChange(value);
+    };
+
+    handleInputChange = (inputValue: string) => {
+        this.setState({ inputValue });
+    };
+
+    handleKeyDown = event => {
+        const { inputValue } = this.state;
+        const { onChange, value } = this.props;
+        if (!inputValue) return;
+        if (event.key === 'Enter' || event.key === 'Tab') {
+            this.setState({
+                inputValue: '',
+            });
+            onChange([...value, createOption(inputValue)]);
+            event.preventDefault();
+        }
+    };
+
+    render() {
+        const { inputValue } = this.state;
+        const { value } = this.props;
+        return (
+            <CreatableSelect
+                components={components}
+                inputValue={inputValue}
+                isClearable
+                isMulti
+                menuIsOpen={false}
+                onChange={this.handleChange}
+                onInputChange={this.handleInputChange}
+                onKeyDown={this.handleKeyDown}
+                placeholder={this.props.placeholder}
+                value={value}
+            />
+        );
+    }
+}

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -11,6 +11,7 @@ import { withStyles } from '@material-ui/core/styles';
 import uniq from 'lodash/uniq';
 
 import ShowOnly from './ShowOnly';
+import CreatableInputOnly from './CreatableInputOnly';
 
 import {
     updateContributorTypeFilter,
@@ -308,7 +309,7 @@ function FilterSidebarExtendedSearch({
                 >
                     Product Type
                 </InputLabel>
-                <Creatable
+                <CreatableInputOnly
                     isMulti
                     id={PRODUCT_TYPE}
                     name={PRODUCT_TYPE}
@@ -316,7 +317,8 @@ function FilterSidebarExtendedSearch({
                     classNamePrefix="select"
                     value={productType}
                     onChange={updateProductType}
-                    disabled={fetchingExtendedOptions || fetchingFacilities}
+                    disabled={fetchingFacilities}
+                    placeholder="e.g. Jackets"
                 />
             </div>
             <div className="form__field">

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -26,7 +26,6 @@ import {
 import {
     fetchContributorTypeOptions,
     fetchFacilityProcessingTypeOptions,
-    fetchProductTypeOptions,
     fetchNumberOfWorkersOptions,
 } from '../actions/filterOptions';
 
@@ -118,7 +117,6 @@ function FilterSidebarExtendedSearch({
     contributorOptions,
     contributorTypeOptions,
     facilityProcessingTypeOptions,
-    productTypeOptions,
     numberOfWorkersOptions,
     contributorTypes,
     updateContributorType,
@@ -141,7 +139,6 @@ function FilterSidebarExtendedSearch({
     classes,
     fetchContributorTypes,
     fetchFacilityProcessingType,
-    fetchProductType,
     fetchNumberOfWorkers,
 }) {
     useEffect(() => {
@@ -155,12 +152,6 @@ function FilterSidebarExtendedSearch({
             fetchFacilityProcessingType();
         }
     }, [facilityProcessingTypeOptions, fetchFacilityProcessingType]);
-
-    useEffect(() => {
-        if (!productTypeOptions.length) {
-            fetchProductType();
-        }
-    }, [productTypeOptions, fetchProductType]);
 
     useEffect(() => {
         if (!numberOfWorkersOptions.length) {
@@ -323,7 +314,6 @@ function FilterSidebarExtendedSearch({
                     name={PRODUCT_TYPE}
                     className={`basic-multi-select ${classes.selectStyle}`}
                     classNamePrefix="select"
-                    options={productTypeOptions}
                     value={productType}
                     onChange={updateProductType}
                     disabled={fetchingExtendedOptions || fetchingFacilities}
@@ -358,7 +348,6 @@ FilterSidebarExtendedSearch.propTypes = {
     contributorTypeOptions: contributorTypeOptionsPropType.isRequired,
     facilityProcessingTypeOptions:
         facilityProcessingTypeOptionsPropType.isRequired,
-    productTypeOptions: productTypeOptionsPropType.isRequired,
     numberOfWorkersOptions: numberOfWorkerOptionsPropType.isRequired,
     updateContributorType: func.isRequired,
     contributorTypes: contributorTypeOptionsPropType.isRequired,
@@ -385,10 +374,6 @@ function mapStateToProps({
             data: facilityProcessingTypeOptions,
             fetching: fetchingFacilityProcessingType,
         },
-        productType: {
-            data: productTypeOptions,
-            fetching: fetchingProductType,
-        },
         numberOfWorkers: {
             data: numberOfWorkersOptions,
             fetching: fetchingNumberofWorkers,
@@ -413,7 +398,6 @@ function mapStateToProps({
         contributorOptions,
         contributorTypeOptions,
         facilityProcessingTypeOptions,
-        productTypeOptions,
         numberOfWorkersOptions,
         contributorTypes,
         parentCompany,
@@ -429,7 +413,6 @@ function mapStateToProps({
             fetchingContributors ||
             fetchingContributorTypes ||
             fetchingFacilityProcessingType ||
-            fetchingProductType ||
             fetchingNumberofWorkers,
         embed: !!embed,
     };
@@ -454,7 +437,6 @@ function mapDispatchToProps(dispatch) {
         fetchContributorTypes: () => dispatch(fetchContributorTypeOptions()),
         fetchFacilityProcessingType: () =>
             dispatch(fetchFacilityProcessingTypeOptions()),
-        fetchProductType: () => dispatch(fetchProductTypeOptions()),
         fetchNumberOfWorkers: () => dispatch(fetchNumberOfWorkersOptions()),
     };
 }

--- a/src/app/src/reducers/FilterOptionsReducer.js
+++ b/src/app/src/reducers/FilterOptionsReducer.js
@@ -17,9 +17,6 @@ import {
     startFetchFacilityProcessingTypeOptions,
     failFetchFacilityProcessingTypeOptions,
     completeFetchFacilityProcessingTypeOptions,
-    startFetchProductTypeOptions,
-    failFetchProductTypeOptions,
-    completeFetchProductTypeOptions,
     startFetchNumberOfWorkersOptions,
     failFetchNumberOfWorkersOptions,
     completeFetchNumberOfWorkersTypeOptions,
@@ -171,28 +168,6 @@ export default createReducer(
         [completeFetchFacilityProcessingTypeOptions]: (state, payload) =>
             update(state, {
                 facilityProcessingType: {
-                    fetching: { $set: false },
-                    error: { $set: null },
-                    data: { $set: payload },
-                },
-            }),
-        [startFetchProductTypeOptions]: state =>
-            update(state, {
-                productType: {
-                    fetching: { $set: true },
-                    error: { $set: null },
-                },
-            }),
-        [failFetchProductTypeOptions]: (state, payload) =>
-            update(state, {
-                productType: {
-                    fetching: { $set: false },
-                    error: { $set: payload },
-                },
-            }),
-        [completeFetchProductTypeOptions]: (state, payload) =>
-            update(state, {
-                productType: {
                     fetching: { $set: false },
                     error: { $set: null },
                     data: { $set: payload },

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -354,7 +354,6 @@ export const approvedFacilityClaimPropType = shape({
     facility_types: arrayOf(arrayOf(string)).isRequired,
     affiliation_choices: arrayOf(arrayOf(string)).isRequired,
     certification_choices: arrayOf(arrayOf(string)).isRequired,
-    product_type_choices: arrayOf(arrayOf(string)).isRequired,
     production_type_choices: arrayOf(arrayOf(string)).isRequired,
 });
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -125,7 +125,6 @@ export const makeGetContributorTypesURL = () => '/api/contributor-types/';
 export const makeGetCountriesURL = () => '/api/countries/';
 export const makeGetFacilitiesTypeProcessingTypeURL = () =>
     '/api/facility-processing-types/';
-export const makeGetProductTypeURL = () => '/api/product-types/';
 export const makeGetNumberOfWorkersURL = () => '/api/workers-ranges/';
 export const makeGetNativeLanguageName = () => '/api/native_language_name/';
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -44,7 +44,6 @@ from api.processing import get_country_code
 from api.helpers import (prefix_a_an,
                          get_single_contributor_field_values,
                          get_list_contributor_field_values)
-from api.extended_fields import get_product_types
 from api.facility_type_processing_type import (
     ALL_FACILITY_TYPE_CHOICES,
     ALL_PROCESSING_TYPE_CHOICES
@@ -1119,7 +1118,6 @@ class ApprovedFacilityClaimSerializer(ModelSerializer):
     facility_parent_company = SerializerMethodField()
     affiliation_choices = SerializerMethodField()
     certification_choices = SerializerMethodField()
-    product_type_choices = SerializerMethodField()
     production_type_choices = SerializerMethodField()
 
     class Meta:
@@ -1142,7 +1140,7 @@ class ApprovedFacilityClaimSerializer(ModelSerializer):
                   'affiliation_choices', 'certification_choices',
                   'facility_affiliations', 'facility_certifications',
                   'facility_product_types', 'facility_production_types',
-                  'product_type_choices', 'production_type_choices')
+                  'production_type_choices')
 
     def get_facility(self, claim):
         return FacilityDetailsSerializer(
@@ -1169,13 +1167,6 @@ class ApprovedFacilityClaimSerializer(ModelSerializer):
 
     def get_certification_choices(self, claim):
         return FacilityClaim.CERTIFICATION_CHOICES
-
-    def get_product_type_choices(self, claim):
-        return [
-            (choice, choice)
-            for choice
-            in get_product_types()
-        ]
 
     def get_production_type_choices(self, claim):
         return ALL_PROCESSING_TYPE_CHOICES

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -4593,10 +4593,6 @@ class FacilityClaimSerializerTests(TestCase):
     def test_product_and_production_options_are_serialized(self):
         data = ApprovedFacilityClaimSerializer(self.claim).data
 
-        self.assertIn('product_type_choices', data)
-        self.assertIsNotNone(data['product_type_choices'])
-        self.assertNotEqual([], data['product_type_choices'])
-
         self.assertIn('production_type_choices', data)
         self.assertIsNotNone(data['production_type_choices'])
         self.assertNotEqual([], data['production_type_choices'])


### PR DESCRIPTION
## Overview

Removes product type options from search UI list and the claim form.

Connects #1730 

## Demo

### Search

![2022-03-19 13 41 29](https://user-images.githubusercontent.com/17363/159137748-106ba4b3-370c-4f5b-b516-1d4b85050fe5.gif)

### Claim

![2022-03-19 13 40 37](https://user-images.githubusercontent.com/17363/159137759-994bb443-e261-4226-91c7-4b5f4909ab3d.gif)


## Testing Instructions

* Open the home page
* Go to extended fields
  - [x] Ensure that the dropdown has been replaced with a creatable text field
  - [x] Ensure you can still search as before
* Log in as c2@example.com and claim a facility
* In a separate session log in as c1@example.com, browse http://localhost:6543/dashboard/claims, and approve the claim
* In the original session browse http://localhost:6543/claimed, open the claim, and exercised the product types fields. 
  * [x] Ensure you can add/remove choices and that that they save and reload on refresh.
  * [x] Use the link at the upper right of the claim to jump to the facility details and verify that the product types appear as an extended field.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines