### PR TITLE
Update DB anonymization script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
+
 ### Deprecated
 
 ### Removed

--- a/load-tests/anonymize-the-database/generate_anon_queries
+++ b/load-tests/anonymize-the-database/generate_anon_queries
@@ -58,7 +58,7 @@ fake_uuid4() {
 
 establish_fake_context
 
-for user_id in $(run_query openapparelregistry 'select id from "api_user"'); do
+for user_id in $(run_query openapparelregistry "select id from \"api_user\" where email not like '%@azavea.com' and email not like '%@openapparel.org'"); do
     fake_email="${RANDOM}$(fake mail)"
     echo "\
 UPDATE \"api_user\" \

--- a/load-tests/anonymize-the-database/generate_anon_queries
+++ b/load-tests/anonymize-the-database/generate_anon_queries
@@ -72,4 +72,10 @@ email = '$fake_email' \
 WHERE user_id = '$user_id';"
 done
 
+echo "UPDATE api_facilitylistitem SET ppe_contact_email = NULL;"
+
+echo "UPDATE api_facility SET ppe_contact_email = NULL;"
+
+echo "UPDATE api_facilityclaim SET email = 'anonymous@example.com';"
+
 close_fake_context

--- a/load-tests/anonymize-the-database/generate_anon_queries
+++ b/load-tests/anonymize-the-database/generate_anon_queries
@@ -78,4 +78,6 @@ echo "UPDATE api_facility SET ppe_contact_email = NULL;"
 
 echo "UPDATE api_facilityclaim SET email = 'anonymous@example.com';"
 
+echo "DELETE FROM authtoken_token;"
+
 close_fake_context


### PR DESCRIPTION
Update the DB anonymization script to remove additional content.

Connects #1775

## Testing Instructions

I restored a production snapshot to a new instances in the staging VPC and followed the instructions in `load-tests/anonymize-the-database/READMEN.md`

* In one shell establish an ssh tunnel to the new staging database. NOTE if your are running inside Vagrant you will need to 1) Make the pem file available inside the vagrant VM (one way is by copying it to ~/.aws which is already mapped to the same location inside vagrant) and 2) starting the tunnel in a vagrant ssh shell
```
ssh -i ~/.ssh/oar-stg.pem -L 5433:openapparelregistry-enc-stg-from-prd-2022-03-23-21-31.ctdp4povekhv.eu-west-1.rds.amazonaws.com:5432 -N ec2-user@bastion.staging.openapparel.org
```
NOTE this command will appear to "hang" but if there is no error output than the tunnel should be open

* Edit `docker-compose.yml` to change the django database conneciton environment variables

If running with local docker on macOS without Vagrant:
```
  django:
    image: openapparelregistry
    env_file: .env
    environment:
      - POSTGRES_HOST=host.docker.internal
      - POSTGRES_PORT=5433
      - POSTGRES_USER=openapparelregistry
      - POSTGRES_PASSWORD={ the staging DB password }
      - POSTGRES_DB=openapparelregistry
```

If running inside Vagrant

```
  django:
    image: openapparelregistry
    env_file: .env
    network_mode: host 
    environment:
      - POSTGRES_HOST=localhost
      - POSTGRES_PORT=5433
      - POSTGRES_USER=openapparelregistry
      - POSTGRES_PASSWORD={ the staging DB password }
      - POSTGRES_DB=openapparelregistry
```


* Run ./scripts/manage dbshell
* Verify changes made by the anonymize script 
```
openapparelregistry=> select email from api_user where id = 123;
         email
------------------------
 244kenneth75@gmail.com
(1 row)

openapparelregistry=> select distinct email from api_facilityclaim;
         email
-----------------------
 anonymous@example.com
(1 row)

openapparelregistry=> select count(*) from api_facility where ppe_contact_email is not null;
 count
-------
     0
(1 row)

openapparelregistry=> select count(*) from api_facilitylistitem where ppe_contact_email is not null;
 count
-------
     0
(1 row)

openapparelregistry=> select count(*) from authtoken_token ;
 count
-------
     0
(1 row)
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
