### PR TITLE
Add duplicate status to list filter and item counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ignore duplicate rows [#2032](https://github.com/open-apparel-registry/open-apparel-registry/pull/2032)
 - Add status fields to Facility List [#2015](https://github.com/open-apparel-registry/open-apparel-registry/pull/2025)
 - Add list status to /lists pages [#2044](https://github.com/open-apparel-registry/open-apparel-registry/pull/2044)
+- Add duplicate status to list filter and item counts [#2061](https://github.com/open-apparel-registry/open-apparel-registry/pull/2061)
 
 ### Changed
 - Upgrade terraform to 1.1.9 [#2054](https://github.com/open-apparel-registry/open-apparel-registry/pull/2054)

--- a/src/app/src/components/FacilityListsTable.jsx
+++ b/src/app/src/components/FacilityListsTable.jsx
@@ -46,6 +46,7 @@ function FacilityListsTable({ facilityLists, history: { push } }) {
                             <TableCell padding="dense">Parsed</TableCell>
                             <TableCell padding="dense">Geocoded</TableCell>
                             <TableCell padding="dense">Matched</TableCell>
+                            <TableCell padding="dense">Duplicate</TableCell>
                             <TableCell padding="dense">Error</TableCell>
                             <TableCell padding="dense">
                                 Potential Match
@@ -144,6 +145,14 @@ function FacilityListsTable({ facilityLists, history: { push } }) {
                                     tableCellText={sum([
                                         list.status_counts.MATCHED,
                                         list.status_counts.CONFIRMED_MATCH,
+                                    ])}
+                                />
+                                <FacilityListsTooltipTableCell
+                                    tooltipTitle={
+                                        facilitiesListTableTooltipTitles.duplicate
+                                    }
+                                    tableCellText={sum([
+                                        list.status_counts.DUPLICATE,
                                     ])}
                                 />
                                 <FacilityListsTooltipTableCell

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -413,6 +413,10 @@ export const facilityListStatusFilterChoices = Object.freeze([
         value: facilityListItemStatusChoicesEnum.NEW_FACILITY,
     },
     {
+        label: facilityListItemStatusChoicesEnum.DUPLICATE,
+        value: facilityListItemStatusChoicesEnum.DUPLICATE,
+    },
+    {
         label: facilityListItemStatusChoicesEnum.ERROR,
         value: facilityListItemStatusChoicesEnum.ERROR,
     },
@@ -482,6 +486,8 @@ export const facilitiesListTableTooltipTitles = Object.freeze({
     geocoded: 'Number of items that have been geocoded but not yet matched.',
     matched:
         'Number of items that have been matched with an existing facility or created a new facility.',
+    duplicate:
+        'Number of items that match to a facility also matched by a previous item in the same list.',
     error: 'Number of items that have encountered errors during processing',
     potentialMatch:
         'Number of items with potential matches to confirm or reject.',

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -487,7 +487,7 @@ export const facilitiesListTableTooltipTitles = Object.freeze({
     matched:
         'Number of items that have been matched with an existing facility or created a new facility.',
     duplicate:
-        'Number of items that match to a facility also matched by a previous item in the same list.',
+        'Number of items identified as a duplicate of another item in the same list.',
     error: 'Number of items that have encountered errors during processing',
     potentialMatch:
         'Number of items with potential matches to confirm or reject.',


### PR DESCRIPTION
## Overview

Adds support for filtering list items by "DUPLICATE" status, and displays counts for that status on the lists list table

Connects #2041 

## Demo

![Screenshot 2022-08-17 151245](https://user-images.githubusercontent.com/4432106/185226449-c9f25584-0c34-4756-80a4-fda9fe50f57e.png)
![Screenshot 2022-08-17 151308](https://user-images.githubusercontent.com/4432106/185226453-14132a15-a300-4200-8db6-346e16ce91de.png)

## Testing Instructions

* `scripts/resetdb`
* Log in as c3@example.com and go to [http://localhost:6543/lists](http://localhost:6543/lists), you should see a new duplicate column and the one list should have 2 items in the duplicate status
* Go to the list, and verify you can filter by the `DUPLICATE` status

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
