### PR TITLE
Create a log group for AWS Batch jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Split batch steps [#2028](https://github.com/open-apparel-registry/open-apparel-registry/pull/2028)
 - Update list match confirm / rejection to be done by admins [#2030](https://github.com/open-apparel-registry/open-apparel-registry/pull/2030)
 - Update moderation UI to trigger batch processing [#2048](https://github.com/open-apparel-registry/open-apparel-registry/pull/2048)
+- Create a log group for AWS Batch jobs [#2060](https://github.com/open-apparel-registry/open-apparel-registry/pull/2060)
 
 ### Deprecated
 

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -68,6 +68,7 @@ data "template_file" "default_job_definition" {
     aws_region                       = var.aws_region
     batch_job_queue_name             = "queue${local.short}Default"
     batch_job_def_name               = "job${local.short}Default"
+    log_group_name                   = "log${local.short}Batch"
   }
 }
 
@@ -153,6 +154,7 @@ data "template_file" "notifications_job_definition" {
     aws_region                       = var.aws_region
     batch_job_queue_name             = "queue${local.short}Notifications"
     batch_job_def_name               = "job${local.short}Notifications"
+    log_group_name                   = "log${local.short}Batch"
   }
 }
 
@@ -167,3 +169,10 @@ resource "aws_batch_job_definition" "notifications" {
   }
 }
 
+#
+# CloudWatch Resources
+#
+resource "aws_cloudwatch_log_group" "batch" {
+  name              = "log${local.short}Batch"
+  retention_in_days = 0
+}

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -21,5 +21,13 @@
       { "name": "BATCH_MODE", "value": "True" },
       { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" },
       { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" }
-  ]
+  ],
+  "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+          "awslogs-group": "${log_group_name}",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "default"
+      }
+  }
 }

--- a/deployment/terraform/job-definitions/notifications.json
+++ b/deployment/terraform/job-definitions/notifications.json
@@ -21,5 +21,13 @@
       { "name": "BATCH_MODE", "value": "True" },
       { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" },
       { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" }
-  ]
+  ],
+  "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+          "awslogs-group": "${log_group_name}",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "notifications"
+      }
+  }
 }


### PR DESCRIPTION
## Overview

Before this change the log output for all batch jobs across all environments was being written to an AWS-created generic batch log group. Using a dedicated group will simplify searching and allow us to set separate retention for these logs. We want to keep these log records forever.

Connects #1998

## Demo

Abbreviated plan output

```
  # aws_batch_job_definition.default must be replaced
-/+ resource "aws_batch_job_definition" "default" {
      ~ arn                   = "arn:aws:batch:eu-west-1:249322298638:job-definition/jobOpenSupplyHubStagingDefault:65" -> (known after apply)
      ~ container_properties  = jsonencode(
          ~ {
              ~ environment          = [
        ...snip...
                ]
              ~ image                = "249322298638.dkr.ecr.eu-west-1.amazonaws.com/opensupplyhub-batch:e5a42e3" -> "249322298638.dkr.ecr.eu-west-1.amazonaws.com/opensupplyhub-batch:e5a42e"
              + logConfiguration     = {
                  + logDriver = "awslogs"
                  + options   = {
                      + awslogs-group         = "logOpenSupplyHubStagingBatch"
                      + awslogs-region        = "eu-west-1"
                      + awslogs-stream-prefix = "default"
                    }
                }
              - mountPoints          = [] -> null
              - resourceRequirements = [] -> null
              - secrets              = [] -> null
              - ulimits              = [] -> null
              - volumes              = [] -> null
                # (3 unchanged elements hidden)
            } # forces replacement
        )
      ~ id                    = "arn:aws:batch:eu-west-1:249322298638:job-definition/jobOpenSupplyHubStagingDefault:65" -> (known after apply)
        name                  = "jobOpenSupplyHubStagingDefault"
      - parameters            = {} -> null
      - platform_capabilities = [] -> null
      ~ revision              = 65 -> (known after apply)
      - tags                  = {} -> null
      ~ tags_all              = {} -> (known after apply)
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # aws_batch_job_definition.notifications must be replaced
-/+ resource "aws_batch_job_definition" "notifications" {
      ~ arn                   = "arn:aws:batch:eu-west-1:249322298638:job-definition/jobOpenSupplyHubStagingNotifications:12" -> (known after apply)
      ~ container_properties  = jsonencode(
          ~ {
              ~ environment          = [
                ...snip...
                ]
              ~ image                = "249322298638.dkr.ecr.eu-west-1.amazonaws.com/opensupplyhub-batch:e5a42e3" -> "249322298638.dkr.ecr.eu-west-1.amazonaws.com/opensupplyhub-batch:e5a42e"
              + logConfiguration     = {
                  + logDriver = "awslogs"
                  + options   = {
                      + awslogs-group         = "logOpenSupplyHubStagingBatch"
                      + awslogs-region        = "eu-west-1"
                      + awslogs-stream-prefix = "notifications"
                    }
                }
              - mountPoints          = [] -> null
              - resourceRequirements = [] -> null
              - secrets              = [] -> null
              - ulimits              = [] -> null
              - volumes              = [] -> null
                # (3 unchanged elements hidden)
            } # forces replacement
        )
      ~ id                    = "arn:aws:batch:eu-west-1:249322298638:job-definition/jobOpenSupplyHubStagingNotifications:12" -> (known after apply)
        name                  = "jobOpenSupplyHubStagingNotifications"
      - parameters            = {} -> null
      - platform_capabilities = [] -> null
      ~ revision              = 12 -> (known after apply)
      - tags                  = {} -> null
      ~ tags_all              = {} -> (known after apply)
        # (2 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }


  # aws_cloudwatch_log_group.batch will be created
  + resource "aws_cloudwatch_log_group" "batch" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "logOpenSupplyHubStagingBatch"
      + retention_in_days = 0
      + tags_all          = (known after apply)
    }
```

## Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Verify that the plan output looks correct

```
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-5.1# export GIT_COMMIT=e5a42e (or whatever the head of `ogr/develop` is)
bash-5.1# ./scripts/infra plan
```


## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
