### PR TITLE
Set pagination_class on ApiBlockViewSet to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update sectors in FacilityIndex after upload [#2004](https://github.com/open-apparel-registry/open-apparel-registry/pull/2004)
 - Fix delete facility [#2020](https://github.com/open-apparel-registry/open-apparel-registry/pull/2020)
 - Fix facility details sector display [#2029](https://github.com/open-apparel-registry/open-apparel-registry/pull/2029)
+- Set pagination_class on ApiBlockViewSet to None [#2057](https://github.com/open-apparel-registry/open-apparel-registry/pull/2057)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3916,6 +3916,7 @@ class ApiBlockViewSet(mixins.ListModelMixin,
     serializer_class = ApiBlockSerializer
     permission_classes = [IsSuperuser]
     swagger_schema = None
+    pagination_class = None
 
 
 class ContributorWebhookViewSet(mixins.CreateModelMixin,


### PR DESCRIPTION
## Overview

The frontend code does not support pagination and expects to receive a simple data array.

Connects #2056

## Testing Instructions

* Check out `ogr/develop`
* Log in as c1@example.com
* Browse http://localhost:6543/dashboard/apiblocks and verify that a React error is raised
* Check out this branch
* Browse http://localhost:6543/dashboard/apiblocks and verify that the page loads without error

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
