### PR TITLE
Replace + character in ISO date string when in batch job name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Exclude null claim sector value when serializing facility details [#1963](https://github.com/open-apparel-registry/open-apparel-registry/pull/1963)
 - Ensure inactive matches have anonymized sectors [#1968](https://github.com/open-apparel-registry/open-apparel-registry/pull/1968)
 - Fix showing anonymous contributors on sidebar [#1994](https://github.com/open-apparel-registry/open-apparel-registry/pull/1994)
+- Replace + character in ISO date string when in batch job name [#2008](https://github.com/open-apparel-registry/open-apparel-registry/pull/2008)
 
 ### Security
 

--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -54,7 +54,10 @@ def submit_jobs(facility_list, skip_parse=False):
     queue_arn = fetch_batch_queue_arn(client)
     job_def_arn = fetch_latest_active_batch_job_definition_arn(client)
     job_time = (timezone.now().isoformat()
-                .replace(':', '-').replace('.', '-').replace('T', '-'))
+                .replace(':', '-')
+                .replace('.', '-')
+                .replace('T', '-')
+                .replace('+', '-'))
 
     item_table = FacilityListItem.objects.model._meta.db_table
     results_column = 'processing_results'


### PR DESCRIPTION
## Overview

When switching to timezone-aware datetime objects we ended up attempting to create a batch job name with a + character, which AWS Batch does not allow.

Connects #2007
Connects  #1908

## Testing Instructions

I pushed copy of this branch prefixed with `ogr/test` so it could be tested on staging.

After deploying this branch to staging I was able to upload a list

![2022-07-28 13 48 53](https://user-images.githubusercontent.com/17363/181635313-38d52510-3b1c-4ede-9c92-860033c91317.gif)


## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
