### PR TITLE
Fix facility details sector display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replace + character in ISO date string when in batch job name [#2008](https://github.com/open-apparel-registry/open-apparel-registry/pull/2008)
 - Update sectors in FacilityIndex after upload [#2004](https://github.com/open-apparel-registry/open-apparel-registry/pull/2004)
 - Fix delete facility [#2020](https://github.com/open-apparel-registry/open-apparel-registry/pull/2020)
+- Fix facility details sector display [#2029](https://github.com/open-apparel-registry/open-apparel-registry/pull/2029)
 
 ### Security
 

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -250,9 +250,10 @@ const FacilityDetailSidebar = ({
         const sectors = get(data, 'properties.sector', []).map(item => ({
             primary: item.values.join(', '),
             secondary: formatAttribution(
-                item.created_at,
+                item.updated_at,
                 item.contributor_name,
             ),
+            isFromClaim: item.is_from_claim,
             key: item.contributor_id,
         }));
         return [sectors[0], sectors.slice(1)];

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -1321,8 +1321,8 @@ class FacilityDetailsSerializer(FacilitySerializer):
             for c in claims
         ]
 
-        return sorted(item_sectors + claim_sectors,
-                      key=lambda i: i['updated_at'], reverse=True)
+        return claim_sectors + sorted(
+            item_sectors, key=lambda i: i['updated_at'], reverse=True)
 
 
 class FacilityCreateBodySerializer(Serializer):


### PR DESCRIPTION
## Overview

The sector date in the sidebar was attempting to render the date
based on the sector's created_at date, which is not sent from the
backend, resulting in the current date being displayed instead of the
correct date. We now use the updated_at date, which displays as
expected.

Sectors from claims should be prioritized and marked with the 
verified badge, as we do for other fields. 

Connects #1988 

## Demo

<img width="360" alt="Screen Shot 2022-08-10 at 3 57 28 PM" src="https://user-images.githubusercontent.com/21046714/184008457-91b64c1f-8ef1-40f5-9dd9-271f59747fb2.png">

## Notes

In other sections, we also prioritize the Facility.created_from list item. We should consider doing that for sectors as well, for consistency. 

## Testing Instructions

* Run `./scripts/server`
* View a facility's details. Confirm that the displayed sector shows the appropriate date. 
* Claim that facility, and then add an additional sector as claim details.
* Resubmit the same facility (matching the name, address, country code, and original sector) via API or list. 
* View the facility details. The claim should appear first with a badge, the original list item should appear second, and the new facility list litem should appear third. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
