### PR TITLE
Fix contributor list API

### DIFF
--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1492,7 +1492,7 @@ class FacilityActivityReportSerializer(ModelSerializer):
 class ContributorListQueryParamsSerializer(Serializer):
     contributors = ListField(
         child=IntegerField(required=True),
-        required=True,
+        required=False,
         allow_empty=False
     )
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3859,7 +3859,7 @@ class ContributorFacilityListViewSet(viewsets.ReadOnlyModelViewSet):
         openapi.IN_QUERY,
         description='The contributor ID.',
         type=openapi.TYPE_INTEGER,
-        required=True
+        required=False
     )], responses={200: ''})
     def list(self, request):
         params = ContributorListQueryParamsSerializer(


### PR DESCRIPTION
## Overview

This fixes a bug introduced in #1951 - I noted the docs had said `contributors` parameter was required, but the backend code didn't seem to require it. I assumed the docs were correct and "fixed" the serializer - which seems to have broken the main page!

## Testing Instructions

* On `ogr/develop` loading the map page will show http://localhost:6543/api/contributors/ returning 400, on this branch it should succeed

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
