### PR TITLE
Only show contributed extended fields in embed sidebar search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
 - Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
+- Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794)
 
 ### Deprecated
 

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -108,6 +108,9 @@ const mapProcessingTypeOptions = (fPTypes, fTypes) => {
     return mapDjangoChoiceTuplesValueToSelectOptions(uniq(pTypes.sort()));
 };
 
+const isExtendedFieldForThisContributor = (field, extendedFields) =>
+    extendedFields.includes(field.toLowerCase());
+
 function FilterSidebarExtendedSearch({
     contributorTypeOptions,
     facilityProcessingTypeOptions,
@@ -127,6 +130,7 @@ function FilterSidebarExtendedSearch({
     fetchingFacilities,
     fetchingExtendedOptions,
     embed,
+    embedExtendedFields,
     classes,
     fetchContributorTypes,
     fetchFacilityProcessingType,
@@ -396,7 +400,7 @@ function mapStateToProps({
     facilities: {
         facilities: { data: facilities, fetching: fetchingFacilities },
     },
-    embeddedMap: { embed },
+    embeddedMap: { embed, config },
 }) {
     return {
         contributorTypeOptions,
@@ -416,6 +420,7 @@ function mapStateToProps({
             fetchingFacilityProcessingType ||
             fetchingNumberofWorkers,
         embed: !!embed,
+        embedExtendedFields: config.extended_fields,
     };
 }
 

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -162,8 +162,8 @@ function FilterSidebarExtendedSearch({
 
     return (
         <>
-            <div className="form__field">
-                <ShowOnly when={!embed}>
+            <ShowOnly when={!embed}>
+                <div className="form__field">
                     <InputLabel
                         shrink={false}
                         htmlFor={CONTRIBUTOR_TYPES}
@@ -182,8 +182,8 @@ function FilterSidebarExtendedSearch({
                         onChange={updateContributorType}
                         disabled={fetchingExtendedOptions || fetchingFacilities}
                     />
-                </ShowOnly>
-            </div>
+                </div>
+            </ShowOnly>
             <div className="form__field">
                 <Divider />
                 <div
@@ -193,112 +193,162 @@ function FilterSidebarExtendedSearch({
                     {EXTENDED_FIELDS_EXPLANATORY_TEXT}
                 </div>
             </div>
-            <div className="form__field">
-                <InputLabel
-                    shrink={false}
-                    htmlFor={PARENT_COMPANY}
-                    className={classes.inputLabelStyle}
-                >
-                    Parent Company
-                </InputLabel>
-                <CreatableInputOnly
-                    isMulti
-                    id={PARENT_COMPANY}
-                    name={PARENT_COMPANY}
-                    className={`basic-multi-select ${classes.selectStyle}`}
-                    classNamePrefix="select"
-                    value={parentCompany}
-                    onChange={updateParentCompany}
-                    disabled={fetchingFacilities}
-                    placeholder="e.g. ABC Textiles Limited"
-                />
-            </div>
-            <div className="form__field">
-                <InputLabel
-                    shrink={false}
-                    htmlFor={FACILITY_TYPE}
-                    className={classes.inputLabelStyle}
-                >
-                    Facility Type
-                </InputLabel>
-                <ReactSelect
-                    isMulti
-                    id={FACILITY_TYPE}
-                    name={FACILITY_TYPE}
-                    className={`basic-multi-select ${classes.selectStyle}`}
-                    classNamePrefix="select"
-                    options={mapFacilityTypeOptions(
-                        facilityProcessingTypeOptions,
-                        processingType,
-                    )}
-                    value={facilityType}
-                    onChange={updateFacilityType}
-                    disabled={fetchingExtendedOptions || fetchingFacilities}
-                />
-            </div>
-            <div className="form__field">
-                <InputLabel
-                    shrink={false}
-                    htmlFor={PROCESSING_TYPE}
-                    className={classes.inputLabelStyle}
-                >
-                    Processing Type
-                </InputLabel>
-                <ReactSelect
-                    isMulti
-                    id={PROCESSING_TYPE}
-                    name={PROCESSING_TYPE}
-                    className={`basic-multi-select ${classes.selectStyle}`}
-                    classNamePrefix="select"
-                    options={mapProcessingTypeOptions(
-                        facilityProcessingTypeOptions,
-                        facilityType,
-                    )}
-                    value={processingType}
-                    onChange={updateProcessingType}
-                    disabled={fetchingExtendedOptions || fetchingFacilities}
-                />
-            </div>
-            <div className="form__field">
-                <InputLabel
-                    shrink={false}
-                    htmlFor={PRODUCT_TYPE}
-                    className={classes.inputLabelStyle}
-                >
-                    Product Type
-                </InputLabel>
-                <CreatableInputOnly
-                    isMulti
-                    id={PRODUCT_TYPE}
-                    name={PRODUCT_TYPE}
-                    className={`basic-multi-select ${classes.selectStyle}`}
-                    classNamePrefix="select"
-                    value={productType}
-                    onChange={updateProductType}
-                    disabled={fetchingFacilities}
-                    placeholder="e.g. Jackets"
-                />
-            </div>
-            <div className="form__field">
-                <InputLabel
-                    shrink={false}
-                    htmlFor={NUMBER_OF_WORKERS}
-                    className={classes.inputLabelStyle}
-                >
-                    Number of Workers
-                </InputLabel>
-                <ReactSelect
-                    isMulti
-                    id={NUMBER_OF_WORKERS}
-                    name={NUMBER_OF_WORKERS}
-                    className={`basic-multi-select ${classes.selectStyle}`}
-                    classNamePrefix="select"
-                    options={numberOfWorkersOptions}
-                    value={numberOfWorkers}
-                    onChange={updateNumberOfWorkers}
-                    disabled={fetchingExtendedOptions || fetchingFacilities}
-                />
-            </div>
+            <ShowOnly
+                when={
+                    !embed ||
+                    isExtendedFieldForThisContributor(
+                        PARENT_COMPANY,
+                        embedExtendedFields,
+                    )
+                }
+            >
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={PARENT_COMPANY}
+                        className={classes.inputLabelStyle}
+                    >
+                        Parent Company
+                    </InputLabel>
+                    <CreatableInputOnly
+                        isMulti
+                        id={PARENT_COMPANY}
+                        name={PARENT_COMPANY}
+                        className={`basic-multi-select ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        value={parentCompany}
+                        onChange={updateParentCompany}
+                        disabled={fetchingFacilities}
+                        placeholder="e.g. ABC Textiles Limited"
+                    />
+                </div>
+            </ShowOnly>
+            <ShowOnly
+                when={
+                    !embed ||
+                    isExtendedFieldForThisContributor(
+                        FACILITY_TYPE,
+                        embedExtendedFields,
+                    )
+                }
+            >
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={FACILITY_TYPE}
+                        className={classes.inputLabelStyle}
+                    >
+                        Facility Type
+                    </InputLabel>
+                    <ReactSelect
+                        isMulti
+                        id={FACILITY_TYPE}
+                        name={FACILITY_TYPE}
+                        className={`basic-multi-select ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        options={mapFacilityTypeOptions(
+                            facilityProcessingTypeOptions,
+                            processingType,
+                        )}
+                        value={facilityType}
+                        onChange={updateFacilityType}
+                        disabled={fetchingExtendedOptions || fetchingFacilities}
+                    />
+                </div>
+            </ShowOnly>
+            <ShowOnly
+                when={
+                    !embed ||
+                    isExtendedFieldForThisContributor(
+                        PROCESSING_TYPE,
+                        embedExtendedFields,
+                    )
+                }
+            >
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={PROCESSING_TYPE}
+                        className={classes.inputLabelStyle}
+                    >
+                        Processing Type
+                    </InputLabel>
+                    <ReactSelect
+                        isMulti
+                        id={PROCESSING_TYPE}
+                        name={PROCESSING_TYPE}
+                        className={`basic-multi-select ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        options={mapProcessingTypeOptions(
+                            facilityProcessingTypeOptions,
+                            facilityType,
+                        )}
+                        value={processingType}
+                        onChange={updateProcessingType}
+                        disabled={fetchingExtendedOptions || fetchingFacilities}
+                    />
+                </div>
+            </ShowOnly>
+            <ShowOnly
+                when={
+                    !embed ||
+                    isExtendedFieldForThisContributor(
+                        PRODUCT_TYPE,
+                        embedExtendedFields,
+                    )
+                }
+            >
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={PRODUCT_TYPE}
+                        className={classes.inputLabelStyle}
+                    >
+                        Product Type
+                    </InputLabel>
+                    <CreatableInputOnly
+                        isMulti
+                        id={PRODUCT_TYPE}
+                        name={PRODUCT_TYPE}
+                        className={`basic-multi-select ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        value={productType}
+                        onChange={updateProductType}
+                        disabled={fetchingFacilities}
+                        placeholder="e.g. Jackets"
+                    />
+                </div>
+            </ShowOnly>
+            <ShowOnly
+                when={
+                    !embed ||
+                    isExtendedFieldForThisContributor(
+                        NUMBER_OF_WORKERS,
+                        embedExtendedFields,
+                    )
+                }
+            >
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={NUMBER_OF_WORKERS}
+                        className={classes.inputLabelStyle}
+                    >
+                        Number of Workers
+                    </InputLabel>
+                    <ReactSelect
+                        isMulti
+                        id={NUMBER_OF_WORKERS}
+                        name={NUMBER_OF_WORKERS}
+                        className={`basic-multi-select ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        options={numberOfWorkersOptions}
+                        value={numberOfWorkers}
+                        onChange={updateNumberOfWorkers}
+                        disabled={fetchingExtendedOptions || fetchingFacilities}
+                    />
+                </div>
+            </ShowOnly>
         </>
     );
 }

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -151,6 +151,7 @@ function FilterSidebarSearchTab({
     lists,
     classes,
     textSearchLabel,
+    embedExtendedFields,
 }) {
     const extendedFields = [
         contributorTypes,
@@ -495,23 +496,26 @@ function FilterSidebarSearchTab({
                 <div className="form__action" style={{ marginBottom: '40px' }}>
                     {searchResetButtonGroup()}
                 </div>
-                <div className="form__field">
-                    {expandButton}
-                    <ShowOnly when={!expand}>
-                        <div className="form__info">
-                            Contributor type · Parent company · Facility type ·
-                            Processing type · Product type · Number of workers{' '}
-                            <Tooltip
-                                title={EXTENDED_FIELDS_EXPLANATORY_TEXT}
-                                classes={{ tooltip: classes.tooltip }}
-                            >
-                                <i
-                                    className={`${classes.icon} fas fa-fw fa-info-circle`}
-                                />
-                            </Tooltip>
-                        </div>
-                    </ShowOnly>
-                </div>
+                <ShowOnly when={!embed || embedExtendedFields.length}>
+                    <div className="form__field">
+                        {expandButton}
+                        <ShowOnly when={!expand}>
+                            <div className="form__info">
+                                Contributor type · Parent company · Facility
+                                type · Processing type · Product type · Number
+                                of workers{' '}
+                                <Tooltip
+                                    title={EXTENDED_FIELDS_EXPLANATORY_TEXT}
+                                    classes={{ tooltip: classes.tooltip }}
+                                >
+                                    <i
+                                        className={`${classes.icon} fas fa-fw fa-info-circle`}
+                                    />
+                                </Tooltip>
+                            </div>
+                        </ShowOnly>
+                    </div>
+                </ShowOnly>
                 <div
                     className="form__report"
                     style={{ flex: 1, alignItems: 'flex-end', display: 'flex' }}
@@ -620,6 +624,7 @@ function mapStateToProps({
         embed: !!embed,
         fetchingLists,
         textSearchLabel: config.text_search_label,
+        embedExtendedFields: config.extended_fields,
     };
 }
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1449,7 +1449,8 @@ class EmbedConfigSerializer(ModelSerializer):
         model = EmbedConfig
         fields = ('id', 'width', 'height', 'color', 'font', 'contributor',
                   'embed_fields', 'prefer_contributor_name',
-                  'contributor_name', 'text_search_label', 'map_style', 'extended_fields')
+                  'contributor_name', 'text_search_label', 'map_style',
+                  'extended_fields')
 
     def get_contributor(self, instance):
         try:
@@ -1467,7 +1468,7 @@ class EmbedConfigSerializer(ModelSerializer):
         embed_fields = EmbedField.objects.filter(
                             embed_config=instance).order_by('order')
         return EmbedFieldsSerializer(embed_fields, many=True).data
-    
+
     def get_extended_fields(self, instance):
         try:
             extended_fields = ExtendedField.objects \
@@ -1476,6 +1477,7 @@ class EmbedConfigSerializer(ModelSerializer):
             return extended_fields
         except Contributor.DoesNotExist:
             return []
+
 
 class ExtendedFieldListSerializer(ModelSerializer):
     contributor_name = SerializerMethodField()

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1443,12 +1443,13 @@ class EmbedConfigSerializer(ModelSerializer):
     contributor = SerializerMethodField()
     embed_fields = SerializerMethodField()
     contributor_name = SerializerMethodField()
+    extended_fields = SerializerMethodField()
 
     class Meta:
         model = EmbedConfig
         fields = ('id', 'width', 'height', 'color', 'font', 'contributor',
                   'embed_fields', 'prefer_contributor_name',
-                  'contributor_name', 'text_search_label', 'map_style')
+                  'contributor_name', 'text_search_label', 'map_style', 'extended_fields')
 
     def get_contributor(self, instance):
         try:
@@ -1466,7 +1467,15 @@ class EmbedConfigSerializer(ModelSerializer):
         embed_fields = EmbedField.objects.filter(
                             embed_config=instance).order_by('order')
         return EmbedFieldsSerializer(embed_fields, many=True).data
-
+    
+    def get_extended_fields(self, instance):
+        try:
+            extended_fields = ExtendedField.objects \
+                        .filter(contributor_id=instance.contributor.id) \
+                        .values_list('field_name', flat=True).distinct()
+            return extended_fields
+        except Contributor.DoesNotExist:
+            return []
 
 class ExtendedFieldListSerializer(ModelSerializer):
     contributor_name = SerializerMethodField()


### PR DESCRIPTION
## Overview

In embed mode, we only want the extended profile fields that are contributed by the contributor to appear on the filter sidebar. Perviously, it would be a confusing experience for an Embedded Map if the Embedded Map owner had not contributed Type of Product, but that still appeared as a searchable field on their map.

This PR add extended_fields to embed_configs endpoint and use the returned value to check if the extended profile fields are contributed by the user.

Connects #1561

## Demo

![2022-04-08 16 26 28](https://user-images.githubusercontent.com/60887686/162546101-ae3c8aa3-b44b-4a03-ad7b-afac7d5bbdae.gif)

## Notes

When users contributing facilities with extended fields, we will match the processing type with the associated facility type based on taxonomy (see #1616), which means we may populate the facility type / processing type automatically without explicitly contributing that field.

## Testing Instructions

This PR assumes `resetdb` has been run.
* Check out this branch, run `./script/update`
* Log in as c3@example.com, and make sure it has any level of embed access
    - [x] Open [embed](http://localhost:6543/facilities?contributors=2&embed=1) mode and there should be no "More Filter" since no extended fields are contributed
    - [x] Open OAR [front-page ](http://localhost:6543/) and make sure the sidebar looks as normal
* Contribute [ExtendedFieldsTestListLimited.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8465965/ExtendedFieldsTestListLimited.csv) and fully process it using `./tools/batch-process {list-id}`
    - [x] Open [embed](http://localhost:6543/facilities?contributors=2&embed=1) mode, extend "More Filters", and make sure only "Facility Type", "Number of Workers", "Processing Type", and "Product Type" filters are shown.
    - [x] Open OAR [front-page ](http://localhost:6543/) and make sure the sidebar looks as normal

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
