### PR TITLE
Migrate from django-swagger to drf-yasg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rename OAR to OS Hub / Open Apparel Registry to Open Supply Hub [#1935](https://github.com/open-apparel-registry/open-apparel-registry/pull/1935)
 - Update favicon images with OS Hub logo [#1938](https://github.com/open-apparel-registry/open-apparel-registry/pull/1938)
 - Use name prefix and create before destroy for batch compute [#1952](https://github.com/open-apparel-registry/open-apparel-registry/pull/1952)
+- Switched from `django-swagger` to `drf-yasg` [#1951](https://github.com/open-apparel-registry/open-apparel-registry/pull/1951/files)
 
 ### Deprecated
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1491,8 +1491,9 @@ class FacilityActivityReportSerializer(ModelSerializer):
 
 class ContributorListQueryParamsSerializer(Serializer):
     contributors = ListField(
-        child=IntegerField(required=False),
-        required=False,
+        child=IntegerField(required=True),
+        required=True,
+        allow_empty=False
     )
 
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2624,30 +2624,6 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             raise NotFound()
 
 
-class FacilityListViewSetSchema(AutoSchema):
-    def get_serializer_fields(self, path, method):
-        if path[-7:] == '/items/':
-            statuses = ', '.join(
-                [c[0] for c in FacilityListItem.STATUS_CHOICES])
-            return [
-                coreapi.Field(
-                    name='status',
-                    location='query',
-                    type='string',
-                    required=False,
-                    description=('Only return items matching this status.'
-                                 'Must be one of {}').format(statuses),
-                ),
-            ]
-
-        return []
-
-    # This suppresses the FacilityList documentation altogether. See:
-    # https://github.com/open-apparel-registry/open-apparel-registry/issues/349
-    def get_link(self, path, method, base_url):
-        return None
-
-
 def create_nonstandard_fields(fields, contributor):
     unique_fields = list(set(fields))
 
@@ -2677,8 +2653,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
     serializer_class = FacilityListSerializer
     permission_classes = [IsRegisteredAndConfirmed]
     http_method_names = ['get', 'post', 'head', 'options', 'trace']
-
-    schema = FacilityListViewSetSchema()
+    swagger_schema = None
 
     def _validate_header(self, header):
         if header is None or header == '':
@@ -3067,12 +3042,6 @@ def api_feature_flags(request):
     return Response(response_data)
 
 
-class FacilityClaimsAutoSchema(AutoSchema):
-    def get_link(self, path, method, base_url):
-        return None
-
-
-@schema(FacilityClaimsAutoSchema())
 class FacilityClaimViewSet(viewsets.ModelViewSet):
     """
     Viewset for admin operations on FacilityClaims.
@@ -3080,6 +3049,7 @@ class FacilityClaimViewSet(viewsets.ModelViewSet):
     queryset = FacilityClaim.objects.all()
     serializer_class = FacilityClaimSerializer
     permission_classes = [IsAdminUser]
+    swagger_schema = None
 
     def create(self, request):
         pass
@@ -3782,12 +3752,6 @@ def get_tile(request, layer, cachekey, z, x, y, ext):
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
 
-class ApiBlockAutoSchema(AutoSchema):
-    def get_link(self, path, method, base_url):
-        return None
-
-
-@schema(ApiBlockAutoSchema())
 class ApiBlockViewSet(mixins.ListModelMixin,
                       mixins.RetrieveModelMixin,
                       mixins.UpdateModelMixin,
@@ -3797,6 +3761,7 @@ class ApiBlockViewSet(mixins.ListModelMixin,
     """
     queryset = ApiBlock.objects.all()
     serializer_class = ApiBlockSerializer
+    swagger_schema = None
 
     def validate_request(self, request):
         if request.user.is_anonymous:
@@ -3981,11 +3946,6 @@ class ContributorFacilityListViewSet(viewsets.ReadOnlyModelViewSet):
         return Response(response_data)
 
 
-class EmbedConfigAutoSchema(AutoSchema):
-    def get_link(self, path, method, base_url):
-        return None
-
-
 def create_embed_fields(fields_data, embed_config, previously_searchable=None):
     if previously_searchable is None:
         previously_searchable = list()
@@ -4020,7 +3980,6 @@ def get_contributor(request):
     return contributor
 
 
-@schema(EmbedConfigAutoSchema())
 class EmbedConfigViewSet(mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
                          mixins.UpdateModelMixin,
@@ -4031,6 +3990,7 @@ class EmbedConfigViewSet(mixins.ListModelMixin,
     """
     queryset = EmbedConfig.objects.all()
     serializer_class = EmbedConfigSerializer
+    swagger_schema = None
 
     @transaction.atomic
     def create(self, request):
@@ -4093,18 +4053,13 @@ class EmbedConfigViewSet(mixins.ListModelMixin,
         return super(EmbedConfigViewSet, self).update(request, pk=pk)
 
 
-class NonstandardFieldsAutoSchema(AutoSchema):
-    def get_link(self, path, method, base_url):
-        return None
-
-
-@schema(NonstandardFieldsAutoSchema())
 class NonstandardFieldsViewSet(mixins.ListModelMixin,
                                viewsets.GenericViewSet):
     """
     View nonstandard fields submitted by a contributor.
     """
     queryset = NonstandardField.objects.all()
+    swagger_schema = None
 
     def list(self, request):
         if not request.user.is_authenticated:

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -55,7 +55,6 @@ from waffle.decorators import waffle_switch
 from waffle.models import Switch
 
 
-from oar import urls
 from oar.settings import MAX_UPLOADED_FILE_SIZE_IN_BYTES, ENVIRONMENT
 
 from api.constants import (CsvHeaderField,
@@ -199,15 +198,6 @@ def add_user_to_mailing_list(email, name, contrib_type):
         requests.post(endpoint, data=data, auth=auth)
     except Exception:
         _report_mailchimp_error_to_rollbar(email, name, contrib_type)
-
-
-@api_view()
-@permission_classes([AllowAny])
-@renderer_classes([SwaggerUIRenderer, OpenAPIRenderer])
-def schema_view(request):
-    generator = schemas.SchemaGenerator(title='Open Supply Hub API',
-                                        patterns=urls.public_apis)
-    return Response(generator.get_schema())
 
 
 class SubmitNewUserForm(CreateAPIView):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -27,7 +27,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.shortcuts import redirect
 from django.views.decorators.cache import cache_control
-from rest_framework import viewsets, status, mixins, schemas
+from rest_framework import viewsets, status, mixins
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.authtoken.models import Token
 from rest_framework.exceptions import (ValidationError,
@@ -39,8 +39,7 @@ from rest_framework.generics import CreateAPIView, RetrieveUpdateAPIView
 from rest_framework.decorators import (api_view,
                                        permission_classes,
                                        renderer_classes,
-                                       action,
-                                       schema)
+                                       action)
 from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
 from drf_yasg import openapi
@@ -848,6 +847,7 @@ facilities_create_parameters = [
             '5 highest confidence results are returned'),
     ),
 ]
+
 
 class FacilitiesViewSet(mixins.ListModelMixin,
                         mixins.RetrieveModelMixin,
@@ -1720,7 +1720,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @swagger_auto_schema(paginator_inspectors=[DisabledPaginationInspector], responses={200: ''})
+    @swagger_auto_schema(paginator_inspectors=[DisabledPaginationInspector],
+                         responses={200: ''})
     @action(detail=False, methods=['get'])
     def count(self, request):
         """
@@ -2407,7 +2408,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
 
         return Response(facility_history)
 
-    @swagger_auto_schema(request_body=no_body, responses={200: FacilityDetailsSerializer})
+    @swagger_auto_schema(request_body=no_body,
+                         responses={200: FacilityDetailsSerializer})
     @action(detail=True, methods=['POST'],
             permission_classes=(IsRegisteredAndConfirmed,),
             url_path='dissociate')
@@ -3736,6 +3738,7 @@ facility_activity_report_schema = openapi.Schema(
     type=openapi.TYPE_OBJECT,
     description=('The reason for the report status change.'),
 )
+
 
 def update_facility_activity_report_status(facility_activity_report,
                                            request, status):

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -110,7 +110,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'rest_framework_gis',
-    'rest_framework_swagger',
+    'drf_yasg',
     'rest_auth',
     'allauth',
     'allauth.account',
@@ -165,13 +165,7 @@ SWAGGER_SETTINGS = {
             'name': 'Authorization',
         },
     },
-    'doc_expansion': 'list',
-    'info': {
-        'description': 'Open Supply Hub API',
-        'license': 'MIT',
-        'licenseUrl': 'https://github.com/open-apparel-registry/open-apparel-registry/blob/develop/LICENSE',  # noqa
-        'title': 'Open Supply Hub API',
-    },
+    'DOC_EXPANSION': 'none',
     'USE_SESSION_AUTH': False,
 }
 

--- a/src/django/oar/urls.py
+++ b/src/django/oar/urls.py
@@ -21,8 +21,9 @@ from api import views
 from api.admin import admin_site
 from web.views import environment
 
-from rest_framework import routers
-from rest_framework_swagger.views import get_swagger_view
+from rest_framework import routers, permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 from oar import settings
 
@@ -67,6 +68,19 @@ public_apis = [
     url(r'^api/sectors', views.sectors, name='sectors'),
 ]
 
+schema_view = get_schema_view(
+    openapi.Info(
+        title='Open Supply Hub API',
+        default_version='1',
+        description='Open Supply Hub API',
+        terms_of_service="https://info.openapparel.org/terms-of-service",
+        license=openapi.License(name='MIT', url='https://github.com/open-apparel-registry/open-apparel-registry/blob/develop/LICENSE')  # NOQA
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+    patterns=[url("^", include(public_apis))],
+)
+
 info_apis = [
     url(r'^api/info/contributors/', views.active_contributors_count,
         name='active_contributors_count'),
@@ -77,13 +91,11 @@ info_apis = [
         name='facilities_count'),
 ]
 
-schema_view = get_swagger_view(title='Open Supply Hub API Documentation',
-                               patterns=public_apis)
-
 internal_apis = [
     url(r'^', include('django.contrib.auth.urls')),
     url(r'^web/environment\.js', environment, name='environment'),
-    url(r'^api/docs/', views.schema_view),
+    url(r'^api/docs/$', schema_view.with_ui('swagger'),
+        name='schema-swagger-ui'),
     path('admin/', admin_site.urls),
     re_path(r'^health-check/', include('watchman.urls')),
     url(r'^api-auth/', include('rest_framework.urls')),

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -8,11 +8,11 @@ django-ecsmanage==2.0.1
 django-extensions==2.1.9
 django-jsonview==1.2.0
 django-rest-auth[with_social]==0.9.5
-django-rest-swagger==2.1.2
 django-simple-history==2.7.2
 django-spa==0.2.0
 django-waffle==0.17.0
 django-watchman==0.17.0
+drf-yasg==1.20.0
 djangorestframework-gis==0.14
 djangorestframework==3.11.2
 flake8==3.6.0


### PR DESCRIPTION
## Overview

Updates the generated Swagger API docs to use `drf-yasg`

Connects #1907 

## Demo

![localhost_8081_api_docs_ (1)](https://user-images.githubusercontent.com/4432106/177417925-73fff2e6-6ff3-4dd4-be7f-3e56afcd3259.png)


## Testing Instructions

* `scripts/update`
* Verify that the output of http://localhost:8081/api/docs/ looks correct

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- ~[ ] If this PR applies to both OAR and OGR a companion PR has been created~
