### PR TITLE
Dont duplicate check items with parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix delete facility [#2020](https://github.com/open-apparel-registry/open-apparel-registry/pull/2020)
 - Fix facility details sector display [#2029](https://github.com/open-apparel-registry/open-apparel-registry/pull/2029)
 - Set pagination_class on ApiBlockViewSet to None [#2057](https://github.com/open-apparel-registry/open-apparel-registry/pull/2057)
+- Dont duplicate check items with parsing errors [#2073](https://github.com/open-apparel-registry/open-apparel-registry/pull/2073)
 
 ### Security
 

--- a/src/django/api/management/commands/batch_process.py
+++ b/src/django/api/management/commands/batch_process.py
@@ -130,13 +130,14 @@ class Command(BaseCommand):
                                 item.save()
                     elif action == ProcessingAction.PARSE:
                         process(item)
-                        core_fields = '{}-{}-{}'.format(item.country_code,
-                                                        item.clean_name,
-                                                        item.clean_address)
-                        if core_fields in parsed_items:
-                            item.status = FacilityListItem.DUPLICATE
-                        else:
-                            parsed_items.add(core_fields)
+                        if item.status != FacilityListItem.ERROR_PARSING:
+                            core_fields = '{}-{}-{}'.format(item.country_code,
+                                                            item.clean_name,
+                                                            item.clean_address)
+                            if core_fields in parsed_items:
+                                item.status = FacilityListItem.DUPLICATE
+                            else:
+                                parsed_items.add(core_fields)
                         item.save()
                     else:
                         process(item)


### PR DESCRIPTION
## Overview

Skip duplicate check for `FacilityListItem` which fail parsing

## Demo
Before:
![localhost_6543_lists_62](https://user-images.githubusercontent.com/4432106/185703920-da892dff-55db-43e9-b835-42da3d19a268.png)


After:
![localhost_6543_lists_61](https://user-images.githubusercontent.com/4432106/185703653-4a1d9587-8b8a-4c25-b82e-c98d95d4758d.png)


## Testing Instructions

* On `ogr/develop` upload this list: [test.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9385313/test.csv), it should have many `DUPLICATE` errors for items w/o a country name or address
* On this branch upload the same CSV - the empty rows should be in an `ERROR_PARSING` status instead

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
