### PR TITLE
Fix list URL construction when running as a Batch job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix facility details sector display [#2029](https://github.com/open-apparel-registry/open-apparel-registry/pull/2029)
 - Set pagination_class on ApiBlockViewSet to None [#2057](https://github.com/open-apparel-registry/open-apparel-registry/pull/2057)
 - Dont duplicate check items with parsing errors [#2073](https://github.com/open-apparel-registry/open-apparel-registry/pull/2073)
+- Fix list URL construction when running as a Batch job [#2066](https://github.com/open-apparel-registry/open-apparel-registry/pull/2066)
 
 ### Security
 

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -12,7 +12,10 @@ def make_oar_url(request):
         host = 'localhost:6543'
     else:
         protocol = 'https'
-        host = request.get_host()
+        if request:
+            host = request.get_host()
+        else:
+            host = settings.EXTERNAL_DOMAIN
 
     return '{}://{}'.format(protocol, host)
 
@@ -358,7 +361,7 @@ def notify_facility_list_complete(list_id):
     notification_to = facility_list.source.contributor.admin.email
 
     notification_dictionary = {
-        'list_url': make_facility_list_url(list_id),
+        'list_url': make_facility_list_url(None, list_id),
         'list_name': facility_list.name
     }
 


### PR DESCRIPTION
## Overview

The `notify_complete` job needs to build list URLs but does not have access to a `request` object when run via AWS Batch.

Connects #2018
Connects #2064

## Testing Instructions

* Log in as c3@example.com and submit [azavea.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9366486/azavea.csv). Note the ID of the list in the address bar
* Run the notification action. Verify that it prints an email to the console
  * `./scripts/manage batch_process --list-id {id} --action notify_complete` 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
