### PR TITLE
Add test case for geocoder status code error message

### DIFF
--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -754,6 +754,12 @@ class GeocodingTest(TestCase):
         self.assertEqual(expected_point, results["geocoded_point"])
         self.assertEqual(expected_address, results['geocoded_address'])
 
+    @patch('api.geocoding.requests.get')
+    def test_geocode_non_200_response(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=400)
+        with self.assertRaisesRegexp(ValueError, '400'):
+            geocode_address('Noorbagh, Kaliakoir Gazipur Dhaka 1704', 'BD')
+
 
 class FacilityAndProcessingTypeTest(TestCase):
     def test_exact_processing_type_match(self):


### PR DESCRIPTION
## Overview

Adds the new test-case from https://github.com/open-apparel-registry/open-apparel-registry/pull/1854

Connects #1788 

## Testing Instructions

* CI should pass

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- ~[ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines~
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
