### PR TITLE
Use autocomplete ordered by name for admin Contributors dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Use autocomplete ordered by name for admin contributors dropdown [#1848](https://github.com/open-apparel-registry/open-apparel-registry/pull/1848)
 
 ### Deprecated
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -94,8 +94,12 @@ class ContributorAdmin(SimpleHistoryAdmin):
     history_list_display = ('is_verified', 'verification_notes')
     search_fields = ('name', 'admin__email')
 
+    def get_ordering(self, request):
+        return ['name']
+
 
 class FacilityClaimAdmin(SimpleHistoryAdmin):
+    autocomplete_fields = ('parent_company', )
     history_list_display = ('id', 'contact_person', 'created_at', 'status')
     readonly_fields = ('contributor', 'facility', 'status_change_reason',
                        'status_change_by', 'status_change_date', 'status')
@@ -112,6 +116,7 @@ class FacilityAliasAdmin(SimpleHistoryAdmin):
 
 
 class SourceAdmin(admin.ModelAdmin):
+    autocomplete_fields = ('contributor', )
     readonly_fields = ('source_type', 'facility_list', 'create')
     list_filter = ('source_type', 'contributor')
 
@@ -137,6 +142,7 @@ class RequestLogAdmin(admin.ModelAdmin):
 
 
 class ApiLimitAdmin(admin.ModelAdmin):
+    autocomplete_fields = ('contributor', )
     history_list_display = ('contributor', 'yearly_limit', 'created_at',
                             'updated_at', 'period_start_date')
 


### PR DESCRIPTION
## Overview

Use autocomplete ordered by name for admin Contributors dropdown.

As a side-effect of the method used for sorting the autocomplete list, the Contributor admin list is now also sorted by name - I assume this is fine.

Connects #1643


## Demo

![localhost_8081_admin_api_source_15_change_](https://user-images.githubusercontent.com/4432106/168601992-6d5f55b5-49e0-4b21-baa8-05c2b6ba842d.png)

## Notes

I _think_ despite `contributor` being a FK to more than just 3 models, these are the only 3 models that have Django admin support.

Potentially also addresses some of https://github.com/open-apparel-registry/open-apparel-registry/issues/1206?

## Testing Instructions

* `./scripts/server`
* Go to a Facility Claim, Source, or Api Limit Django admin Change or Add page. instead of an unsorted `<select>` field for contributors, there should be an autocomplete w/ results sorted by name

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
