### PR TITLE
Fix a terraform deploy bug caused by git security settings

### DIFF
--- a/scripts/infra
+++ b/scripts/infra
@@ -32,6 +32,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     if [[ -n "${OAR_SETTINGS_BUCKET}" ]]; then
         pushd "${TERRAFORM_DIR}"
+        git config --global --add safe.directory /usr/local/src
 
         aws s3 cp "s3://${OAR_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${OAR_SETTINGS_BUCKET}.tfvars"
 


### PR DESCRIPTION
## Overview

Due to a recent security change implemented by git, we are receiving the following error while the
`infra/plan` is running:
`fatal: unsafe repository ('/usr/local/src' is owned by someone else)`

We're adding a git command to the `infra` script, to set the working
directory as a safe directory, which should resolve this error

Connects #1998
This resolves a bug caused after merging #2054 

## Testing Instructions
* if the `infra` step in jenkins passes on merge, this PR has been successful

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
