### PR TITLE
Update tileer load test script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
+- Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
 
 ### Deprecated
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -8,6 +8,7 @@ components necessary to execute a load test are encapsulated in this directory.
 
 - `K6_CLOUD_TOKEN`: An Auth Token for interacting with the k6 Cloud (optional)
 - `CACHE_KEY_SUFFIX`: A suffix to append in the path to ensure tile requests miss the cache (optional)
+- `VU_MULTIPLER`: An integer number of parallel executions of each batch of requests
 
 ## Running
 
@@ -57,6 +58,16 @@ default ✓ [======================================] 10 VUs  01m38.9s/10m0s  10/
     vus_max....................: 10     min=10 max=10
 
 ERRO[0101] some thresholds have failed
+```
+
+To invoke an instance of the load test running with 10 times the number of
+parallel requests and a random cache key suffix to avoid CloudFront
+
+```console
+VU_MULTIPLIER=10 \
+CACHE_KEY_SUFFIX=$(echo $(date) | sha1sum | cut -c1-8) \
+docker-compose -f docker-compose.yml run --rm \
+  k6 run /scripts/zoom_rio_de_janerio_with_contributor_filter.js
 ```
 
 To invoke an instance of the load test streaming output to the k6 Cloud:

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -75,6 +75,6 @@ To invoke an instance of the load test streaming output to the k6 Cloud:
 ```console
 $ export K6_CLOUD_TOKEN=...
 $ docker-compose \
-    -f docker-compose.k6.yml \
-    run --rm k6 run -o cloud scripts/zoom_rio_de_janerio_with_contributor_filter.js
+    -f docker-compose.yml \
+    run --rm k6 run -o cloud /scripts/zoom_rio_de_janerio_with_contributor_filter.js
 ```

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - K6_CLOUD_TOKEN
       - CACHE_KEY_SUFFIX
+      - VU_MULTIPLIER
     volumes:
       - ./:/scripts/
     command: run /scripts/zoom_rio_de_janerio_with_contributor_filter.js

--- a/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
+++ b/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
@@ -24,9 +24,14 @@ har.log.entries.forEach((entry) => {
     const cacheKey = crypto
         .sha1(entry.request.url.match(pattern)[5], "hex")
         .slice(0, 8);
+    // Including the __VU in the cache key should generate a worse situation
+    // than typical. Each batch of requests is made by a separate VU and when
+    // VU_MULTIPLIER is larger than 1, we repeat the same batch of requests a
+    // number of times equal to VU_MULTIPLIER. Using __VU in the cache key means
+    // subsequent requests for the same batch will not hit the cache.
     const url = entry.request.url.replace(
         pattern,
-        `${cacheKey}${__ENV.CACHE_KEY_SUFFIX}/$2/$3/$4.pbf?$5`
+        `${cacheKey}-vu-${__VU}-${__ENV.CACHE_KEY_SUFFIX}/$2/$3/$4.pbf?$5`
     );
 
     const referer = entry.request.headers.find(

--- a/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
+++ b/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
@@ -63,11 +63,13 @@ batches = batches.sort((a, b) => a - b);
 
 const failRate = new Rate("failed requests");
 
+const VU_MULTIPLIER = __ENV.VU_MULTIPLIER || 1;
+
 export const options = {
     // We want VUs and iterations to match the number of parallel request
     // batches we're going to issue so we can replay traffic 1:1.
-    vus: batches.length,
-    iterations: batches.length,
+    vus: batches.length * VU_MULTIPLIER,
+    iterations: batches.length * VU_MULTIPLIER,
 
     discardResponseBodies: true,
     maxRedirects: 0,
@@ -79,7 +81,8 @@ export const options = {
 export default function () {
     // Sleep each Batch so that everything doesn't happen at once
     const firstBatchTime = batches[0];
-    const thisBatchTime = batches[__VU - 1];
+    const batchIndex = (__VU - 1) % batches.length;
+    const thisBatchTime = batches[batchIndex];
     sleep(Math.floor((thisBatchTime - firstBatchTime) / 1000));
 
     const responses = http.batch(requests[thisBatchTime]);


### PR DESCRIPTION
Update the tile request load testing scripts to

1) Allow running multiple sets of requests in parallel
1) Break the cache for each set of parallel requests to make the load as aggressive as possible

Connects #1776

## Demo

```
> VU_MULTIPLIER=10 \
> CACHE_KEY_SUFFIX=$(echo $(date) | sha1sum | cut -c1-8) \
> docker-compose -f docker-compose.yml run --rm \
>   k6 run /scripts/zoom_rio_de_janerio_with_contributor_filter.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: /scripts/zoom_rio_de_janerio_with_contributor_filter.js
     output: -

  scenarios: (100.00%) 1 scenario, 100 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 100 iterations shared among 100 VUs (maxDuration: 10m0s, gracefulStop: 30s)


running (00m16.3s), 000/100 VUs, 100 complete and 0 interrupted iterations
default ✓ [======================================] 100 VUs  00m16.3s/10m0s  100/100 shared iters

     ✓ is status 200

     checks.........................: 100.00% ✓ 950       ✗ 0
     data_received..................: 3.5 MB  213 kB/s
     data_sent......................: 325 kB  20 kB/s
   ✓ failed requests................: 0.00%   ✓ 0         ✗ 950
     http_req_blocked...............: avg=29.13ms  min=88ns     med=264ns    max=1.02s    p(90)=164.73ms p(95)=196.82ms
     http_req_connecting............: avg=10.99ms  min=0s       med=0s       max=161.78ms p(90)=82.33ms  p(95)=98.8ms
     http_req_duration..............: avg=2.24s    min=196.15ms med=2.38s    max=3.93s    p(90)=3.35s    p(95)=3.59s
       { expected_response:true }...: avg=2.24s    min=196.15ms med=2.38s    max=3.93s    p(90)=3.35s    p(95)=3.59s
     http_req_failed................: 0.00%   ✓ 0         ✗ 950
     http_req_receiving.............: avg=101.85µs min=20.42µs  med=83.64µs  max=2.18ms   p(90)=164.75µs p(95)=208.28µs
     http_req_sending...............: avg=141.91µs min=23.51µs  med=102.45µs max=2.56ms   p(90)=262.91µs p(95)=360.88µs
     http_req_tls_handshaking.......: avg=10.55ms  min=0s       med=0s       max=197.98ms p(90)=72.39ms  p(95)=97.47ms
     http_req_waiting...............: avg=2.24s    min=195.6ms  med=2.38s    max=3.93s    p(90)=3.35s    p(95)=3.59s
     http_reqs......................: 950     58.341884/s
     iteration_duration.............: avg=10.59s   min=4.67s    med=9.99s    max=16.24s   p(90)=15.25s   p(95)=16.1s
     iterations.....................: 100     6.141251/s
     vus............................: 9       min=9       max=100
     vus_max........................: 100     min=100     max=100
```

## Testing Instructions

* `cd` into `load-tests`
* Run the example from the README and verify that it completes
```shell
VU_MULTIPLIER=10 \
CACHE_KEY_SUFFIX=$(echo $(date) | sha1sum | cut -c1-8) \
docker-compose -f docker-compose.yml run --rm \
  k6 run /scripts/zoom_rio_de_janerio_with_contributor_filter.js
```
* Repeat the test run with VU_MULTIPLIER=20. You should see higher latency and some failed responses
* View the staging CloudWatch dashboard to verify the increases in request, latency, and DB CPU.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
