### PR TITLE
Exclude null claim sector value when serializing facility details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
 - Fix processing_type_facility_type_unmatched [#1875](https://github.com/open-apparel-registry/open-apparel-registry/pull/1875)
 - Fix VectorGrid bug [#1928](https://github.com/open-apparel-registry/open-apparel-registry/pull/1928)
+- Exclude null claim sector value when serializing facility details [#1963](https://github.com/open-apparel-registry/open-apparel-registry/pull/1963)
 
 ### Security
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1048,6 +1048,7 @@ class FacilityDetailsSerializer(FacilitySerializer):
         claim_sectors = FacilityClaim \
             .objects \
             .filter(facility=facility, status=FacilityClaim.APPROVED) \
+            .exclude(sector=None) \
             .order_by('contributor_id', '-updated_at') \
             .distinct('contributor_id') \
             .values('updated_at',

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -8983,6 +8983,22 @@ class FacilityDetailSerializerTest(TestCase):
         self.assertEqual(self.contrib_one_name,
                          data['properties']['sector'][0]['contributor_name'])
 
+    def test_excludes_null_sectors_from_approved_claim(self):
+        self.source_two.is_active = False
+        self.source_two.save()
+
+        FacilityClaim.objects.create(
+            contributor=self.contrib_two,
+            facility=self.facility,
+            status=FacilityClaim.APPROVED,
+        )
+
+        data = FacilityDetailsSerializer(self.facility).data
+
+        self.assertEqual(1, len(data['properties']['sector']))
+        self.assertEqual(self.contrib_one_name,
+                         data['properties']['sector'][0]['contributor_name'])
+
 
 class SectorChoiceViewTest(APITestCase):
     def setUp(self):


### PR DESCRIPTION
## Overview

If a claimant has not provided a sector value, we want to skip serializing facility sector array item entirely rather than serializing an item with a null value.

Connects #1959

## Testing Instructions

### Reproduce the error

* Check out `ogr/develop`
* Log in as c2@example.com
* Claim a facility
* In a separate session log in as c1@example.com, browse http://localhost:6543/dashboard/claims, and approve the claim. 
* In the original session refresh the detail page for the claimed facility. You should see an error page

### Test the fix
 
* Check out this PR branch
* Refresh the facility details page and verify that it loads without error.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
