### PR TITLE
Add notify managment command notify (#1999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add status fields to Facility List [#2015](https://github.com/open-apparel-registry/open-apparel-registry/pull/2025)
 - Add list status to /lists pages [#2044](https://github.com/open-apparel-registry/open-apparel-registry/pull/2044)
 - Add duplicate status to list filter and item counts [#2061](https://github.com/open-apparel-registry/open-apparel-registry/pull/2061)
+- Add notify management command [#2045](https://github.com/open-apparel-registry/open-apparel-registry/pull/2045)
 
 ### Changed
 - Upgrade terraform to 1.1.9 [#2054](https://github.com/open-apparel-registry/open-apparel-registry/pull/2054)

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -27,6 +27,7 @@ class ProcessingAction:
 
 class FacilitiesQueryParams:
     Q = 'q'
+    ID = 'id'
     NAME = 'name'
     CONTRIBUTORS = 'contributors'
     LISTS = 'lists'

--- a/src/django/api/management/commands/notify.py
+++ b/src/django/api/management/commands/notify.py
@@ -1,16 +1,93 @@
+import logging
+import requests
+from django.http import QueryDict
+from django.conf import settings
+import sys
 from django.core.management.base import BaseCommand
+from api.models import ContributorWebhook, Event, Facility
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'POST notifications for an Event to configured webhook endpoints'
+    help = "POST notifications for an Event to configured webhook endpoints"
 
     def add_arguments(self, parser):
         # Create a group of arguments explicitly labeled as required,
         # because by default named arguments are considered optional.
-        group = parser.add_argument_group('required arguments')
-        group.add_argument('-e', '--event-id',
-                           required=True,
-                           help='The ID of an existingEvent record.')
+        group = parser.add_argument_group("required arguments")
+        group.add_argument(
+            "-e",
+            "--event-id",
+            required=True,
+            help="The ID of an existingEvent record."
+        )
 
     def handle(self, *args, **options):
-        print('TODO: REPLACE THIS STUB IMPLEMENTATION')
+        notification_webhook_timeout = getattr(
+            settings, "NOTIFICATION_WEBHOOK_TIMEOUT", 10
+        )
+        ROLLBAR = getattr(settings, "ROLLBAR", {})
+
+        event_id = options["event_id"]
+        event = Event.objects.get(pk=event_id)
+
+        cwh = ContributorWebhook.objects.order_by("created_at")
+
+        for contributor_webhook in cwh:
+            try:
+                query_params = QueryDict(
+                    contributor_webhook.filter_query_string.replace("?", ""),
+                    mutable=True,
+                )
+                query_params.update({"id": event.object_id})
+
+                if (
+                    contributor_webhook.notification_type
+                    == ContributorWebhook.ASSOCIATED
+                ):
+                    query_params.update(
+                        {"contributors": contributor_webhook.contributor_id}
+                    )
+
+                facilities_qs = Facility \
+                    .objects \
+                    .filter_by_query_params(query_params)
+
+                if facilities_qs.count() > 0:
+                    body = {
+                        "event_type": event.event_type,
+                        "event_time": event.event_time.isoformat(),
+                        "event_details": event.event_details,
+                    }
+                    response = requests.post(
+                        contributor_webhook.url,
+                        json=body,
+                        timeout=notification_webhook_timeout,
+                    )
+                    status = (
+                        ContributorWebhook.DELIVERED
+                        if (response.status_code >= 200
+                            and response.status_code < 300)
+                        else ContributorWebhook.FAILED
+                    )
+                else:
+                    status = ContributorWebhook.SKIPPED
+            except:  # noqa: E722
+                status = ContributorWebhook.FAILED
+
+                if ROLLBAR:
+                    import rollbar
+
+                    rollbar.report_exc_info(
+                        sys.exc_info(),
+                        extra_data={
+                            "contributor_webhook_id": contributor_webhook.id,
+                        },
+                    )
+                else:
+                    logger.exception(
+                        "Exception delivering event {} to webhook {}".format(
+                            event_id, contributor_webhook.id))
+
+            contributor_webhook.log_event(event, status)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1313,6 +1313,8 @@ class FacilityManager(models.Manager):
         A queryset on the Facility model
         """
 
+        id = params.get(FacilitiesQueryParams.ID, None)
+
         free_text_query = params.get(FacilitiesQueryParams.Q, None)
 
         name = params.get(FacilitiesQueryParams.NAME, None)
@@ -1358,6 +1360,9 @@ class FacilityManager(models.Manager):
         sectors = params.getlist(FacilitiesQueryParams.SECTOR)
 
         facilities_qs = FacilityIndex.objects.all()
+
+        if id is not None:
+            facilities_qs = facilities_qs.filter(id=id)
 
         if free_text_query is not None:
             custom_text = (
@@ -2270,6 +2275,11 @@ class ContributorWebhook(models.Model):
         (ALL_FACILITIES, ALL_FACILITIES),
         (ASSOCIATED, ASSOCIATED),
     ]
+
+    # Statuses for logging notification delivery
+    SKIPPED = "SKIPPED"
+    DELIVERED = "DELIVERED"
+    FAILED = "FAILED"
 
     contributor = models.ForeignKey(
         'Contributor',

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib import auth
@@ -10055,3 +10056,209 @@ class WebhookTests(APITestCase):
             webhook.log_event(event, "DELIVERED")
             self.assertEqual(1, len(cm.output))
             self.assertIn("ContributorWebhook DELIVERED", cm.output[0])
+
+
+class NotificationTests(FacilityAPITestCaseBase):
+    def notify(self, *args, **kwargs):
+        call_command(
+            "notify",
+            *args,
+            **kwargs,
+        )
+
+    def create_another_facility(self):
+        user_email = "test2@example.com"
+        user_password = "example123"
+        user = User.objects.create(email=user_email)
+        user.set_password(user_password)
+        user.save()
+
+        contributor = Contributor.objects.create(
+            admin=user,
+            name="test contributor 2",
+            contrib_type=Contributor.OTHER_CONTRIB_TYPE,
+        )
+        contributor.save()
+
+        list = FacilityList.objects.create(
+            header="header", file_name="two", name="Second List"
+        )
+        list.save()
+
+        source = Source.objects.create(
+            facility_list=list,
+            source_type=Source.LIST,
+            is_active=True,
+            is_public=True,
+            contributor=contributor,
+        )
+        source.save()
+
+        list_item = FacilityListItem.objects.create(
+            name="Cat",
+            address="Dog",
+            country_code="US",
+            sector=["Apparel"],
+            row_index=1,
+            geocoded_point=Point(10, 10),
+            status=FacilityListItem.CONFIRMED_MATCH,
+            source=source,
+        )
+
+        facility = Facility.objects.create(
+            name="Cat",
+            address="Dog",
+            country_code="US",
+            location=Point(10, 10),
+            created_from=list_item,
+        )
+        facility.save()
+
+        match = FacilityMatch.objects.create(
+            status=FacilityMatch.AUTOMATIC,
+            facility=facility,
+            facility_list_item=list_item,
+            confidence=0.85,
+            results="",
+        )
+        match.save()
+
+        list_item.facility = facility
+        list_item.save()
+
+        return facility
+
+    def test_notifications_with_no_event_match(self):
+        self.assertRaises(Event.DoesNotExist, self.notify, event_id="2")
+
+    @patch("requests.post")
+    def test_notifications_with_all_facility_matches(
+        self, mock_post
+    ):
+        mock_post.return_value = Mock(ok=True, status_code=200)
+
+        facility = self.create_another_facility()
+
+        contributor_webhook = ContributorWebhook(
+            contributor=self.contributor,
+            notification_type=ContributorWebhook.ALL_FACILITIES,
+        )
+        contributor_webhook.save()
+
+        e = Event(
+            content_object=facility,
+            event_type=FacilityHistoryActions.UPDATE,
+            event_time=timezone.now(),
+            event_details={},
+        )
+        e.save()
+
+        with self.assertLogs() as cm:
+            self.notify(event_id=e.id)
+            self.assertEqual(1, len(cm.output))
+            self.assertIn("ContributorWebhook DELIVERED", cm.output[0])
+
+    @patch("requests.post")
+    def test_notifications_with_associated_facility_matches(
+        self, mock_post
+    ):
+        mock_post.return_value = Mock(ok=True, status_code=200)
+
+        contributor_webhook = ContributorWebhook(
+            contributor=self.contributor,
+            notification_type=ContributorWebhook.ASSOCIATED,
+        )
+        contributor_webhook.save()
+
+        e = Event(
+            content_object=self.facility,
+            event_type=FacilityHistoryActions.UPDATE,
+            event_time=timezone.now(),
+            event_details={},
+        )
+        e.save()
+
+        with self.assertLogs() as cm:
+            self.notify(event_id=e.id)
+            self.assertEqual(1, len(cm.output))
+            self.assertIn("ContributorWebhook DELIVERED", cm.output[0])
+
+    @patch("requests.post")
+    def test_notifications_with_no_associated_facility_matches(
+        self, mock_post
+    ):
+        mock_post.return_value = Mock(ok=True, status_code=200)
+
+        facility = self.create_another_facility()
+
+        contributor_webhook = ContributorWebhook(
+            contributor=self.contributor,
+            notification_type=ContributorWebhook.ASSOCIATED,
+        )
+        contributor_webhook.save()
+
+        e = Event(
+            content_object=facility,
+            event_type=FacilityHistoryActions.UPDATE,
+            event_time=timezone.now(),
+            event_details={},
+        )
+        e.save()
+
+        with self.assertLogs() as cm:
+            self.notify(event_id=e.id)
+            self.assertEqual(1, len(cm.output))
+            self.assertIn("ContributorWebhook SKIPPED", cm.output[0])
+
+    @patch("requests.post")
+    def test_bad_response_leads_to_failed_status(self, mock_post):
+        mock_post.return_value = Mock(ok=True, status_code=500)
+
+        contributor_webhook = ContributorWebhook(
+            contributor=self.contributor,
+            notification_type=ContributorWebhook.ALL_FACILITIES,
+        )
+        contributor_webhook.save()
+
+        e = Event(
+            content_object=self.facility,
+            event_type=FacilityHistoryActions.UPDATE,
+            event_time=timezone.now(),
+            event_details={},
+        )
+        e.save()
+
+        with self.assertLogs() as cm:
+            self.notify(event_id=e.id)
+            self.assertEqual(1, len(cm.output))
+            self.assertIn("ContributorWebhook FAILED", cm.output[0])
+
+    @patch("requests.post")
+    def test_one_failure_doesnt_stop_execution(self, mock_post):
+        mock_post.side_effect = [
+            Mock(ok=True, status_code=500),
+            Mock(ok=True, status_code=200),
+        ]
+
+        ContributorWebhook.objects.create(
+            contributor=self.contributor,
+            notification_type=ContributorWebhook.ALL_FACILITIES,
+        )
+        ContributorWebhook.objects.create(
+            contributor=self.contributor,
+            notification_type=ContributorWebhook.ALL_FACILITIES,
+        )
+
+        e = Event(
+            content_object=self.facility,
+            event_type=FacilityHistoryActions.UPDATE,
+            event_time=timezone.now(),
+            event_details={},
+        )
+        e.save()
+
+        with self.assertLogs() as cm:
+            self.notify(event_id=e.id)
+            self.assertEqual(2, len(cm.output))
+            self.assertIn("ContributorWebhook FAILED", cm.output[0])
+            self.assertIn("ContributorWebhook DELIVERED", cm.output[1])

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -305,6 +305,10 @@ DEFAULT_FROM_EMAIL = os.getenv(
 NOTIFICATION_EMAIL_TO = os.getenv(
     'NOTIFICATION_EMAIL_TO', 'notification@example.com')
 
+# Notifications
+
+NOTIFICATION_WEBHOOK_TIMEOUT = 10
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 


### PR DESCRIPTION
## Overview

Connects #1999 

## Testing Instructions

* Log in at c2@example.com, browse http://localhost:6543/settings and create a webhook for all events and no query string using a beeceptor callback URL
* Use `./scripts/manage` shell plus to create an `Event`. Note the ID of the new event
* Run `./scripts/manage notify -e 1` and verify that the event is delivered
* Set the querystring on the webhook to `q=willnotmatch`, reprocess the notification and verify that it is skipped
* Make the webhook URL invalid, reprocess the notification and verify that the delivery has a failed status

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
