### PR TITLE
Fix delete facility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix showing anonymous contributors on sidebar [#1994](https://github.com/open-apparel-registry/open-apparel-registry/pull/1994)
 - Replace + character in ISO date string when in batch job name [#2008](https://github.com/open-apparel-registry/open-apparel-registry/pull/2008)
 - Update sectors in FacilityIndex after upload [#2004](https://github.com/open-apparel-registry/open-apparel-registry/pull/2004)
+- Fix delete facility [#2020](https://github.com/open-apparel-registry/open-apparel-registry/pull/2020)
 
 ### Security
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1608,10 +1608,13 @@ class Facility(PPEMixin):
         ]
         return sources + anonymous_sources
 
-    def get_created_from_match(self):
+    def get_created_from_matches(self):
         return self.facilitymatch_set.filter(
             facility_list_item=self.created_from
-        ).first()
+        )
+
+    def get_created_from_match(self):
+        return self.get_created_from_matches().first()
 
     def get_other_matches(self):
         return self.facilitymatch_set.exclude(

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -3546,6 +3546,25 @@ class FacilityDeleteTest(APITestCase):
         self.assertEqual(
             0, FacilityMatch.objects.filter(facility=self.facility).count())
 
+    def test_can_delete_multiple_created_froms(self):
+        FacilityMatch \
+            .objects \
+            .create(status=FacilityMatch.PENDING,
+                    facility=self.facility,
+                    facility_list_item=self.facility.created_from,
+                    confidence=0.85,
+                    results='')
+
+        self.client.login(email=self.superuser_email,
+                          password=self.superuser_password)
+        response = self.client.delete(self.facility_url)
+        self.assertEqual(204, response.status_code)
+
+        self.assertEqual(
+            0, Facility.objects.filter(id=self.facility.id).count())
+        self.assertEqual(
+            0, FacilityMatch.objects.filter(facility=self.facility).count())
+
 
 class FacilityMergeTest(APITestCase):
     def setUp(self):

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1645,9 +1645,9 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             list_item.facility = None
             list_item.save()
 
-        match = facility.get_created_from_match()
-        match._change_reason = 'Deleted {}'.format(facility.id)
-        match.delete()
+        for match in facility.get_created_from_matches():
+            match.changeReason = 'Deleted {}'.format(facility.id)
+            match.delete()
 
         other_matches = facility.get_other_matches()
         if other_matches.count() > 0:


### PR DESCRIPTION
## Overview

Allows facilities to be deleted when their created_from
FacilityListItem has multiple associated FacilityMatches.

Connects #1992 
Pair to #2019 

## Testing Instructions

* See instructions on #2019 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
