### PR TITLE
Fix VectorGrid (OSH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
 - Fix processing_type_facility_type_unmatched [#1875](https://github.com/open-apparel-registry/open-apparel-registry/pull/1875)
+- Fix VectorGrid bug [#1928](https://github.com/open-apparel-registry/open-apparel-registry/pull/1928)
 
 ### Security
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -153,13 +153,16 @@ function VectorTileFacilitiesMap({
                 minZoom={maxVectorTileFacilitiesGridZoom + 1}
                 maxZoom={22}
             />
-            <VectorTileFacilityGridLayer
-                handleCellClick={handleCellClick}
-                minZoom={1}
-                maxZoom={maxVectorTileFacilitiesGridZoom}
-                zoomLevel={currentMapZoomLevel}
-            />
+            {currentMapZoomLevel <= maxVectorTileFacilitiesGridZoom && (
+                <VectorTileFacilityGridLayer
+                    handleCellClick={handleCellClick}
+                    minZoom={1}
+                    maxZoom={maxVectorTileFacilitiesGridZoom}
+                    zoomLevel={currentMapZoomLevel}
+                />
+            )}
             {drawFilterActive && <PolygonalSearchControl />}
+
             {boundary != null && (
                 <GeoJSON
                     data={boundary}


### PR DESCRIPTION
## Overview

We use two layers to display facilities in the map - the
VectorTileFacilitiesLayer and the VectorTileFacilityGridLayer.
The VectorTileFacilityGridLayer is the 'dots' on the map, and
is shown when the map is zoomed out to a certain level.

When the map was zoomed in far enough that the grid is hidden,
and the user navigated away from the map, an error was being thrown.
By only rendering the grid layer when it's visible, that error is
prevented.

This PR is a duplicate of #1919. 

Connects #1563 

## Testing Instructions

On `develop`:
* Run `./scripts/server` and navigate to a facility details page.
* Navigate to the login page or dashboard (or anywhere in the site away from the map).
* You will see an error message. 

On this branch:
* Repeat the steps above, and you should not see an error message.
* Zoom in and out on the map and confirm that the dots appear and disappear at the appropriate level, and in general works the same as before. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
