### PR TITLE
Log notification events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add notifications section to settings page [#2013](https://github.com/open-apparel-registry/open-apparel-registry/pull/2013)
 - Add transfer status to the Adjust Facility Matches interface [#1945](https://github.com/open-apparel-registry/open-apparel-registry/pull/2014)
 - Add facility_location to FacilityClaim [#2012](https://github.com/open-apparel-registry/open-apparel-registry/pull/2012https://github.com/open-apparel-registry/open-apparel-registry/pull/2012)
+- Add webhook event logging utility [#2024](https://github.com/open-apparel-registry/open-apparel-registry/pull/2024)
 
 ### Changed
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 from itertools import groupby
+import json
+import logging
 from unidecode import unidecode
 
 from django.contrib.auth.models import (AbstractBaseUser,
@@ -34,6 +36,9 @@ from api.helpers import (prefix_a_an,
 from api.facility_type_processing_type import (
     ALL_FACILITY_TYPE_CHOICES,
     get_facility_and_processing_type)
+
+
+logger = logging.getLogger(__name__)
 
 
 class ArrayLength(models.Func):
@@ -2243,6 +2248,12 @@ class ContributorWebhook(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
+
+    def log_event(self, event, status):
+        detail = {"event_id": event.pk, "webhook_id": self.pk,
+                  "contributor_id": self.contributor_id, "status": status,
+                  "event_time": event.event_time.isoformat()}
+        logger.info("ContributorWebhook %s: %s", status, json.dumps(detail))
 
 
 class FacilityActivityReport(models.Model):

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -264,6 +264,10 @@ LOGGING = {
             'class': 'logging.StreamHandler',
         },
     },
+    'root': {
+        'handlers': ['console'],
+        'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+    },
     'loggers': {
         'django': {
             'handlers': ['console'],


### PR DESCRIPTION
## Overview

Add helper function for logging webhook events

Connects #2000

## Notes

This was simplified quite a bit from the issue description, as we discussed it on Slack and decided we can log to the main CloudWatch log group and use querying to filter for webhook event logs, rather than connecting these logs to a separate stream from the rest of the application logs.

## Testing Instructions

* CI should pass
* ?
 
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- ~[ ] If this PR applies to both OAR and OGR a companion PR has been created~
