### PR TITLE
Hide contributor details in embed downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Hide contributor details in embed downloads [#1742](https://github.com/open-apparel-registry/open-apparel-registry/pull/1742)
+
 ### Security
 
 ## [62] - 2022-03-18

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1473,10 +1473,6 @@ class ExtendedFieldListSerializer(ModelSerializer):
                   'is_from_claim', 'field_name', 'verified_count')
 
     def should_display_contributor(self, instance):
-        embed_mode_active = self.context.get("embed_mode_active")
-        if embed_mode_active:
-            return None
-
         user_can_see_detail = self.context.get("user_can_see_detail")
 
         should_display_association = True
@@ -1490,10 +1486,16 @@ class ExtendedFieldListSerializer(ModelSerializer):
         return should_display_association and user_can_see_detail
 
     def get_contributor_name(self, instance):
+        embed_mode_active = self.context.get("embed_mode_active")
+        if embed_mode_active:
+            return None
         return get_contributor_name(instance.contributor,
                                     self.should_display_contributor(instance))
 
     def get_contributor_id(self, instance):
+        embed_mode_active = self.context.get("embed_mode_active")
+        if embed_mode_active:
+            return None
         return get_contributor_id(instance.contributor,
                                   self.should_display_contributor(instance))
 


### PR DESCRIPTION
## Overview

Facilities downloaded from embed maps had contributor attributions.
We only show extended fields from a single contributor, so there should
not be any attributions included.

Hides the attributions the CSV downloads when in embedded map mode.

Connects #1741 

## Demo

[EmbeddedCSV.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8311528/EmbeddedCSV.csv)

## Testing Instructions

* Log in as [c2@example.com](mailto:c2@example.com)
* Submit data with extended fields
* Use the Embed tab of https://staging.openapparel.org/settings to configure and view the example embed
* Download the search results from the embed
     - [x] No contributor should be listed in the embed fields

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
