### PR TITLE
Suppress pure-python SequenceMatcher warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
-
+- Suppress "pure-python SequenceMatcher" warning [#2011](https://github.com/open-apparel-registry/open-apparel-registry/pull/2011)
 - Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
 - Fix processing_type_facility_type_unmatched [#1875](https://github.com/open-apparel-registry/open-apparel-registry/pull/1875)
 - Fix VectorGrid bug [#1928](https://github.com/open-apparel-registry/open-apparel-registry/pull/1928)

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -3,8 +3,8 @@ warnings.filterwarnings(
     "ignore",
     message="Using slow pure-python SequenceMatcher. Install python-Levenshte")
 
-from api.helpers import clean # NOQA
-from thefuzz import process # NOQA
+from api.helpers import clean  # NOQA: E402
+from thefuzz import process  # NOQA: E402
 
 HEADQUARTERS = 'headquarters'
 NO_PROCESSING = 'no processing'

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -1,8 +1,10 @@
 import warnings
-warnings.filterwarnings("ignore", message="Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning")
+warnings.filterwarnings(
+    "ignore",
+    message="Using slow pure-python SequenceMatcher. Install python-Levenshte")
 
-from api.helpers import clean
-from thefuzz import process
+from api.helpers import clean # NOQA
+from thefuzz import process # NOQA
 
 HEADQUARTERS = 'headquarters'
 NO_PROCESSING = 'no processing'

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.filterwarnings("ignore", message="Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning")
+
 from api.helpers import clean
 from thefuzz import process
 


### PR DESCRIPTION
Using the slow pure-python module isn't necessarily a problem for our use of this library, and this is a very noisy warning. We're suppressing this warning as we consider the implications of switching to a faster module in #2010 

## Notes

This PR suppresses only the warning:
"Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning"

This warning is thrown when thefuzz module is loaded, which is why the call to `warnings.filterwarnings` is so early in the file.

Connects #2009 

## Testing Instructions

Running `./scripts update` in `ogr/develop` will give output that looks like this, displaying the relevant warning a few times:
```
[+] Running 2/2
 ⠿ Container open-apparel-registry-database-1  Healthy                                                         0.6s
 ⠿ Container open-apparel-registry-django-1    Started                                                         0.9s
[+] Running 1/0
 ⠿ Container open-apparel-registry-database-1  Running                                                         0.0s
/usr/local/lib/python3.7/site-packages/thefuzz/fuzz.py:11: UserWarning: Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning
  warnings.warn('Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning')
Operations to perform:
  Apply all migrations: account, admin, api, auth, authtoken, contenttypes, sessions, sites, socialaccount, waffle
Running migrations:
  No migrations to apply.
```

* Check out this branch
* run `./scripts/update`. The output text will no longer display that warning.
```
[+] Running 2/2
 ⠿ Container open-apparel-registry-database-1  Healthy                                                         1.3s
 ⠿ Container open-apparel-registry-django-1    Started                                                         1.6s
[+] Running 1/0
 ⠿ Container open-apparel-registry-database-1  Running                                                         0.0s
Operations to perform:
  Apply all migrations: account, admin, api, auth, authtoken, contenttypes, sessions, sites, socialaccount, waffle
Running migrations:
  No migrations to apply.
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
