### PR TITLE
Read percentage as string in Excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
 - Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794) [#1800](https://github.com/open-apparel-registry/open-apparel-registry/pull/1800)
 - Use exact match in parent company when creating extended field [#1804](https://github.com/open-apparel-registry/open-apparel-registry/pull/1804)
+- Read percentage as string in Excel [#1811](https://github.com/open-apparel-registry/open-apparel-registry/pull/1811)
 
 ### Deprecated
 

--- a/src/app/src/components/ContributeForm.jsx
+++ b/src/app/src/components/ContributeForm.jsx
@@ -184,7 +184,7 @@ class ContributeForm extends Component {
                     <p style={contributeFormStyles.fileNameText}>{filename}</p>
                     <input
                         type="file"
-                        accept=".csv,.xls,.xlsx"
+                        accept=".csv,.xlsx"
                         ref={this.fileInput}
                         style={contributeFormStyles.fileInputHidden}
                         onChange={this.updateSelectedFileName}

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -3,7 +3,8 @@ import csv
 import traceback
 import sys
 
-import xlrd
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
 
 from datetime import datetime
 
@@ -33,36 +34,58 @@ def _report_error_to_rollbar(file, request):
                 'file_name': file.name})
 
 
-def get_excel_sheet(file, request):
+def get_xlsx_sheet(file, request):
     import defusedxml
     from defusedxml.common import EntitiesForbidden
 
     defusedxml.defuse_stdlib()
 
     try:
-        return xlrd.open_workbook(file_contents=file.read(),
-                                  on_demand=True).sheet_by_index(0)
+        wb = load_workbook(filename=file)
+        ws = wb[wb.sheetnames[0]]
+
+        return ws
+
     except EntitiesForbidden:
         _report_error_to_rollbar(file, request)
         raise ValidationError('This file may be damaged and '
                               'cannot be processed safely')
 
 
-def parse_excel(file, request):
-    try:
-        sheet = get_excel_sheet(file, request)
+def format_percent(value):
+    if value <= 1.0:
+        str_value = str(value * 100)
+    else:
+        str_value = str(value)
+    if str_value[-2:] == '.0':
+        str_value = str_value[0:len(str_value)-2]
+    return str_value + '%'
 
-        header = ','.join(sheet.row_values(0))
-        # Use use `str(x)` here since numbers in an Excel column will be
-        # returns as a Python number type
+
+def parse_xlsx(file, request):
+    try:
+        ws = get_xlsx_sheet(file, request)
+
+        # openpyxl package is 1-indexed
+        percent_col = [get_column_letter(cell.column)
+                       for cell in ws[2] if '%' in cell.number_format]
+
+        if percent_col:
+            for col in percent_col:
+                for cell in ws[col]:
+                    if cell.row != 1:
+                        cell.value = format_percent(cell.value)
+
+        header = ','.join([cell.value for cell in ws[1]])
+
         rows = ['"{}"'.format(
-            '","'.join([str(x) for x in sheet.row_values(idx)]))
-                for idx in range(1, sheet.nrows)]
+            '","'.join([str(cell.value) for cell in ws[idx]]))
+                for idx in range(2, ws.max_row + 1)]
 
         return header, rows
     except Exception:
         _report_error_to_rollbar(file, request)
-        raise ValidationError('Error parsing Excel file')
+        raise ValidationError('Error parsing Excel (.xlsx) file')
 
 
 def parse_csv(file, request):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -98,11 +98,6 @@ class FacilityListCreateTest(APITestCase):
             content_type='text/csv')
 
         lists_dir = '/usr/local/src/api/management/commands/facility_lists/'
