### PR TITLE
Show sectors on facility detail sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Get sector from CSV or API and store on `FacilityListItem` [#1868](https://github.com/open-apparel-registry/open-apparel-registry/pull/1868)
 - Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871)
 - Add sector to FacilityIndex [#1883](https://github.com/open-apparel-registry/open-apparel-registry/pull/1883)
+- Show sectors on facility detail sidebar [#1898](https://github.com/open-apparel-registry/open-apparel-registry/pull/1898)
 
 ### Changed
 

--- a/src/app/src/components/FacilityDetailSidebarExtended.jsx
+++ b/src/app/src/components/FacilityDetailSidebarExtended.jsx
@@ -242,6 +242,18 @@ const FacilityDetailSidebar = ({
         [data],
     );
 
+    const [sectorField, otherSectors] = useMemo(() => {
+        const sectors = get(data, 'properties.sector', []).map(item => ({
+            primary: item.values.join(', '),
+            secondary: formatAttribution(
+                item.created_at,
+                item.contributor_name,
+            ),
+            key: item.contributor_id,
+        }));
+        return [sectors[0], sectors.slice(1)];
+    });
+
     if (fetching) {
         return (
             <div className={classes.root}>
@@ -385,6 +397,12 @@ const FacilityDetailSidebar = ({
                     label="Name"
                     {...nameField}
                     additionalContent={otherNames}
+                    embed={embed}
+                />
+                <FacilityDetailSidebarItem
+                    label="Sector"
+                    {...sectorField}
+                    additionalContent={otherSectors}
                     embed={embed}
                 />
                 <FacilityDetailSidebarItem

--- a/src/django/api/fixtures/facility_list_items.json
+++ b/src/django/api/fixtures/facility_list_items.json
@@ -3869,7 +3869,7 @@
         "fields": {
             "source": 7,
             "row_index": 6,
-            "raw_data": "China,Regina Miracle Intimate Apparel (Shenzhen Ltd.),\"No.5 Cengyao Industrial Estate,Yulu,Gongming,Baoan,Shenzhen\",Apparel,22.7829489,113.8891105",
+            "raw_data": "China,Regina Miracle Intimate Apparel (Shenzhen Ltd.),\"No.5 Cengyao Industrial Estate,Yulu,Gongming,Baoan,Shenzhen\",Apparel|Health,22.7829489,113.8891105",
             "sector": [],
             "status": "UPLOADED",
             "processing_results": [],
@@ -8307,7 +8307,7 @@
         "fields": {
             "source": 15,
             "row_index": 12,
-            "raw_data": "CN,Regina Miracle Intimate Apparel (Shenzhen) Ltd.,\"No.5 Cengyao Industrial Estate Yulu, Gongming Baoan ,Shenzhen,Guangdong, P.R.China , Gongming Yulu, Bao'an District, Shenzhen, 518132, Guangdong\",Apparel,22.7237606,113.9068159",
+            "raw_data": "CN,Regina Miracle Intimate Apparel (Shenzhen) Ltd.,\"No.5 Cengyao Industrial Estate Yulu, Gongming Baoan ,Shenzhen,Guangdong, P.R.China , Gongming Yulu, Bao'an District, Shenzhen, 518132, Guangdong\",Apparel|Health,22.7237606,113.9068159",
             "sector": [],
             "status": "UPLOADED",
             "processing_results": [],

--- a/src/django/api/management/commands/facility_lists/15.csv
+++ b/src/django/api/management/commands/facility_lists/15.csv
@@ -11,7 +11,7 @@ GT,Mata Textiles S.A.,"KM 16.5 Carretera A San Juan Scatepequez, Parque Industri
 CN,"Shanghai Qianrun Garments Co., Ltd","No.233, Lane1888, Daye Road,, WuQiao Industrial Zone,, FengXian District,, Shanghai, 201402, Shanghai Shi",Apparel
 SV,Textiles Opico SA de CV,"KM 31.4 Carretera a Santa Ana, San Juan Opico, 1101, La Libertad",Apparel
 VN,"PHI Co., Ltd.","No. 10, Dai An Industrial Zone, Tu Minh , Hai Duong, 17000, Hai Duong",Apparel
-CN,Regina Miracle Intimate Apparel (Shenzhen) Ltd.,"No.5 Cengyao Industrial Estate Yulu, Gongming Baoan ,Shenzhen,Guangdong, P.R.China , Gongming Yulu, Bao'an District, Shenzhen, 518132, Guangdong",Apparel
+CN,Regina Miracle Intimate Apparel (Shenzhen) Ltd.,"No.5 Cengyao Industrial Estate Yulu, Gongming Baoan ,Shenzhen,Guangdong, P.R.China , Gongming Yulu, Bao'an District, Shenzhen, 518132, Guangdong",Apparel|Health
 CN,"Shanghai Weijie Garment Co., Ltd.","No. of 1228, Huiping Road,, Nanxiang Town, Jiading District, Shanghai, 201802, Shanghai",Apparel
 CN,ZHUCHENG HENGWEI CLOTHING CO.LTD,"Southern head of east ourter ring, Shandong Province, Zhucheng City, 262200, Shandong",Apparel
 ID,PT. Kanindo Makmur Jaya,"Jl. Raya Jepara Kudus KM 19,, Ds. Pendosawalan,, Kecamatan Kalinyamatan, Kabupaten Jepara, 59462, Jawa Tengah",Apparel

--- a/src/django/api/management/commands/facility_lists/6.csv
+++ b/src/django/api/management/commands/facility_lists/6.csv
@@ -34,7 +34,7 @@ Mexico,GFSI Southwest S DE Rl DE CV,"PRIVADA MARTEL SN MANZANA 4,LOTE 7 & 8,Reyn
 Vietnam,Phu Bai,An Qiu Xin Tian Heng Computerized  Embroidery Co. Ltd.,Apparel
 Philippines,PIPLAY - Binan Laguna Plant,"Laguna Int'l Industrial Park,Mamplasan,Biban,Laguna",Apparel
 United States,GTM Sportwear,"520 McCall Rd.,Manhattan,KS",Apparel
-United States,Mount Airy Sock,"643 West Pine St.,Mt. Airy,NC",Apparel
+United States,Mount Airy Sock,"643 West Pine St.,Mt. Airy,NC",Apparel|Mining
 Argentina,San Juan - Indumentaria Andina,"Buenos Aires 1364,San Juan City,Argentina",Apparel
 El Salvador,ES Sock,"Km 34 Carretera,San Juan Opico,La Libertad",Apparel
 Argentina,Buenos Aires - Alsina 1771,"Alsina 1771,San Martin,Buenos Aires,Argentina",Apparel

--- a/src/django/api/management/commands/facility_lists/7.csv
+++ b/src/django/api/management/commands/facility_lists/7.csv
@@ -5,7 +5,7 @@ China,Jung Myung Textile Co. Ltd.,"289 Jiefang West Road,Yuewang Industrial Zone
 China,Longnan County Top Form Underwear,JIN TANG INDUSTRY PARK JIANGXI Jiangxi,Apparel
 China,Chaohu Galaxy Vegas Textile,"No 8,Jinchao Avenue,Heifei City,Anhui",Apparel
 China,Zhejiang Jianlimei Knitting Clothing Co. Ltd.,"No. 78 Qiushi West Road,Yiwu City,Zhejiang",Apparel
-China,Regina Miracle Intimate Apparel (Shenzhen Ltd.),"No.5 Cengyao Industrial Estate,Yulu,Gongming,Baoan,Shenzhen",Apparel
+China,Regina Miracle Intimate Apparel (Shenzhen Ltd.),"No.5 Cengyao Industrial Estate,Yulu,Gongming,Baoan,Shenzhen",Apparel|Health
 El Salvador,Confecciones Del Valle,"KM 24 Carretera A Santa Ana,Colon",Apparel
 El Salvador,F&D,ZONA FRANCA BUILDING 8 A & B SAN MARCOS,Apparel
 Haiti,MD Industries,"Parque Industrial CODEVI,Ouanaminthe",Apparel

--- a/src/django/api/management/commands/facility_lists/geocoded/15.csv
+++ b/src/django/api/management/commands/facility_lists/geocoded/15.csv
@@ -11,7 +11,7 @@ GT,Mata Textiles S.A.,"KM 16.5 Carretera A San Juan Scatepequez, Parque Industri
 CN,"Shanghai Qianrun Garments Co., Ltd","No.233, Lane1888, Daye Road,, WuQiao Industrial Zone,, FengXian District,, Shanghai, 201402, Shanghai Shi",Apparel,30.9574299,121.39279
 SV,Textiles Opico SA de CV,"KM 31.4 Carretera a Santa Ana, San Juan Opico, 1101, La Libertad",Apparel,13.8758656,-89.3582599
 VN,"PHI Co., Ltd.","No. 10, Dai An Industrial Zone, Tu Minh , Hai Duong, 17000, Hai Duong",Apparel,20.9335662,106.2687817
-CN,Regina Miracle Intimate Apparel (Shenzhen) Ltd.,"No.5 Cengyao Industrial Estate Yulu, Gongming Baoan ,Shenzhen,Guangdong, P.R.China , Gongming Yulu, Bao'an District, Shenzhen, 518132, Guangdong",Apparel,22.7265199,113.90445
+CN,Regina Miracle Intimate Apparel (Shenzhen) Ltd.,"No.5 Cengyao Industrial Estate Yulu, Gongming Baoan ,Shenzhen,Guangdong, P.R.China , Gongming Yulu, Bao'an District, Shenzhen, 518132, Guangdong",Apparel|Health,22.7265199,113.90445
 CN,"Shanghai Weijie Garment Co., Ltd.","No. of 1228, Huiping Road,, Nanxiang Town, Jiading District, Shanghai, 201802, Shanghai",Apparel,31.29412,121.32027
 CN,ZHUCHENG HENGWEI CLOTHING CO.LTD,"Southern head of east ourter ring, Shandong Province, Zhucheng City, 262200, Shandong",Apparel,36.62517,119.21849
 ID,PT. Kanindo Makmur Jaya,"Jl. Raya Jepara Kudus KM 19,, Ds. Pendosawalan,, Kecamatan Kalinyamatan, Kabupaten Jepara, 59462, Jawa Tengah",Apparel,-6.732359,110.7302234

--- a/src/django/api/management/commands/facility_lists/geocoded/6.csv
+++ b/src/django/api/management/commands/facility_lists/geocoded/6.csv
@@ -32,7 +32,7 @@ Mexico,GFSI Southwest S DE Rl DE CV,"PRIVADA MARTEL SN MANZANA 4,LOTE 7 & 8,Reyn
 Vietnam,Phu Bai,An Qiu Xin Tian Heng Computerized  Embroidery Co. Ltd.,Apparel,14.058324,108.277199
 Philippines,PIPLAY - Binan Laguna Plant,"Laguna Int'l Industrial Park,Mamplasan,Biban,Laguna",Apparel,14.2925475,121.0834976
 United States,GTM Sportwear,"520 McCall Rd.,Manhattan,KS",Apparel,39.1879912,-96.5498677
-United States,Mount Airy Sock,"643 West Pine St.,Mt. Airy,NC",Apparel,36.497605,-80.6169172
+United States,Mount Airy Sock,"643 West Pine St.,Mt. Airy,NC",Apparel|Mining,36.497605,-80.6169172
 Argentina,San Juan - Indumentaria Andina,"Buenos Aires 1364,San Juan City,Argentina",Apparel,-34.6036844,-58.3815591
 El Salvador,ES Sock,"Km 34 Carretera,San Juan Opico,La Libertad",Apparel,13.8283931,-89.3557981
 Argentina,Buenos Aires - Alsina 1771,"Alsina 1771,San Martin,Buenos Aires,Argentina",Apparel,-34.5837832,-58.53996950000001

--- a/src/django/api/management/commands/facility_lists/geocoded/7.csv
+++ b/src/django/api/management/commands/facility_lists/geocoded/7.csv
@@ -5,7 +5,7 @@ China,Jung Myung Textile Co. Ltd.,"289 Jiefang West Road,Yuewang Industrial Zone
 China,Longnan County Top Form Underwear,JIN TANG INDUSTRY PARK JIANGXI Jiangxi,Apparel,28.6741699,115.91004
 China,Chaohu Galaxy Vegas Textile,"No 8,Jinchao Avenue,Heifei City,Anhui",Apparel,31.626075,117.910867
 China,Zhejiang Jianlimei Knitting Clothing Co. Ltd.,"No. 78 Qiushi West Road,Yiwu City,Zhejiang",Apparel,29.31292,120.03759
-China,Regina Miracle Intimate Apparel (Shenzhen Ltd.),"No.5 Cengyao Industrial Estate,Yulu,Gongming,Baoan,Shenzhen",Apparel,22.7489399,113.93588
+China,Regina Miracle Intimate Apparel (Shenzhen Ltd.),"No.5 Cengyao Industrial Estate,Yulu,Gongming,Baoan,Shenzhen",Apparel|Health,22.7489399,113.93588
 El Salvador,Confecciones Del Valle,"KM 24 Carretera A Santa Ana,Colon",Apparel,13.707793,-89.3487791
 El Salvador,F&D,ZONA FRANCA BUILDING 8 A & B SAN MARCOS,Apparel,13.6638852,-89.184883
 India,SCM Garments Pvt. Ltd.,"S.F.40A,NG Palyampudur Pirivu Pudhupalyam Post Avinashi",Apparel,11.1729571,77.2686033

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1043,6 +1043,11 @@ class FacilityDetailsSerializer(FacilitySerializer):
                     contributor_id=F('source__contributor_id'),
                     contributor_name=F('source__contributor__name'),
                     values=F('sector'))
+
+        contributor_id = get_embed_contributor_id(self)
+        if is_embed_mode_active(self) and contributor_id is not None:
+            sectors = sectors.filter(source__contributor_id=contributor_id)
+
         return sorted(sectors, key=lambda i: i['updated_at'], reverse=True)
 
 


### PR DESCRIPTION
## Overview

Adds an expandable row displaying the latest sector values per contributor on the facility detail sidebar

Connects #1840 

## Demo

![localhost_6543_facilities_CN2022160Z3RP4J_q=Regina%20Miracle%20Intimate](https://user-images.githubusercontent.com/4432106/172912273-ad9c8110-1fb3-41c1-9655-ce8cb3307bf4.png)

## Testing Instructions

* `scripts/resetdb`
* Search for "Regina Miracle Intimate", and click through to the Facility detail. You should see a section for "Sector" below Name and above Address. If you expand it you should see 2 more rows w/ "Apparel, Health" and "Apparel" as values.
* Search for "Confecciones Del Valle" or another facility w/ at least two list items in the checked in fixtures. It should have 2 sector values after expanding, both of which are "Apparel"

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- ~[ ] If this PR applies to both OAR and OGR a companion PR has been created~
