### PR TITLE
Update moderation UI to trigger batch processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update "adjust facility matches" dashboard [#2005](https://github.com/open-apparel-registry/open-apparel-registry/pull/2005)
 - Split batch steps [#2028](https://github.com/open-apparel-registry/open-apparel-registry/pull/2028)
 - Update list match confirm / rejection to be done by admins [#2030](https://github.com/open-apparel-registry/open-apparel-registry/pull/2030)
+- Update moderation UI to trigger batch processing [#2048](https://github.com/open-apparel-registry/open-apparel-registry/pull/2048)
 
 ### Deprecated
 

--- a/src/app/src/actions/facilityListDetails.js
+++ b/src/app/src/actions/facilityListDetails.js
@@ -12,6 +12,8 @@ import {
     createRemoveFacilityListItemURL,
     makeFacilityListDataURLs,
     downloadListItemCSV,
+    makeApproveFacilityListURL,
+    makeRejectFacilityListURL,
 } from '../util/util';
 
 export const setSelectedFacilityListItemsRowIndex = createAction(
@@ -62,6 +64,24 @@ export const failAssembleAndDownloadFacilityListCSV = createAction(
 );
 export const completeAssembleAndDownloadFacilityListCSV = createAction(
     'COMPLETE_ASSEMBLE_AND_DOWNLOAD_FACILITY_LIST_CSV',
+);
+
+export const startApproveFacilityList = createAction(
+    'START_APPROVE_FACILITY_LIST',
+);
+export const failApproveFacilityList = createAction(
+    'FAIL_APPROVE_FACILITY_LIST',
+);
+export const completeApproveFacilityList = createAction(
+    'COMPLETE_APPROVE_FACILITY_LIST',
+);
+
+export const startRejectFacilityList = createAction(
+    'START_REJECT_FACILITY_LIST',
+);
+export const failRejectFacilityList = createAction('FAIL_REJECT_FACILITY_LIST');
+export const completeRejectFacilityList = createAction(
+    'COMPLETE_REJECT_FACILITY_LIST',
 );
 
 export function fetchFacilityList(listID = null) {
@@ -271,6 +291,64 @@ export function removeFacilityListItem(listID, listItemID) {
                         err,
                         'An error prevented removing that facility list item',
                         failRemoveFacilityListItem,
+                    ),
+                ),
+            );
+    };
+}
+
+export function approveFacilityList(facilityListID) {
+    return dispatch => {
+        dispatch(startApproveFacilityList());
+
+        if (!facilityListID) {
+            return dispatch(
+                logErrorAndDispatchFailure(
+                    null,
+                    'facilityListID is a required parameter',
+                    failApproveFacilityList,
+                ),
+            );
+        }
+
+        return apiRequest
+            .post(makeApproveFacilityListURL(facilityListID))
+            .then(({ data }) => dispatch(completeApproveFacilityList(data)))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented approving that list',
+                        failApproveFacilityList,
+                    ),
+                ),
+            );
+    };
+}
+
+export function rejectFacilityList(facilityListID, reason) {
+    return dispatch => {
+        dispatch(startRejectFacilityList());
+
+        if (!facilityListID) {
+            return dispatch(
+                logErrorAndDispatchFailure(
+                    null,
+                    'facilityListID is a required parameter',
+                    failRejectFacilityList,
+                ),
+            );
+        }
+
+        return apiRequest
+            .post(makeRejectFacilityListURL(facilityListID), { reason })
+            .then(({ data }) => dispatch(completeRejectFacilityList(data)))
+            .catch(err =>
+                dispatch(
+                    logErrorAndDispatchFailure(
+                        err,
+                        'An error prevented rejecting that list',
+                        failRejectFacilityList,
                     ),
                 ),
             );

--- a/src/app/src/components/FacilityListControls.jsx
+++ b/src/app/src/components/FacilityListControls.jsx
@@ -15,6 +15,10 @@ import TextField from '@material-ui/core/TextField';
 import { facilityListStatusChoicesEnum } from '../util/constants';
 
 import { getValueFromEvent } from '../util/util';
+import {
+    approveFacilityList,
+    rejectFacilityList,
+} from '../actions/facilityListDetails';
 
 const dialogTypesEnum = Object.freeze({ REJECT: 'REJECT', INFORM: 'INFORM' });
 
@@ -295,14 +299,10 @@ function mapStateToProps({
     };
 }
 
-function mapDispatchToProps(_, { id }) {
+function mapDispatchToProps(dispatch, { id }) {
     return {
-        approveList: () =>
-            console.warn(`This is a stubbed method for approving list ${id}.`),
-        rejectList: reason =>
-            console.warn(
-                `This is a stubbed method for rejecting list ${id} for reason ${reason}.`,
-            ),
+        approveList: () => dispatch(approveFacilityList(id)),
+        rejectList: reason => dispatch(rejectFacilityList(id, reason)),
     };
 }
 

--- a/src/app/src/components/FacilityListItems.jsx
+++ b/src/app/src/components/FacilityListItems.jsx
@@ -222,10 +222,12 @@ class FacilityListItems extends Component {
                                 </div>
                             </div>
                         </div>
-                        <FacilityListControls
-                            isAdminUser={isAdminUser}
-                            id={list.id}
-                        />
+                        {list.status_counts.UPLOADED === 0 ? (
+                            <FacilityListControls
+                                isAdminUser={isAdminUser}
+                                id={list.id}
+                            />
+                        ) : null}
                         <div style={facilityListItemsStyles.subheadStyles}>
                             The processing time may be longer for lists that
                             include additional data points beyond facility name

--- a/src/app/src/components/FacilityListItemsTable.jsx
+++ b/src/app/src/components/FacilityListItemsTable.jsx
@@ -50,7 +50,9 @@ import {
     rowsPerPageOptions,
     facilityListItemStatusChoicesEnum,
     facilityListItemErrorStatuses,
+    facilityListStatusChoicesEnum,
     facilityListStatusFilterChoices,
+    facilityListSummaryStatusMessages,
     matchResponsibilityEnum,
 } from '../util/constants';
 
@@ -346,7 +348,9 @@ class FacilityListItemsTable extends Component {
                     md={6}
                     style={facilityListItemsTableStyles.summaryStatusStyles}
                 >
-                    {makeFacilityListSummaryStatus(list.statuses)}
+                    {list.status !== facilityListStatusChoicesEnum.REJECTED
+                        ? makeFacilityListSummaryStatus(list.statuses)
+                        : facilityListSummaryStatusMessages.REJECTED}
                 </Grid>
                 <Grid item sm={12} md={6}>
                     <TablePagination

--- a/src/app/src/reducers/FacilityListDetailsReducer.js
+++ b/src/app/src/reducers/FacilityListDetailsReducer.js
@@ -22,6 +22,12 @@ import {
     startRemoveFacilityListItem,
     failRemoveFacilityListItem,
     completeRemoveFacilityListItem,
+    startApproveFacilityList,
+    failApproveFacilityList,
+    completeApproveFacilityList,
+    startRejectFacilityList,
+    failRejectFacilityList,
+    completeRejectFacilityList,
 } from '../actions/facilityListDetails';
 
 import { completeSubmitLogOut } from '../actions/auth';
@@ -65,6 +71,37 @@ const failConfirmOrRejectMatchOrRemoveItem = (state, payload) =>
         confirmOrRejectMatchOrRemoveItem: {
             fetching: { $set: false },
             error: { $set: payload },
+        },
+    });
+
+const startApproveOrRejectList = state =>
+    update(state, {
+        list: {
+            $merge: {
+                fetching: true,
+                error: null,
+            },
+        },
+    });
+
+const failFetchOrUpdateList = (state, payload) =>
+    update(state, {
+        list: {
+            $merge: {
+                data: null,
+                fetching: false,
+                error: payload,
+            },
+        },
+    });
+const completeFetchOrUpdateList = (state, payload) =>
+    update(state, {
+        list: {
+            $merge: {
+                data: payload,
+                fetching: false,
+                error: null,
+            },
         },
     });
 
@@ -132,26 +169,8 @@ export default createReducer(
                     },
                 },
             }),
