### PR TITLE
Hide extended field messages in embed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
 - Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
-- Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794)
+- Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794) [#1800](https://github.com/open-apparel-registry/open-apparel-registry/pull/1800)
 
 ### Deprecated
 

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -190,12 +190,14 @@ function FilterSidebarExtendedSearch({
             </ShowOnly>
             <div className="form__field">
                 <Divider />
-                <div
-                    className="form__info"
-                    style={{ color: 'rgba(0, 0, 0, 0.8)' }}
-                >
-                    {EXTENDED_FIELDS_EXPLANATORY_TEXT}
-                </div>
+                <ShowOnly when={!embed}>
+                    <div
+                        className="form__info"
+                        style={{ color: 'rgba(0, 0, 0, 0.8)' }}
+                    >
+                        {EXTENDED_FIELDS_EXPLANATORY_TEXT}
+                    </div>
+                </ShowOnly>
             </div>
             <ShowOnly
                 when={

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -499,7 +499,7 @@ function FilterSidebarSearchTab({
                 <ShowOnly when={!embed || embedExtendedFields.length}>
                     <div className="form__field">
                         {expandButton}
-                        <ShowOnly when={!expand}>
+                        <ShowOnly when={!expand && !embed}>
                             <div className="form__info">
                                 Contributor type · Parent company · Facility
                                 type · Processing type · Product type · Number


### PR DESCRIPTION
## Overview

The explanatory text mentions fields that may not be displayed and the caveat that data may not be available because the feature is new is also not relevant.

Connects #1561

## Demo

<img width="360" alt="Screen Shot 2022-04-14 at 7 12 43 AM" src="https://user-images.githubusercontent.com/17363/163410086-30943ff6-e41a-4c09-8d41-18fc33832f5a.png">

<img width="367" alt="Screen Shot 2022-04-14 at 7 12 34 AM" src="https://user-images.githubusercontent.com/17363/163410096-5d1b99b6-8d64-400e-9fba-7cb6958d895d.png">

## Testing Instructions

* Log in as c2@example.com
* Set up the embed config
* Contribute [ExtendedFieldsTestListLimited.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8465965/ExtendedFieldsTestListLimited.csv) and fully process it using `./tools/batch-process {list-id}` so there there 
* Confirm that the embed messages are not  displayed in embed mode but still show in the full map

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
