### PR TITLE
Exclude details from facility list API by defaut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Delay loading search field dropdown data [#1731](https://github.com/open-apparel-registry/open-apparel-registry/pull/1731)
+- Exclude details from facility list API by defaut [#1739](https://github.com/open-apparel-registry/open-apparel-registry/pull/1739)
 
 ### Deprecated
 

--- a/src/app/src/actions/logDownload.js
+++ b/src/app/src/actions/logDownload.js
@@ -18,8 +18,6 @@ export const completeLogDownload = createAction('COMPLETE_LOG_DOWNLOAD');
 
 export function logDownload(format, options) {
     return async (dispatch, getState) => {
-        dispatch(startLogDownload());
-
         const downloadFacilities =
             format === 'csv' ? downloadFacilitiesCSV : downloadFacilitiesXLSX;
 

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -7,7 +7,13 @@ import MenuItem from '@material-ui/core/MenuItem';
 
 import { toast } from 'react-toastify';
 
-import { logDownload } from '../actions/logDownload';
+import {
+    logDownload,
+    startLogDownload,
+    failLogDownload,
+} from '../actions/logDownload';
+import { fetchFacilities } from '../actions/facilities';
+import { FACILITIES_REQUEST_PAGE_SIZE } from '../util/constants';
 
 const downloadFacilitiesStyles = Object.freeze({
     listHeaderButtonStyles: Object.freeze({
@@ -38,8 +44,17 @@ function DownloadFacilitiesButton({
     const handleClick = event => setAnchorEl(event.currentTarget);
     const handleClose = () => setAnchorEl(null);
 
-    const handleDownload = format =>
-        dispatch(logDownload(format, { isEmbedded }));
+    const handleDownload = format => {
+        dispatch(startLogDownload());
+        dispatch(
+            fetchFacilities({
+                pageSize: FACILITIES_REQUEST_PAGE_SIZE,
+                detail: true,
+                onSuccess: () => dispatch(logDownload(format, { isEmbedded })),
+                onFailure: () => dispatch(failLogDownload()),
+            }),
+        );
+    };
 
     const selectFormatAndDownload = format => {
         if (user || isEmbedded) {

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -239,7 +239,11 @@ function FilterSidebarFacilitiesTab({
                         containerHeight={resultListHeight}
                         infiniteLoadBeginEdgeOffset={100}
                         isInfiniteLoading={fetching || isInfiniteLoading}
-                        onInfiniteLoad={fetchNextPage}
+                        onInfiniteLoad={() => {
+                            if (!downloadingCSV) {
+                                fetchNextPage();
+                            }
+                        }}
                         loadingSpinnerDelegate={loadingElement}
                         list={facilities.map(
                             ({

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -219,6 +219,7 @@ export const createQueryStringFromSearchFilters = (
         ppe = '',
     },
     withEmbed,
+    detail,
 ) => {
     const inputForQueryString = Object.freeze({
         q: facilityFreeTextQuery,
@@ -244,6 +245,7 @@ export const createQueryStringFromSearchFilters = (
         boundary: isEmpty(boundary) ? '' : JSON.stringify(boundary),
         ppe,
         embed: !withEmbed ? '' : '1',
+        detail: detail ? 'true' : undefined,
     });
 
     return querystring.stringify(omitBy(inputForQueryString, isEmpty));

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -476,6 +476,7 @@ class FacilityQueryParamsSerializer(Serializer):
     pageSize = IntegerField(required=False)
     boundary = CharField(required=False)
     ppe = BooleanField(default=False, required=False)
+    detail = BooleanField(default=False, required=False)
 
 
 class FacilityListQueryParamsSerializer(Serializer):
@@ -562,6 +563,14 @@ class FacilitySerializer(GeoFeatureModelSerializer):
                   'ppe_contact_email', 'ppe_website', 'is_closed',
                   'contributor_fields', 'extended_fields')
         geo_field = 'location'
+
+    def __init__(self, *args, **kwargs):
+        exclude_fields = kwargs.pop('exclude_fields', None)
+        super(FacilitySerializer, self).__init__(*args, **kwargs)
+
+        if exclude_fields:
+            for field_name in exclude_fields:
+                self.fields.pop(field_name, None)
 
     # Added to ensure including the OAR ID in the geojson properties map
     def get_oar_id(self, facility):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -892,7 +892,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
     def list(self, request):
         """
         Returns a list of facilities in GeoJSON format for a given query.
-        (Maximum of 500 facilities per page.)
+        (Maximum of 50 facilities per page.)
 
         ### Sample Response
             {


### PR DESCRIPTION
Serializing contributor fields and extended fields requires multiple database lookups and is expensive. We add a `detail` query parameter to the facilities list and only include the `contributors`, `contributor_fields`, and `extended_fields` in the serialized output if that `detail` parameter is set to true.

This change creates a regressing in the CSV downloads because the additional fields are no longer available. That should be fixed in a future commit.

Connects #1737

## Demo

### Quick search

![2022-03-19 20 59 37](https://user-images.githubusercontent.com/17363/159147624-0cbded96-3a82-4605-9f52-26994a49fc16.gif)

### Full download for CSV/Excel

![2022-03-19 21 03 50](https://user-images.githubusercontent.com/17363/159147666-8e911b25-926a-4637-99a5-d462eb098998.gif)


## Notes

While testing embedded map downloads I saw that there were contributor attributions in the fields. I opened #1741 to look into those.

## Testing Instructions

* Run searches. Verify that they are fast.
* Log in as c2@example.com
* Upload  [100-nodupes-latlng-extended.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8310613/100-nodupes-latlng-extended.csv) and `./tools/batc_process {id}`
* Search for number of workers less than 100. View details for some facilities and and verify the extended fields appear.
* Download the search results. They should be slow as the data is refetched. Verify that the downloaded file includes extended fields
* **BUG** in my testing I found the result count returned and shown on the list tab did not match the row count in the file when searching by Number of Workers. See if you can repeat this and diagnose it
* Use the Embed tab on http://localhost:6543/settings and verify that searching and downloading work correctly

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
