### PR TITLE
Update tile load test script and add scripts for hompage load, facility download, and facility POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Use autocomplete ordered by name for admin contributors dropdown [#1848](https://github.com/open-apparel-registry/open-apparel-registry/pull/1848)
 - Document parallel OGR workflow in the README [#1851](https://github.com/open-apparel-registry/open-apparel-registry/pull/1851)
+- Update tile load test script and add scripts for hompage load, facility download, and facility POST [#1777](https://github.com/open-apparel-registry/open-apparel-registry/pull/1777)
 
 ### Deprecated
 

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -11,6 +11,7 @@ components necessary to execute a load test are encapsulated in this directory.
 - `VU_MULTIPLER`: An integer number of parallel executions of each batch of requests
 - `CLIENT_KEY`: For load tests that fetch data from the API this must be set to a string that is the same as the value in the staging app service environmant
 - `FILTERS`: For the tile and facility download load tests this may be set to a string formatted like the query string filter arguments passed to the facilities api (e.g. contributors=1&&countries=CN)
+- `TOKEN`: For load tests that POST data the string API token to be included with the POST.
 
 ## Running
 
@@ -95,4 +96,13 @@ To invoke the facility download load test with a custom filter
 $ CLIENT_KEY=... FILTERS="contributors=699" \
 docker-compose -f docker-compose.yml \
   run --rm k6 run  /scripts/download_facilities.js
+```
+
+To invoke the facility creation load test simulating 5 contributors POSTing 1000
+random facilities each
+
+```console
+$ TOKEN=... \
+docker-compose -f docker-compose.yml \
+  run --rm k6 run -u 5 -i 5000  /scripts/post_facility.js
 ```

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -9,10 +9,12 @@ components necessary to execute a load test are encapsulated in this directory.
 - `K6_CLOUD_TOKEN`: An Auth Token for interacting with the k6 Cloud (optional)
 - `CACHE_KEY_SUFFIX`: A suffix to append in the path to ensure tile requests miss the cache (optional)
 - `VU_MULTIPLER`: An integer number of parallel executions of each batch of requests
+- `CLIENT_KEY`: For load tests that fetch data from the API this must be set to a string that is the same as the value in the staging app service environmant
+- `FILTERS`: For the tile and facility download load tests this may be set to a string formatted like the query string filter arguments passed to the facilities api (e.g. contributors=1&&countries=CN)
 
 ## Running
 
-Below is an example of how to invoke an instance of the load test with Docker
+Below is an example of how to invoke an instance of the tile request load test with Docker
 Compose:
 
 ```console
@@ -60,8 +62,8 @@ default ✓ [======================================] 10 VUs  01m38.9s/10m0s  10/
 ERRO[0101] some thresholds have failed
 ```
 
-To invoke an instance of the load test running with 10 times the number of
-parallel requests and a random cache key suffix to avoid CloudFront
+To invoke an instance of the tile request load test running with 10 times the
+number of parallel requests and a random cache key suffix to avoid CloudFront
 
 ```console
 VU_MULTIPLIER=10 \
@@ -70,11 +72,27 @@ docker-compose -f docker-compose.yml run --rm \
   k6 run /scripts/zoom_rio_de_janerio_with_contributor_filter.js
 ```
 
-To invoke an instance of the load test streaming output to the k6 Cloud:
+To invoke an instance of the tile request load test streaming output to the k6 Cloud:
 
 ```console
 $ export K6_CLOUD_TOKEN=...
 $ docker-compose \
     -f docker-compose.yml \
     run --rm k6 run -o cloud /scripts/zoom_rio_de_janerio_with_contributor_filter.js
+```
+
+To invoke the homepage load test with 10 concurrent virtual users each running the test 10 times
+
+```console
+$ CLIENT_KEY=... \
+docker-compose -f docker-compose.yml \
+  run --rm k6 run -u 10 -i 100 /scripts/browse_homepage.js
+```
+
+To invoke the facility download load test with a custom filter
+
+```console
+$ CLIENT_KEY=... FILTERS="contributors=699" \
+docker-compose -f docker-compose.yml \
+  run --rm k6 run  /scripts/download_facilities.js
 ```

--- a/load-tests/browse_homepage.js
+++ b/load-tests/browse_homepage.js
@@ -1,0 +1,133 @@
+import { check, sleep, group } from 'k6';
+import http from 'k6/http';
+
+export const options = {
+    userAgent: 'k6LoadTest',
+};
+
+const check2xx = res => {
+    const resArray = Array.isArray(res) ? res : [res];
+    resArray.forEach(res =>
+        check(res, {
+            'is status 2xx': (r) => r.status >= 200 && r.status < 300,
+        })
+    );
+};
+
+const referer = 'https://staging.openapparel.org/';
+
+// rootUrl should NOT have a trailing slash
+const rootUrl = 'https://staging.openapparel.org';
+
+const staticHeaders = {
+    'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    referer,
+};
+
+const apiHeaders = {
+    accept: 'application/json, text/plain, */*',
+    'x-oar-client-key': __ENV.CLIENT_KEY || 'NOT_SPECIFIED',
+    credentials: 'same-origin',
+    'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    referer,
+};
+
+const buildGet = (url, headers) => {
+    return {
+        method: 'GET',
+        url,
+        params: {
+            headers: headers || staticHeaders,
+        }
+    };
+};
+
+export default function main() {
+    let responses;
+
+    // Wait up to 5 seconds so that the iterations aren't exactly overlapping
+    sleep(Math.random() * 5);
+
+    group('https://staging.openapparel.org/', function () {
+        responses = http.batch([
+            buildGet(`${rootUrl}/web/environment.js`),
+            buildGet(`${rootUrl}/static/css/2.037bc208.chunk.css`),
+            buildGet(`${rootUrl}/static/css/main.cfc7f5ef.chunk.css`),
+            buildGet(`${rootUrl}/static/js/2.27e1f047.chunk.js`),
+            buildGet(`${rootUrl}/static/js/main.602f4e63.chunk.js`),
+        ]);
+        check2xx(responses);
+
+        // This was inserted by k6.io when converting the recording. We assume
+        // it sumulates JS parsing
+        sleep(1.2);
+
+        responses = http.batch([
+            buildGet(`${rootUrl}/static/media/Creative-Commons-Attribution-ShareAlike-40-International-Public.03c38fcb.png`),
+        ]);
+        check2xx(responses);
+
+        responses = http.batch([
+            buildGet(`${rootUrl}/api/contributors/`, apiHeaders),
+            buildGet(`${rootUrl}/api/countries/`, apiHeaders),
+            buildGet(`${rootUrl}/api/contributor-lists/`, apiHeaders),
+            buildGet(`${rootUrl}/api/api-feature-feature-flags/`, apiHeaders),
+        ]);
+        check2xx(responses);
+
+        responses = http.batch([
+            buildGet(`${rootUrl}/user-login/`, apiHeaders),
+        ]);
+        // We do NOT check for a 2xx response here because for an
+        // unauthenticated user this will return 4xx
+
+        // TODO: Consider how to break the tile cache in a way that is a
+        // reasonable simulation
+        responses = http.batch([
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/1/1.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/2/1.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/1/0.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/2/0.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/1/2.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/2/2.pbf`),
+        ]);
+        check2xx(responses);
+
+        responses = http.batch([
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/0/1.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/3/1.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/0/0.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/3/0.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/0/2.pbf`),
+            buildGet(`${rootUrl}/tile/facilitygrid/1647621241-89-aec180a4/2/3/2.pbf`),
+        ]);
+        check2xx(responses);
+
+        responses = http.batch([
+            // TODO There are 2 for contributors in the HAR file made from
+            // browsing the home page. This should be fixed in the app then
+            // removed from the load test
+            buildGet(`${rootUrl}/api/contributors/`, apiHeaders),
+            buildGet(`${rootUrl}/api/current_tile_cache_key`, apiHeaders),
+        ]);
+        check2xx(responses);
+
+        responses = http.batch([
+            buildGet(`${rootUrl}/api/facilities/?&pageSize=50`, apiHeaders),
+        ]);
+        check2xx(responses);
+
+        // This was inserted by the HAR conversion
+        sleep(1.4);
+
+        responses = http.batch([
+            buildGet(`${rootUrl}/favicon/site.webmanifest`),
+            buildGet(`${rootUrl}/favicon/favicon-32x32.png`),
+        ]);
+        check2xx(responses);
+    });
+}

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - K6_CLOUD_TOKEN
       - CACHE_KEY_SUFFIX
+      - CLIENT_KEY
       - VU_MULTIPLIER
       - FILTERS
     volumes:

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - CLIENT_KEY
       - VU_MULTIPLIER
       - FILTERS
+      - TOKEN
     volumes:
       - ./:/scripts/
     command: run /scripts/zoom_rio_de_janerio_with_contributor_filter.js

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - K6_CLOUD_TOKEN
       - CACHE_KEY_SUFFIX
       - VU_MULTIPLIER
+      - FILTERS
     volumes:
       - ./:/scripts/
     command: run /scripts/zoom_rio_de_janerio_with_contributor_filter.js

--- a/load-tests/download_facilities.js
+++ b/load-tests/download_facilities.js
@@ -1,0 +1,55 @@
+import { check, sleep, group } from 'k6';
+import http from 'k6/http';
+
+export const options = {
+    userAgent: 'k6LoadTest',
+};
+
+const check2xx = res => {
+    const resArray = Array.isArray(res) ? res : [res];
+    resArray.forEach(res =>
+        check(res, {
+            'is status 2xx': (r) => r.status >= 200 && r.status < 300,
+        })
+    );
+};
+
+const referer = 'https://staging.openapparel.org/';
+
+// rootUrl should NOT have a trailing slash
+const rootUrl = 'https://staging.openapparel.org';
+
+const apiHeaders = {
+    accept: 'application/json, text/plain, */*',
+    'x-oar-client-key': __ENV.CLIENT_KEY || 'NOT_SPECIFIED',
+    credentials: 'same-origin',
+    'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"',
+    'sec-ch-ua-mobile': '?0',
+    'sec-ch-ua-platform': '"macOS"',
+    referer,
+};
+
+const buildGet = (url, headers) => {
+    return {
+        method: 'GET',
+        url,
+        params: {
+            headers: headers || apiHeaders,
+        }
+    };
+};
+
+const FILTERS = __ENV.FILTERS || 'contributors=699&detail=true&lists=929';
+
+export default function main() {
+    let responses;
+    let next;
+    responses = http.batch([buildGet(`${rootUrl}/api/facilities/?detail=true&pageSize=10&${FILTERS}`)]);
+    check2xx(responses);
+    next = JSON.parse(responses[0].body).next;
+    while (next) {
+        responses = http.batch([buildGet(next)]);
+        check2xx(responses);
+        next = JSON.parse(responses[0].body).next;
+    }
+}

--- a/load-tests/post_facility.js
+++ b/load-tests/post_facility.js
@@ -1,0 +1,318 @@
+import { check, sleep, group } from "k6";
+import http from "k6/http";
+import { SharedArray } from "k6/data";
+
+const randElem = l => l[Math.floor(Math.random() * l.length)];
+
+const addresses = new SharedArray("addresses", function() {
+    const a = open("./addresses.csv").split("\n");
+    a.shift();
+    return a;
+});
+
+const randomUnit = () => {
+    if (Math.random() > 0.5) {
+        return `Unit ${Math.floor(Math.random() * 100)}`;
+    }
+    return "";
+};
+
+const catchPhraseWords = [
+    "Adaptive",
+    "Advanced",
+    "Ameliorated",
+    "Assimilated",
+    "Automated",
+    "Balanced",
+    "Business-focused",
+    "Centralized",
+    "Cloned",
+    "Compatible",
+    "Configurable",
+    "Cross-group",
+    "Cross-platform",
+    "Customer-focused",
+    "Customizable",
+    "Decentralized",
+    "De-engineered",
+    "Devolved",
+    "Digitized",
+    "Distributed",
+    "Diverse",
+    "Down-sized",
+    "Enhanced",
+    "Enterprise-wide",
+    "Ergonomic",
+    "Exclusive",
+    "Expanded",
+    "Extended",
+    "Face-to-face",
+    "Focused",
+    "Front-line",
+    "Fully-configurable",
+    "Function-based",
+    "Fundamental",
+    "Future-proofed",
+    "Grass-roots",
+    "Horizontal",
+    "Implemented",
+    "Innovative",
+    "Integrated",
+    "Intuitive",
+    "Inverse",
+    "Managed",
+    "Mandatory",
+    "Monitored",
+    "Multi-channeled",
+    "Multi-lateral",
+    "Multi-layered",
+    "Multi-tiered",
+    "Networked",
+    "Object-based",
+    "Open-architected",
+    "Open-source",
+    "Operative",
+    "Optimized",
+    "Optional",
+    "Organic",
+    "Organized",
+    "Persevering",
+    "Persistent",
+    "Phased",
+    "Polarized",
+    "Pre-emptive",
+    "Proactive",
+    "Profit-focused",
+    "Profound",
+    "Programmable",
+    "Progressive",
+    "Public-key",
+    "Quality-focused",
+    "Reactive",
+    "Realigned",
+    "Re-contextualized",
+    "Re-engineered",
+    "Reduced",
+    "Reverse-engineered",
+    "Right-sized",
+    "Robust",
+    "Seamless",
+    "Secured",
+    "Self-enabling",
+    "Sharable",
+    "Stand-alone",
+    "Streamlined",
+    "Switchable",
+    "Synchronized",
+    "Synergistic",
+    "Synergized",
+    "Team-oriented",
+    "Total",
+    "Triple-buffered",
+    "Universal",
+    "Up-sized",
+    "Upgradable",
+    "User-centric",
+    "User-friendly",
+    "Versatile",
+    "Virtual",
+    "Visionary",
+    "Vision-oriented"
+];
+
+const processingTypes = [
+    "headquarters",
+    "no processing",
+    "office",
+    "office hq",
+    "sourcing agent",
+    "trading",
+    "packing",
+    "warehousing distribution",
+    "assembly",
+    "cutting",
+    "cut & sew",
+    "embellishment",
+    "embroidery",
+    "final product assembly",
+    "finished goods",
+    "ironing",
+    "knitwear assembly",
+    "knit composite",
+    "linking",
+    "manufacturing",
+    "making up",
+    "marker making",
+    "molding",
+    "pattern grading",
+    "pleating",
+    "product finishing",
+    "ready made garment",
+    "sample making",
+    "seam taping",
+    "sewing",
+    "steaming",
+    "stitching",
+    "tailoring",
+    "batch dyeing",
+    "coating",
+    "continuous dyeing",
+    "direct digital ink printing",
+    "dyeing",
+    "fabric all over print",
+    "fabric chemical finishing",
+    "finishing",
+    "fiber dye",
+    "flat screen printing",
+    "garment dyeing",
+    "garment place print",
+    "garment wash",
+    "garment finishing",
+    "hand dye",
+    "laundering",
+    "laundry",
+    "pre treatment",
+    "printing",
+    "printing product dyeing and laundering",
+    "product dyeing",
+    "rotary printing",
+    "screen printing",
+    "spray dye",
+    "sublimation",
+    "textile dyeing",
+    "textile printing",
+    "textile chemical finishing",
+    "textile mechanical finishing",
+    "tye dye",
+    "washing",
+    "wet processing",
+    "wet roller printing",
+    "yarn dyeing",
+    "blending",
+    "bonding",
+    "buffing",
+    "components",
+    "doubling",
+    "embossing",
+    "fabric mill",
+    "flat knit",
+    "fusing",
+    "garment accessories manufacturing",
+    "knitting",
+    "circular knitting",
+    "lace knitting",
+    "knitting seamless",
+    "knitting v bed",
+    "knitting warp",
+    "laminating",
+    "material creation",
+    "material production",
+    "mill",
+    "non woven manufacturing",
+    "non woven processing",
+    "straight bar knitting",
+    "textile or material production",
+    "textile mill",
+    "weaving",
+    "biological recycling",
+    "boiling",
+    "breeding",
+    "chemical recycling",
+    "chemical synthesis",
+    "collecting",
+    "concentrating",
+    "disassembly",
+    "down processing",
+    "dry spinning",
+    "extrusion",
+    "ginning",
+    "hatchery",
+    "mechanical recycling",
+    "melt spinning",
+    "preparation",
+    "preparatory",
+    "processing site",
+    "pulp making",
+    "raw material processing or production",
+    "retting",
+    "scouring",
+    "shredding",
+    "slaughterhouse",
+    "slaughtering",
+    "sorting",
+    "spinning",
+    "standardization chemical finishing",
+    "synthetic leather production",
+    "tannery",
+    "tanning",
+    "textile recycling",
+    "top making",
+    "twisting texturizing facility",
+    "wet spinning",
+    "yarn spinning"
+];
+
+const suffixes = ["Inc", "and Associates", "LLC", "Group", "PLC", "Ltd"];
+
+const randomSuffix = () => {
+    if (Math.random() > 0.3) {
+        return randElem(suffixes);
+    }
+    return "";
+};
+
+const randomName = () => {
+    return `${randElem(catchPhraseWords)} ${randElem(
+        processingTypes
+    )} ${randomSuffix()} ${randomUnit()}`;
+};
+
+const randomFacilityObject = () => {
+    const line = randElem(addresses);
+    const country = line.substring(1, 3);
+    const address = line.substring(6, line.length - 1);
+    const name = randomName();
+    const number_of_workers = Math.ceil(Math.random() * 20000);
+    const processing_type = randElem(processingTypes);
+    return {
+        country,
+        name,
+        address,
+        number_of_workers,
+        processing_type
+    };
+};
+
+export const options = {
+    userAgent: "k6LoadTest"
+};
+
+const check2xx = res => {
+    const resArray = Array.isArray(res) ? res : [res];
+    resArray.forEach(res =>
+        check(res, {
+            "is status 2xx": r => r.status >= 200 && r.status < 300
+        })
+    );
+};
+
+const referer = "https://staging.openapparel.org/";
+
+// rootUrl should NOT have a trailing slash
+const rootUrl = "https://staging.openapparel.org";
+
+const token = __ENV.TOKEN || "NOT_SPECIFIED";
+
+const headers = {
+    "content-type": "application/json",
+    referer,
+    authorization: `Token ${token}`
+};
+
+const url = `${rootUrl}/api/facilities/`;
+
+export default function main() {
+    const payload = JSON.stringify(randomFacilityObject());
+    const response = http.post(url, payload, { headers });
+    check2xx(response);
+}

--- a/load-tests/tile_test_infinite_loop.bash
+++ b/load-tests/tile_test_infinite_loop.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+while :
+do
+    CACHE_KEY_SUFFIX=$(echo $(date) | sha1sum | cut -c1-8) docker-compose -f docker-compose.yml run --rm   k6 run /scripts/zoom_rio_de_janerio_with_contributor_filter.js
+    sleep 1
+done

--- a/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
+++ b/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
@@ -90,7 +90,9 @@ export default function () {
     const firstBatchTime = batches[0];
     const batchIndex = (__VU - 1) % batches.length;
     const thisBatchTime = batches[batchIndex];
-    sleep(Math.floor((thisBatchTime - firstBatchTime) / 1000));
+    // Include a random number of milliseconds between 0 an 1000 to that batches
+    // in parallel executions don't line up
+    sleep(Math.floor((thisBatchTime - firstBatchTime) / 1000) + Math.random());
 
     const responses = http.batch(requests[thisBatchTime]);
 

--- a/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
+++ b/load-tests/zoom_rio_de_janerio_with_contributor_filter.js
@@ -12,6 +12,8 @@ const requests = {};
 // <cachekey>/<int:z>/<int:x>/<int:y>.pbf?<filters>
 const pattern = new RegExp(/(.{8})\/(\d+)\/(\d+)\/(\d+)\.pbf\?(.+)/);
 
+const FILTERS = __ENV.FILTERS || '$5';
+
 har.log.entries.forEach((entry) => {
     const startedDateTime = new Date(entry.startedDateTime);
     startedDateTime.setMilliseconds(0);
@@ -31,7 +33,7 @@ har.log.entries.forEach((entry) => {
     // subsequent requests for the same batch will not hit the cache.
     const url = entry.request.url.replace(
         pattern,
-        `${cacheKey}-vu-${__VU}-${__ENV.CACHE_KEY_SUFFIX}/$2/$3/$4.pbf?$5`
+        `${cacheKey}-vu-${__VU}-${__ENV.CACHE_KEY_SUFFIX}/$2/$3/$4.pbf?${FILTERS}`
     );
 
     const referer = entry.request.headers.find(


### PR DESCRIPTION
## Overview

Update tile load test script and add scripts for hompage load, facility download, and facility POST

Connects #1776

## Testing Instructions

**NOTE** these scripts have been successfully used on staging so this can be a cursory review.

* Register an account on staging and generate an API token
* Obtain the `CLIENT_KEY` used on staging
* `cd` into the `load-tests` directory.
* Verify that you can run the new load test commands added to the README in the PR

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
