### PR TITLE
Add sector to CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add sector to Facility Claim [#1934](https://github.com/open-apparel-registry/open-apparel-registry/pull/1934)
 - Added a script to automate restoring an anonymized production snapshot [#1948](https://github.com/open-apparel-registry/open-apparel-registry/pull/1948/commits/b7fecdca30c011a5ef3a8a68971e4ce5fbe8c319)
 - Add Event model [#1995](https://github.com/open-apparel-registry/open-apparel-registry/pull/1995)
+- Add sector to CSV [#1987](https://github.com/open-apparel-registry/open-apparel-registry/pull/1987)
 
 ### Changed
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -767,6 +767,7 @@ class FacilityDownloadSerializer(Serializer):
             'country_name',
             'lat',
             'lng',
+            'sector',
         ]
 
         if not is_embed_mode_active(self):
@@ -790,6 +791,7 @@ class FacilityDownloadSerializer(Serializer):
             contributor_fields = self.get_contributor_fields()
 
         def add_non_base_fields(row, list_item, match_is_active):
+            row.append('|'.join(list_item.sector))
             if not is_embed_mode:
                 contribution = get_download_contribution(
                     list_item.source, match_is_active, user_can_see_detail)
@@ -830,6 +832,11 @@ class FacilityDownloadSerializer(Serializer):
         try:
             claim = FacilityClaim.objects.get(facility=facility,
                                               status=FacilityClaim.APPROVED)
+
+            sector = claim.sector if claim.sector is not None \
+                else facility.created_from.sector
+            base_row.append('|'.join(sector))
+
             if not is_embed_mode:
                 contribution = get_download_claim_contribution(
                     claim, user_can_see_detail)

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -9246,7 +9246,7 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
     def setUp(self):
         super(FacilityDownloadTest, self).setUp()
         self.download_url = '/api/facilities-downloads/'
-        self.contributor_column_index = 8
+        self.contributor_column_index = 9
         self.date = timezone.now().strftime("%Y-%m-%d")
         self.embed_config = EmbedConfig.objects.create()
 
@@ -9374,7 +9374,7 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
 
         self.default_headers = ['oar_id', 'contribution_date', 'name',
                                 'address', 'country_code', 'country_name',
-                                'lat', 'lng', 'contributor (list)',
+                                'lat', 'lng', 'sector', 'contributor (list)',
                                 'number_of_workers', 'parent_company',
                                 'processing_type_facility_type_raw',
                                 'facility_type', 'processing_type',
@@ -9383,7 +9383,7 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         self.contrib_facility_base_row = [self.contrib_facility.id,
                                           self.date, 'Towel Factory 42',
                                           '42 Dolphin St', 'US',
-                                          'United States', 0.0, 0.0,
+                                          'United States', 0.0, 0.0, 'Apparel',
                                           'test contributor 1 (First List)',
                                           '', '', '', '', '', '', 'False']
 
@@ -9586,8 +9586,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         params = 'embed=1&contributors={}'.format(self.contributor.id)
         response = self.get_facility_download(params)
         headers = self.get_headers(response)
-        self.assertEquals(headers[8], 'extra_1')
-        self.assertEquals(headers[9], 'extra_2')
+        self.assertEquals(headers[9], 'extra_1')
+        self.assertEquals(headers[10], 'extra_2')
 
     def test_embed_headers_dedupe_extended_fields(self):
         params = 'embed=1&contributors={}'.format(self.contributor.id)
@@ -9607,8 +9607,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         base_row = self.get_rows(response)[0]
         expected_base_row = [self.facility.id, self.date, 'Name',
                              'Address', 'US', 'United States', 0.0, 0.0,
-                             'test contributor 1 (First List)', '', '', '', '',
-                             '', '', 'False']
+                             'Apparel', 'test contributor 1 (First List)', '',
+                             '', '', '', '', '', 'False']
         self.assertEqual(len(base_row), len(expected_base_row))
         self.assertEqual(base_row, expected_base_row)
 
@@ -9619,7 +9619,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         base_row = self.get_rows(response)[0]
         expected_base_row = [self.facility.id, self.date, 'Name',
                              'Address', 'US', 'United States', 0.0, 0.0,
-                             '', '', '', '', '', '', '', '', 'False']
+                             'Apparel', '', '', '', '', '', '', '', '',
+                             'False']
         self.assertEqual(len(base_row), len(expected_base_row))
         self.assertEqual(base_row, expected_base_row)
 
@@ -9630,8 +9631,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         base_row = self.get_rows(response)[0]
         expected_base_row = [self.contrib_facility.id, self.date,
                              'Towel Factory 42', '42 Dolphin St', 'US',
-                             'United States', 0.0, 0.0, 'data one', '', '', '',
-                             '', '', '', '', 'False']
+                             'United States', 0.0, 0.0, 'Apparel', 'data one',
+                             '', '', '', '', '', '', '', 'False']
         self.assertEqual(len(base_row), len(expected_base_row))
         self.assertEqual(base_row, expected_base_row)
 
@@ -9642,7 +9643,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         base_row = self.get_rows(response)[0]
         expected_base_row = [self.contrib_facility_two.id, self.date, 'Item',
                              'Address', 'US', 'United States', 0.0, 0.0,
-                             '', 'data two', '', '', '', '', '', '', 'False']
+                             'Apparel', '', 'data two', '', '', '', '', '', '',
+                             'False']
         self.assertEqual(len(base_row), len(expected_base_row))
         self.assertEqual(base_row, expected_base_row)
 
