### PR TITLE
Update "adjust facility matches" dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade Django to 3.2, Python to 3.10, as well as other dependencies [#1965](https://github.com/open-apparel-registry/open-apparel-registry/pull/1965/)
 - Update facility download [#1981](https://github.com/open-apparel-registry/open-apparel-registry/pull/1981)
 - Limit parent company dropdown options to other parent companies and allow freeform text entry [#1983](https://github.com/open-apparel-registry/open-apparel-registry/pull/1983)
+- Update "adjust facility matches" dashboard [#2005](https://github.com/open-apparel-registry/open-apparel-registry/pull/2005)
 
 ### Deprecated
 

--- a/src/app/src/components/DashboardAdjustMatchCard.jsx
+++ b/src/app/src/components/DashboardAdjustMatchCard.jsx
@@ -12,12 +12,14 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
 import find from 'lodash/find';
+import capitalize from 'lodash/capitalize';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 import MoveMatchDialog from './MoveMatchDialog';
 
 import { makeFacilityDetailLink } from '../util/util';
+import { facilityMatchStatusChoicesEnum } from '../util/constants';
 
 import { facilityDetailsPropType } from '../util/propTypes';
 
@@ -74,6 +76,13 @@ const adjustMatchCardStyles = Object.freeze({
         margin: '0 5px',
     }),
 });
+
+const completeStatuses = [
+    facilityMatchStatusChoicesEnum.AUTOMATIC,
+    facilityMatchStatusChoicesEnum.CONFIRMED,
+    facilityMatchStatusChoicesEnum.MERGED,
+];
+const isCompleteStatus = status => completeStatuses.includes(status);
 
 const MatchDetailItem = ({ label, value = null, style = {} }) =>
     value && (
@@ -185,6 +194,8 @@ export default function DashboardAdjustMatchCard({
             );
         }
 
+        const matchIsNotComplete = !isCompleteStatus(match.status);
+
         return (
             <div
                 style={{
@@ -196,7 +207,7 @@ export default function DashboardAdjustMatchCard({
                     <Button
                         variant="contained"
                         color="primary"
-                        disabled={adjusting}
+                        disabled={adjusting || matchIsNotComplete}
                         onClick={() =>
                             openDialogForMatchToAdjust(
                                 match,
@@ -211,7 +222,7 @@ export default function DashboardAdjustMatchCard({
                 <Button
                     variant="contained"
                     color="primary"
-                    disabled={adjusting}
+                    disabled={adjusting || matchIsNotComplete}
                     onClick={() => setMatchToMove(match)}
                     style={adjustMatchCardStyles.buttonStyles}
                 >
@@ -220,7 +231,7 @@ export default function DashboardAdjustMatchCard({
                 <Button
                     variant="contained"
                     color="primary"
-                    disabled={adjusting}
+                    disabled={adjusting || matchIsNotComplete}
                     onClick={() =>
                         openDialogForMatchToAdjust(
                             match,
@@ -368,6 +379,18 @@ export default function DashboardAdjustMatchCard({
                             <MatchDetailItem
                                 label="Country Code"
                                 value={match.country_code}
+                            />
+                            <MatchDetailItem
+                                label="Status"
+                                value={capitalize(match.status)}
+                            />
+                            <MatchDetailItem
+                                label="Active"
+                                value={match.is_active ? 'True' : 'False'}
+                            />
+                            <MatchDetailItem
+                                label="Confidence Score"
+                                value={match.confidence}
                             />
                         </div>
                     ))}

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2078,6 +2078,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                         'match_id': m.id,
                         'is_geocoded':
                         m.facility_list_item.geocoded_point is not None,
+                        'status': m.status,
+                        'is_active': m.is_active,
+                        'confidence': m.confidence,
                         'facility_created_by_item':
                         Facility.objects.filter(
                             created_from=m.facility_list_item.id)[0].id


### PR DESCRIPTION
## Overview

Admin users have had a number of instances where they attempted to
adjust a match but were unable to due to the current status of the
match. This shows additional information about the matches to assist
admins in using the tool, and also disables the adjustment buttons
for certain match statuses.

Connects #1943 

## Demo

<img width="528" alt="Screen Shot 2022-07-28 at 1 11 17 PM" src="https://user-images.githubusercontent.com/21046714/181597671-9feaf87c-a575-4bee-aa77-c6c8a4c5ba20.png">

## Testing Instructions

* Run `./scripts/server`
* Login as c1@example.com
* Visit http://localhost:6543/dashboard/adjustfacilitymatches and search for a facility with a pending or rejected match ("Nantong Solamoda Garments Co. Ltd" worked in my environment).
     * The correct match data should be displayed, including the is_active value, the confidence score, and the match status
     * The split, transfer, and promote buttons should *not* be interactive
* Search for a facility with a confirmed, automatic, or merged match
     * The correct match data should be displayed, including the is_active value, the confidence score, and the match status
     * The split, transfer, and promote buttons should be interactive

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
