### PR TITLE
Avoid exception when parsing arrays in raw data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Avoid exception when parsing arrays in raw data [#1904](https://github.com/open-apparel-registry/open-apparel-registry/pull/1904)
+
 ### Security
 
 ## [68] 2022-06-09

--- a/src/django/api/helpers.py
+++ b/src/django/api/helpers.py
@@ -50,7 +50,7 @@ def get_csv_values(csv_data):
 def try_parse_int_from_float(value):
     try:
         return str(int(float(value)))
-    except ValueError:
+    except (ValueError, TypeError):
         return value
 
 


### PR DESCRIPTION


## Overview

When submitting a facility via the API the raw data for fields like `product_type` can contain an array value. Attempting to call `fload()` on a list was raiding a `TypeError` rather than a `ValueError`, resulting in an unhandled exception in the `try_parse_int_from_float` helper.

Connects #1903

## Testing Instructions

This assumes you have run `./scripts/resetdb`

* Check out develop
* Log in as c2@example.com
* Browse http://localhost:8081/api/docs/#!/facilities/facilities_create and authenticate with token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051
* POST this facility detail that matches a dev data facility
```json
{
"name":"1v1 Fight Gear",
"address": "5320 Tower Way, Sanford, 32773, Florida ",
"country":"us",
"product_type": ["api a", "api b"]
}
```
* Browse http://localhost:6543/settings, selected the embed tab, and check the "100%"  box to get the preview to display
* In the embed iframe, view the details of the "1v1 Fight Gear" facility
* Verify that an exception is raised
* Checkout this branch
* Refresh them embed and verify that the exception is resolved

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
