### PR TITLE
Filter facilities by sectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Filter facilities by sectors [#1930](https://github.com/open-apparel-registry/open-apparel-registry/pull/1930)
 - Add new Average Match Count, Confirm Reject Counts, and Error Items reports [#1855](https://github.com/open-apparel-registry/open-apparel-registry/pull/1855/commits)
 - Get sector from CSV or API and store on `FacilityListItem` [#1868](https://github.com/open-apparel-registry/open-apparel-registry/pull/1868)
 - Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871)

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -42,6 +42,7 @@ class FacilitiesQueryParams:
     PRODUCT_TYPE = 'product_type'
     NUMBER_OF_WORKERS = 'number_of_workers'
     NATIVE_LANGUAGE_NAME = 'native_language_name'
+    SECTOR = 'sectors'
 
 
 class FacilityListQueryParams:

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1258,6 +1258,8 @@ class FacilityManager(models.Manager):
             FacilitiesQueryParams.NATIVE_LANGUAGE_NAME, None
         )
 
+        sectors = params.getlist(FacilitiesQueryParams.SECTOR)
+
         facilities_qs = FacilityIndex.objects.all()
 
         if free_text_query is not None:
@@ -1359,6 +1361,11 @@ class FacilityManager(models.Manager):
             unidecode_name = unidecode(native_language_name)
             facilities_qs = facilities_qs.filter(
                 native_language_name__icontains=unidecode_name
+            )
+
+        if len(sectors):
+            facilities_qs = facilities_qs.filter(
+                sector__overlap=sectors
             )
 
         facility_ids = facilities_qs.values_list('id', flat=True)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -8674,6 +8674,34 @@ class NativeLanguageNameAPITest(FacilityAPITestCaseBase):
         self.assertEquals(data['features'][0]['id'], facility_id)
 
 
+class SectorAPITest(FacilityAPITestCaseBase):
+    def setUp(self):
+        super(SectorAPITest, self).setUp()
+        self.url = reverse('facility-list')
+
+    @patch('api.geocoding.requests.get')
+    def test_search(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        facility_response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'sector': ['Apparel', 'Beauty']
+        }), content_type='application/json')
+        facility_data = json.loads(facility_response.content)
+        facility_id = facility_data['oar_id']
+
+        response = self.client.get(
+            self.url + '?sectors=Beauty'
+        )
+        data = json.loads(response.content)
+        print(data)
+        self.assertEquals(data['count'], 1)
+        self.assertEquals(data['features'][0]['id'], facility_id)
+
+
 class ExactMatchTest(FacilityAPITestCaseBase):
     def setUp(self):
         super(ExactMatchTest, self).setUp()

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -811,6 +811,17 @@ class FacilitiesAPIFilterBackend(BaseFilterBackend):
                         'setting this to true will make the response '
                         'significantly slower to return.'),
                 ),
+                coreapi.Field(
+                    name='sectors',
+                    location='query',
+                    type='string',
+                    required=False,
+                    description=(
+                        'The sectors that this facility belongs to. '
+                        'Values must match those returned from the '
+                        '`GET /api/sectors` endpoint'
+                        )
+                )
             ]
 
             return fields


### PR DESCRIPTION
## Overview

Allow users to filter facilities by the `sectors` in Swagger and front-end. We capitalize the first letter of each query value to match the stored value, then any facilities which have any matching sector are returned.

Connects #1832 

## Demo

In Swagger:
![image](https://user-images.githubusercontent.com/60887686/174924365-3c0a5eb5-4d6e-4fc0-afd9-a392a25e3e50.png)

In front-end:
![2022-06-21 18 34 36](https://user-images.githubusercontent.com/60887686/174924481-b2e29da6-4596-4f19-aa85-c8349db12898.gif)

## Note

`sector` is used as the title in the facility filter and detail sidebar, but here we use `sectors` as the parameter name to match the name in variable name returned from the facility detail API.

## Testing Instructions

* Check out this branch and run `./scripts/server`
* Log in as `c3@example.com, contribute and fully process the list [ExtendedFieldsTestListLimited - Sector.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/8954699/ExtendedFieldsTestListLimited.-.Sector.csv)
* To test in back-end: Go to [Swagger](http://localhost:8081/api/docs/#!/facilities/facilities_list), add `sectors` param (including upper- and lower- cases)
    - [x] Make sure the returned facilities are in valid sectors
* To test in front-end: go to main page, choose sectors based on the choices (new sectors choices should be added automatically as implemented in #1899), and click "Search"
    - [x] Make sure the returned facilities are in valid sectors

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
