### PR TITLE
Refactor sector choices API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Filter facilities by sectors [#1930](https://github.com/open-apparel-registry/open-apparel-registry/pull/1930)
 - Add new Average Match Count, Confirm Reject Counts, and Error Items reports [#1855](https://github.com/open-apparel-registry/open-apparel-registry/pull/1855/commits)
 - Get sector from CSV or API and store on `FacilityListItem` [#1868](https://github.com/open-apparel-registry/open-apparel-registry/pull/1868)
-- Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871)
+- Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871) & [#1967](https://github.com/open-apparel-registry/open-apparel-registry/pull/1967)
 - Add sector to FacilityIndex [#1883](https://github.com/open-apparel-registry/open-apparel-registry/pull/1883)
 - Show sectors on facility detail sidebar [#1898](https://github.com/open-apparel-registry/open-apparel-registry/pull/1898)
 - Add sector search controls [#1899](https://github.com/open-apparel-registry/open-apparel-registry/pull/1899)

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -639,17 +639,12 @@ def sectors(request):
         ]
 
     """
-    item_sectors = FacilityListItem \
+    sectors = FacilityIndex \
         .objects \
-        .filter(source__is_active=True, source__is_public=True) \
         .annotate(all_sectors=Func(F('sector'), function='unnest')) \
-        .values_list('all_sectors', flat=True).distinct()
-    claim_sectors = FacilityClaim \
-        .objects \
-        .filter(status=FacilityClaim.APPROVED) \
-        .annotate(all_sectors=Func(F('sector'), function='unnest')) \
-        .values_list('all_sectors', flat=True).distinct()
-    return Response(sorted(item_sectors.union(claim_sectors)))
+        .values_list('all_sectors', flat=True) \
+        .distinct()
+    return Response(sorted(sectors))
 
 
 @swagger_auto_schema(methods=['POST'], auto_schema=None)


### PR DESCRIPTION
## Overview

This reworks the Sector choice API to use denormalized data stored in the `FacilityIndex.sector` column instead of querying `FacilityListItem` / `FacilityClaim` directly.

We had missed a few different ways that the supplied `sector` could be invalidated, and rather than updating this API to match all of those, I've instead switched it to query from the `FacilityIndex.sector` column which is already being populated by a set of queries very similar to the one we would have had to replace the current query with.

Connects #1964 

## Testing Instructions
* `scripts/resetdb`
* On the main sidebar search, you should see Apparel & Health as options for the sector dropdown
* Log in as `c3@example.com` and upload 
[ExtendedFieldsTestListLimited.-.Sector.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9096333/ExtendedFieldsTestListLimited.-.Sector.csv)
* Process it using `./tools/batch_process`
* You should see additional values in the sector search dropdown after this
* Removing all the rows in the uploaded list should cause the sector search dropdown to go back to just Apparel & Health

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- ~[ ] If this PR applies to both OAR and OGR a companion PR has been created~