-        [failFetchFacilityList]: (state, payload) =>
-            update(state, {
-                list: {
-                    $merge: {
-                        data: null,
-                        fetching: false,
-                        error: payload,
-                    },
-                },
-            }),
-        [completeFetchFacilityList]: (state, payload) =>
-            update(state, {
-                list: {
-                    $merge: {
-                        data: payload,
-                        fetching: false,
-                        error: null,
-                    },
-                },
-            }),
+        [failFetchFacilityList]: failFetchOrUpdateList,
+        [completeFetchFacilityList]: completeFetchOrUpdateList,
         [startFetchFacilityListItems]: state =>
             update(state, {
                 items: {
@@ -206,6 +225,12 @@ export default createReducer(
                     error: { $set: null },
                 },
             }),
+        [startApproveFacilityList]: startApproveOrRejectList,
+        [failApproveFacilityList]: failFetchOrUpdateList,
+        [completeApproveFacilityList]: completeFetchOrUpdateList,
+        [startRejectFacilityList]: startApproveOrRejectList,
+        [failRejectFacilityList]: failFetchOrUpdateList,
+        [completeRejectFacilityList]: completeFetchOrUpdateList,
         [resetFacilityListItems]: () => initialState,
         [startConfirmFacilityListItemPotentialMatch]: startConfirmOrRejectMatchOrRemoveItem,
         [startRejectFacilityListItemPotentialMatch]: startConfirmOrRejectMatchOrRemoveItem,

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -443,6 +443,7 @@ export const facilityListSummaryStatusMessages = Object.freeze({
     AWAITING: 'Some potential matches require your feedback.',
     PROCESSING: 'The list is still being processed.',
     COMPLETED: 'This list has been processed successfully.',
+    REJECTED: 'This list was rejected and with not be processed.',
 });
 
 export const DEFAULT_PAGE = 1;

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -105,6 +105,15 @@ export const makeSingleFacilityListURL = id => `/api/facility-lists/${id}/`;
 export const makeSingleFacilityListItemsURL = id =>
     `/api/facility-lists/${id}/items/`;
 
+export const createRemoveFacilityListItemURL = listID =>
+    `/api/facility-lists/${listID}/remove/`;
+
+export const makeApproveFacilityListURL = listID =>
+    `/api/facility-lists/${listID}/approve/`;
+
+export const makeRejectFacilityListURL = listID =>
+    `/api/facility-lists/${listID}/reject/`;
+
 export const makeDashboardFacilityListsURL = () => '/api/admin-facility-lists/';
 
 export const makeDashboardApiBlocksURL = () => '/api/api-blocks/';
@@ -642,9 +651,6 @@ export const createConfirmFacilityListItemMatchURL = matchID =>
 
 export const createRejectFacilityListItemMatchURL = matchID =>
     `/api/facility-matches/${matchID}/reject/`;
-
-export const createRemoveFacilityListItemURL = listID =>
-    `/api/facility-lists/${listID}/remove/`;
 
 export const makeMyFacilitiesRoute = contributorID =>
     `/facilities/?contributors=${contributorID}`;

--- a/src/django/api/templates/mail/facility_list_rejection_body.html
+++ b/src/django/api/templates/mail/facility_list_rejection_body.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>
+            Your contribution to the Open Supply Hub was rejected
+        </title>
+    </head>
+    <body>
+        <p>
+            Hi,
+        </p>
+        <p>
+            You're receiving this email because we rejected your request to upload data to the
+            Open Supply Hub:
+        </p>
+        <ul>
+            <li>
+                Facility list: {{ facility_list_name }} created on {{ facility_list_created_at }}
+            </li>
+            <li>
+                Facility list description: {{ facility_list_description }}
+            </li>
+            <li>
+                Facility list URL: <a href="{{ facility_list_url }}">{{ facility_list_url }}</a>
+            </li>
+        </ul>
+        {% if rejection_reason|length %}
+        <p>
+            Here's the reason for the rejection:
+        </p>
+        <p>
+            {{ rejection_reason }}
+        </p>
+        {% endif %}
+        <p>
+            Best wishes,
+        </p>
+        {% include "mail/signature_block.html" %}
+    </body>
+</html>

--- a/src/django/api/templates/mail/facility_list_rejection_body.txt
+++ b/src/django/api/templates/mail/facility_list_rejection_body.txt
@@ -1,0 +1,19 @@
+{% block content %}
+Hi,
+
+You're receiving this email because we rejected your request to upload data to the Open Supply Hub:
+
+- Facility list: {{ facility_list_name }} created on {{ facility_list_created_at }}
+- Facility list description: {{ facility_list_description }}
+- Facility list URL: {{ facility_list_url }}
+
+{% if rejection_reason|length %}
+Here's the reason for the rejection:
+
+{{ rejection_reason }}
+{% endif %}
+
+Best wishes,
+
+{% include "mail/signature_block.txt" %}
+{% endblock content %}

--- a/src/django/api/templates/mail/facility_list_rejection_subject.txt
+++ b/src/django/api/templates/mail/facility_list_rejection_subject.txt
@@ -1,0 +1,1 @@
+Your contribution to Open Supply Hub facility was rejected


### PR DESCRIPTION
## Overview

Implements the backend for the stubs added in #2044 to approve/reject lists

Connects #2018 

## Demo

![approve](https://user-images.githubusercontent.com/4432106/184717997-38f6085e-8b59-4b4c-95cd-f9fb685dde0d.gif)

![reject](https://user-images.githubusercontent.com/4432106/184718645-96ceb42a-1c56-47fe-86ee-81a6a46fbf5b.gif)


## Testing Instructions

* `scripts/server`
* Add a new new, and note it's ID
  * Log in as a superuser and go to the detail page for this list - you should _not_ see approve / reject buttons
* Use ` ./scripts/manage batch_process --list-id 16 --action parse` to run the first part of batch processing
  * You should now see approve / reject buttons for the list above
* You should be able to update the status dropdown to approved / rejected on the admin list dashboard to see your list(s) after approving / rejecting it
* Rejecting a list should print an email in the console

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