@@ -9653,8 +9655,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         base_row = self.get_rows(response)[0]
         expected_base_row = [self.facility.id, self.date, 'Name',
                              'Address', 'US', 'United States', 0.0, 0.0,
-                             'test contributor 1 (First List)', '100-5000',
-                             'Contributor', 'biological recycling',
+                             'Apparel', 'test contributor 1 (First List)',
+                             '100-5000', 'Contributor', 'biological recycling',
                              'Raw Material Processing or Production',
                              'Biological Recycling', 'Shirts', 'False']
         self.assertEqual(len(base_row), len(expected_base_row))
@@ -9666,14 +9668,14 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         response = self.get_facility_download(params)
         rows = self.get_rows(response)
         claim_row = [self.facility.id, self.date, 'Claim Name',
-                     'Address', 'US', 'United States', 0.0, 0.0,
-                     'test contributor 1 (Claimed)', '20', 'Contributor',
-                     'biological recycling',
+                     'Address', 'US', 'United States', 0.0, 0.0, 'Apparel',
+                     'test contributor 1 (Claimed)', '20',
+                     'Contributor', 'biological recycling',
                      'Raw Material Processing or Production',
                      'Biological Recycling', 'Shirts', 'False']
         list_item_row = [self.facility.id, self.date, '', '', '', '', '', '',
-                         'test contributor 1 (First List)', '', '', '', '', '',
-                         '', '']
+                         'Apparel', 'test contributor 1 (First List)', '', '',
+                         '', '', '', '', '']
         self.assertEquals(rows[0], claim_row)
         self.assertEquals(rows[1], list_item_row)
 
@@ -9692,7 +9694,7 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         self.assertEqual(expected_base_row, rows[0])
 
         expected_additional_row = [self.contrib_facility.id, self.date, '',
-                                   '', '', '', '', '',
+                                   '', '', '', '', '', 'Apparel',
                                    'test contributor 1 (API)', '0-100',
                                    'Contributor A', 'biological recycling',
                                    'Raw Material Processing or Production',
@@ -9713,8 +9715,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
 
         expected_base_row = [self.contrib_facility.id, self.date,
                              'Towel Factory 42', '42 Dolphin St',
-                             'US', 'United States', 0.0, 0.0, 'data one', '',
-                             '', '', '', '', '', '', 'False']
+                             'US', 'United States', 0.0, 0.0, 'Apparel',
+                             'data one', '', '', '', '', '', '', '', 'False']
         self.assertEquals(rows[0], expected_base_row)
 
     def test_private_source_is_anonymized(self):


### PR DESCRIPTION
## Overview

Adds sector data to the facilities download. The sector data is
listed for each row.

Connects #1841 

## Demo

[facilities_with_sectors.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9183070/facilities_with_sectors.csv)

## Notes

The issue noted to add the sector for each contributor, so unlike the other core fields I added it to the additional list item rows, and not just the base row. 

## Testing Instructions

* Run `./scripts/server`
* Download a list that includes a claim and some list items with multiple fields
* Confirm that the 'sector' column contains the expected sector values

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
