### PR TITLE
Filter out invalid facility_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Hide contributor details in embed downloads [#1742](https://github.com/open-apparel-registry/open-apparel-registry/pull/1742)
 - Wrap long filenames in My Lists page [#1756](https://github.com/open-apparel-registry/open-apparel-registry/pull/1756)
 - Fix handling of numeric custom fields [#1757](https://github.com/open-apparel-registry/open-apparel-registry/pull/1757)
+- Filter out invalid facility_types [#1759](https://github.com/open-apparel-registry/open-apparel-registry/pull/1759)
 
 ### Security
 

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -733,14 +733,8 @@ export const EXTENDED_FIELD_TYPES = [
     {
         label: 'Facility Type',
         fieldName: 'facility_type',
-        formatValue: v => {
-            const rawValues = Array.isArray(v.raw_values)
-                ? v.raw_values
-                : v.raw_values.toString().split('|');
-            return v.matched_values.map((val, i) =>
-                val[2] !== null ? val[2] : rawValues[i],
-            );
-        },
+        formatValue: v =>
+            v.matched_values.map(val => val[2]).filter(val => val),
     },
     {
         label: 'Product Type',


### PR DESCRIPTION
## Overview

Multiple values can be submitted for a single facility type field.
When some of these values are valid and others are invalid, we need to
filter out the invalid values to only display the valid ones.

Connects #1749 

## Testing Instructions

* Upload and process [ProcessFacilityType.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8317870/ProcessFacilityType.csv). Confirm matches if needed
* View each facility. Confirm that no raw values display under facility type. 
* For facility TEST VALID confirm that "making shirts" is not displayed under facility type, but Raw Material Processing or Production is. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
