### PR TITLE
replace thefuzz with rapidfuzz

### DIFF
--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -445,14 +445,15 @@ def get_facility_and_processing_type(facility_or_processing_type):
 
         # Try for fuzzy match
         if not matched_value or matched_value is None:
+            # Match must score 85 or higher to be considered usable.
             matched_value = process.extractOne(
                 cleaned_input,
-                ALL_PROCESSING_TYPES.keys()
+                ALL_PROCESSING_TYPES.keys(),
+                score_cutoff=85
             )
             match_type = FUZZY_MATCH
 
-            # Match must score 85 or higher to be considered usable.
-            if not matched_value or matched_value[1] < 85:
+            if not matched_value:
                 return (None, None, None, None)
 
             matched_value = matched_value[0]

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -1,5 +1,5 @@
 from api.helpers import clean
-from thefuzz import process
+from rapidfuzz import process
 
 HEADQUARTERS = 'headquarters'
 NO_PROCESSING = 'no processing'

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -23,7 +23,7 @@ pyflakes==2.0.0
 pytz==2018.7
 requests==2.21.0
 rollbar==0.14.6
-thefuzz==0.19.0
+rapidfuzz==2.5.0
 Unidecode==1.0.23
 django-cors-headers==3.10.0
 debugpy==1.5.1


### PR DESCRIPTION
This replaces `thefuzz` with `rapidfuzz` to resolve #2010. This is probably the simplest way to resolve the issue, since rapidfuzz provides a compatible API.
This is faster, does not print the warning and is MIT licensed which should be a better fit for this project.