### PR TITLE
Fix anonymous contributors section on sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Fix showing anonymous contributors on sidebar [#1993](https://github.com/open-apparel-registry/open-apparel-registry/pull/1993)
 
 ### Security
 

--- a/src/app/src/components/FacilityDetailSidebarContributors.jsx
+++ b/src/app/src/components/FacilityDetailSidebarContributors.jsx
@@ -42,7 +42,9 @@ const detailsSidebarStyles = theme =>
     });
 
 const FacilityDetailSidebarContributors = ({ classes, contributors, push }) => {
-    const visibleContributors = contributors.filter(c => !!c.contributor_name);
+    const visibleContributors = contributors.filter(
+        c => !!c.contributor_name || !!c.name,
+    );
 
     if (!visibleContributors.length) return null;
 
@@ -63,7 +65,9 @@ const FacilityDetailSidebarContributors = ({ classes, contributors, push }) => {
                         <BadgeVerified />
                     </ShowOnly>
                     <ListItemText
-                        primary={contributor.contributor_name}
+                        primary={
+                            contributor.contributor_name || contributor.name
+                        }
                         secondary={contributor.list_name}
                         classes={{ primary: classes.primaryText }}
                     />


### PR DESCRIPTION
## Overview

Restores how we used to handle anonymous contributors like in https://github.com/open-apparel-registry/open-apparel-registry/blob/cf827be88c158414c075aa0aeab252c4266db305/src/app/src/components/FacilityDetailSidebarInfo.jsx

Connects #1796

## Demo

![image](https://user-images.githubusercontent.com/4432106/181093940-e7cf8a0f-ae46-49bc-a94a-c83ea86674e9.png)


## Notes

I assume we originally only had `id` and `name` and at some point switched to `id` & `contributor_name` _or_ `name`, and that change didn't get reflected in the new sidebar?

## Testing Instructions

* Find a facility, and verify that it has 1 line for the contributors section
* Using the Django shell, set the `FacilityMatch` for that facility to be `in_active`: `FacilityMatch.objects.filter(facility_id='...').update(is_active=False)`
* Refresh page showing the facility detail - on `develop` the contributors section will be hidden, but on this branch it should still show, but w/o linking to a contributors detail page

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
