### PR TITLE
Exclude specified users from anonymization script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Display claim information [#1901](https://github.com/open-apparel-registry/open-apparel-registry/pull/1901)
 
 ### Changed
+- Added option to exclude specified users from anonymization script [#1906](https://github.com/open-apparel-registry/open-apparel-registry/pull/1906)
 
 ### Deprecated
 

--- a/load-tests/anonymize-the-database/README.md
+++ b/load-tests/anonymize-the-database/README.md
@@ -26,9 +26,11 @@ ssh -i ~/.ssh/oar-stg.pem -L 5433:database.service.oar.internal:5432 -N ec2-user
 
 Invoke `generate_anon_queries` to generate an SQL file containing queries that
 will anonymize user data.
+Optionally, you may specify a space-separated list of email addresses to exclude from anonymization.
 
 ```bash
 PGPASSWORD="" \
+ALLOWED_EMAILS="person@example.com contributor@example.co.uk" \
     generate_anon_queries > queries.sql
 ```
 

--- a/load-tests/anonymize-the-database/generate_anon_queries
+++ b/load-tests/anonymize-the-database/generate_anon_queries
@@ -56,9 +56,17 @@ fake_uuid4() {
     echo $(tail -n 1 /tmp/faker_out)
 }
 
+select_users() {
+    echo "select id from \"api_user\" where email not like '%@azavea.com' and email not like '%@openapparel.org'"
+    if [ -n "$ALLOWED_EMAILS" ]; then
+        echo " and not (email = ANY(string_to_array('$ALLOWED_EMAILS', ' ')))"
+    fi
+}
+
 establish_fake_context
 
-for user_id in $(run_query openapparelregistry "select id from \"api_user\" where email not like '%@azavea.com' and email not like '%@openapparel.org'"); do
+SQL=$(select_users)
+for user_id in $(run_query openapparelregistry "$SQL"); do
     fake_email="${RANDOM}$(fake mail)"
     echo "\
 UPDATE \"api_user\" \
@@ -70,6 +78,8 @@ UPDATE \"account_emailaddress\" \
 SET \
 email = '$fake_email' \
 WHERE user_id = '$user_id';"
+
+    echo "DELETE FROM authtoken_token WHERE user_id = '$user_id';"
 done
 
 echo "UPDATE api_facilitylistitem SET ppe_contact_email = NULL;"
@@ -77,7 +87,5 @@ echo "UPDATE api_facilitylistitem SET ppe_contact_email = NULL;"
 echo "UPDATE api_facility SET ppe_contact_email = NULL;"
 
 echo "UPDATE api_facilityclaim SET email = 'anonymous@example.com';"
-
-echo "DELETE FROM authtoken_token;"
 
 close_fake_context


### PR DESCRIPTION
## Overview

This adds to the existing option to exclude email addresses ending with `@azavea.com` or `@openapparel.org` from anonymization by also allowing a list of other emails to be excluded to be specified in a space-separated list passed as an environment variable.

Connects #1812

## Testing Instructions

* Follow the instructions in `load-tests/anonymize-the-database/README.md` to run `generate_anon_queries`, without setting `ALLOWED_EMAILS`, and save the results to a file.
* Run `generate_anon_queries`, but this time set `ALLOWED_EMAILS` to contain email addresses known to exist on staging (that don't end with `@azavea.com` or `@openapparel.org`), and save the results to a different file.
* The first file should be longer than the second, and the SQL should contain the IDs of the excluded users, while the second file should not contain their IDs

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
