### PR TITLE
Add sector search controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871)
 - Add sector to FacilityIndex [#1883](https://github.com/open-apparel-registry/open-apparel-registry/pull/1883)
 - Show sectors on facility detail sidebar [#1898](https://github.com/open-apparel-registry/open-apparel-registry/pull/1898)
+- Add sector search controls [#1899](https://github.com/open-apparel-registry/open-apparel-registry/pull/1899)
 
 ### Changed
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -74,6 +74,7 @@ const {
     anyListItemMatchesAreInactive,
     pluralizeResultsCount,
     removeDuplicatesFromOtherLocationsData,
+    makeGetSectorsURL,
 } = require('../util/util');
 
 const {
@@ -118,14 +119,16 @@ it('creates an API URL for generating an API token', () => {
     expect(makeAPITokenURL(uid)).toEqual(expectedMatch);
 });
 
-it('creates API URLs for getting contributor, contributor type, and country options', () => {
+it('creates API URLs for getting contributor, contributor type, country, and sector options', () => {
     const contributorMatch = '/api/contributors/';
     const contributorTypesMatch = '/api/contributor-types/';
     const countriesMatch = '/api/countries/';
+    const sectorsMatch = '/api/sectors/';
 
     expect(makeGetContributorsURL()).toEqual(contributorMatch);
     expect(makeGetContributorTypesURL()).toEqual(contributorTypesMatch);
     expect(makeGetCountriesURL()).toEqual(countriesMatch);
+    expect(makeGetSectorsURL()).toEqual(sectorsMatch);
 });
 
 it('creates an API URL for getting all facilities', () => {
@@ -157,6 +160,7 @@ it('creates a querystring from a set of filter selection', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
     };
 
     const expectedEmptySelectionQSMatch = '';
@@ -174,10 +178,15 @@ it('creates a querystring from a set of filter selection', () => {
         countries: [
             { value: 'country', label: 'country' },
         ],
+        sectors: [
+            { value: 'Apparel', label: 'Apparel' },
+            { value: 'Mining', label: 'Mining' },
+        ],
     };
 
     const expectedMultipleFilterSelectionsMatch =
-        'contributors=bar&contributors=baz&contributors=foo&countries=country';
+        'contributors=bar&contributors=baz&contributors=foo&countries=country'
+            .concat('&sectors=Apparel&sectors=Mining');
     expect(createQueryStringFromSearchFilters(multipleFilterSelections))
         .toEqual(expectedMultipleFilterSelectionsMatch);
 
@@ -193,11 +202,14 @@ it('creates a querystring from a set of filter selection', () => {
         countries: [
             { value: 'bar', label: 'bar' },
         ],
+        sectors: [
+            { value: 'baz', label: 'baz' },
+        ],
     };
 
     const expectedAllFiltersMatch =
         'q=hello&contributors=hello&contributors=world'
-            .concat('&contributor_types=foo&countries=bar');
+            .concat('&contributor_types=foo&countries=bar&sectors=baz');
     expect(createQueryStringFromSearchFilters(allFilters))
         .toEqual(expectedAllFiltersMatch);
 });
@@ -244,6 +256,7 @@ it('creates a set of filters from a querystring', () => {
         ],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -275,6 +288,7 @@ it('creates a set of filters from a querystring', () => {
         ],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -302,6 +316,7 @@ it('creates a set of filters from a querystring', () => {
         ],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [
             {
                 value: 2,
@@ -338,6 +353,7 @@ it('creates a set of filters from a querystring', () => {
             },
         ],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -369,6 +385,7 @@ it('creates a set of filters from a querystring', () => {
                 label: 'CN',
             },
         ],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -396,6 +413,7 @@ it('creates a set of filters from a querystring', () => {
             },
         ],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -418,6 +436,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -440,6 +459,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [{
             value: 1,
@@ -469,6 +489,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [{
@@ -498,6 +519,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -527,6 +549,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -556,6 +579,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],
@@ -585,6 +609,7 @@ it('creates a set of filters from a querystring', () => {
         contributors: [],
         contributorTypes: [],
         countries: [],
+        sectors: [],
         lists: [],
         parentCompany: [],
         facilityType: [],

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -9,6 +9,7 @@ import {
     makeGetListsURL,
     makeGetContributorTypesURL,
     makeGetCountriesURL,
+    makeGetSectorsURL,
     makeGetFacilitiesTypeProcessingTypeURL,
     makeGetNumberOfWorkersURL,
     mapDjangoChoiceTuplesToSelectOptions,
@@ -52,6 +53,14 @@ export const failFetchCountryOptions = createAction(
 );
 export const completeFetchCountryOptions = createAction(
     'COMPLETE_FETCH_COUNTRY_OPTIONS',
+);
+
+export const startFetchSectorOptions = createAction(
+    'START_FETCH_SECTOR_OPTIONS',
+);
+export const failFetchSectorOptions = createAction('FAIL_FETCH_SECTOR_OPTIONS');
+export const completeFetchSectorOptions = createAction(
+    'COMPLETE_FETCH_SECTOR_OPTIONS',
 );
 
 export const startFetchFacilityProcessingTypeOptions = createAction(
@@ -168,6 +177,26 @@ export function fetchCountryOptions() {
     };
 }
 
+export function fetchSectorOptions() {
+    return dispatch => {
+        dispatch(startFetchSectorOptions());
+
+        return apiRequest
+            .get(makeGetSectorsURL())
+            .then(({ data }) => mapDjangoChoiceTuplesValueToSelectOptions(data))
+            .then(data => dispatch(completeFetchSectorOptions(data)))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented fetching sector options',
+                        failFetchSectorOptions,
+                    ),
+                ),
+            );
+    };
+}
+
 export function fetchFacilityProcessingTypeOptions() {
     return dispatch => {
         dispatch(startFetchFacilityProcessingTypeOptions());
@@ -215,6 +244,7 @@ export function fetchAllPrimaryFilterOptions() {
     return dispatch => {
         dispatch(fetchContributorOptions());
         dispatch(fetchCountryOptions());
+        dispatch(fetchSectorOptions());
         dispatch(fetchListOptions());
     };
 }

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -244,7 +244,6 @@ export function fetchAllPrimaryFilterOptions() {
     return dispatch => {
         dispatch(fetchContributorOptions());
         dispatch(fetchCountryOptions());
-        dispatch(fetchSectorOptions());
         dispatch(fetchListOptions());
     };
 }

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -18,6 +18,7 @@ export const updateContributorTypeFilter = createAction(
 );
 export const updateListFilter = createAction('UPDATE_LIST_FILTER');
 export const updateCountryFilter = createAction('UPDATE_COUNTRY_FILTER');
+export const updateSectorFilter = createAction('UPDATE_SECTOR_FILTER');
 export const updateParentCompanyFilter = createAction(
     'UPDATE_PARENT_COMPANY_FILTER',
 );

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -29,12 +29,14 @@ import {
     fetchContributorOptions,
     fetchListOptions,
     fetchCountryOptions,
+    fetchSectorOptions,
     fetchAllPrimaryFilterOptions,
 } from '../actions/filterOptions';
 
 import {
     contributorOptionsPropType,
     countryOptionsPropType,
+    sectorOptionsPropType,
 } from '../util/propTypes';
 
 import { allListsAreEmpty } from '../util/util';
@@ -58,14 +60,16 @@ class FilterSidebar extends Component {
         const {
             contributorsData,
             countriesData,
+            sectorsData,
             fetchFilterOptions,
             fetchContributors,
             fetchLists,
             fetchCountries,
+            fetchSectors,
             contributors,
         } = this.props;
 
-        if (allListsAreEmpty(contributorsData, countriesData)) {
+        if (allListsAreEmpty(contributorsData, countriesData, sectorsData)) {
             return fetchFilterOptions();
         }
 
@@ -75,6 +79,10 @@ class FilterSidebar extends Component {
 
         if (!countriesData.length) {
             fetchCountries();
+        }
+
+        if (!sectorsData.length) {
+            fetchSectors();
         }
 
         if (contributors && contributors.length) {
@@ -205,8 +213,10 @@ FilterSidebar.propTypes = {
     fetchFilterOptions: func.isRequired,
     fetchContributors: func.isRequired,
     fetchCountries: func.isRequired,
+    fetchSectors: func.isRequired,
     contributorsData: contributorOptionsPropType.isRequired,
     countriesData: countryOptionsPropType.isRequired,
+    sectorsData: sectorOptionsPropType.isRequired,
     vectorTileFeatureIsActive: bool.isRequired,
     fetchingFeatureFlags: bool.isRequired,
 };
@@ -217,6 +227,7 @@ function mapStateToProps({
         contributors: { data: contributorsData },
         lists: { data: listsData },
         countries: { data: countriesData },
+        sectors: { data: sectorsData },
     },
     featureFlags: { flags, fetching: fetchingFeatureFlags },
     embeddedMap: { embed },
@@ -229,6 +240,7 @@ function mapStateToProps({
         activeFilterSidebarTab,
         contributorsData,
         countriesData,
+        sectorsData,
         listsData,
         vectorTileFeatureIsActive: get(flags, 'vector_tile', false),
         fetchingFeatureFlags,
@@ -247,6 +259,7 @@ function mapDispatchToProps(dispatch) {
         fetchContributors: () => dispatch(fetchContributorOptions()),
         fetchLists: () => dispatch(fetchListOptions()),
         fetchCountries: () => dispatch(fetchCountryOptions()),
+        fetchSectors: () => dispatch(fetchSectorOptions()),
     };
 }
 

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -29,7 +29,6 @@ import {
     fetchContributorOptions,
     fetchListOptions,
     fetchCountryOptions,
-    fetchSectorOptions,
     fetchAllPrimaryFilterOptions,
 } from '../actions/filterOptions';
 
@@ -65,7 +64,6 @@ class FilterSidebar extends Component {
             fetchContributors,
             fetchLists,
             fetchCountries,
-            fetchSectors,
             contributors,
         } = this.props;
 
@@ -79,10 +77,6 @@ class FilterSidebar extends Component {
 
         if (!countriesData.length) {
             fetchCountries();
-        }
-
-        if (!sectorsData.length) {
-            fetchSectors();
         }
 
         if (contributors && contributors.length) {
@@ -213,7 +207,6 @@ FilterSidebar.propTypes = {
     fetchFilterOptions: func.isRequired,
     fetchContributors: func.isRequired,
     fetchCountries: func.isRequired,
-    fetchSectors: func.isRequired,
     contributorsData: contributorOptionsPropType.isRequired,
     countriesData: countryOptionsPropType.isRequired,
     sectorsData: sectorOptionsPropType.isRequired,
@@ -259,7 +252,6 @@ function mapDispatchToProps(dispatch) {
         fetchContributors: () => dispatch(fetchContributorOptions()),
         fetchLists: () => dispatch(fetchListOptions()),
         fetchCountries: () => dispatch(fetchCountryOptions()),
-        fetchSectors: () => dispatch(fetchSectorOptions()),
     };
 }
 

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -25,6 +25,7 @@ import {
     updateListFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
+    updateSectorFilter,
     updateParentCompanyFilter,
     updateFacilityTypeFilter,
     updateProcessingTypeFilter,
@@ -45,6 +46,7 @@ import {
     contributorOptionsPropType,
     contributorTypeOptionsPropType,
     countryOptionsPropType,
+    sectorOptionsPropType,
     facilityTypeOptionsPropType,
     processingTypeOptionsPropType,
     productTypeOptionsPropType,
@@ -119,6 +121,7 @@ const FACILITIES = 'FACILITIES';
 const CONTRIBUTORS = 'CONTRIBUTORS';
 const LISTS = 'LISTS';
 const COUNTRIES = 'COUNTRIES';
+const SECTORS = 'SECTORS';
 
 const checkIfAnyFieldSelected = fields => fields.some(f => f.length !== 0);
 
@@ -126,6 +129,7 @@ function FilterSidebarSearchTab({
     contributorOptions,
     listOptions,
     countryOptions,
+    sectorOptions,
     resetFilters,
     facilityFreeTextQuery,
     updateFacilityFreeTextQuery,
@@ -133,7 +137,9 @@ function FilterSidebarSearchTab({
     updateContributor,
     contributorTypes,
     countries,
+    sectors,
     updateCountry,
+    updateSector,
     parentCompany,
     facilityType,
     processingType,
@@ -168,6 +174,7 @@ function FilterSidebarSearchTab({
         facilityFreeTextQuery,
         contributors,
         countries,
+        sectors,
     ]);
 
     const [
@@ -491,6 +498,26 @@ function FilterSidebarSearchTab({
                         disabled={fetchingOptions || fetchingFacilities}
                     />
                 </div>
+                <div className="form__field">
+                    <InputLabel
+                        shrink={false}
+                        htmlFor={SECTORS}
+                        className={classes.inputLabelStyle}
+                    >
+                        Sector
+                    </InputLabel>
+                    <ReactSelect
+                        isMulti
+                        id={SECTORS}
+                        name={SECTORS}
+                        className={`basic-multi-select notranslate ${classes.selectStyle}`}
+                        classNamePrefix="select"
+                        options={sectorOptions}
+                        value={sectors}
+                        onChange={updateSector}
+                        disabled={fetchingOptions || fetchingFacilities}
+                    />
+                </div>
                 <FeatureFlag flag={EXTENDED_PROFILE_FLAG}>
                     <ShowOnly when={expand}>
                         <FilterSidebarExtendedSearch />
@@ -545,6 +572,7 @@ FilterSidebarSearchTab.defaultProps = {
 FilterSidebarSearchTab.propTypes = {
     contributorOptions: contributorOptionsPropType.isRequired,
     countryOptions: countryOptionsPropType.isRequired,
+    sectorOptions: sectorOptionsPropType.isRequired,
     resetFilters: func.isRequired,
     updateFacilityFreeTextQuery: func.isRequired,
     updateContributor: func.isRequired,
@@ -554,6 +582,7 @@ FilterSidebarSearchTab.propTypes = {
     contributors: contributorOptionsPropType.isRequired,
     contributorTypes: contributorTypeOptionsPropType.isRequired,
     countries: countryOptionsPropType.isRequired,
+    sectors: sectorOptionsPropType.isRequired,
     parentCompany: contributorOptionsPropType.isRequired,
     facilityType: facilityTypeOptionsPropType.isRequired,
     processingType: processingTypeOptionsPropType.isRequired,
@@ -575,6 +604,7 @@ function mapStateToProps({
         },
         lists: { data: listOptions, fetching: fetchingLists },
         countries: { data: countryOptions, fetching: fetchingCountries },
+        sectors: { data: sectorOptions, fetching: fetchingSectors },
     },
     filters: {
         facilityFreeTextQuery,
@@ -582,6 +612,7 @@ function mapStateToProps({
         lists,
         contributorTypes,
         countries,
+        sectors,
         parentCompany,
         facilityType,
         processingType,
@@ -608,11 +639,13 @@ function mapStateToProps({
         contributorOptions,
         listOptions,
         countryOptions,
+        sectorOptions,
         facilityFreeTextQuery,
         contributors,
         lists,
         contributorTypes,
         countries,
+        sectors,
         parentCompany,
         facilityType,
         processingType,
@@ -623,7 +656,8 @@ function mapStateToProps({
         fetchingFacilities,
         facilities,
         boundary,
-        fetchingOptions: fetchingContributors || fetchingCountries,
+        fetchingOptions:
+            fetchingContributors || fetchingCountries || fetchingSectors,
         embed: !!embed,
         fetchingLists,
         textSearchLabel: config.text_search_label,
@@ -644,6 +678,7 @@ function mapDispatchToProps(dispatch, { history: { push } }) {
         updateContributorType: v => dispatch(updateContributorTypeFilter(v)),
         updateList: v => dispatch(updateListFilter(v)),
         updateCountry: v => dispatch(updateCountryFilter(v)),
+        updateSector: v => dispatch(updateSectorFilter(v)),
         updateParentCompany: v => dispatch(updateParentCompanyFilter(v)),
         updateFacilityType: v => dispatch(updateFacilityTypeFilter(v)),
         updateProcessingType: v => dispatch(updateProcessingTypeFilter(v)),

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -67,6 +67,7 @@ import {
     EXTENDED_PROFILE_FLAG,
     EXTENDED_FIELDS_EXPLANATORY_TEXT,
 } from '../util/constants';
+import { fetchSectorOptions } from '../actions/filterOptions';
 
 const filterSidebarSearchTabStyles = theme =>
     Object.freeze({
@@ -130,6 +131,7 @@ function FilterSidebarSearchTab({
     listOptions,
     countryOptions,
     sectorOptions,
+    fetchSectors,
     resetFilters,
     facilityFreeTextQuery,
     updateFacilityFreeTextQuery,
@@ -148,6 +150,7 @@ function FilterSidebarSearchTab({
     combineContributors,
     updateCombineContributors,
     fetchingFacilities,
+    fetchingSectors,
     searchForFacilities,
     facilities,
     fetchingOptions,
@@ -515,7 +518,15 @@ function FilterSidebarSearchTab({
                         options={sectorOptions}
                         value={sectors}
                         onChange={updateSector}
-                        disabled={fetchingOptions || fetchingFacilities}
+                        onFocus={() =>
+                            sectorOptions.length === 0 &&
+                            !fetchingSectors &&
+                            fetchSectors()
+                        }
+                        noOptionsMessage={() =>
+                            fetchingSectors ? 'Loading..' : 'No options'
+                        }
+                        disabled={fetchingOptions || fetchingSectors}
                     />
                 </div>
                 <FeatureFlag flag={EXTENDED_PROFILE_FLAG}>
@@ -578,6 +589,7 @@ FilterSidebarSearchTab.propTypes = {
     updateContributor: func.isRequired,
     updateCountry: func.isRequired,
     updateCombineContributors: func.isRequired,
+    fetchSectors: func.isRequired,
     facilityFreeTextQuery: string.isRequired,
     contributors: contributorOptionsPropType.isRequired,
     contributorTypes: contributorTypeOptionsPropType.isRequired,
@@ -656,8 +668,8 @@ function mapStateToProps({
         fetchingFacilities,
         facilities,
         boundary,
-        fetchingOptions:
-            fetchingContributors || fetchingCountries || fetchingSectors,
+        fetchingOptions: fetchingContributors || fetchingCountries,
+        fetchingSectors,
         embed: !!embed,
         fetchingLists,
         textSearchLabel: config.text_search_label,
@@ -692,6 +704,7 @@ function mapDispatchToProps(dispatch, { history: { push } }) {
                     e.target.checked ? 'AND' : '',
                 ),
             ),
+        fetchSectors: () => dispatch(fetchSectorOptions()),
         resetFilters: embedded => {
             dispatch(recordSearchTabResetButtonClick());
             return dispatch(resetAllFilters(embedded));

--- a/src/app/src/components/SearchControls.jsx
+++ b/src/app/src/components/SearchControls.jsx
@@ -57,7 +57,6 @@ function ZoomToSearchControl({
                 variant="text"
                 onClick={activateDrawFilter}
                 disableRipple
-                color="black"
                 fullWidth
                 className={classes.areaStyle}
             >
@@ -68,7 +67,7 @@ function ZoomToSearchControl({
                 variant="text"
                 onClick={clearDrawFilter}
                 disableRipple
-                color="black"
+                color="secondary"
                 fullWidth
                 className={classes.areaStyle}
             >

--- a/src/app/src/reducers/FilterOptionsReducer.js
+++ b/src/app/src/reducers/FilterOptionsReducer.js
@@ -14,6 +14,9 @@ import {
     startFetchCountryOptions,
     failFetchCountryOptions,
     completeFetchCountryOptions,
+    startFetchSectorOptions,
+    failFetchSectorOptions,
+    completeFetchSectorOptions,
     startFetchFacilityProcessingTypeOptions,
     failFetchFacilityProcessingTypeOptions,
     completeFetchFacilityProcessingTypeOptions,
@@ -40,6 +43,11 @@ const initialState = Object.freeze({
         error: null,
     }),
     countries: Object.freeze({
+        data: Object.freeze([]),
+        fetching: false,
+        error: null,
+    }),
+    sectors: Object.freeze({
         data: Object.freeze([]),
         fetching: false,
         error: null,
@@ -146,6 +154,28 @@ export default createReducer(
         [completeFetchCountryOptions]: (state, payload) =>
             update(state, {
                 countries: {
+                    fetching: { $set: false },
+                    error: { $set: null },
+                    data: { $set: payload },
+                },
+            }),
+        [startFetchSectorOptions]: state =>
+            update(state, {
+                sectors: {
+                    fetching: { $set: true },
+                    error: { $set: null },
+                },
+            }),
+        [failFetchSectorOptions]: (state, payload) =>
+            update(state, {
+                sectors: {
+                    fetching: { $set: false },
+                    error: { $set: payload },
+                },
+            }),
+        [completeFetchSectorOptions]: (state, payload) =>
+            update(state, {
+                sectors: {
                     fetching: { $set: false },
                     error: { $set: null },
                     data: { $set: payload },

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -7,6 +7,7 @@ import {
     updateListFilter,
     updateContributorTypeFilter,
     updateCountryFilter,
+    updateSectorFilter,
     updateParentCompanyFilter,
     updateFacilityTypeFilter,
     updateProcessingTypeFilter,
@@ -24,6 +25,7 @@ import {
     completeFetchContributorOptions,
     completeFetchContributorTypeOptions,
     completeFetchCountryOptions,
+    completeFetchSectorOptions,
 } from '../actions/filterOptions';
 
 import { completeSubmitLogOut } from '../actions/auth';
@@ -35,6 +37,7 @@ const initialState = Object.freeze({
     contributors: Object.freeze([]),
     contributorTypes: Object.freeze([]),
     countries: Object.freeze([]),
+    sectors: Object.freeze([]),
     parentCompany: Object.freeze([]),
     facilityType: Object.freeze([]),
     processingType: Object.freeze([]),
@@ -79,6 +82,10 @@ export default createReducer(
         [updateCountryFilter]: (state, payload) =>
             update(state, {
                 countries: { $set: payload },
+            }),
+        [updateSectorFilter]: (state, payload) =>
+            update(state, {
+                sectors: { $set: payload },
             }),
         [updateParentCompanyFilter]: (state, payload) =>
             update(state, {
@@ -136,6 +143,7 @@ export default createReducer(
             'contributorTypes',
         ),
         [completeFetchCountryOptions]: maybeSetFromQueryString('countries'),
+        [completeFetchSectorOptions]: maybeSetFromQueryString('sectors'),
         [completeSubmitLogOut]: () => initialState,
     },
     initialState,

--- a/src/app/src/util/propTypes.js
+++ b/src/app/src/util/propTypes.js
@@ -179,6 +179,13 @@ export const countryOptionsPropType = arrayOf(
     }),
 );
 
+export const sectorOptionsPropType = arrayOf(
+    shape({
+        value: string.isRequired,
+        label: string.isRequired,
+    }),
+);
+
 export const facilityTypeOptionsPropType = arrayOf(
     shape({
         value: string.isRequired,
@@ -268,6 +275,7 @@ export const filtersPropType = shape({
     contributors: arrayOf(reactSelectOptionPropType).isRequired,
     contributorTypes: arrayOf(reactSelectOptionPropType).isRequired,
     countries: arrayOf(reactSelectOptionPropType).isRequired,
+    sectors: arrayOf(reactSelectOptionPropType).isRequired,
     combineContributors: string.isRequired,
 });
 

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -123,6 +123,7 @@ export const makeGetContributorsURL = () => '/api/contributors/';
 export const makeGetListsURL = () => '/api/contributor-lists/';
 export const makeGetContributorTypesURL = () => '/api/contributor-types/';
 export const makeGetCountriesURL = () => '/api/countries/';
+export const makeGetSectorsURL = () => '/api/sectors/';
 export const makeGetFacilitiesTypeProcessingTypeURL = () =>
     '/api/facility-processing-types/';
 export const makeGetNumberOfWorkersURL = () => '/api/workers-ranges/';
@@ -207,6 +208,7 @@ export const createQueryStringFromSearchFilters = (
         contributors = [],
         contributorTypes = [],
         countries = [],
+        sectors = [],
         parentCompany = [],
         facilityType = [],
         processingType = [],
@@ -229,6 +231,7 @@ export const createQueryStringFromSearchFilters = (
             contributorTypes,
         ),
         countries: createCompactSortedQuerystringInputObject(countries),
+        sectors: createCompactSortedQuerystringInputObject(sectors),
         parent_company: createCompactSortedQuerystringInputObject(
             parentCompany,
         ),
@@ -287,6 +290,7 @@ export const createFiltersFromQueryString = qs => {
         lists = [],
         contributor_types: contributorTypes = [],
         countries = [],
+        sectors = [],
         parent_company: parentCompany = [],
         facility_type: facilityType = [],
         processing_type: processingType = [],
@@ -304,6 +308,7 @@ export const createFiltersFromQueryString = qs => {
         lists: createSelectOptionsFromParams(lists),
         contributorTypes: createSelectOptionsFromParams(contributorTypes),
         countries: createSelectOptionsFromParams(countries),
+        sectors: createSelectOptionsFromParams(sectors),
         parentCompany: createSelectOptionsFromParams(parentCompany),
         facilityType: createSelectOptionsFromParams(facilityType),
         processingType: createSelectOptionsFromParams(processingType),


### PR DESCRIPTION
## Overview

Adds controls to the frontend to allow for facilities searching by sector

Connects #1833

## Demo

![image](https://user-images.githubusercontent.com/4432106/172919898-af6bcdd0-efc6-4f9b-ac81-9882704a4456.png)


## Notes

The backend is not implemented yet and so just ignores the `search` parameter(s). The results should begin to be limited by sector once #1832 is implemented

## Testing Instructions

* With the default fixture set, you should have an option to search by "Apparel" on the new sidebar filter
* After you add / process some new CSVs with other sector values, they should become possible options in the filter as well
* Sector searches should add `sector` parameter(s) to the facility search API query

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- ~[ ] If this PR applies to both OAR and OGR a companion PR has been created~