-        with open(os.path.join(lists_dir, '12.xls'), 'rb') as xls:
-            self.test_file_xls = SimpleUploadedFile(
-                '12.xls',
-                xls.read(),
-                content_type='application/vnd.ms-excel')
 
         with open(os.path.join(lists_dir, '12.xlsx'), 'rb') as xlsx:
             self.test_file_xlsx = SimpleUploadedFile(
@@ -164,26 +159,6 @@ class FacilityListCreateTest(APITestCase):
         self.assertEqual(items[0].raw_data, self.test_csv_rows[1])
         for item in items:
             self.assertEqual(source, item.source)
-
-    def test_creates_list_and_items_xls(self):
-        previous_list_count = FacilityList.objects.all().count()
-        previous_item_count = FacilityListItem.objects.all().count()
-        response = self.client.post(reverse('facility-list-list'),
-                                    {'name': 'creates_list_and_items_xls',
-                                     'file': self.test_file_xls},
-                                    format='multipart')
-        self.test_file_xls.seek(0)
-        sheet = xlrd.open_workbook(file_contents=self.test_file_xls.read(),
-                                   on_demand=True).sheet_by_index(0)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(FacilityList.objects.all().count(),
-                         previous_list_count + 1)
-        self.assertEqual(FacilityListItem.objects.all().count(),
-                         previous_item_count + sheet.nrows - 1)
-
-        items = list(FacilityListItem.objects.all().order_by('row_index'))
-        self.assertEqual(items[0].raw_data, '"{}"'.format(
-            '","'.join(sheet.row_values(1))))
 
     def test_creates_list_and_items_xlsx(self):
         previous_list_count = FacilityList.objects.all().count()

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -98,7 +98,7 @@ from api.models import (FacilityList,
                         index_extendedfields)
 from api.processing import (parse_csv_line,
                             parse_csv,
-                            parse_excel,
+                            parse_xlsx,
                             get_country_code,
                             save_match_details,
                             save_exact_match_details,
@@ -2629,8 +2629,8 @@ class FacilityListViewSet(viewsets.ModelViewSet):
     def _extract_header_rows(self, file, request):
         ext = file.name[-4:]
 
-        if ext in ['.xls', 'xlsx']:
-            header, rows = parse_excel(file, request)
+        if ext == 'xlsx':
+            header, rows = parse_xlsx(file, request)
         elif ext == '.csv':
             header, rows = parse_csv(file, request)
         else:

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -28,3 +28,4 @@ Unidecode==1.0.23
 xlrd==1.2.0
 django-cors-headers==3.10.0
 debugpy==1.5.1
+openpyxl==3.0.9

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -25,7 +25,6 @@ requests==2.21.0
 rollbar==0.14.6
 thefuzz==0.19.0
 Unidecode==1.0.23
-xlrd==1.2.0
 django-cors-headers==3.10.0
 debugpy==1.5.1
 openpyxl==3.0.9


### PR DESCRIPTION
## Overview

Make sure values in excel sheets that appears to be percentage actually read as strings. E.g. in excel sheets, the value of the cell `68%` can be `0.68`, and this PR makes sure that `'68%'` is being read and displayed in the embedded maps.

Connects [#85](https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/85)

## Demo

![image](https://user-images.githubusercontent.com/60887686/165268829-0ce250d7-fcf8-4d59-9699-3f4d6bccf3be.png)

## Testing Instructions

**Baseline**
* Log in as c2@example.com (make sure it has embed access), contribute [XLSX - Testing.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8561783/XLSX.-.Testing.xlsx) and fully process it.
* Go to embed map setting, make sure `PERCENT_FEMALE_WORKERS` and `DECIMAL_FIELD` are both visible
* Open any facility under the new list
    - [x] Both `PERCENT_FEMALE_WORKERS` and `DECIMAL_FIELD` should appear as `0`

**Test**
* Check out this branch and run `update` and `server`
* Log in as c2@example.com, contribute [XLSX - Testing.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8561783/XLSX.-.Testing.xlsx) and fully process it.
* In [embed map](http://localhost:6543/facilities?contributors=1&embed=1), open any facility under the new list
    - [x] `PERCENT_FEMALE_WORKERS` should have a percentage value and `DECIMAL_FIELD` should appear as `0`

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
