### PR TITLE
Skip rendering embed fields with empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -817,6 +817,7 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 ### Fixed
 
 - Handle cases when Source contributor or facility_list are None [#903](https://github.com/open-apparel-registry/open-apparel-registry/pull/903)
+- Skip rendering embed fields with empty values [#1809](https://github.com/open-apparel-registry/open-apparel-registry/pull/1809)
 
 ### Security
 

--- a/src/app/src/components/FacilityDetailSidebarExtended.jsx
+++ b/src/app/src/components/FacilityDetailSidebarExtended.jsx
@@ -7,6 +7,7 @@ import uniqBy from 'lodash/uniqBy';
 import partition from 'lodash/partition';
 import includes from 'lodash/includes';
 import filter from 'lodash/filter';
+import isNil from 'lodash/isNil';
 import moment from 'moment';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import List from '@material-ui/core/List';
@@ -311,14 +312,18 @@ const FacilityDetailSidebar = ({
         );
     };
 
-    const renderContributorField = ({ label, value }) =>
-        value !== null ? (
+    const renderContributorField = ({ label, value }) => {
+        if (isNil(value) || value.toString().trim() === '') {
+            return null;
+        }
+        return (
             <FacilityDetailSidebarItem
                 label={label}
                 primary={value}
                 key={label}
             />
-        ) : null;
+        );
+    };
 
     const contributorFields = filter(
         get(data, 'properties.contributor_fields', null),


### PR DESCRIPTION
## Overview

Whether a facility was submitted without a value for an embed field or was submitted with an empty string or other effectively null value do not want to show the field header on the detail page.

Connects #1561

## Testing Instructions

The test CSVs were created by pulling header and raw values from the example facilities in #1561

### Setup

* Checkout `develop`
* Run `./scripts/resetdb`
* Log in as `c2@example.com`
* Contribute [1561-1.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8556983/1561-1.csv)
  * Run `./tools/batch_process 16`
* Contribute  [1561-2a.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8556985/1561-2a.csv)
  * Run `./tools/batch_process 17`
* Log out. Log in as `c3@example.com`
* Contributed [1561-2b.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8556991/1561-2b.csv)
  * Run `./tools/batch_process 18`
* Log out. Log in as `c2@example.com`
* Browse http://localhost:6543/settings and select the embed tab
* Enable all of the custom fields and set a size so that the embed preview loads
* Use the embed preview to view the 2 submitted facilities and verify that fields with empty values appear
* Checkout this branch, `feature/jcw/hide-empty-embed-fields`
* Refresg http://localhost:6543/settings and select the embed tab
* Use the embed preview to view the 2 submitted facilities and verify that no empty fields are rendered on the embed detail pages.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
