### PR TITLE
Split batch steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update facility download [#1981](https://github.com/open-apparel-registry/open-apparel-registry/pull/1981)
 - Limit parent company dropdown options to other parent companies and allow freeform text entry [#1983](https://github.com/open-apparel-registry/open-apparel-registry/pull/1983)
 - Update "adjust facility matches" dashboard [#2005](https://github.com/open-apparel-registry/open-apparel-registry/pull/2005)
+- Split batch steps [#2028](https://github.com/open-apparel-registry/open-apparel-registry/pull/2028)
 
 ### Deprecated
 

--- a/src/django/api/aws_batch.py
+++ b/src/django/api/aws_batch.py
@@ -44,98 +44,88 @@ def fetch_latest_active_batch_job_definition_arn(client):
             'No job queues available. Response {0}'.format(response))
 
 
-def submit_jobs(facility_list, skip_parse=False):
-    """
-    Submit AWS Batch jobs to process each FacilityListItem in a FacilityList
-    through all processing steps.
-    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job
-    """
-    client = boto3.client('batch')
-    queue_arn = fetch_batch_queue_arn(client)
-    job_def_arn = fetch_latest_active_batch_job_definition_arn(client)
-    job_time = (timezone.now().isoformat()
-                .replace(':', '-')
-                .replace('.', '-')
-                .replace('T', '-')
-                .replace('+', '-'))
+def submit_job(action, job_data, is_array=False, depends_on=None):
+    client = job_data['client']
+    queue_arn = job_data['queue_arn']
+    job_def_arn = job_data['job_def_arn']
+    job_time = job_data['job_time']
+    facility_list = job_data['facility_list']
 
-    item_table = FacilityListItem.objects.model._meta.db_table
+    if depends_on is None:
+        depends_on = []
+    array_properties = {}
+    if is_array:
+        array_properties = {
+            'size': facility_list.source.facilitylistitem_set.count()
+        }
+    job_name = 'list-{0}-{1}-{2}'.format(
+        facility_list.id, action, job_time)
+    job = client.submit_job(
+        jobName=job_name,
+        jobQueue=queue_arn,
+        jobDefinition=job_def_arn,
+        dependsOn=depends_on,
+        arrayProperties=array_properties,
+        parameters={
+            'listid': str(facility_list.id),
+            'action': action,
+        }
+    )
+    if 'jobId' in job:
+        return job['jobId']
+    else:
+        raise RuntimeError(
+            'Failed to submit job {0}. Response {1}'.format(job_name, job))
+
+
+def append_processing_result(result_dict, facility_list):
     results_column = 'processing_results'
     source_id_column = 'source_id'
+    item_table = FacilityListItem.objects.model._meta.db_table
+    query = ("UPDATE {item_table} "
+             "SET {results_column} = {results_column} || '{dict_json}' "
+             "WHERE {source_id_column} = {source_id}")
+    query = query.format(
+        item_table=item_table,
+        results_column=results_column,
+        dict_json=json.dumps(result_dict),
+        source_id_column=source_id_column,
+        source_id=facility_list.source.id
+    )
+    with connection.cursor() as cursor:
+        cursor.execute(query)
 
-    def submit_job(action, is_array=False, depends_on=None):
-        if depends_on is None:
-            depends_on = []
-        array_properties = {}
-        if is_array:
-            array_properties = {
-                'size': facility_list.source.facilitylistitem_set.count()
-            }
-        job_name = 'list-{0}-{1}-{2}'.format(
-            facility_list.id, action, job_time)
-        job = client.submit_job(
-            jobName=job_name,
-            jobQueue=queue_arn,
-            jobDefinition=job_def_arn,
-            dependsOn=depends_on,
-            arrayProperties=array_properties,
-            parameters={
-                'listid': str(facility_list.id),
-                'action': action,
-            }
-        )
-        if 'jobId' in job:
-            return job['jobId']
-        else:
-            raise RuntimeError(
-                'Failed to submit job {0}. Response {1}'.format(job_name, job))
 
-    def append_processing_result(result_dict):
-        query = ("UPDATE {item_table} "
-                 "SET {results_column} = {results_column} || '{dict_json}' "
-                 "WHERE {source_id_column} = {source_id}")
-        query = query.format(
-            item_table=item_table,
-            results_column=results_column,
-            dict_json=json.dumps(result_dict),
-            source_id_column=source_id_column,
-            source_id=facility_list.source.id
-        )
-        with connection.cursor() as cursor:
-            cursor.execute(query)
+def parse(job_data, facility_list):
+    started = str(timezone.now())
+    # The parse task is just quick string manipulation. We submit it as a
+    # normal job rather than as an array job to avoid extra overhead that
+    # just slows things down.
+    parse_job_id = submit_job('parse', job_data)
+    finished = str(timezone.now())
+    append_processing_result({
+        'action': ProcessingAction.SUBMIT_JOB,
+        'type': 'parse',
+        'job_id': parse_job_id,
+        'error': False,
+        'is_array': False,
+        'started_at': started,
+        'finished_at': finished,
+    }, facility_list)
 
-    depends_on = None
-    job_ids = []
+    return [parse_job_id]
 
-    # PARSE
-    if not skip_parse:
-        started = str(timezone.now())
-        # The parse task is just quick string manipulation. We submit it as a
-        # normal job rather than as an array job to avoid extra overhead that
-        # just slows things down.
-        parse_job_id = submit_job('parse')
-        job_ids.append(parse_job_id)
-        depends_on = [{'jobId': parse_job_id}]
-        finished = str(timezone.now())
-        append_processing_result({
-            'action': ProcessingAction.SUBMIT_JOB,
-            'type': 'parse',
-            'job_id': parse_job_id,
-            'error': False,
-            'is_array': False,
-            'started_at': started,
-            'finished_at': finished,
-        })
 
-    # GEOCODE
+def geocode(job_data, facility_list, job_ids):
     started = str(timezone.now())
     row_count = facility_list.source.facilitylistitem_set.count()
     is_array = row_count > 1
+    depends_on = [{'jobId': job_ids[-1]}] if len(job_ids) > 0 else None
     geocode_job_id = submit_job('geocode',
+                                job_data,
                                 depends_on=depends_on,
                                 is_array=is_array)
     job_ids.append(geocode_job_id)
-    depends_on = [{'jobId': geocode_job_id}]
     finished = str(timezone.now())
     append_processing_result({
         'action': ProcessingAction.SUBMIT_JOB,
@@ -145,12 +135,15 @@ def submit_jobs(facility_list, skip_parse=False):
         'is_array': is_array,
         'started_at': started,
         'finished_at': finished,
-    })
+    }, facility_list)
 
-    # MATCH
+    return job_ids
+
+
+def match(job_data, facility_list, job_ids):
     started = str(timezone.now())
-    match_job_id = submit_job('match', depends_on=depends_on)
-    depends_on = [{'jobId': match_job_id}]
+    depends_on = [{'jobId': job_ids[-1]}] if len(job_ids) > 0 else None
+    match_job_id = submit_job('match', job_data, depends_on=depends_on)
     job_ids.append(match_job_id)
     finished = str(timezone.now())
     append_processing_result({
@@ -161,11 +154,17 @@ def submit_jobs(facility_list, skip_parse=False):
         'is_array': False,
         'started_at': started,
         'finished_at': finished,
-    })
+    }, facility_list)
 
