### PR TITLE
Handle None and string values in Excel percent column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
 - Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794) [#1800](https://github.com/open-apparel-registry/open-apparel-registry/pull/1800)
 - Use exact match in parent company when creating extended field [#1804](https://github.com/open-apparel-registry/open-apparel-registry/pull/1804)
-- Read percentage as string in Excel [#1811](https://github.com/open-apparel-registry/open-apparel-registry/pull/1811)
+- Read percentage as string in Excel [#1811](https://github.com/open-apparel-registry/open-apparel-registry/pull/1811) [#1822](https://github.com/open-apparel-registry/open-apparel-registry/pull/1822)
 
 ### Deprecated
 

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -53,6 +53,8 @@ def get_xlsx_sheet(file, request):
 
 
 def format_percent(value):
+    if value is None or isinstance(value, str):
+        return value
     if value <= 1.0:
         str_value = str(value * 100)
     else:
@@ -60,6 +62,12 @@ def format_percent(value):
     if str_value[-2:] == '.0':
         str_value = str_value[0:len(str_value)-2]
     return str_value + '%'
+
+
+def format_cell_value(value):
+    if value is None:
+        return ''
+    return str(value)
 
 
 def parse_xlsx(file, request):
@@ -79,7 +87,7 @@ def parse_xlsx(file, request):
         header = ','.join([cell.value for cell in ws[1]])
 
         rows = ['"{}"'.format(
-            '","'.join([str(cell.value) for cell in ws[idx]]))
+            '","'.join([format_cell_value(cell.value) for cell in ws[idx]]))
                 for idx in range(2, ws.max_row + 1)]
 
         return header, rows


### PR DESCRIPTION
## Overview

This change attempts to prevent exceptions when there are non-numeric values in an Excel column that mostly contains numbers formatted as percentages.

In addition we fix the handling of empty cells so that a None value is not
transformed into the string `"None"`.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/85

## Testing Instructions

* Check out `develop`
* Run `./scripts/resetdb`
* Log in as c2@example.com and attempt to submit. [percent-test-with-empty-and-string.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8577014/percent-test-with-empty-and-string.xlsx)
Verify that an exception is raised
* Check out this branch `bugfix/jcw/handle-none-and-string-in-percent-col`
* Try submitting the workbook again and verify that it succeeds
* Use `./tools/batch_process {id}` to process the list. Verify that there are 2 expected parse failures.
* Browse http://localhost:6543/settings select Embed and enable the `percent_female_workers` field and set the embed size
* Use the embed test at  https://open-apparel-registry.github.io/embeded-map-test-full-width.html?host=localhost:6543&protocol=http&contributors=1 and verify that the facilities have correct values
  * `KH EXPORTS` has a product type but non of the other examples here has a product type of "None"
  * `KH EXPORTS INDIA PRIVATE LTD` shows `60%` for percent_female_workers
  * `SAGE CREATIONS` shows `fifteen percent` for percent_female_workers
  * `GAURAV` does not have percent_female_workers value
  * `CENTURY OVERSEAS` has a parse error due to missing address
  * `JIVA DESIGNS` does not have a number of workers value but does have `18%` for percent_female_workers
 



## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
