### PR TITLE
Handle blank rows and columns in .xlsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Handle blank rows and columns in .xlsx [#1837](https://github.com/open-apparel-registry/open-apparel-registry/pull/1837)
+
 ### Security
 
 ## [65] - 2022-04-28

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -84,11 +84,12 @@ def parse_xlsx(file, request):
                     if cell.row != 1:
                         cell.value = format_percent(cell.value)
 
-        header = ','.join([cell.value for cell in ws[1]])
+        header = ','.join([format_cell_value(cell.value) for cell in ws[1]])
 
         rows = ['"{}"'.format(
             '","'.join([format_cell_value(cell.value) for cell in ws[idx]]))
-                for idx in range(2, ws.max_row + 1)]
+                for idx in range(2, ws.max_row + 1)
+                if any(cell.value is not None for cell in ws[idx])]
 
         return header, rows
     except Exception:


### PR DESCRIPTION
## Overview

Blank cells have the value 'None', which cause an error when attempting
to .join the cell values for the header. We now format None values to strings
before joining.

After fixing that error, blank rows were then being imported as facility list items and
throwing parse errors. We now skip rows where all the cells are blank.

Connects #1835 

## Demo

<img width="1073" alt="Screen Shot 2022-05-05 at 11 42 54 AM" src="https://user-images.githubusercontent.com/21046714/166961332-345af319-67ee-4993-bede-469de64fda4c.png">

## Testing Instructions

* On `develop`, contribute any list from #1835, and confirm that it throws an error.
* On this branch, contribute any list from #1835, and confirm that it uploads without error.
* On this branch, contribute [OAR_Contributor_Template_Additional_Data_Points_Excel.5.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/8632705/OAR_Contributor_Template_Additional_Data_Points_Excel.5.xlsx) and confirm that it is considered to have only one row. 
* Run `./tools/batch_process {id}` for OAR_Contributor_Template_Additional_Data_Points_Excel.5.xlsx and confirm that it processes correctly and only produces one facility list item. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
