### PR TITLE
Fix geocoding error message to include status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
 
 ### Security
 

--- a/src/django/api/geocoding.py
+++ b/src/django/api/geocoding.py
@@ -80,7 +80,7 @@ def geocode_address(address, country_code):
     r = requests.get(GEOCODING_URL, params=params)
 
     if r.status_code != 200:
-        raise ValueError("Geocoding request failed with status"
+        raise ValueError("Geocoding request failed with status {}"
                          .format(r.status_code))
 
     data = r.json()


### PR DESCRIPTION
## Overview

I was unable to determine the cause of some of geocoding errors being logged here - including the status code should help when this error occurs in the future (and it seems like it was always the intent to include the status code here).

Connects #1788 

## Testing Instructions

* I'm not actually sure how to trigger this error?

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
