### PR TITLE
Reduce pageSize when downloading to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Reduce pageSize when downloading to 10 [#1763](https://github.com/open-apparel-registry/open-apparel-registry/pull/1763)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -13,7 +13,7 @@ import {
     failLogDownload,
 } from '../actions/logDownload';
 import { fetchFacilities } from '../actions/facilities';
-import { FACILITIES_REQUEST_PAGE_SIZE } from '../util/constants';
+import { FACILITIES_DOWNLOAD_REQUEST_PAGE_SIZE } from '../util/constants';
 
 const downloadFacilitiesStyles = Object.freeze({
     listHeaderButtonStyles: Object.freeze({
@@ -48,7 +48,7 @@ function DownloadFacilitiesButton({
         dispatch(startLogDownload());
         dispatch(
             fetchFacilities({
-                pageSize: FACILITIES_REQUEST_PAGE_SIZE,
+                pageSize: FACILITIES_DOWNLOAD_REQUEST_PAGE_SIZE,
                 detail: true,
                 onSuccess: () => dispatch(logDownload(format, { isEmbedded })),
                 onFailure: () => dispatch(failLogDownload()),

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -4,6 +4,7 @@ import { checkWhetherUserHasDashboardAccess } from './util';
 export const OTHER = 'Other';
 
 export const FACILITIES_REQUEST_PAGE_SIZE = 50;
+export const FACILITIES_DOWNLOAD_REQUEST_PAGE_SIZE = 10;
 
 export const WEB_HEADER_HEIGHT = '80px';
 export const MOBILE_HEADER_HEIGHT = '68px';


### PR DESCRIPTION
## Overview

At a pageSize of 50 with `detail=true` we are seeing response times near 30s, sometimes timing out.

In some brief testing reducing the pageSize to 10 results in requests that take 3 to 6 seconds. Setting a pageSize of 20 doubles the response time but interestingly setting a pageSize of 5 doe _not_ reduce the request time. There appears to be a performance floor.

## Demo

### The effects of reducing page size in production

<img width="1280" alt="Screen Shot 2022-03-22 at 1 33 36 PM" src="https://user-images.githubusercontent.com/17363/159571129-c6d6189e-a71d-4ad5-886a-1f99ef181bcd.png">

### Download testing in development

<img width="1280" alt="Screen Shot 2022-03-22 at 1 40 20 PM" src="https://user-images.githubusercontent.com/17363/159572081-4a6dc92f-b9a2-4323-9fca-f39c03d7d534.png">



## Testing Instructions

* Open the network tab
* Download a CSV and verify that the data requests have a page size of 10

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [X] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
