### PR TITLE
Return anonymized sectors and index them instead of excluding them when items are private or inactive 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update favicon images with OS Hub logo [#1938](https://github.com/open-apparel-registry/open-apparel-registry/pull/1938)
 - Use name prefix and create before destroy for batch compute [#1952](https://github.com/open-apparel-registry/open-apparel-registry/pull/1952)
 - Switched from `django-swagger` to `drf-yasg` [#1951](https://github.com/open-apparel-registry/open-apparel-registry/pull/1951/files)
+- Return anonymized sectors and index them instead of excluding them when items are private or inactive [#1966](https://github.com/open-apparel-registry/open-apparel-registry/pull/1966)
 
 ### Deprecated
 

--- a/src/django/api/management/commands/index_sectors.py
+++ b/src/django/api/management/commands/index_sectors.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+from api.models import FacilityIndex, get_sector_dict
+
+
+class Command(BaseCommand):
+    help = 'Adds custom text to the index table based on the provided id(s).'
+
+    def add_arguments(self, parser):
+        parser.add_argument('facility_ids', type=str, nargs='*')
+
+    def handle(self, *args, **options):
+        facility_ids = options.get('facility_ids', [])
+        for facility_id, sectors in get_sector_dict(facility_ids).items():
+            FacilityIndex.objects.filter(id=facility_id).update(sector=sectors)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -9174,12 +9174,10 @@ class IndexFacilitiesTest(FacilityAPITestCaseBase):
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(resp.data['oar_id'], facility_id)
         facility_index = FacilityIndex.objects.get(id=facility_id)
-        # Should have mining/metals/mech eng. w/ no duplicates
         self.assertIn('Mining', facility_index.sector)
         self.assertIn('Metals', facility_index.sector)
-        self.assertIn('Mechanical Engineering', facility_index.sector)
         self.assertNotIn('Apparel', facility_index.sector)
-        self.assertEqual(len(facility_index.sector), 3)
+        self.assertEqual(len(facility_index.sector), 2)
 
     @override_switch('claim_a_facility', active=True)
     def test_updating_claim_sector_updates_index(self):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -53,7 +53,8 @@ from api.permissions import referring_host_is_allowed, referring_host
 from api.serializers import (ApprovedFacilityClaimSerializer,
                              FacilityCreateBodySerializer,
                              FacilityListSerializer,
-                             FacilityDetailsSerializer)
+                             FacilityDetailsSerializer,
+                             get_contributor_name)
 from api.limits import check_api_limits, get_end_of_year
 from api.close_list import close_list
 from api.facility_type_processing_type import (
@@ -8791,7 +8792,7 @@ class FacilityDetailSerializerTest(TestCase):
             .objects \
             .create(admin=self.user_one,
                     name=self.contrib_one_name,
-                    contrib_type=Contributor.OTHER_CONTRIB_TYPE)
+                    contrib_type=Contributor.CONTRIB_TYPE_CHOICES[0][0])
 
         self.contrib_two = Contributor \
             .objects \
@@ -8973,16 +8974,6 @@ class FacilityDetailSerializerTest(TestCase):
         self.assertEqual(self.contrib_two_name,
                          data['properties']['sector'][1]['contributor_name'])
 
-    def test_excludes_from_inactive_sources(self):
-        self.source_two.is_active = False
-        self.source_two.save()
-
-        data = FacilityDetailsSerializer(self.facility).data
-
-        self.assertEqual(1, len(data['properties']['sector']))
-        self.assertEqual(self.contrib_one_name,
-                         data['properties']['sector'][0]['contributor_name'])
-
     def test_excludes_null_sectors_from_approved_claim(self):
         self.source_two.is_active = False
         self.source_two.save()
@@ -8995,9 +8986,28 @@ class FacilityDetailSerializerTest(TestCase):
 
         data = FacilityDetailsSerializer(self.facility).data
 
-        self.assertEqual(1, len(data['properties']['sector']))
-        self.assertEqual(self.contrib_one_name,
+        self.assertEqual(2, len(data['properties']['sector']))
+        self.assertEqual(get_contributor_name(self.contrib_two, False),
                          data['properties']['sector'][0]['contributor_name'])
+        self.assertEqual(self.contrib_one_name,
+                         data['properties']['sector'][1]['contributor_name'])
+
+    def test_inactive_and_private_sources_serializes_anonymized_sectors(self):
+        self.source_one.is_active = False
+        self.source_one.save()
+
+        self.source_two.is_public = False
+        self.source_two.save()
+
+        data = FacilityDetailsSerializer(self.facility).data
+
+        self.assertEqual(2, len(data['properties']['sector']))
+        self.assertEqual(get_contributor_name(self.contrib_two, False),
+                         data['properties']['sector'][0]['contributor_name'])
+        self.assertIsNone(data['properties']['sector'][0]['contributor_id'])
+        self.assertEqual(get_contributor_name(self.contrib_one, False),
+                         data['properties']['sector'][1]['contributor_name'])
+        self.assertIsNone(data['properties']['sector'][1]['contributor_id'])
 
 
 class SectorChoiceViewTest(APITestCase):


### PR DESCRIPTION
## Overview

Previously if all sources for a facility were private or inactive then no sector details were being serialized. To fix this we follow the patter of other private or inactive data and anonymize the contributor information during serialization rather than excluding it.

We also extends this change to the facility indexing process, introducing similar filtering and sorting changes to ensure that the index is updated with the correct sectors.

Since we are updating the way the list of sectors is calculated for a facility we need to update all sector values in the index. We add a new `index_sectors` management command do a targeted update of the sector column.

Connects #1949 
Connects #1958

## Demo

<img width="294" alt="Screen Shot 2022-07-08 at 3 20 26 PM" src="https://user-images.githubusercontent.com/17363/178078059-fc93acd0-e4ff-465f-bd24-9620cab09d14.png">

## Testing Instructions

### Setup

* Run `./scripts/resetdb`

### Test serialization

* Log in as c2@example.com
* Contribute [sector-test-1.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/9075351/sector-test-1.xlsx) and run `./tools/batch_process 16` 
* Browse http://localhost:6543/?q=sector%20test and verify the two facilities loaded properly
* Contribute [sector-test-2.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/9075374/sector-test-2.xlsx) **making sure** to select the previous list in the "Select a list to replace" box
* Run `./scripts/manage batch_process -l 17 -a parse`
* Browse http://localhost:6543/?q=sector%20test and verify:
  *  Sector Test Facility One still has the sectors `Automotive, Agrigulture`
  *  Sector Test Facility Two displays a sector but the attribution is anonymized to "a Service Provider"
* Run `./scripts/manage batch_process -l 17 -a geocode` and `./scripts/manage batch_process -l 17 -a match`
* Browse http://localhost:6543/?q=sector%20test and verify:
  *  Sector Test Facility One now has the sector `Foodservice`
* Contribute [sector-test-3.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/9075387/sector-test-3.xlsx) but **do not** select a previous list for replacement
* Run `./tools/batch_process 18` 
* Browse http://localhost:6543/?q=sector%20test and verify:
  *  Sector Test Facility One now has the sector `Technology`
* Browse http://localhost:8081/api/docs/#/ and authenticate with `Token 1d18b962d6f976b0b7e8fcf9fcc39b56cf278051` 
* Use the POST /api/facilities endpoint to submit a private facility (**making sure** to set `public` to `false`)
```
{
    "sector": "Transportation",
    "country": "US",
    "name": "Sector Test API",
    "address": "777 main st pittsburgh pa"
}
```
* Browse http://localhost:6543/?q=sector%20test and verify:
  *  Sector Test Facility Three now has the sector `Transportation` with an anonymized contributor name

### Test reindexing

* From `./scripts/manage dbshell` clear the sector sector column with `UPDATE api_facilityindex  SET sector = '{}';`
* Verify a sector search no longer returns facilities http://localhost:6543/facilities?sectors=Apparel
* Run `./scripts/manage index_sectors` and  `./scripts/manage incrementtileversion`
* Verify that sector search is fixed http://localhost:6543/facilities?sectors=Apparel
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