-    # NOTIFY
+    return job_ids
+
+
+def notify(job_data, facility_list, job_ids):
     started = str(timezone.now())
-    notify_job_id = submit_job('notify_complete', depends_on=depends_on)
+    depends_on = [{'jobId': job_ids[-1]}] if len(job_ids) > 0 else None
+    notify_job_id = submit_job('notify_complete',
+                               job_data,
+                               depends_on=depends_on)
     job_ids.append(notify_job_id)
     finished = str(timezone.now())
     append_processing_result({
@@ -176,6 +175,58 @@ def submit_jobs(facility_list, skip_parse=False):
         'is_array': False,
         'started_at': started,
         'finished_at': finished,
-    })
+    }, facility_list)
+
+    return job_ids
+
+
+def submit_parse_job(facility_list):
+    """
+    Submit AWS Batch job to parse each FacilityListItem in a FacilityList.
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job
+    """
+    client = boto3.client('batch')
+    job_data = {
+        'client': client,
+        'queue_arn': fetch_batch_queue_arn(client),
+        'job_def_arn': fetch_latest_active_batch_job_definition_arn(client),
+        'job_time': (timezone.now().isoformat()
+                     .replace(':', '-')
+                     .replace('.', '-')
+                     .replace('T', '-')
+                     .replace('+', '-')),
+        'facility_list': facility_list,
+    }
+
+    return parse(job_data, facility_list)
+
+
+def submit_jobs(facility_list, job_ids=None):
+    """
+    Submit AWS Batch jobs to process each FacilityListItem in a FacilityList
+    through the geocode, match, and notify list processing steps.
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job
+    """
+    client = boto3.client('batch')
+    job_data = {
+        'client': client,
+        'queue_arn': fetch_batch_queue_arn(client),
+        'job_def_arn': fetch_latest_active_batch_job_definition_arn(client),
+        'job_time': (timezone.now().isoformat()
+                     .replace(':', '-')
+                     .replace('.', '-')
+                     .replace('T', '-')
+                     .replace('+', '-')),
+        'facility_list': facility_list,
+    }
+
+    if job_ids is None:
+        job_ids = []
+
+    # The following three methods mutate the job_ids parameter
+    # by adding additional ids
+    geocode(job_data, facility_list, job_ids)
+    match(job_data, facility_list, job_ids)
+    notify(job_data, facility_list, job_ids)
 
     return job_ids

