### PR TITLE
Add new taxonomy processing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add new taxonomy processing types [#1827](https://github.com/open-apparel-registry/open-apparel-registry/pull/1827)
+
 ### Changed
 
 ### Deprecated

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -51,6 +51,7 @@ MANUFACTURING = 'manufacturing'
 MAKING_UP = 'making up'
 MARKER_MAKING = 'marker making'
 MOLDING = 'molding'
+PACKAGING = 'packaging'
 PATTERN_GRADING = 'pattern grading'
 PLEATING = 'pleating'
 PRODUCT_FINISHING = 'product finishing'
@@ -78,6 +79,7 @@ ASSEMBLY_PROCESSING_TYPES = {
     MAKING_UP: 'Making up',
     MARKER_MAKING: 'Marker Making',
     MOLDING: 'Molding',
+    PACKAGING: 'Packaging',
     PATTERN_GRADING: 'Pattern Grading',
     PLEATING: 'Pleating',
     PRODUCT_FINISHING: 'Product Finishing',
@@ -208,10 +210,15 @@ MATERIAL_PRODUCTION = 'material production'
 MILL = 'mill'
 NON_WOVEN_MANUFACTURING = 'non woven manufacturing'
 NON_WOVEN_PROCESSING = 'non woven processing'
+PAINTING = 'painting'
+PELLETIZING = 'pelletizing'
+PRESSING = 'pressing'
+SPRAYING = 'spraying'
 STRAIGHT_BAR_KNITTING = 'straight bar knitting'
 TEXTILE_OR_MATERIAL_PRODUCTION = 'textile or material production'
 TEXTILE_MILL = 'textile mill'
 WEAVING = 'weaving'
+WELDING = 'welding'
 
 TEXTILE_PROCESSING_TYPES = {
     BLENDING: 'Blending',
@@ -238,10 +245,15 @@ TEXTILE_PROCESSING_TYPES = {
     MILL: 'Mill',
     NON_WOVEN_MANUFACTURING: 'Nonwoven manufacturing',
     NON_WOVEN_PROCESSING: 'Nonwoven Processing',
+    PAINTING: 'Painting',
+    PELLETIZING: 'Pelletizing',
+    PRESSING: 'Pressing',
+    SPRAYING: 'Spraying',
     STRAIGHT_BAR_KNITTING: 'Straight Bar Knitting',
     TEXTILE_OR_MATERIAL_PRODUCTION: 'Textile or Material Production',
     TEXTILE_MILL: 'Textile Mill',
     WEAVING: 'Weaving',
+    WELDING: 'Welding',
 }
 
 TEXTILE_PROCESSING_TYPES_ALIAS = {


### PR DESCRIPTION
## Overview

Adds the new processing types ("Packaging", "Welding", "Painting",
"Spraying", "Pressing", and "Pelletizing") to the taxonomy.

Connects #1820 

## Demo

<img width="306" alt="Screen Shot 2022-05-02 at 4 22 08 PM" src="https://user-images.githubusercontent.com/21046714/166323127-e92b3ecb-c94b-4fc0-abfa-58c27542e0cb.png">
<img width="636" alt="Screen Shot 2022-05-02 at 4 36 58 PM" src="https://user-images.githubusercontent.com/21046714/166323552-56875926-880f-443f-bafe-0bcf59ac4861.png">

## Testing Instructions

* Run `./scripts/server` and navigate to http://localhost:8081/api/docs/#!/facilities/facilities_create
* Authenticate using an API token (found in http://localhost:6543/settings, with 'Token' prefixed)
* Submit the following and note the returned OAR ID
```
{
    "country": "China",
    "name": "Nantong Jackbeanie Headwear &amp; Garment Co. Ltd.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500.",
    "processing_type": ["Packaging", "Welding", "Painting", "Spraying", "Pressing", "Pelletizing"]
}
```
* Visit the returned facility and confirm the new processing types are present
* View the facility details in the network tab and confirm the new taxonomy types are present and nested under the appropriate facility types

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
