### PR TITLE
Hide raw facility_type values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Minor UX changes [#1745](https://github.com/open-apparel-registry/open-apparel-registry/pull/1745)
 - Increase database work_mem to 20MB [#1744](https://github.com/open-apparel-registry/open-apparel-registry/pull/1744)
 - Swap copy between My Lists and Individual List page [#1756](https://github.com/open-apparel-registry/open-apparel-registry/pull/1756)
+- Hide raw facility_type values [#1758](https://github.com/open-apparel-registry/open-apparel-registry/pull/1758)
 
 ### Deprecated
 

--- a/src/app/src/components/FacilityDetailSidebarExtended.jsx
+++ b/src/app/src/components/FacilityDetailSidebarExtended.jsx
@@ -285,11 +285,19 @@ const FacilityDetailSidebar = ({
     const claimFacility = () => push(makeClaimFacilityLink(oarId));
 
     const renderExtendedField = ({ label, fieldName, formatValue }) => {
-        const values = get(data, `properties.extended_fields.${fieldName}`, []);
-        if (!values.length || !values[0]) return null;
+        let values = get(data, `properties.extended_fields.${fieldName}`, []);
 
         const formatField = item =>
             formatExtendedField({ ...item, formatValue });
+
+        if (fieldName === 'facility_type') {
+            // Filter by values where a matched value has a facility_type field
+            values = values.filter(v =>
+                v?.value?.matched_values?.some(mv => mv[2]),
+            );
+        }
+
+        if (!values.length || !values[0]) return null;
 
         const topValue = formatField(values[0]);
 


### PR DESCRIPTION
## Overview

Unmatched raw values are stored for both processing type, facility type,
and the combined submission field. However, we want to only display
unmatched raw values under processing_type, not under facility_type.

Connects #1749 

## Demo

<img width="319" alt="Screen Shot 2022-03-21 at 11 27 59 AM" src="https://user-images.githubusercontent.com/21046714/159295867-f266705e-c034-4779-ac5f-03d95544013d.png">

## Testing Instructions

* Submit a facility via API with no processing/facility fields. Search for it in the facilities sidebar and confirm that you can load the details page without errors and that the facility_type and processing_type fields are empty
```
{
"name": "Testing testing 123",
"address": "1234 Rua Valentin Schmidt, 255",
"country": "Brazil"
}
```
* Submit a facility via API with invalid processing/facility fields. Search for it in the facilities sidebar and confirm that you can load the details page without errors. The facility types list should NOT show the invalid fields. The processing types list SHOULD show the invalid processing type field. 
```
{
"name": "Testing a facility",
"address": "Rua Valentin Schmidt, 255",
"country": "Brazil",
"facility_type": "cool value",
"processing_type": "invalid value"
}
```

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
