### PR TITLE
Add list status to /lists pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add AWS Batch resources for delivering notifications [#2026](https://github.com/open-apparel-registry/open-apparel-registry/pull/2026)
 - Ignore duplicate rows [#2032](https://github.com/open-apparel-registry/open-apparel-registry/pull/2032)
 - Add status fields to Facility List [#2015](https://github.com/open-apparel-registry/open-apparel-registry/pull/2025)
+- Add list status to /lists pages [#2044](https://github.com/open-apparel-registry/open-apparel-registry/pull/2044)
 
 ### Changed
 

--- a/src/app/src/actions/dashboardLists.js
+++ b/src/app/src/actions/dashboardLists.js
@@ -61,6 +61,7 @@ export const resetDashboardFacilityLists = createAction(
 export function fetchDashboardFacilityLists({
     contributorID,
     matchResponsibility,
+    status,
     page,
     pageSize,
 }) {
@@ -74,7 +75,7 @@ export function fetchDashboardFacilityLists({
                     pageSize,
                     contributor: contributorID,
                     match_responsibility: matchResponsibility,
-                    status: 'MATCHED',
+                    status,
                 },
             })
             .then(({ data }) =>

--- a/src/app/src/components/DashboardLists.jsx
+++ b/src/app/src/components/DashboardLists.jsx
@@ -166,14 +166,18 @@ function DashboardLists({
         fetchLists,
     ]);
 
+    const newParams = {
+        contributorID,
+        matchResponsibility,
+        status,
+        page: DEFAULT_PAGE,
+        rowsPerPage,
+    };
     const onContributorUpdate = c => {
         replace(
             makeDashboardContributorListLink({
+                ...newParams,
                 contributorID: c.value,
-                matchResponsibility,
-                status,
-                page: DEFAULT_PAGE,
-                rowsPerPage,
             }),
         );
         setContributor(c);
@@ -182,11 +186,8 @@ function DashboardLists({
     const onMatchResponsibilityUpdate = opt => {
         replace(
             makeDashboardContributorListLink({
-                contributorID,
+                ...newParams,
                 matchResponsibility: opt.value,
-                status,
-                page: DEFAULT_PAGE,
-                rowsPerPage,
             }),
         );
     };
@@ -194,11 +195,8 @@ function DashboardLists({
     const onStatusUpdate = s => {
         replace(
             makeDashboardContributorListLink({
-                contributorID,
-                matchResponsibility,
+                ...newParams,
                 status: s.value,
-                page: DEFAULT_PAGE,
-                rowsPerPage,
             }),
         );
     };
@@ -206,11 +204,8 @@ function DashboardLists({
     const onPageChange = (_, newPage) => {
         replace(
             makeDashboardContributorListLink({
-                contributorID,
-                matchResponsibility,
-                status,
+                ...newParams,
                 page: newPage + 1,
-                rowsPerPage,
             }),
         );
     };
@@ -218,10 +213,7 @@ function DashboardLists({
     const onPageSizeChange = e => {
         replace(
             makeDashboardContributorListLink({
-                contributorID,
-                matchResponsibility,
-                status,
-                page: DEFAULT_PAGE,
+                ...newParams,
                 rowsPerPage: e.target.value,
             }),
         );

--- a/src/app/src/components/DashboardLists.jsx
+++ b/src/app/src/components/DashboardLists.jsx
@@ -29,6 +29,7 @@ import {
     facilitiesListTableTooltipTitles,
     matchResponsibilityChoices,
     rowsPerPageOptions,
+    facilityListStatusChoices,
 } from '../util/constants';
 
 import {
@@ -47,6 +48,7 @@ import {
 const CONTRIBUTORS = 'CONTRIBUTORS';
 const RESPONSIBILITY = 'RESPONSIBILITY';
 const ALL_CONTRIBUTORS = { label: 'All', value: '' };
+const STATUS = 'STATUS';
 
 const styles = {
     container: {
@@ -74,6 +76,21 @@ const styles = {
     },
 };
 
+const getSelectTheme = theme => ({
+    ...theme,
+    colors: {
+        ...theme.colors,
+        primary: '#00319D',
+    },
+});
+
+const selectStyles = {
+    control: provided => ({
+        ...provided,
+        height: '56px',
+    }),
+};
+
 function DashboardLists({
     dashboardLists: {
         contributor,
@@ -93,6 +110,7 @@ function DashboardLists({
     const {
         contributor: contributorID,
         matchResponsibility,
+        status,
     } = getDashboardListParamsFromQueryString(search);
 
     const { page, rowsPerPage } = createPaginationOptionsFromQueryString(
@@ -133,6 +151,7 @@ function DashboardLists({
             fetchLists({
                 contributorID: contributor?.value || undefined,
                 matchResponsibility,
+                status,
                 page,
                 pageSize: rowsPerPage,
             });
@@ -141,6 +160,7 @@ function DashboardLists({
         contributor,
         contributors.fetching,
         matchResponsibility,
+        status,
         page,
         rowsPerPage,
         fetchLists,
@@ -151,6 +171,7 @@ function DashboardLists({
             makeDashboardContributorListLink({
                 contributorID: c.value,
                 matchResponsibility,
+                status,
                 page: DEFAULT_PAGE,
                 rowsPerPage,
             }),
@@ -163,6 +184,19 @@ function DashboardLists({
             makeDashboardContributorListLink({
                 contributorID,
                 matchResponsibility: opt.value,
+                status,
+                page: DEFAULT_PAGE,
+                rowsPerPage,
+            }),
+        );
+    };
+
+    const onStatusUpdate = s => {
+        replace(
+            makeDashboardContributorListLink({
+                contributorID,
+                matchResponsibility,
+                status: s.value,
                 page: DEFAULT_PAGE,
                 rowsPerPage,
             }),
@@ -174,6 +208,7 @@ function DashboardLists({
             makeDashboardContributorListLink({
                 contributorID,
                 matchResponsibility,
+                status,
                 page: newPage + 1,
                 rowsPerPage,
             }),
@@ -185,6 +220,7 @@ function DashboardLists({
             makeDashboardContributorListLink({
                 contributorID,
                 matchResponsibility,
+                status,
                 page: DEFAULT_PAGE,
                 rowsPerPage: e.target.value,
             }),
@@ -199,6 +235,8 @@ function DashboardLists({
             facilityLists.data?.length === 0,
     };
 
+    const fetchingData = contributors.fetching || facilityLists.fetching;
+
     return (
         <Paper style={styles.container}>
             <div style={styles.filterRow}>
@@ -212,22 +250,9 @@ function DashboardLists({
                         value={contributorID ? contributor : ALL_CONTRIBUTORS}
                         placeholder=""
                         onChange={onContributorUpdate}
-                        disabled={
-                            contributors.fetching || facilityLists.fetching
-                        }
-                        styles={{
-                            control: provided => ({
-                                ...provided,
-                                height: '56px',
-                            }),
-                        }}
-                        theme={theme => ({
-                            ...theme,
-                            colors: {
-                                ...theme.colors,
-                                primary: '#00319D',
-                            },
-                        })}
+                        disabled={fetchingData}
+                        styles={selectStyles}
+                        theme={getSelectTheme}
                     />
                 </div>
                 <div style={styles.filter}>
@@ -241,22 +266,25 @@ function DashboardLists({
                             m => m.value === matchResponsibility,
                         )}
                         onChange={onMatchResponsibilityUpdate}
-                        disabled={
-                            contributors.fetching || facilityLists.fetching
-                        }
-                        styles={{
-                            control: provided => ({
-                                ...provided,
-                                height: '56px',
-                            }),
-                        }}
-                        theme={theme => ({
-                            ...theme,
-                            colors: {
-                                ...theme.colors,
-                                primary: '#00319D',
-                            },
-                        })}
+                        disabled={fetchingData}
+                        styles={selectStyles}
+                        theme={getSelectTheme}
+                    />
+                </div>
+                <div style={styles.filter}>
+                    <label htmlFor={STATUS}>List Status</label>
+                    <ReactSelect
+                        id={STATUS}
+                        name={STATUS}
+                        classNamePrefix="select"
+                        options={facilityListStatusChoices}
+                        value={facilityListStatusChoices.find(
+                            s => s.value === status,
+                        )}
+                        onChange={onStatusUpdate}
+                        disabled={fetchingData}
+                        styles={selectStyles}
+                        theme={getSelectTheme}
                     />
                 </div>
             </div>

--- a/src/app/src/components/FacilityListControls.jsx
+++ b/src/app/src/components/FacilityListControls.jsx
@@ -1,0 +1,312 @@
+import React, { useState } from 'react';
+import { arrayOf, bool, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Typography from '@material-ui/core/Typography';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
+
+import { facilityListStatusChoicesEnum } from '../util/constants';
+
+import { getValueFromEvent } from '../util/util';
+
+const dialogTypesEnum = Object.freeze({ REJECT: 'REJECT', INFORM: 'INFORM' });
+
+const facilityListControlStyles = Object.freeze({
+    containerStyles: Object.freeze({
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'start',
+    }),
+    controlsContainerStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '1rem 0',
+    }),
+    buttonStyles: Object.freeze({
+        margin: '10px',
+    }),
+    errorSectionStyles: Object.freeze({
+        color: 'red',
+    }),
+    statusChangeSectionStyles: Object.freeze({
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '5px',
+        width: '300px',
+        height: '90px',
+    }),
+    titleStyles: Object.freeze({
+        marginLeft: '10px',
+    }),
+    listIDAndStatusStyles: Object.freeze({
+        padding: '1%',
+    }),
+    statusLabelStyles: Object.freeze({
+        padding: '1rem 0',
+        display: 'flex',
+        alignItems: 'center',
+    }),
+    dialogActionsStyles: Object.freeze({
+        display: 'flex',
+        justifyContent: 'space-evenly',
+        alignItems: 'center',
+        padding: '10px',
+    }),
+    dialogContainerStyles: Object.freeze({
+        padding: '10px',
+    }),
+    dialogTextFieldStyles: Object.freeze({
+        width: '100%',
+        marginTop: '10px',
+    }),
+});
+
+function FacilityListControls({
+    status,
+    statusChangeReason,
+    fetching,
+    error,
+    approveList,
+    rejectList,
+    isAdminUser,
+}) {
+    const [statusChangeText, setStatusChangeText] = useState('');
+    const [displayedDialogType, setDisplayedDialogType] = useState(null);
+
+    const openRejectDialog = () =>
+        setDisplayedDialogType(dialogTypesEnum.REJECT);
+    const openInformationDialog = () =>
+        setDisplayedDialogType(dialogTypesEnum.INFORM);
+
+    const closeDialog = () => {
+        setDisplayedDialogType(null);
+        setStatusChangeText('');
+    };
+
+    const handleUpdateStatusChangeText = e =>
+        setStatusChangeText(getValueFromEvent(e));
+
+    const handleApproveList = () => {
+        approveList(statusChangeText);
+        closeDialog();
+    };
+
+    const handleRejectList = () => {
+        rejectList(statusChangeText);
+        closeDialog();
+    };
+
+    const controlsSection = (() => {
+        if (fetching) {
+            return <CircularProgress />;
+        }
+
+        if (status === facilityListStatusChoicesEnum.PENDING && isAdminUser) {
+            return (
+                <>
+                    <Button
+                        onClick={handleApproveList}
+                        variant="contained"
+                        color="primary"
+                        style={facilityListControlStyles.buttonStyles}
+                    >
+                        Approve List
+                    </Button>
+                    <Button
+                        onClick={openRejectDialog}
+                        variant="contained"
+                        color="secondary"
+                        style={facilityListControlStyles.buttonStyles}
+                    >
+                        Reject List
+                    </Button>
+                </>
+            );
+        }
+
+        return <div />;
+    })();
+
+    const errorSection = error && (
+        <Typography
+            variant="body1"
+            style={facilityListControlStyles.errorSectionStyles}
+        >
+            An error prevented updating the facility list status
+        </Typography>
+    );
+
+    return (
+        <div style={facilityListControlStyles.containerStyles}>
+            <div style={facilityListControlStyles.listIDAndStatusStyles}>
+                <Typography variant="title">List Status</Typography>
+                <Typography
+                    variant="display1"
+                    style={facilityListControlStyles.statusLabelStyles}
+                >
+                    {status}{' '}
+                    {status === facilityListStatusChoicesEnum.REJECTED && (
+                        <Button
+                            onClick={openInformationDialog}
+                            variant="outlined"
+                            color="primary"
+                            style={facilityListControlStyles.buttonStyles}
+                        >
+                            More information
+                        </Button>
+                    )}
+                </Typography>
+            </div>
+            {status === facilityListStatusChoicesEnum.PENDING && isAdminUser && (
+                <div
+                    style={facilityListControlStyles.statusChangeSectionStyles}
+                >
+                    <Typography
+                        variant="title"
+                        style={facilityListControlStyles.titleStyles}
+                    >
+                        Update Status
+                    </Typography>
+                    {errorSection}
+                    <div
+                        style={
+                            facilityListControlStyles.controlsContainerStyles
+                        }
+                    >
+                        {controlsSection}
+                    </div>
+                </div>
+            )}
+            <Dialog
+                open={!!displayedDialogType || false}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+                style={facilityListControlStyles.dialogContainerStyles}
+            >
+                {displayedDialogType === dialogTypesEnum.REJECT && (
+                    <>
+                        <DialogTitle>Reject this facility list?</DialogTitle>
+                        <DialogContent>
+                            <InputLabel htmlFor="dialog-text-field">
+                                <Typography variant="body2">
+                                    Enter a reason. (This will be emailed to the
+                                    person who submitted the facility list.)
+                                </Typography>
+                            </InputLabel>
+                            <TextField
+                                id="dialog-text-field"
+                                variant="outlined"
+                                value={statusChangeText}
+                                onChange={handleUpdateStatusChangeText}
+                                autoFocus
+                                multiline
+                                rows={4}
+                                style={
+                                    facilityListControlStyles.dialogTextFieldStyles
+                                }
+                            />
+                        </DialogContent>
+                        <DialogActions
+                            style={
+                                facilityListControlStyles.dialogActionsStyles
+                            }
+                        >
+                            <Button
+                                variant="outlined"
+                                color="primary"
+                                onClick={closeDialog}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                variant="contained"
+                                color="secondary"
+                                onClick={handleRejectList}
+                            >
+                                Reject
+                            </Button>
+                        </DialogActions>
+                    </>
+                )}
+                {displayedDialogType === dialogTypesEnum.INFORM && (
+                    <>
+                        <DialogTitle>Reason for status</DialogTitle>
+                        <DialogContent>
+                            <DialogContentText>
+                                {statusChangeReason}
+                            </DialogContentText>
+                        </DialogContent>
+                        <DialogActions
+                            style={
+                                facilityListControlStyles.dialogActionsStyles
+                            }
+                        >
+                            <Button
+                                variant="outlined"
+                                color="primary"
+                                onClick={closeDialog}
+                            >
+                                Close
+                            </Button>
+                        </DialogActions>
+                    </>
+                )}
+            </Dialog>
+        </div>
+    );
+}
+
+FacilityListControls.defaultProps = {
+    error: null,
+    isAdminUser: false,
+};
+
+FacilityListControls.propTypes = {
+    status: string.isRequired,
+    statusChangeReason: string.isRequired,
+    fetching: bool.isRequired,
+    error: arrayOf(string),
+    approveList: func.isRequired,
+    rejectList: func.isRequired,
+    isAdminUser: bool,
+};
+
+function mapStateToProps({
+    facilityListDetails: {
+        list: { data, fetching, error },
+    },
+}) {
+    return {
+        fetching,
+        error,
+        status: data?.status,
+        statusChangeReason: data?.status_change_reason,
+    };
+}
+
+function mapDispatchToProps(_, { id }) {
+    return {
+        approveList: () =>
+            console.warn(`This is a stubbed method for approving list ${id}.`),
+        rejectList: reason =>
+            console.warn(
+                `This is a stubbed method for rejecting list ${id} for reason ${reason}.`,
+            ),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(FacilityListControls);

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -11,6 +11,7 @@ import AppGrid from './AppGrid';
 import AppOverflow from './AppOverflow';
 import FacilityListItemsEmpty from './FacilityListItemsEmpty';
 import FacilityListItemsTable from './FacilityListItemsTable';
+import FacilityListControls from './FacilityListControls';
 
 import {
     fetchFacilityList,
@@ -221,6 +222,10 @@ class FacilityListItems extends Component {
                                 </div>
                             </div>
                         </div>
+                        <FacilityListControls
+                            isAdminUser={isAdminUser}
+                            id={list.id}
+                        />
                         <div style={facilityListItemsStyles.subheadStyles}>
                             The processing time may be longer for lists that
                             include additional data points beyond facility name
@@ -248,6 +253,7 @@ FacilityListItems.defaultProps = {
     error: null,
     csvDownloadingError: null,
     adminSearch: null,
+    isAdminUser: false,
 };
 
 FacilityListItems.propTypes = {
@@ -261,7 +267,7 @@ FacilityListItems.propTypes = {
     downloadingCSV: bool.isRequired,
     csvDownloadingError: arrayOf(string),
     userHasSignedIn: bool.isRequired,
-    isAdminUser: bool.isRequired,
+    isAdminUser: bool,
     readOnly: bool.isRequired,
     adminSearch: string,
 };

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -369,6 +369,7 @@ export const facilityListItemStatusChoicesEnum = Object.freeze({
     ERROR_MATCHING: 'ERROR_MATCHING',
     DELETED: 'DELETED',
     REMOVED: 'REMOVED', // This is not a status that appears in the database
+    DUPLICATE: 'DUPLICATE',
 });
 
 export const facilityListItemErrorStatuses = Object.freeze([

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -53,6 +53,19 @@ export const facilityClaimStatusChoicesEnum = Object.freeze({
     REVOKED: 'REVOKED',
 });
 
+export const facilityListStatusChoicesEnum = Object.freeze({
+    PENDING: 'PENDING',
+    APPROVED: 'APPROVED',
+    REJECTED: 'REJECTED',
+    MATCHED: 'MATCHED',
+});
+export const facilityListStatusChoices = [
+    { value: facilityListStatusChoicesEnum.MATCHED, label: 'Matched' },
+    { value: facilityListStatusChoicesEnum.PENDING, label: 'Pending' },
+    { value: facilityListStatusChoicesEnum.APPROVED, label: 'Approved' },
+    { value: facilityListStatusChoicesEnum.REJECTED, label: 'Rejected' },
+];
+
 // These choices must be kept in sync with the identical list
 // kept in the Django API's constants.py file
 export const matchResponsibilityEnum = Object.freeze({

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -51,7 +51,6 @@ import {
     facilityListSummaryStatusMessages,
     minimum100PercentWidthEmbedHeight,
     matchResponsibilityEnum,
-    facilityListStatusChoicesEnum,
 } from './constants';
 
 import { createListItemCSV } from './util.listItemCSV';
@@ -384,13 +383,19 @@ export const getTokenFromQueryString = qs => {
     return isArray(token) ? head(token) : token;
 };
 
+export const dashboardListParamsDefaults = Object.freeze({
+    contributor: null,
+    matchResponsibility: matchResponsibilityEnum.MODERATOR,
+    status: facilityListItemStatusChoicesEnum.MATCHED,
+});
+
 export const getDashboardListParamsFromQueryString = qs => {
     const qsToParse = startsWith(qs, '?') ? qs.slice(1) : qs;
 
     const {
         contributor,
-        matchResponsibility = matchResponsibilityEnum.MODERATOR,
-        status = facilityListStatusChoicesEnum.MATCHED,
+        matchResponsibility = dashboardListParamsDefaults.matchResponsibility,
+        status = dashboardListParamsDefaults.status,
     } = querystring.parse(qsToParse);
 
     return Object.freeze({
@@ -580,17 +585,17 @@ export const makeDashboardContributorListLink = ({
     page,
     rowsPerPage,
 }) => {
+    const getQuery = (
+        value,
+        field,
+        initial = dashboardListParamsDefaults[field],
+    ) => (value && value !== initial ? `${field}=${value}` : '');
     const params = [
-        contributorID ? `contributor=${contributorID}` : '',
-        matchResponsibility &&
-        matchResponsibility !== matchResponsibilityEnum.MODERATOR
-            ? `matchResponsibility=${matchResponsibility}`
-            : '',
-        status ? `status=${status}` : '',
-        page && page !== DEFAULT_PAGE ? `page=${page}` : '',
-        rowsPerPage && rowsPerPage !== DEFAULT_ROWS_PER_PAGE
-            ? `rowsPerPage=${rowsPerPage}`
-            : '',
+        getQuery(contributorID, 'contributor'),
+        getQuery(matchResponsibility, 'matchResponsibility'),
+        getQuery(status, 'status'),
+        getQuery(page, 'page', DEFAULT_PAGE),
+        getQuery(rowsPerPage, 'rowsPerPage', DEFAULT_ROWS_PER_PAGE),
     ].filter(p => !!p);
     return `/dashboard/lists/${
         params.length > 0 ? `?${params.join('&')}` : ''

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -51,6 +51,7 @@ import {
     facilityListSummaryStatusMessages,
     minimum100PercentWidthEmbedHeight,
     matchResponsibilityEnum,
+    facilityListStatusChoicesEnum,
 } from './constants';
 
 import { createListItemCSV } from './util.listItemCSV';
@@ -389,6 +390,7 @@ export const getDashboardListParamsFromQueryString = qs => {
     const {
         contributor,
         matchResponsibility = matchResponsibilityEnum.MODERATOR,
+        status = facilityListStatusChoicesEnum.MATCHED,
     } = querystring.parse(qsToParse);
 
     return Object.freeze({
@@ -397,6 +399,7 @@ export const getDashboardListParamsFromQueryString = qs => {
             null,
         ),
         matchResponsibility,
+        status,
     });
 };
 
@@ -573,6 +576,7 @@ export const makeFacilityClaimDetailsLink = claimID =>
 export const makeDashboardContributorListLink = ({
     contributorID,
     matchResponsibility,
+    status,
     page,
     rowsPerPage,
 }) => {
@@ -582,6 +586,7 @@ export const makeDashboardContributorListLink = ({
         matchResponsibility !== matchResponsibilityEnum.MODERATOR
             ? `matchResponsibility=${matchResponsibility}`
             : '',
+        status ? `status=${status}` : '',
         page && page !== DEFAULT_PAGE ? `page=${page}` : '',
         rowsPerPage && rowsPerPage !== DEFAULT_ROWS_PER_PAGE
             ? `rowsPerPage=${rowsPerPage}`

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -477,6 +477,8 @@ class FacilityList(models.Model):
     PENDING = 'PENDING'
     REJECTED = 'REJECTED'
 
+    MATCHED = 'MATCHED'
+
     STATUS_CHOICES = (
         (PENDING, PENDING),
         (APPROVED, APPROVED),

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -46,7 +46,7 @@ from api.models import (FacilityList,
                         EmbedField,
                         NonstandardField,
                         ExtendedField)
-from api.constants import FacilityListStatus, MatchResponsibility
+from api.constants import MatchResponsibility
 from api.countries import COUNTRY_NAMES, COUNTRY_CHOICES
 from api.processing import get_country_code, parse_array_values
 from api.helpers import (prefix_a_an,
@@ -520,7 +520,8 @@ class FacilityListQueryParamsSerializer(Serializer):
     contributor = IntegerField(required=False)
     match_responsibility = ChoiceField(choices=MatchResponsibility.CHOICES,
                                        required=False)
-    status = ChoiceField(choices=[FacilityListStatus.MATCHED],
+    status = ChoiceField(choices=[FacilityList.MATCHED, FacilityList.APPROVED,
+                                  FacilityList.REJECTED, FacilityList.PENDING],
                          required=False)
 
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -361,7 +361,7 @@ class FacilityListSerializer(ModelSerializer):
         fields = ('id', 'name', 'description', 'file_name', 'is_active',
                   'is_public', 'item_count', 'items_url', 'statuses',
                   'status_counts', 'contributor_id', 'created_at',
-                  'match_responsibility')
+                  'match_responsibility', 'status', 'status_change_reason')
         read_only_fields = ('created_at', 'match_responsibility')
 
     def get_is_active(self, facility_list):

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -465,6 +465,11 @@ class FacilityListSerializer(ModelSerializer):
             0
         )
 
+        duplicate = status_counts_dictionary.get(
+            FacilityListItem.DUPLICATE,
+            0
+        )
+
         deleted = status_counts_dictionary.get(
             FacilityListItem.DELETED,
             0
@@ -482,6 +487,7 @@ class FacilityListSerializer(ModelSerializer):
             FacilityListItem.ERROR_PARSING: error_parsing,
             FacilityListItem.ERROR_GEOCODING: error_geocoding,
             FacilityListItem.ERROR_MATCHING: error_matching,
+            FacilityListItem.DUPLICATE: duplicate,
             FacilityListItem.DELETED: deleted,
         }
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -2752,6 +2752,8 @@ class AdminFacilityListView(ListAPIView):
                             FacilityListItem.ERROR_MATCHING
                         ])
             facility_lists = facility_lists.filter(source__in=sources)
+        elif status is not None:
+            facility_lists = facility_lists.filter(status=status)
 
         return facility_lists
 


### PR DESCRIPTION
## Overview

Updates /dashboard/lists and /lists/{id} pages to incorporate list status, including adding controls to show additional information, approve, and reject lists. Note that the approval and rejection buttons will be hooked up to actions in #2018

Connects #2017 

## Demo

<img width="1135" alt="Screen Shot 2022-08-11 at 4 35 39 PM" src="https://user-images.githubusercontent.com/21046714/184407327-6f02f09f-d100-419f-aee8-a74034f9b1f1.png">
<img width="1137" alt="Screen Shot 2022-08-11 at 4 35 54 PM" src="https://user-images.githubusercontent.com/21046714/184407411-e7b83de4-f246-464b-a8c6-f7419809ecc8.png">
<img width="1136" alt="Screen Shot 2022-08-11 at 4 36 14 PM" src="https://user-images.githubusercontent.com/21046714/184407421-e7deade8-25e9-43f0-8ef5-82127f306300.png">

Non-admin user
<img width="1137" alt="Screen Shot 2022-08-11 at 4 37 54 PM" src="https://user-images.githubusercontent.com/21046714/184407458-e953670f-41a8-4585-801d-c3ca66247364.png">

## Testing Instructions

* Run  `./scripts/server`. Login as c2@example.com and submit a list. Note the list id. Process the list. 

* View the list details page. It should show the status as PENDING, but there should be no action buttons. 

* Login as c1@example.com

* Visit the admin dashboard facility lists page. The list should appear when you filter by PENDING. Click to visit the link details. The status should be listed as PENDING, and action buttons should be available. 

* Click 'approve' and note that text is printed to the console. (Approve is currently a stub function.)

* Click 'reject' and a dialog should open with the ability to enter a change reason. Enter text and click 'reject'. Note that text is printed to the console. (Reject is current a stub function.)

* Run `./scripts/manage shell_plus`

```
f = FacilityList.objects.get(id=16)
f.status = 'APPROVED'
f.save()
```

* Refresh the page. The status should now be APPROVED and the buttons should be hidden. On the main lists page, filtering by APPROVED should find this list. 

```
f.status = 'REJECTED'
f.status_change_reason = 'This list has invalid data.'
f.save()
```

* Refresh the page. The status should now be REJECTED and the buttons should be hidden. There should be a 'More information' button that opens a dialog showing the status_change_reason. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
