### PR TITLE
Use exact match in parent company when creating extended field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
 - Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
 - Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794) [#1800](https://github.com/open-apparel-registry/open-apparel-registry/pull/1800)
+- Use exact match in parent company when creating extended field [#1804](https://github.com/open-apparel-registry/open-apparel-registry/pull/1804)
 
 ### Deprecated
 

--- a/src/django/api/migrations/0089_reprocess_parent_company.py
+++ b/src/django/api/migrations/0089_reprocess_parent_company.py
@@ -1,0 +1,79 @@
+from django.db import migrations
+from api.extended_fields import (get_parent_company_extendedfield_value)
+
+
+def index_parentcompany(apps, facility_ids=list):
+    Facility = apps.get_model('api', 'Facility')
+    ExtendedField = apps.get_model('api', 'ExtendedField')
+    FacilityIndex = apps.get_model('api', 'FacilityIndex')
+
+    # If passed an empty array, update all facilities (where applicable)
+    if len(facility_ids) == 0:
+        print('Indexing extended fields for all facilities...')
+        facility_ids = Facility.objects.all().values_list('id', flat=True)
+
+    fields = ExtendedField.objects.filter(facility__id__in=facility_ids,
+                                          value__isnull=False)
+
+    facilities = FacilityIndex.objects.filter(id__in=facility_ids) \
+                                      .iterator()
+    for facility in facilities:
+        facility_fields = fields.filter(facility__id=facility.id)
+
+        # Set parent_company_name and parent_company_id:
+        parent_company_values = facility_fields.filter(
+            field_name='parent_company',
+            value__has_any_keys=['name', 'contributor_name',
+                                 'contributor_id']) \
+            .values('value__contributor_name', 'value__name',
+                    'value__contributor_id')
+        parent_company_name = set()
+        parent_company_id = set()
+        for parent_company in parent_company_values:
+            contributor_name = parent_company.get('value__contributor_name',
+                                                  None)
+            name = parent_company.get('value__name', None)
+            contributor_id = parent_company.get('value__contributor_id',
+                                                None)
+            if contributor_name is not None:
+                parent_company_name.add(contributor_name)
+            elif name is not None:
+                parent_company_name.add(name)
+            if contributor_id is not None:
+                parent_company_id.add(contributor_id)
+        facility.parent_company_name = list(parent_company_name)
+        facility.parent_company_id = list(parent_company_id)
+
+        facility.save()
+
+
+def process_parent_company_field(apps, schema_editor): 
+    ExtendedField = apps.get_model('api', 'ExtendedField')
+    extended_fields = ExtendedField.objects.filter(field_name='parent_company')
+    for extended_field in extended_fields.iterator():
+        raw_parent_company_value = getattr(extended_field, 'value')['raw_value']
+        parent_company_value = get_parent_company_extendedfield_value(
+                    raw_parent_company_value
+                )
+        extended_field.value = parent_company_value
+        extended_field.save()
+    
+    facility_ids_for_indexing = ExtendedField.objects \
+                            .filter(field_name='parent_company') \
+                            .values_list('facility_id', flat=True)
+    index_parentcompany(apps, facility_ids_for_indexing)
+
+
+def do_nothing_on_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0088_migrate_claim_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(process_parent_company_field, do_nothing_on_reverse),
+    ]

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -9,7 +9,6 @@ from django.contrib.gis.db import models as gis_models
 from django.contrib.postgres import fields as postgres
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.aggregates.general import ArrayAgg
-from django.contrib.postgres.search import TrigramSimilarity
 from django.db import models, transaction
 from django.db.models import (F, Q, ExpressionWrapper)
 from django.db.models.signals import post_save
@@ -94,19 +93,13 @@ class EmailAsUsernameUserManager(BaseUserManager):
 
 
 class ContributorManager(models.Manager):
-    TRIGRAM_SIMILARITY_THRESHOLD = 0.5
 
+    # TODO: Will revisit trigram thresholds.
+    # Temporary change to iexact to fix Ralph Lauren upload issue
     def filter_by_name(self, name):
         """
-        Perform a fuzzy match on contributor name where the match exceeds a
-        confidence trheshold. The results are ordered by similarity, then
-        whether the Contirbutor is verified, then by whether the contributor
-        has active sources.
-
-        False is less than True so we order_by boolean fields in descending
-        order
+        Perform an exact match on contributor names
         """
-        threshold = ContributorManager.TRIGRAM_SIMILARITY_THRESHOLD
         matches = self \
             .annotate(active_source_count=models.Count(
                 Q(source__is_active=True))) \
@@ -114,9 +107,8 @@ class ContributorManager(models.Manager):
                 has_active_sources=ExpressionWrapper(
                     Q(active_source_count__gt=0),
                     models.BooleanField())) \
-            .annotate(similarity=TrigramSimilarity('name', name)) \
-            .filter(similarity__gte=threshold) \
-            .order_by('-similarity', '-is_verified', '-has_active_sources')
+            .filter(name__iexact=name) \
+            .order_by('-is_verified', '-has_active_sources')
         return matches
 
 


### PR DESCRIPTION
## Overview

Use exact match instead of fuzzy match to when creating the parent company field. Create migration to reprocess and index the parent company field.

Tests are updated accordingly, including revising the `ParentCompanyTestCase` inputs to be exactly the same as the contributor, and change the sequence of results in `test_filter_by_name_verified`

Will visit trigram matching at #1805. 

Connects #85

## Demo

![image](https://user-images.githubusercontent.com/60887686/163654021-6a8781e1-e6c2-4447-8b2d-89edad8d94ea.png)

## Notes

In test_filter_by_name_verified, we suspect that not using `similarity`  changes the sorting of same names, making the second name comes at first when both names are the same. So we mark `c1` as verified to test if sorting by verified is working as expected.


## Testing Instructions

* Checkout this branch and run `./scripts/update`
* Go to the django admin [site](http://localhost:8081/admin/api/contributor/) and log in as c1@example.com
* Make a new contributor - Kith Fashion Limited 
* Go to local [OAR](http://localhost:6543/) page and log in as c2@example.com
* Contribute [RalphLaurenTesting.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8537268/RalphLaurenTesting.csv) and fully process it with `./tools/batch_process {list-id}`
- [x] Go to Company A and Company B detail page, the parent company field should match the original list




## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines