### PR TITLE
Add script to copy/anonymize the production database onto staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Added a script to automate restoring an anonymized production snapshot [#1948](https://github.com/open-apparel-registry/open-apparel-registry/pull/1948)
 
 ### Changed
 

--- a/load-tests/anonymize-the-database/generate_anon_queries
+++ b/load-tests/anonymize-the-database/generate_anon_queries
@@ -6,7 +6,7 @@
 # 1st Argument: DB Name
 # 2nd Argument: Query
 run_query() {
-    psql -h localhost -p 5433 -U openapparelregistry -t -A \
+    psql -h "${PGHOST:-localhost}" -p "${PGPORT:-5433}" -U openapparelregistry -t -A \
         "$1" -c "$2"
 }
 

--- a/tools/copy_production_db_to_staging
+++ b/tools/copy_production_db_to_staging
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${OAR_DEBUG}" ]]; then
+    set -x
+fi
+
+# Constants
+STAGING_ID="openapparelregistry-enc-stg"
+PRODUCTION_ID="openapparelregistry-enc-prd"
+
+# Derived constants
+PROJECT_ROOT="$(dirname $( dirname -- "$BASH_SOURCE"; ))";
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Clones, anonymizes & restores the production database on-top of the staging database
+"
+}
+
+function required() {
+    if [ -z "$1" ]; then
+        echo "$2 is required"
+        exit 1
+    fi
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        # Read required variables from user input / AWS CLI
+        read -s -p "Staging PGPASSWORD: " STAGING_PGPASSWORD
+        echo
+        required "$STAGING_PGPASSWORD" "Staging PGPASSWORD"
+
+        read -s -p "Production PGPASSWORD: " PRODUCTION_PGPASSWORD
+        echo
+        required "$PRODUCTION_PGPASSWORD" "Production PGPASSWORD"
+
+        read -p "Allowed emails to exclude from anonymization: " ALLOWED_EMAILS
+        echo
+
+        STAGING_DATABASE_ENDPOINT="$(aws rds describe-db-instances \
+            --db-instance-identifier $STAGING_ID \
+            --query DBInstances[0].Endpoint.Address --output text)"
+        read -e -p "Staging database endpoint: " -i "$STAGING_DATABASE_ENDPOINT" STAGING_DATABASE_ENDPOINT
+        required "$STAGING_DATABASE_ENDPOINT" "Staging database endpoint"
+
+        SNAPSHOT_ID="$(aws rds describe-db-snapshots \
+            --db-instance-identifier $PRODUCTION_ID \
+            --query="max_by(DBSnapshots, &SnapshotCreateTime).DBSnapshotIdentifier" \
+            --output text)"
+
+        read -e -p "Snapshot id: " -i "$SNAPSHOT_ID" SNAPSHOT_ID
+        required "$SNAPSHOT_ID" "Snaphsot id"
+
+        STAGING_RDS_INSTANCE_TYPE="$(aws rds describe-db-instances \
+            --db-instance-identifier $STAGING_ID \
+            --query "DBInstances[0].DBInstanceClass" \
+            --output text)"
+
+        read -e -p "Instance class: " -i "$STAGING_RDS_INSTANCE_TYPE" STAGING_RDS_INSTANCE_TYPE
+        required "$STAGING_RDS_INSTANCE_TYPE" "Instance class"
+
+        STAGING_RDS_SUBNET_GROUP="$(aws rds describe-db-instances \
+            --db-instance-identifier $STAGING_ID \
+            --query "DBInstances[0].DBSubnetGroup.DBSubnetGroupName" \
+            --output text)"
+
+        STAGING_RDS_VPC_SECURITY_GROUP="$(aws rds describe-db-instances \
+            --db-instance-identifier $STAGING_ID \
+            --query "DBInstances[0].VpcSecurityGroups[0].VpcSecurityGroupId" \
+            --output text)"
+
+        # Remove rds: from snapshot ID & use as database ID
+        NEW_DATABASE_ID="${SNAPSHOT_ID:4}"
+
+        RESTORE="aws rds restore-db-instance-from-db-snapshot \
+            --no-paginate \
+            --db-instance-identifier $NEW_DATABASE_ID \
+            --db-snapshot-identifier $SNAPSHOT_ID \
+            --db-instance-class $STAGING_RDS_INSTANCE_TYPE \
+            --db-subnet-group-name $STAGING_RDS_SUBNET_GROUP\
+            --vpc-security-group-ids $STAGING_RDS_VPC_SECURITY_GROUP"
+
+        echo "Will run '$RESTORE'"
+        read -n 1 -s -r -p "Press any key to begin"
+        echo
+
+        $RESTORE
+
+        # Restore will complete right away, but we can't begin to query
+        # the database until the status is "available"
+        CHECK_STATUS="aws rds describe-db-instances \
+            --db-instance-identifier $NEW_DATABASE_ID \
+            --query DBInstances[0].DBInstanceStatus --output text"
+
+        echo -n "Polling until new instance is ready"
+        while [ "$($CHECK_STATUS)" != 'available' ]; do
+            echo -n "."
+            sleep 10
+        done
+        echo
+
+        NEW_DATABASE_ENDPOINT="$(aws rds describe-db-instances \
+            --db-instance-identifier $NEW_DATABASE_ID \
+            --query DBInstances[0].Endpoint.Address --output text)"
+
+        pushd "$PROJECT_ROOT/load-tests/anonymize-the-database"
+
+        echo "Installing requirements for anonymization script"
+        python3 -m venv ./venv
+        source ./venv/bin/activate
+        pip install -r requirements.txt
+
+        ANONYMIZATION_QUERIES="$(PGPASSWORD=$PRODUCTION_PGPASSWORD PGHOST=$NEW_DATABASE_ENDPOINT \
+                                 PGPORT=5432 ALLOWED_EMAILS=$ALLOWED_EMAILS \
+                                 ./generate_anon_queries)"
+
+        popd
+
+        read -n 1 -s -r -p "Press any key to start anonymizing the database"
+        echo
+        export PGPASSWORD="$PRODUCTION_PGPASSWORD" 
+        echo "$ANONYMIZATION_QUERIES" | psql -h "$NEW_DATABASE_ENDPOINT" -U openapparelregistry -t -A openapparelregistry -f -
+
+        # Run pg_dump
+        read -n 1 -s -r -p "Press any key to start pg_dump"
+        echo
+        DUMP_FILE="$NEW_DATABASE_ID.dump"
+        pg_dump -Fc -h "$NEW_DATABASE_ENDPOINT" -U openapparelregistry openapparelregistry > "$DUMP_FILE"
+
+        DELETE="aws rds delete-db-instance \
+            --no-paginate \
+            --db-instance-identifier $NEW_DATABASE_ID \
+            --skip-final-snapshot"
+        echo "Will run '$DELETE'"
+        read -n 1 -s -r -p "Press any key to delete $NEW_DATABASE_ID"
+        echo
+        $DELETE
+
+        # Run pg_restore
+        export PGPASSWORD="$STAGING_PGPASSWORD" 
+        PG_RESTORE="pg_restore -h $STAGING_DATABASE_ENDPOINT  -U openapparelregistry -d openapparelregistry --clean --if-exists --no-owner $DUMP_FILE"
+        echo "Will run '$PG_RESTORE'"
+        read -n 1 -s -r -p "Press any key to start pg_restore"
+        echo
+        $PG_RESTORE
+
+        read -n 1 -s -r -p "Press any key to delete $DUMP_FILE"
+        echo
+        rm "$DUMP_FILE"
+    fi
+fi


### PR DESCRIPTION
## Overview

This adds an interactive script meant to be run on the staging bastion, which automates the process of restoring a production database snapshot, anonymizing it, creating a dump, and restoring that dump on top of staging.

Connects #1813 

## Demo
![Screenshot 2022-07-01 111901](https://user-images.githubusercontent.com/4432106/176929159-c687b53d-7090-4748-89e9-6b82b245e896.png)

![Screenshot 2022-07-01 105902](https://user-images.githubusercontent.com/4432106/176929157-6992bca6-e57b-4118-8069-4b766a3a3839.png)


## Notes

I ran this from the bastion.

To run it, I first had to manually install `git` and `python3`: `sudo yum install git python37`. Then I clone `open-apparel-registry` and checked out this branch and ran `./tools/copy_production_db_to_staging`.

For testing purposes, I used a copy of the staging database I spun up from a recent snapshot.

## Testing Instructions

* SSH to the staging bastion
* cd into `open-apparel-registry/` and ensure the latest version of this branch is checked out.
* Run `./tools/copy_production_db_to_staging`. You will be asked to supply staging/production database passwords, as well as confirm data determined using the AWS CLI (I substituted the staging database copy for the staging database endpoint determined by the script).
* At each step, confirm results expected for that step of the script in the AWS console or using `psql` on either the temporary RDS database or the database you will be copying onto (staging by default)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
