### PR TITLE
Fix processing_type_facility_type_unmatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fix processing_type_facility_type_unmatched [#1874](https://github.com/open-apparel-registry/open-apparel-registry/pull/1874)
+
 ### Security
 
 ## [67] 2022-05-26

--- a/src/django/api/reports.py
+++ b/src/django/api/reports.py
@@ -214,14 +214,14 @@ def processing_type_facility_type_unmatched():
             for i, raw_value in enumerate(values):
                 if matched_values[i][3] is None:
                     data[raw_value.strip()] = data[raw_value.strip()] + 1
-            else:
-                _report_error_to_rollbar((
-                        'processing_type_facility_type_unmatched encountered '
-                        'mismatched processing type value count'
-                    ), extra_data={
-                        'deduped_values': json.dumps(values),
-                        'matched_values': json.dumps(matched_values),
-                    })
+        else:
+            _report_error_to_rollbar((
+                    'processing_type_facility_type_unmatched encountered '
+                    'mismatched processing type value count'
+                ), extra_data={
+                    'deduped_values': json.dumps(values),
+                    'matched_values': json.dumps(matched_values),
+                })
 
     rows = sort_by_first_column(data.items())
     return [['processing_type_facility_type', 'times_submitted'], rows]


### PR DESCRIPTION
## Overview

The warning we set up in the `processing_type_facility_type_unmatched` 
report to let us know about certain invalid values
in the system was triggering all the time, and not just when it should
be, due to an indentation issue.

Connects https://rollbar.com/OpenApparelRegistry/OpenApparelRegistry/items/1576/?item_page=0&#similar-items

## Testing Instructions

* On `develop`, add a debugger or a print statement at the Rollbar error in `processing_type_facility_type_unmatched()` and ensure you have at least one unmatched processing_type value. Ensure the unmatched value has been added to the system properly.
* Open the processing_type_facility_type_unmatched report and see that the error is triggered incorrectly.
* Repeat the above steps on this branch and see that the error is not triggered. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
