### PR TITLE
Update Swagger docs with correct sector response schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Document parallel OGR workflow in the README [#1851](https://github.com/open-apparel-registry/open-apparel-registry/pull/1851)
 - Update tile load test script and add scripts for hompage load, facility download, and facility POST [#1777](https://github.com/open-apparel-registry/open-apparel-registry/pull/1777)
 - API documentation updates [#1844](https://github.com/open-apparel-registry/open-apparel-registry/pull/1844)
-- Return sector in Facility detail response [#1884](https://github.com/open-apparel-registry/open-apparel-registry/pull/1884)
+- Return sector in Facility detail response [#1884](https://github.com/open-apparel-registry/open-apparel-registry/pull/1884) [#1929](https://github.com/open-apparel-registry/open-apparel-registry/pull/1929)
 - Updated logo and colors on top banner, map and search button [#1900](https://github.com/open-apparel-registry/open-apparel-registry/pull/1900)
 - Avoid exception when parsing arrays in raw data [#1910](https://github.com/open-apparel-registry/open-apparel-registry/pull/1910)
 - Added option to exclude specified users from anonymization script [#1924](https://github.com/open-apparel-registry/open-apparel-registry/pull/1924)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1098,7 +1098,16 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     ]
                   },
                   "properties": {
-                    "sector": ["Apparel"],
+                    "sector": [
+                      {
+                        "updated_at": "2022-01-27T17:36:54.597482Z",
+                        "contributor_id": 4,
+                        "contributor_name": "Researcher A",
+                        "values": [
+                          "Apparel"
+                        ]
+                      }
+                    ],
                     "name": "Nantong Jackbeanie Headwear Garment Co. Ltd.",
                     "address": "No. 808, The Third Industry Park, Guoyuan Town, Rugao City Nantong",
                     "country_code": "CN",
@@ -1160,9 +1169,18 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     ]
                   },
                   "properties": {
-                    "sector": ["Apparel"],
                     "name": "Nantong Jackbeanie Headwear Garment Co. Ltd.",
                     "address": "No. 808, The Third Industry Park, Guoyuan Town, Rugao City Nantong",
+                    "sector": [
+                      {
+                        "updated_at": "2022-01-27T17:36:54.597482Z",
+                        "contributor_id": 4,
+                        "contributor_name": "Researcher A",
+                        "values": [
+                          "Apparel"
+                        ]
+                      }
+                    ],
                     "country_code": "CN",
                     "oar_id": "CN2019303BQ3FZP",
                     "other_names": [],
@@ -1211,10 +1229,19 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     ]
                   },
                   "properties": {
-                    "sector": ["Apparel"],
                     "name": "Nantong Jackbeanie Headwear Garment Co. Ltd.",
                     "address": "No. 808, The Third Industry Park, Guoyuan Town, Rugao City Nantong",
                     "country_code": "CN",
+                    "sector": [
+                      {
+                        "updated_at": "2022-01-27T17:36:54.597482Z",
+                        "contributor_id": 4,
+                        "contributor_name": "Researcher A",
+                        "values": [
+                          "Apparel"
+                        ]
+                      }
+                    ],
                     "oar_id": "CN2019303BQ3FZP",
                     "other_names": [],
                     "other_addresses": [],


### PR DESCRIPTION
## Overview

Sectors are returned with additional metadata so they can be displayed as an expandable list with contributor attribution.

Connects #1872

## Demo

<img width="666" alt="Screen Shot 2022-06-21 at 4 27 29 PM" src="https://user-images.githubusercontent.com/17363/174912911-e008f71f-0cdf-4ba0-85e3-779e016588e1.png">

## Testing Instructions

* Verify the example responses on http://localhost:8081/api/docs/#!/facilities/facilities_create encode sector with the same schema as the actual API response.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