--- a/src/django/api/management/commands/reprocess_geocode_failures.py
+++ b/src/django/api/management/commands/reprocess_geocode_failures.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         self.stdout.write('Reprocessing {} lists'.format(str(lists.count())))
         for facility_list in lists:
             if ENVIRONMENT in ('Staging', 'Production'):
-                job_ids = submit_jobs(facility_list, skip_parse=True)
+                job_ids = submit_jobs(facility_list)
                 self.stdout.write('{} {}'.format(facility_list.id, job_ids))
             else:
                 command = ('./scripts/manage batch_process '

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -127,7 +127,7 @@ from api.serializers import (ContributorWebhookSerializer,
                              FacilityActivityReportSerializer,
                              EmbedConfigSerializer)
 from api.countries import COUNTRY_CHOICES
-from api.aws_batch import submit_jobs
+from api.aws_batch import submit_jobs, submit_parse_job
 from api.permissions import IsRegisteredAndConfirmed, IsAllowedHost
 from api.pagination import (FacilitiesGeoJSONPagination,
                             PageAndSizePagination)
@@ -2873,7 +2873,8 @@ class FacilityListViewSet(viewsets.ModelViewSet):
         FacilityListItem.objects.bulk_create(items)
 
         if ENVIRONMENT in ('Staging', 'Production'):
-            submit_jobs(new_list)
+            job_ids = submit_parse_job(new_list)
+            submit_jobs(new_list, job_ids)
 
         serializer = self.get_serializer(new_list)
         return Response(serializer.data)


### PR DESCRIPTION
## Overview

To date the existing code for handling an uploaded list schedules a
sequence of four AWS Batch jobs to fully process the list. We are
introducing moderator approval of lists before they are fully
processed, requiring us to split the job submission process.

The 'parse' step is completed in the first function (`submit_parse_job`), and the 
'geocode', 'match' and 'notify' steps occur in the second function (`submit_jobs`). 
Currently, both functions are being called in the list upload view,
with the parse job id being provided to the `submit_jobs` function 
so that the other jobs don't begin until after parsing. 
In #2018, the `submit_jobs` function will be removed from this view, 
and instead triggered manually. 

Connects #2016 

## Demo

<img width="1023" alt="Screen Shot 2022-08-09 at 11 50 44 AM" src="https://user-images.githubusercontent.com/21046714/183700812-22219c7e-0489-413d-956d-aa2bbca9f9d4.png">
<img width="1234" alt="Screen Shot 2022-08-09 at 11 51 15 AM" src="https://user-images.githubusercontent.com/21046714/183700804-3eb75d3a-6654-4533-8d6a-87e998fb97fb.png">

## Testing Instructions

* This branch is currently live on OSHub staging. Upload a list, and confirm that it processes as expected. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
