### PR TITLE
Add new Average Match Count, Confirm Reject Counts, and Error Items reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Add new Average Match Count, Confirm Reject Counts, and Error Items reports [#1855](https://github.com/open-apparel-registry/open-apparel-registry/pull/1855/commits)
 
 ### Changed
 - Use autocomplete ordered by name for admin contributors dropdown [#1848](https://github.com/open-apparel-registry/open-apparel-registry/pull/1848)

--- a/src/django/api/reports/average_match_count.sql
+++ b/src/django/api/reports/average_match_count.sql
@@ -1,0 +1,17 @@
+-- Average number of potential match addresses fed to a user during confirm/reject
+
+SELECT
+  to_char(li.created_at, 'YYYY-MM') AS month,
+  COUNT(*) as item_count,
+  SUM(m.match_count) as match_count,
+  ROUND(AVG(m.match_count), 2) AS average_match_count
+  FROM (
+    SELECT facility_list_item_id, COUNT(*) as match_count
+      FROM api_facilitymatch
+     GROUP BY facility_list_item_id
+    ) m
+       JOIN api_facilitylistitem li
+              ON m.facility_list_item_id = li.id
+ WHERE li.status IN ('CONFIRMED_MATCH', 'POTENTIAL_MATCH')
+ GROUP BY to_char(li.created_at, 'YYYY-MM')
+ ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/confirm_reject_counts.sql
+++ b/src/django/api/reports/confirm_reject_counts.sql
@@ -1,0 +1,9 @@
+-- Count the number of potential mand and confirmed/rejected list itemss created each month
+
+SELECT
+  to_char(li.created_at, 'YYYY-MM') AS month,
+  SUM(CASE WHEN li.status = 'POTENTIAL_MATCH' THEN 1 ELSE 0 END) as open_count,
+  SUM(CASE WHEN li.status = 'CONFIRMED_MATCH' THEN 1 ELSE 0 END) as confirmed_rejected_count
+  FROM api_facilitylistitem li
+ GROUP BY to_char(li.created_at, 'YYYY-MM')
+ ORDER BY to_char(li.created_at, 'YYYY-MM');

--- a/src/django/api/reports/error_items.sql
+++ b/src/django/api/reports/error_items.sql
@@ -1,0 +1,9 @@
+-- Count the number of items in an error state each month
+
+SELECT
+  to_char(li.created_at, 'YYYY-MM') AS month,
+  COUNT(*) as item_count
+  FROM api_facilitylistitem li
+ WHERE li.status like 'ERROR%'
+ GROUP BY to_char(li.created_at, 'YYYY-MM')
+ ORDER BY to_char(li.created_at, 'YYYY-MM');


### PR DESCRIPTION
## Overview

Adds 3 new reports for metrics requested by the OAR team

- Average Match Count
- Confirm Reject Counts
- Error Items

Connects #1787

## Demo

The production output from these reports is available in the shared project drive under `Reporting/OAR Metrics 2022-05-20` 

## Testing Instructions

* Verify that the logic of the reports is sound
* Verify that the reports run without error in development

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
