### PR TITLE
Add transfer status to Adjust Facility Matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Event model [#1995](https://github.com/open-apparel-registry/open-apparel-registry/pull/1995)
 - Add sector to CSV [#1987](https://github.com/open-apparel-registry/open-apparel-registry/pull/1987)
 - Add notifications section to settings page [#2013](https://github.com/open-apparel-registry/open-apparel-registry/pull/2013)
+- Add transfer status to the Adjust Facility Matches interface [#1945](https://github.com/open-apparel-registry/open-apparel-registry/pull/2014)
 
 ### Changed
 

--- a/src/app/src/components/DashboardAdjustMatchCard.jsx
+++ b/src/app/src/components/DashboardAdjustMatchCard.jsx
@@ -13,6 +13,7 @@ import get from 'lodash/get';
 import merge from 'lodash/merge';
 import find from 'lodash/find';
 import capitalize from 'lodash/capitalize';
+import isNil from 'lodash/isNil';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
@@ -392,6 +393,12 @@ export default function DashboardAdjustMatchCard({
                                 label="Confidence Score"
                                 value={match.confidence}
                             />
+                            {!isNil(match.transferred_from) && (
+                                <MatchDetailItem
+                                    label="Transferred From"
+                                    value={match.transferred_from}
+                                />
+                            )}
                         </div>
                     ))}
                 </CardContent>

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2088,6 +2088,18 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                         if Facility.objects.filter(
                             created_from=m.facility_list_item.id).exists()
                         else None,
+                        'transferred_from':
+                        [r for r
+                            in m.facility_list_item.processing_results
+                            if r.get('action', '')
+                            == ProcessingAction.MOVE_FACILITY]
+                            [0]['previous_facility_oar_id']
+                            if len(
+                                [r for r
+                                    in m.facility_list_item.processing_results
+                                    if r.get('action', '')
+                                    == ProcessingAction.MOVE_FACILITY]) > 0
+                            else None,
                     }
                     for m
                     in facility.get_other_matches()
@@ -2996,7 +3008,7 @@ class FacilityListViewSet(viewsets.ModelViewSet):
 
         def make_q_from_status(status):
             if status in special_case_q_statements:
-                return(special_case_q_statements[status])
+                return (special_case_q_statements[status])
             else:
                 return Q(status=status)
 


### PR DESCRIPTION
## Overview

Add transfer status to Adjust Facility Matches

Connects #1945

## Demo

Optional. Screenshots, `curl` examples, etc.

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

1. Get an authentication token (c2 has one already under settings>tokens) and go to http://localhost:8081/api/docs/#!/facilities/facilities_create and authenticate there
2. Get the name, address, country, and sector for a facility and submit those as the name, address, country and sector for a new facility (under facilities>post)
3. As c1, go to [the Adjust Facility Matches page in the dashboard](http://localhost:6543/dashboard/adjustfacilitymatches)
5. Search using the OAR ID of the match you've just submitted; the new match should not display a "Transferred from" field
6. Transfer the new match to another OAR ID (e.g. US2022214B3QZNE)
7. Search again using the OAR ID of the match you just transferred; the new transfer should display a "Transferred from" field with a value of the prior OAR ID

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
