### PR TITLE
Add the new homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add list status to /lists pages [#2044](https://github.com/open-apparel-registry/open-apparel-registry/pull/2044)
 - Add duplicate status to list filter and item counts [#2061](https://github.com/open-apparel-registry/open-apparel-registry/pull/2061)
 - Add notify management command [#2045](https://github.com/open-apparel-registry/open-apparel-registry/pull/2045)
+- Add the new homepage [#2085](https://github.com/open-apparel-registry/open-apparel-registry/pull/2085)
 
 ### Changed
 - Upgrade terraform to 1.1.9 [#2054](https://github.com/open-apparel-registry/open-apparel-registry/pull/2054)

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -601,8 +601,8 @@ hr {
 
   .map-container {
     width: 100%;
-    height: 40vh;
-    order: -1;
+    height: 50vh;
+    order: 1;
   }
 
   .panel-header {

--- a/src/app/src/Routes.jsx
+++ b/src/app/src/Routes.jsx
@@ -16,6 +16,7 @@ import ResetPasswordForm from './components/ResetPasswordForm';
 import LoginForm from './components/LoginForm';
 import UserProfile from './components/UserProfile';
 import Contribute from './components/Contribute';
+import Homepage from './components/Homepage';
 import MapAndSidebar from './components/MapAndSidebar';
 import FacilityLists from './components/FacilityLists';
 import FacilityListItems from './components/FacilityListItems';
@@ -225,9 +226,7 @@ class Routes extends Component {
                                             return <CircularProgress />;
                                         }
 
-                                        return (
-                                            <Route component={MapAndSidebar} />
-                                        );
+                                        return <Route component={Homepage} />;
                                     }}
                                 />
                                 <Route render={() => <RouteNotFound />} />

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -80,7 +80,7 @@ export function setFiltersFromQueryString(qs = '') {
             : filters;
 
         payload = parentCompanies
-            ? update(filters, {
+            ? update(payload, {
                   parentCompany: {
                       $set: updateListWithLabels(
                           filters.parentCompany,

--- a/src/app/src/actions/filters.js
+++ b/src/app/src/actions/filters.js
@@ -44,6 +44,7 @@ export const updateBoundaryFilter = createAction('UPDATE_BOUNDARY_FILTER');
 export const updatePPEFilter = createAction('UPDATE_PPE_FILTER');
 export const resetAllFilters = createAction('RESET_ALL_FILTERS');
 export const updateAllFilters = createAction('UPDATE_ALL_FILTERS');
+export const resetDrawerFilters = createAction('RESET_DRAWER_FILTERS');
 
 export function setFiltersFromQueryString(qs = '') {
     return (dispatch, getState) => {

--- a/src/app/src/components/CreatableInputOnly.jsx
+++ b/src/app/src/components/CreatableInputOnly.jsx
@@ -54,7 +54,7 @@ export default class CreatableInputOnly extends Component {
 
     render() {
         const { inputValue } = this.state;
-        const { value } = this.props;
+        const { value, ...rest } = this.props;
         return (
             <CreatableSelect
                 components={components}
@@ -68,6 +68,7 @@ export default class CreatableInputOnly extends Component {
                 onBlur={this.handleBlur}
                 placeholder={this.props.placeholder}
                 value={value}
+                {...rest}
             />
         );
     }

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -74,6 +74,7 @@ function FacilitiesMap({
         params: { oarID },
     },
     isEmbedded,
+    isMobile,
 }) {
     const mapRef = useRef(null);
 
@@ -237,7 +238,7 @@ function FacilitiesMap({
             center={initialCenter}
             zoom={initialZoom}
             minZoom={minimumZoom}
-            scrollWheelZoom={!isEmbedded}
+            scrollWheelZoom={!isEmbedded && !isMobile}
             renderer={L.canvas()}
             style={mapComponentStyles.mapContainerStyles}
             zoomControl={false}
@@ -371,6 +372,7 @@ function mapStateToProps({
     },
     ui: {
         facilitiesSidebarTabSearch: { resetButtonClickCount },
+        window: { innerWidth: windowInnerWidth },
     },
     clientInfo: { fetched, countryCode },
     embeddedMap: { embed: isEmbedded },
@@ -383,6 +385,7 @@ function mapStateToProps({
         clientInfoFetched: fetched,
         countryCode: countryCode || COUNTRY_CODES.default,
         isEmbedded,
+        isMobile: windowInnerWidth < 600,
     };
 }
 

--- a/src/app/src/components/FilterSidebarExtendedSearch.jsx
+++ b/src/app/src/components/FilterSidebarExtendedSearch.jsx
@@ -1,15 +1,11 @@
 import React, { useEffect } from 'react';
 import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
-import InputLabel from '@material-ui/core/InputLabel';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import ReactSelect from 'react-select';
-import Divider from '@material-ui/core/Divider';
-import { withStyles } from '@material-ui/core/styles';
 import uniq from 'lodash/uniq';
 
 import ShowOnly from './ShowOnly';
-import CreatableInputOnly from './CreatableInputOnly';
+import StyledSelect from './Filters/StyledSelect';
 
 import {
     updateContributorTypeFilter,
@@ -39,33 +35,10 @@ import {
     parentCompanyOptionsPropType,
 } from '../util/propTypes';
 
-import { filterSidebarStyles } from '../util/styles';
-
 import {
     getValueFromEvent,
     mapDjangoChoiceTuplesValueToSelectOptions,
 } from '../util/util';
-
-import { EXTENDED_FIELDS_EXPLANATORY_TEXT } from '../util/constants';
-
-const filterSidebarExtendedSearchStyles = theme =>
-    Object.freeze({
-        inputLabelStyle: Object.freeze({
-            fontFamily: theme.typography.fontFamily,
-            fontSize: '16px',
-            fontWeight: 500,
-            color: '#000',
-            transform: 'translate(0, -8px) scale(1)',
-            paddingBottom: '0.5rem',
-        }),
-        selectStyle: Object.freeze({
-            fontFamily: theme.typography.fontFamily,
-        }),
-        font: Object.freeze({
-            fontFamily: `${theme.typography.fontFamily} !important`,
-        }),
-        ...filterSidebarStyles,
-    });
 
 const CONTRIBUTOR_TYPES = 'CONTRIBUTOR_TYPES';
 const PARENT_COMPANY = 'PARENT_COMPANY';
@@ -134,7 +107,6 @@ function FilterSidebarExtendedSearch({
     fetchingExtendedOptions,
     embed,
     embedExtendedFields,
-    classes,
     fetchContributorTypes,
     fetchParentCompanies,
     fetchFacilityProcessingType,
@@ -178,19 +150,10 @@ function FilterSidebarExtendedSearch({
         <>
             <ShowOnly when={!embed}>
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={CONTRIBUTOR_TYPES}
-                        className={classes.inputLabelStyle}
-                    >
-                        Contributor Type
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={CONTRIBUTOR_TYPES}
-                        name="contributorTypes"
-                        className={`basic-multi-select notranslate ${classes.selectStyle}`}
-                        classNamePrefix="select"
+                    <StyledSelect
+                        label="Contributor Type"
+                        id="contributorType"
+                        name={CONTRIBUTOR_TYPES}
                         options={contributorTypeOptions || []}
                         value={contributorTypes}
                         onChange={updateContributorType}
@@ -198,17 +161,6 @@ function FilterSidebarExtendedSearch({
                     />
                 </div>
             </ShowOnly>
-            <div className="form__field">
-                <Divider />
-                <ShowOnly when={!embed}>
-                    <div
-                        className="form__info"
-                        style={{ color: 'rgba(0, 0, 0, 0.8)' }}
-                    >
-                        {EXTENDED_FIELDS_EXPLANATORY_TEXT}
-                    </div>
-                </ShowOnly>
-            </div>
             <ShowOnly
                 when={
                     !embed ||
@@ -219,19 +171,10 @@ function FilterSidebarExtendedSearch({
                 }
             >
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={PARENT_COMPANY}
-                        className={classes.inputLabelStyle}
-                    >
-                        Parent Company
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={PARENT_COMPANY}
+                    <StyledSelect
+                        creatable
+                        label="Parent Company"
                         name={PARENT_COMPANY}
-                        className={`basic-multi-select ${classes.selectStyle}`}
-                        classNamePrefix="select"
                         options={parentCompanyOptions || []}
                         value={parentCompany}
                         onChange={updateParentCompany}
@@ -250,19 +193,9 @@ function FilterSidebarExtendedSearch({
                 }
             >
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={FACILITY_TYPE}
-                        className={classes.inputLabelStyle}
-                    >
-                        Facility Type
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={FACILITY_TYPE}
+                    <StyledSelect
+                        label="Facility Type"
                         name={FACILITY_TYPE}
-                        className={`basic-multi-select ${classes.selectStyle}`}
-                        classNamePrefix="select"
                         options={mapFacilityTypeOptions(
                             facilityProcessingTypeOptions || [],
                             processingType,
@@ -283,19 +216,9 @@ function FilterSidebarExtendedSearch({
                 }
             >
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={PROCESSING_TYPE}
-                        className={classes.inputLabelStyle}
-                    >
-                        Processing Type
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={PROCESSING_TYPE}
+                    <StyledSelect
+                        label="Processing Type"
                         name={PROCESSING_TYPE}
-                        className={`basic-multi-select ${classes.selectStyle}`}
-                        classNamePrefix="select"
                         options={mapProcessingTypeOptions(
                             facilityProcessingTypeOptions || [],
                             facilityType,
@@ -316,19 +239,10 @@ function FilterSidebarExtendedSearch({
                 }
             >
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={PRODUCT_TYPE}
-                        className={classes.inputLabelStyle}
-                    >
-                        Product Type
-                    </InputLabel>
-                    <CreatableInputOnly
-                        isMulti
-                        id={PRODUCT_TYPE}
+                    <StyledSelect
+                        creatable
+                        label="Product Type"
                         name={PRODUCT_TYPE}
-                        className={`basic-multi-select ${classes.selectStyle}`}
-                        classNamePrefix="select"
                         value={productType}
                         onChange={updateProductType}
                         disabled={fetchingFacilities}
@@ -346,19 +260,9 @@ function FilterSidebarExtendedSearch({
                 }
             >
                 <div className="form__field">
-                    <InputLabel
-                        shrink={false}
-                        htmlFor={NUMBER_OF_WORKERS}
-                        className={classes.inputLabelStyle}
-                    >
-                        Number of Workers
-                    </InputLabel>
-                    <ReactSelect
-                        isMulti
-                        id={NUMBER_OF_WORKERS}
+                    <StyledSelect
+                        label="Number of Workers"
                         name={NUMBER_OF_WORKERS}
-                        className={`basic-multi-select ${classes.selectStyle}`}
-                        classNamePrefix="select"
                         options={numberOfWorkersOptions || []}
                         value={numberOfWorkers}
                         onChange={updateNumberOfWorkers}
@@ -471,4 +375,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withStyles(filterSidebarExtendedSearchStyles)(FilterSidebarExtendedSearch));
+)(FilterSidebarExtendedSearch);

--- a/src/app/src/components/Filters/ContributorFilter.jsx
+++ b/src/app/src/components/Filters/ContributorFilter.jsx
@@ -1,0 +1,238 @@
+import React, { useState } from 'react';
+import { func, string, bool } from 'prop-types';
+import { connect } from 'react-redux';
+import IconButton from '@material-ui/core/IconButton';
+import Popover from '@material-ui/core/Popover';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import InfoIcon from '@material-ui/icons/Info';
+
+import ShowOnly from '../ShowOnly';
+import StyledSelect from './StyledSelect';
+
+import {
+    contributorOptionsPropType,
+    contributorListOptionsPropType,
+} from '../../util/propTypes';
+
+import {
+    updateContributorFilter,
+    updateListFilter,
+    updateCombineContributorsFilterOption,
+} from '../../actions/filters';
+
+const styles = {
+    popover: {
+        fontSize: '15px',
+        padding: '10px',
+        lineHeight: '22px',
+        maxWidth: '320px',
+        margin: '0 14px',
+    },
+    popoverLineItem: {
+        marginBottom: '6px',
+    },
+    popoverHeading: {
+        fontWeight: 'bold',
+    },
+    icon: {
+        color: 'rgba(0, 0, 0, 0.38)',
+    },
+};
+
+const CONTRIBUTORS = 'CONTRIBUTORS';
+const LISTS = 'LISTS';
+
+function ContributorFilter({
+    embed,
+    contributorOptions,
+    contributors,
+    updateContributor,
+    fetchingOptions,
+    fetchingFacilities,
+    fetchingLists,
+    updateCombineContributors,
+    combineContributors,
+    listOptions,
+    lists,
+    updateList,
+}) {
+    const [
+        contributorPopoverAnchorEl,
+        setContributorPopoverAnchorEl,
+    ] = useState(null);
+
+    const contributorInfoPopoverContent = (
+        <div style={styles.popover}>
+            <p style={styles.popoverHeading}>
+                Do you want to see only facilities which these contributors
+                share? If so, tick this box.
+            </p>
+            <p>
+                There are now two ways to filter a Contributor search on the OS
+                Hub:
+            </p>
+            <ol>
+                <li style={styles.popoverLineItem}>
+                    You can search for all the facilities of multiple
+                    contributors. This means that the results would show all of
+                    the facilities contributed to the OS Hub by, for example,
+                    BRAC University or Clarks. Some facilities might have been
+                    contributed by BRAC University but not by Clarks, or
+                    vice-versa.
+                </li>
+                <li style={styles.popoverLineItem}>
+                    By checking the “Show only shared facilities” box, this
+                    adjusts the search logic to “AND”. This means that your
+                    results will show only facilities contributed by BOTH BRAC
+                    University AND Clarks (as well as potentially other
+                    contributors). In this way, you can more quickly filter to
+                    show the specific Contributor overlap you are interested in.
+                </li>
+            </ol>
+        </div>
+    );
+
+    return (
+        <div className="form__field">
+            <ShowOnly when={!embed}>
+                <StyledSelect
+                    label="Contributor"
+                    name={CONTRIBUTORS}
+                    options={contributorOptions || []}
+                    value={contributors}
+                    onChange={updateContributor}
+                    disabled={fetchingOptions || fetchingFacilities}
+                />
+                <ShowOnly when={contributors && contributors.length > 1}>
+                    <div style={{ marginLeft: '16px' }}>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={!!combineContributors}
+                                    onChange={updateCombineContributors}
+                                    color="primary"
+                                    value={combineContributors}
+                                />
+                            }
+                            label="Show only shared facilities"
+                        />
+                        <IconButton
+                            onClick={
+                                // eslint-disable-next-line no-confusing-arrow
+                                e =>
+                                    contributorPopoverAnchorEl
+                                        ? null
+                                        : setContributorPopoverAnchorEl(
+                                              e.currentTarget,
+                                          )
+                            }
+                        >
+                            <InfoIcon />
+                        </IconButton>
+                        <Popover
+                            id="contributor-info-popover"
+                            anchorOrigin={{
+                                vertical: 'center',
+                                horizontal: 'right',
+                            }}
+                            transformOrigin={{
+                                vertical: 'center',
+                                horizontal: 'left',
+                            }}
+                            open={!!contributorPopoverAnchorEl}
+                            anchorEl={contributorPopoverAnchorEl}
+                            onClick={() => setContributorPopoverAnchorEl(null)}
+                        >
+                            {contributorInfoPopoverContent}
+                        </Popover>
+                    </div>
+                </ShowOnly>
+            </ShowOnly>
+            <ShowOnly
+                when={contributors && !!contributors.length && !fetchingLists}
+            >
+                <div
+                    style={{
+                        marginLeft: embed ? 0 : '16px',
+                        marginTop: '12px',
+                    }}
+                >
+                    <StyledSelect
+                        label="Contributor List"
+                        name={LISTS}
+                        options={listOptions || []}
+                        value={lists}
+                        onChange={updateList}
+                        disabled={fetchingLists || fetchingFacilities}
+                    />
+                </div>
+            </ShowOnly>
+        </div>
+    );
+}
+
+ContributorFilter.defaultProps = {
+    contributorOptions: null,
+    listOptions: null,
+};
+
+ContributorFilter.propTypes = {
+    contributorOptions: contributorOptionsPropType,
+    listOptions: contributorListOptionsPropType,
+    updateContributor: func.isRequired,
+    updateCombineContributors: func.isRequired,
+    contributors: contributorOptionsPropType.isRequired,
+    combineContributors: string.isRequired,
+    fetchingFacilities: bool.isRequired,
+    fetchingOptions: bool.isRequired,
+    fetchingLists: bool.isRequired,
+};
+
+function mapStateToProps({
+    filterOptions: {
+        contributors: {
+            data: contributorOptions,
+            fetching: fetchingContributors,
+        },
+        lists: { data: listOptions, fetching: fetchingLists },
+        countries: { fetching: fetchingCountries },
+    },
+    filters: { contributors, lists, combineContributors },
+    facilities: {
+        facilities: { fetching: fetchingFacilities },
+    },
+    embeddedMap: { embed },
+}) {
+    return {
+        contributorOptions,
+        listOptions,
+        contributors,
+        combineContributors,
+        fetchingFacilities,
+        fetchingOptions: fetchingContributors || fetchingCountries,
+        fetchingLists,
+        lists,
+        embed,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        updateContributor: v => {
+            if (!v || v.length < 2) {
+                dispatch(updateCombineContributorsFilterOption(''));
+            }
+            dispatch(updateContributorFilter(v));
+        },
+        updateList: v => dispatch(updateListFilter(v)),
+        updateCombineContributors: e =>
+            dispatch(
+                updateCombineContributorsFilterOption(
+                    e.target.checked ? 'AND' : '',
+                ),
+            ),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ContributorFilter);

--- a/src/app/src/components/Filters/CountryNameFilter.jsx
+++ b/src/app/src/components/Filters/CountryNameFilter.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
+
+import StyledSelect from './StyledSelect';
+
+import { updateCountryFilter } from '../../actions/filters';
+
+import { countryOptionsPropType } from '../../util/propTypes';
+
+const COUNTRIES = 'COUNTRIES';
+
+function CountryNameFilter({
+    countryOptions,
+    countries,
+    updateCountry,
+    fetching,
+}) {
+    return (
+        <div className="form__field">
+            <StyledSelect
+                label="Country Name"
+                name={COUNTRIES}
+                options={countryOptions || []}
+                value={countries}
+                onChange={updateCountry}
+                disabled={fetching}
+            />
+        </div>
+    );
+}
+
+CountryNameFilter.defaultProps = {
+    countryOptions: null,
+};
+
+CountryNameFilter.propTypes = {
+    countryOptions: countryOptionsPropType,
+    updateCountry: func.isRequired,
+    countries: countryOptionsPropType.isRequired,
+    fetching: bool.isRequired,
+};
+
+function mapStateToProps({
+    filterOptions: {
+        countries: { data: countryOptions, fetching: fetchingCountries },
+    },
+    filters: { countries },
+    facilities: {
+        facilities: { fetching: fetchingFacilities },
+    },
+}) {
+    return {
+        countryOptions,
+        countries,
+        fetching: fetchingCountries || fetchingFacilities,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        updateCountry: v => dispatch(updateCountryFilter(v)),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CountryNameFilter);

--- a/src/app/src/components/Filters/SectorFilter.jsx
+++ b/src/app/src/components/Filters/SectorFilter.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
+
+import StyledSelect from './StyledSelect';
+
+import { updateSectorFilter } from '../../actions/filters';
+import { fetchSectorOptions } from '../../actions/filterOptions';
+
+import { sectorOptionsPropType } from '../../util/propTypes';
+
+const SECTORS = 'SECTORS';
+
+function SectorFilter({
+    sectorOptions,
+    sectors,
+    updateSector,
+    fetchSectors,
+    fetchingSectors,
+    fetchingOptions,
+}) {
+    return (
+        <div className="form__field">
+            <StyledSelect
+                name={SECTORS}
+                label="Sector"
+                options={sectorOptions || []}
+                value={sectors}
+                onChange={updateSector}
+                onFocus={() =>
+                    !sectorOptions && !fetchingSectors && fetchSectors()
+                }
+                noOptionsMessage={() =>
+                    fetchingSectors ? 'Loading..' : 'No options'
+                }
+                disabled={fetchingOptions || fetchingSectors}
+            />
+        </div>
+    );
+}
+
+SectorFilter.defaultProps = {
+    sectorOptions: null,
+};
+
+SectorFilter.propTypes = {
+    sectorOptions: sectorOptionsPropType,
+    updateSector: func.isRequired,
+    fetchSectors: func.isRequired,
+    sectors: sectorOptionsPropType.isRequired,
+    fetchingSectors: bool.isRequired,
+    fetchingOptions: bool.isRequired,
+};
+
+function mapStateToProps({
+    filterOptions: {
+        sectors: { data: sectorOptions, fetching: fetchingSectors },
+        contributors: { fetching: fetchingContributors },
+        countries: { fetching: fetchingCountries },
+    },
+    filters: { sectors },
+}) {
+    return {
+        sectorOptions,
+        sectors,
+        fetchingSectors,
+        fetchingOptions: fetchingCountries || fetchingContributors,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        updateSector: v => dispatch(updateSectorFilter(v)),
+        fetchSectors: () => dispatch(fetchSectorOptions()),
+    };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SectorFilter);

--- a/src/app/src/components/Filters/StyledSelect.jsx
+++ b/src/app/src/components/Filters/StyledSelect.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { string, bool } from 'prop-types';
+import InputLabel from '@material-ui/core/InputLabel';
+import ReactSelect from 'react-select';
+import { withStyles } from '@material-ui/core/styles';
+
+import { makeFilterStyles } from '../../util/styles';
+import { OARColor } from '../../util/constants';
+
+import CreatableInputOnly from '../CreatableInputOnly';
+
+const makeSelectFilterStyles = color => {
+    const themeColor = color || OARColor;
+    return {
+        multiValue: provided => ({
+            ...provided,
+            background: '#C0EBC7',
+            borderRadius: '100px',
+            fontFamily: 'Darker Grotesque',
+            fontWeight: 700,
+            fontSize: '14px',
+            lineHeight: '16px',
+            paddingLeft: '5px',
+            paddingRight: '5px',
+        }),
+        control: (provided, state) => {
+            const isInUse = state.isFocused || state.menuIsOpen;
+            return {
+                ...provided,
+                borderRadius: 0,
+                '*': {
+                    boxShadow: 'none !important',
+                },
+                boxShadow: 'none',
+                borderColor: isInUse ? themeColor : provided.borderColor,
+                '&:hover': {
+                    borderColor: isInUse ? themeColor : provided.borderColor,
+                },
+            };
+        },
+    };
+};
+
+function StyledSelect({ name, label, color, creatable, classes, ...rest }) {
+    const selectFilterStyles = makeSelectFilterStyles(color);
+    return (
+        <>
+            <InputLabel
+                shrink={false}
+                htmlFor={name}
+                className={classes.inputLabelStyle}
+            >
+                {label}
+            </InputLabel>
+            {creatable ? (
+                <CreatableInputOnly
+                    isMulti
+                    id={name}
+                    name={name}
+                    className={`basic-multi-select ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    styles={selectFilterStyles}
+                    placeholder="Select"
+                    {...rest}
+                />
+            ) : (
+                <ReactSelect
+                    isMulti
+                    id={name}
+                    name={name}
+                    className={`basic-multi-select notranslate ${classes.selectStyle}`}
+                    classNamePrefix="select"
+                    styles={selectFilterStyles}
+                    placeholder="Select"
+                    {...rest}
+                />
+            )}
+        </>
+    );
+}
+
+StyledSelect.defaultProps = {
+    creatable: false,
+};
+
+StyledSelect.propTypes = {
+    name: string.isRequired,
+    label: string.isRequired,
+    creatable: bool,
+};
+
+function mapStateToProps({ embeddedMap: { config } }) {
+    return {
+        color: config?.color,
+    };
+}
+
+export default connect(mapStateToProps)(
+    withStyles(makeFilterStyles)(StyledSelect),
+);

--- a/src/app/src/components/Filters/TextSearchFilter.jsx
+++ b/src/app/src/components/Filters/TextSearchFilter.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import SearchIcon from '@material-ui/icons/Search';
+import { withStyles } from '@material-ui/core/styles';
+
+import { updateFacilityFreeTextQueryFilter } from '../../actions/filters';
+
+import {
+    getValueFromEvent,
+    makeSubmitFormOnEnterKeyPressFunction,
+} from '../../util/util';
+
+import { DEFAULT_SEARCH_TEXT } from '../../util/constants';
+
+const filterStyles = Object.freeze({
+    searchInput: Object.freeze({
+        backgroundColor: '#fff',
+        paddingLeft: 0,
+        borderRadius: 0,
+    }),
+    notchedOutline: {
+        borderRadius: 0,
+    },
+});
+
+const FACILITIES = 'FACILITIES';
+
+function TextSearchFilter({
+    facilityFreeTextQuery,
+    updateFacilityFreeTextQuery,
+    searchForFacilities,
+    submitFormOnEnterKeyPress,
+    classes,
+    searchLabel,
+}) {
+    return (
+        <div className="form__field" style={{ marginBottom: '10px' }}>
+            <InputLabel htmlFor={FACILITIES} className="form__label">
+                {searchLabel}
+            </InputLabel>
+            <TextField
+                id={FACILITIES}
+                placeholder="What are you looking for?"
+                className="form__text-input"
+                value={facilityFreeTextQuery}
+                onChange={updateFacilityFreeTextQuery}
+                onKeyPress={submitFormOnEnterKeyPress}
+                variant="outlined"
+                margin="dense"
+                InputProps={{
+                    startAdornment: (
+                        <InputAdornment position="end">
+                            <IconButton
+                                aria-label={searchLabel}
+                                onClick={searchForFacilities}
+                            >
+                                <SearchIcon />
+                            </IconButton>
+                        </InputAdornment>
+                    ),
+                    classes: {
+                        root: classes.searchInput,
+                        notchedOutline: classes.notchedOutline,
+                    },
+                }}
+            />
+        </div>
+    );
+}
+
+TextSearchFilter.propTypes = {
+    updateFacilityFreeTextQuery: func.isRequired,
+    facilityFreeTextQuery: string.isRequired,
+    searchForFacilities: func.isRequired,
+    submitFormOnEnterKeyPress: func.isRequired,
+};
+
+function mapStateToProps({
+    filters: { facilityFreeTextQuery },
+    embeddedMap: { embed, config },
+}) {
+    return {
+        facilityFreeTextQuery,
+        searchLabel: embed ? config.text_search_label : DEFAULT_SEARCH_TEXT,
+        embedExtendedFields: config.extended_fields,
+    };
+}
+
+function mapDispatchToProps(dispatch, { searchForFacilities }) {
+    return {
+        updateFacilityFreeTextQuery: e =>
+            dispatch(updateFacilityFreeTextQueryFilter(getValueFromEvent(e))),
+
+        submitFormOnEnterKeyPress: makeSubmitFormOnEnterKeyPressFunction(() =>
+            searchForFacilities(),
+        ),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(filterStyles)(TextSearchFilter));

--- a/src/app/src/components/Homepage.jsx
+++ b/src/app/src/components/Homepage.jsx
@@ -1,0 +1,64 @@
+import React, { Component, Fragment } from 'react';
+import { Route } from 'react-router-dom';
+import Grid from '@material-ui/core/Grid';
+
+import SidebarWithErrorBoundary from './SidebarWithErrorBoundary';
+import FacilitiesMap from './FacilitiesMap';
+import FacilitiesMapErrorMessage from './FacilitiesMapErrorMessage';
+import FeatureFlag from './FeatureFlag';
+import VectorTileFacilitiesMap from './VectorTileFacilitiesMap';
+
+import '../styles/css/Map.css';
+
+import withQueryStringSync from '../util/withQueryStringSync';
+
+import { VECTOR_TILE } from '../util/constants';
+
+class Homepage extends Component {
+    state = { hasError: false };
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error) {
+        if (window.Rollbar) {
+            window.Rollbar.error(error);
+        }
+    }
+
+    render() {
+        const { hasError } = this.state;
+
+        return (
+            <Fragment>
+                <Grid container className="map-sidebar-container">
+                    <Grid item sm={12} md={6} id="sidebar-container">
+                        <Route component={SidebarWithErrorBoundary} />
+                    </Grid>
+                    <Grid
+                        item
+                        sm={12}
+                        md={6}
+                        style={{ position: 'relative' }}
+                        className="map-container"
+                    >
+                        {!hasError && (
+                            <FeatureFlag
+                                flag={VECTOR_TILE}
+                                alternative={
+                                    <Route component={FacilitiesMap} />
+                                }
+                            >
+                                <Route component={VectorTileFacilitiesMap} />
+                            </FeatureFlag>
+                        )}
+                        {hasError && <FacilitiesMapErrorMessage />}
+                    </Grid>
+                </Grid>
+            </Fragment>
+        );
+    }
+}
+
+export default withQueryStringSync(Homepage);

--- a/src/app/src/components/HomepageSidebar.jsx
+++ b/src/app/src/components/HomepageSidebar.jsx
@@ -1,0 +1,147 @@
+import React, { Component } from 'react';
+import { bool, func } from 'prop-types';
+import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { Route } from 'react-router-dom';
+
+import HomepageSidebarSearch from './HomepageSidebarSearch';
+
+import {
+    fetchContributorOptions,
+    fetchListOptions,
+    fetchCountryOptions,
+    fetchAllPrimaryFilterOptions,
+} from '../actions/filterOptions';
+
+import {
+    contributorOptionsPropType,
+    countryOptionsPropType,
+    sectorOptionsPropType,
+} from '../util/propTypes';
+
+import { allListsAreEmpty } from '../util/util';
+
+import { facilitiesRoute } from '../util/constants';
+
+const controlPanelStyles = Object.freeze({
+    height: 'inherit',
+    width: 'inherit',
+});
+
+const filterSidebarStyles = theme =>
+    Object.freeze({
+        searchTab: Object.freeze({
+            '*': {
+                fontFamily: theme.typography.fontFamily,
+            },
+        }),
+    });
+
+class HomepageSidebar extends Component {
+    componentDidMount() {
+        const {
+            contributorsData,
+            countriesData,
+            sectorsData,
+            fetchFilterOptions,
+            fetchContributors,
+            fetchLists,
+            fetchCountries,
+            contributors,
+            history,
+        } = this.props;
+
+        if (history.location.search.length) {
+            history.replace(`${facilitiesRoute}/${history.location.search}`);
+        }
+
+        if (allListsAreEmpty(contributorsData, countriesData, sectorsData)) {
+            return fetchFilterOptions();
+        }
+
+        if (!contributorsData) {
+            fetchContributors();
+        }
+
+        if (!countriesData) {
+            fetchCountries();
+        }
+
+        if (contributors && contributors.length) {
+            fetchLists();
+        }
+
+        return null;
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.contributors !== prevProps.contributors) {
+            this.props.fetchLists();
+        }
+    }
+
+    render() {
+        const { fetchingFeatureFlags } = this.props;
+
+        if (fetchingFeatureFlags) {
+            return <CircularProgress />;
+        }
+
+        // We wrap this component in a `Route` to give it access to `history.push`
+        // in its `mapDispatchToProps` function.
+        const insetComponent = <Route component={HomepageSidebarSearch} />;
+
+        return (
+            <div className="control_panel" style={controlPanelStyles}>
+                {insetComponent}
+            </div>
+        );
+    }
+}
+HomepageSidebar.defaultProps = {
+    contributorsData: null,
+    countriesData: null,
+    sectorsData: null,
+};
+
+HomepageSidebar.propTypes = {
+    fetchFilterOptions: func.isRequired,
+    fetchContributors: func.isRequired,
+    fetchCountries: func.isRequired,
+    contributorsData: contributorOptionsPropType,
+    countriesData: countryOptionsPropType,
+    sectorsData: sectorOptionsPropType,
+    fetchingFeatureFlags: bool.isRequired,
+};
+
+function mapStateToProps({
+    filterOptions: {
+        contributors: { data: contributorsData },
+        countries: { data: countriesData },
+        sectors: { data: sectorsData },
+    },
+    featureFlags: { fetching: fetchingFeatureFlags },
+    filters: { contributors },
+}) {
+    return {
+        contributorsData,
+        countriesData,
+        sectorsData,
+        fetchingFeatureFlags,
+        contributors,
+    };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        fetchFilterOptions: () => dispatch(fetchAllPrimaryFilterOptions()),
+        fetchContributors: () => dispatch(fetchContributorOptions()),
+        fetchLists: () => dispatch(fetchListOptions()),
+        fetchCountries: () => dispatch(fetchCountryOptions()),
+    };
+}
+
+export default withStyles(filterSidebarStyles)(
+    connect(mapStateToProps, mapDispatchToProps)(HomepageSidebar),
+);

--- a/src/app/src/components/HomepageSidebarSearch.jsx
+++ b/src/app/src/components/HomepageSidebarSearch.jsx
@@ -1,0 +1,397 @@
+import React, { useState } from 'react';
+import { bool, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Drawer from '@material-ui/core/Drawer';
+import IconButton from '@material-ui/core/IconButton';
+import TuneIcon from '@material-ui/icons/Tune';
+import CloseIcon from '@material-ui/icons/Close';
+import { withStyles } from '@material-ui/core/styles';
+
+import ShowOnly from './ShowOnly';
+import FeatureFlag from './FeatureFlag';
+import FilterSidebarExtendedSearch from './FilterSidebarExtendedSearch';
+import TextSearchFilter from './Filters/TextSearchFilter';
+import ContributorFilter from './Filters/ContributorFilter';
+import CountryNameFilter from './Filters/CountryNameFilter';
+import SectorFilter from './Filters/SectorFilter';
+
+import { resetAllFilters } from '../actions/filters';
+
+import { recordSearchTabResetButtonClick } from '../actions/ui';
+
+import COLOURS from '../util/COLOURS';
+
+import {
+    contributorOptionsPropType,
+    contributorTypeOptionsPropType,
+    countryOptionsPropType,
+    sectorOptionsPropType,
+    facilityTypeOptionsPropType,
+    processingTypeOptionsPropType,
+    productTypeOptionsPropType,
+    numberOfWorkerOptionsPropType,
+} from '../util/propTypes';
+
+import { filterSidebarStyles } from '../util/styles';
+
+import { facilitiesRoute, EXTENDED_PROFILE_FLAG } from '../util/constants';
+
+const filterSidebarSearchTabStyles = theme =>
+    Object.freeze({
+        headerStyle: Object.freeze({
+            fontFamily: theme.typography.fontFamily,
+            fontSize: '4.5rem',
+            fontWeight: 900,
+            color: '#191919',
+            letterSpacing: '-0.004em',
+            paddingBottom: '0.5rem',
+            lineHeight: '4.5rem',
+        }),
+        font: Object.freeze({
+            fontFamily: `${theme.typography.fontFamily} !important`,
+        }),
+        reset: Object.freeze({
+            marginLeft: '16px',
+            minWidth: '36px',
+            minHeight: '36px',
+            textTransform: 'none',
+            fontWeight: 900,
+            fontSize: '1rem',
+        }),
+        searchButton: Object.freeze({
+            boxShadow: 'none',
+            backgroundColor: COLOURS.NAVIGATION,
+            color: COLOURS.NEAR_BLACK,
+            textTransform: 'none',
+            fontWeight: 900,
+            fontSize: '1rem',
+        }),
+        buttonGroup: Object.freeze({
+            marginBottom: '40px',
+            marginTop: '40px',
+        }),
+        drawerHeader: Object.freeze({
+            display: 'flex',
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+        }),
+        closeButton: Object.freeze({}),
+        drawerTitle: Object.freeze({
+            fontWeight: 900,
+            fontSize: '2rem',
+        }),
+        drawerSubtitle: Object.freeze({
+            fontWeight: 600,
+            fontSize: '1rem',
+            marginBottom: '2rem',
+        }),
+        drawer: Object.freeze({
+            padding: '1rem 4.5rem',
+            maxWidth: '560px',
+            minWidth: '33%',
+        }),
+        ...filterSidebarStyles,
+    });
+
+const checkIfAnyFieldSelected = fields => fields.some(f => f.length !== 0);
+
+const countHiddenFields = fields =>
+    fields.reduce((count, f) => (f.length !== 0 ? count + 1 : count), 0);
+
+function FilterSidebarSearchTab({
+    resetFilters,
+    facilityFreeTextQuery,
+    contributors,
+    contributorTypes,
+    countries,
+    sectors,
+    parentCompany,
+    facilityType,
+    processingType,
+    productType,
+    numberOfWorkers,
+    fetchingFacilities,
+    searchForFacilities,
+    fetchingOptions,
+    embed,
+    lists,
+    classes,
+    embedExtendedFields,
+}) {
+    const hiddenFields = [
+        contributorTypes,
+        parentCompany,
+        facilityType,
+        processingType,
+        productType,
+        numberOfWorkers,
+        sectors,
+    ];
+
+    const allFields = hiddenFields.concat([
+        facilityFreeTextQuery,
+        contributors,
+        countries,
+        lists,
+    ]);
+
+    const [expand, setExpand] = useState(false);
+
+    if (fetchingOptions) {
+        return (
+            <div className="control-panel__content">
+                <CircularProgress />
+            </div>
+        );
+    }
+
+    const hiddenFieldsCount = countHiddenFields(hiddenFields);
+    const expandButton = (
+        <div>
+            <Button
+                variant="outlined"
+                onClick={() => setExpand(true)}
+                disableRipple
+                color="primary"
+                style={{
+                    textTransform: 'none',
+                    fontWeight: 900,
+                    fontSize: '1rem',
+                }}
+            >
+                <TuneIcon style={{ paddingRight: '0.5rem' }} />
+                {hiddenFieldsCount ? `${hiddenFieldsCount} ` : ''}
+                More Search Filter{hiddenFieldsCount === 1 ? '' : 's'}
+            </Button>
+        </div>
+    );
+
+    const searchButton = (
+        <Button
+            variant="contained"
+            type="submit"
+            className={`${classes.font} ${classes.searchButton}`}
+            onClick={searchForFacilities}
+            disabled={fetchingOptions}
+        >
+            Find Facilities
+        </Button>
+    );
+
+    const applyFiltersButton = (
+        <Button
+            variant="contained"
+            type="submit"
+            className={`${classes.font} ${classes.searchButton}`}
+            onClick={() => setExpand(false)}
+            disabled={fetchingOptions}
+        >
+            Apply Filters
+        </Button>
+    );
+
+    const resetButton = (
+        <Button
+            size="small"
+            variant="outlined"
+            onClick={() => resetFilters(embed)}
+            className={classes.reset}
+            disabled={fetchingOptions}
+        >
+            Reset Search
+        </Button>
+    );
+
+    const resetHiddenFiltersButton = (
+        <Button
+            size="small"
+            variant="outlined"
+            onClick={() => resetFilters(embed)}
+            className={classes.reset}
+            disabled={fetchingOptions}
+        >
+            Reset
+        </Button>
+    );
+
+    const searchResetButtonGroup = () => {
+        if (fetchingFacilities) {
+            return <CircularProgress size={30} />;
+        }
+        if (checkIfAnyFieldSelected(hiddenFields)) {
+            return (
+                <>
+                    {searchButton}
+                    {resetHiddenFiltersButton}
+                </>
+            );
+        }
+        return searchButton;
+    };
+
+    const getHiddenFieldsButtonGroup = () => {
+        if (fetchingFacilities) {
+            return <CircularProgress size={30} />;
+        }
+        if (checkIfAnyFieldSelected(allFields)) {
+            return (
+                <>
+                    {applyFiltersButton}
+                    {resetButton}
+                </>
+            );
+        }
+        return applyFiltersButton;
+    };
+
+    return (
+        <div
+            className={`control-panel__content ${classes.controlPanelContentStyles}`}
+            style={{ padding: '2rem 4.5rem' }}
+        >
+            <div
+                style={{
+                    marginBottom: '60px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    height: '100%',
+                }}
+            >
+                <div className="form__field" style={{ marginBottom: '10px' }}>
+                    <Typography className={classes.headerStyle}>
+                        Explore global supply chain data
+                    </Typography>
+                </div>
+                <TextSearchFilter searchForFacilities={searchForFacilities} />
+                <Grid container spacing={8}>
+                    <Grid item xs={12} md={6}>
+                        <ContributorFilter />
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <CountryNameFilter />
+                    </Grid>
+                </Grid>
+                <ShowOnly when={!embed || embedExtendedFields.length}>
+                    {expandButton}
+                </ShowOnly>
+                <div className={classes.buttonGroup}>
+                    {searchResetButtonGroup()}
+                </div>
+            </div>
+            <Drawer
+                anchor="right"
+                open={expand}
+                onClose={() => setExpand(false)}
+            >
+                <div className={classes.drawer}>
+                    <div className={classes.drawerHeader}>
+                        <IconButton
+                            aria-label="Close"
+                            className={classes.closeButton}
+                            onClick={() => setExpand(false)}
+                        >
+                            <CloseIcon />
+                        </IconButton>
+                    </div>
+                    <Typography className={classes.drawerTitle}>
+                        Find facilities
+                    </Typography>
+                    <Typography className={classes.drawerSubtitle}>
+                        Browse facilities using the criteria below.
+                    </Typography>
+                    <SectorFilter />
+                    <FeatureFlag flag={EXTENDED_PROFILE_FLAG}>
+                        <FilterSidebarExtendedSearch />
+                    </FeatureFlag>
+                    {getHiddenFieldsButtonGroup()}
+                </div>
+            </Drawer>
+        </div>
+    );
+}
+
+FilterSidebarSearchTab.propTypes = {
+    resetFilters: func.isRequired,
+    facilityFreeTextQuery: string.isRequired,
+    contributors: contributorOptionsPropType.isRequired,
+    contributorTypes: contributorTypeOptionsPropType.isRequired,
+    countries: countryOptionsPropType.isRequired,
+    sectors: sectorOptionsPropType.isRequired,
+    parentCompany: contributorOptionsPropType.isRequired,
+    facilityType: facilityTypeOptionsPropType.isRequired,
+    processingType: processingTypeOptionsPropType.isRequired,
+    productType: productTypeOptionsPropType.isRequired,
+    numberOfWorkers: numberOfWorkerOptionsPropType.isRequired,
+    fetchingFacilities: bool.isRequired,
+    searchForFacilities: func.isRequired,
+    fetchingOptions: bool.isRequired,
+};
+
+function mapStateToProps({
+    filterOptions: {
+        contributors: { fetching: fetchingContributors },
+        countries: { fetching: fetchingCountries },
+    },
+    filters: {
+        facilityFreeTextQuery,
+        contributors,
+        lists,
+        contributorTypes,
+        countries,
+        sectors,
+        parentCompany,
+        facilityType,
+        processingType,
+        productType,
+        numberOfWorkers,
+        nativeLanguageName,
+        combineContributors,
+        boundary,
+    },
+    facilities: {
+        facilities: { fetching: fetchingFacilities },
+    },
+    embeddedMap: { embed, config },
+}) {
+    return {
+        facilityFreeTextQuery,
+        contributors,
+        lists,
+        contributorTypes,
+        countries,
+        sectors,
+        parentCompany,
+        facilityType,
+        processingType,
+        productType,
+        numberOfWorkers,
+        nativeLanguageName,
+        combineContributors,
+        fetchingFacilities,
+        boundary,
+        fetchingOptions: fetchingContributors || fetchingCountries,
+        embed: !!embed,
+        textSearchLabel: config.text_search_label,
+        embedExtendedFields: config.extended_fields,
+    };
+}
+
+function mapDispatchToProps(dispatch, { history: { replace, location } }) {
+    return {
+        resetFilters: embedded => {
+            dispatch(recordSearchTabResetButtonClick());
+            return dispatch(resetAllFilters(embedded));
+        },
+        searchForFacilities: () =>
+            replace(`${facilitiesRoute}${location.search}`),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(filterSidebarSearchTabStyles)(FilterSidebarSearchTab));

--- a/src/app/src/components/HomepageSidebarSearch.jsx
+++ b/src/app/src/components/HomepageSidebarSearch.jsx
@@ -19,7 +19,7 @@ import ContributorFilter from './Filters/ContributorFilter';
 import CountryNameFilter from './Filters/CountryNameFilter';
 import SectorFilter from './Filters/SectorFilter';
 
-import { resetAllFilters } from '../actions/filters';
+import { resetAllFilters, resetDrawerFilters } from '../actions/filters';
 
 import { recordSearchTabResetButtonClick } from '../actions/ui';
 
@@ -121,6 +121,7 @@ function FilterSidebarSearchTab({
     lists,
     classes,
     embedExtendedFields,
+    resetHiddenFilters,
 }) {
     const hiddenFields = [
         contributorTypes,
@@ -210,7 +211,7 @@ function FilterSidebarSearchTab({
         <Button
             size="small"
             variant="outlined"
-            onClick={() => resetFilters(embed)}
+            onClick={resetHiddenFilters}
             className={classes.reset}
             disabled={fetchingOptions}
         >
@@ -226,7 +227,7 @@ function FilterSidebarSearchTab({
             return (
                 <>
                     {searchButton}
-                    {resetHiddenFiltersButton}
+                    {resetButton}
                 </>
             );
         }
@@ -241,7 +242,7 @@ function FilterSidebarSearchTab({
             return (
                 <>
                     {applyFiltersButton}
-                    {resetButton}
+                    {resetHiddenFiltersButton}
                 </>
             );
         }
@@ -388,6 +389,7 @@ function mapDispatchToProps(dispatch, { history: { replace, location } }) {
         },
         searchForFacilities: () =>
             replace(`${facilitiesRoute}${location.search}`),
+        resetHiddenFilters: () => dispatch(resetDrawerFilters()),
     };
 }
 

--- a/src/app/src/components/Navbar/Logo.jsx
+++ b/src/app/src/components/Navbar/Logo.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+
 import COLOURS from '../../util/COLOURS';
 
-export default () => (
-    <Link to="/" href="/" className="header__home">
+import { resetAllFilters } from '../../actions/filters';
+
+import { recordSearchTabResetButtonClick } from '../../actions/ui';
+
+const Logo = ({ resetFilters }) => (
+    <Link to="/" href="/" onClick={resetFilters} className="header__home">
         <span className="visually-hidden">OS Hub</span>
         <div className="header__logo">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 972.96 364.15">
@@ -74,3 +80,16 @@ export default () => (
         </div>
     </Link>
 );
+
+function mapDispatchToProps(dispatch) {
+    // We don't load the logo in embed mode.
+    const embedded = false;
+    return {
+        resetFilters: () => {
+            dispatch(recordSearchTabResetButtonClick());
+            return dispatch(resetAllFilters(embedded));
+        },
+    };
+}
+
+export default connect(null, mapDispatchToProps)(Logo);

--- a/src/app/src/components/Navbar/MainMobileNav.jsx
+++ b/src/app/src/components/Navbar/MainMobileNav.jsx
@@ -17,7 +17,7 @@ const styles = {
         top: MOBILE_HEADER_HEIGHT,
         opacity: 1,
     },
-    mobileNavInactive: { left: '100%', opacity: 0 },
+    mobileNavInactive: { left: 0, opacity: 0, display: 'none' },
 };
 
 function MainMobileNav({

--- a/src/app/src/components/Navbar/MobileAuthMenu.jsx
+++ b/src/app/src/components/Navbar/MobileAuthMenu.jsx
@@ -28,7 +28,7 @@ const styles = {
         top: MOBILE_HEADER_HEIGHT,
         opacity: 1,
     },
-    mobileNavInactive: { left: '100%', opacity: 0 },
+    mobileNavInactive: { left: 0, opacity: 0, display: 'none' },
     profileButton: {
         color: COLOURS.NEAR_BLACK,
         display: 'flex',

--- a/src/app/src/components/PolygonalSearchControl.jsx
+++ b/src/app/src/components/PolygonalSearchControl.jsx
@@ -69,9 +69,16 @@ class PolygonalSearchControl extends React.Component {
     }
 }
 
-const mapDispatchToProps = dispatch => ({
-    updateBoundary: boundary => dispatch(updateBoundaryFilter(boundary)),
-    search: () => dispatch(fetchFacilities({})),
+const mapDispatchToProps = (dispatch, { navigateToFacilities }) => ({
+    updateBoundary: boundary => {
+        dispatch(updateBoundaryFilter(boundary));
+    },
+    search: () => {
+        dispatch(fetchFacilities({}));
+        if (navigateToFacilities) {
+            navigateToFacilities();
+        }
+    },
     hideDrawFilter: () => dispatch(showDrawFilter(false)),
 });
 

--- a/src/app/src/components/SearchControls.jsx
+++ b/src/app/src/components/SearchControls.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import Checkbox from '@material-ui/core/Checkbox';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Button from '@material-ui/core/Button';
 
 import { toggleZoomToSearch, showDrawFilter } from '../actions/ui';
@@ -11,6 +10,8 @@ import { toggleZoomToSearch, showDrawFilter } from '../actions/ui';
 import { updateBoundaryFilter } from '../actions/filters';
 
 import { fetchFacilities } from '../actions/facilities';
+
+import { facilitiesRoute } from '../util/constants';
 
 const zoomStyles = theme =>
     Object.freeze({
@@ -20,21 +21,17 @@ const zoomStyles = theme =>
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            padding: '3px',
-            borderRadius: '2px',
-            boxShadow: '0 0 0 2px rgba(0, 0, 0, 0.2)',
+            borderRadius: '0',
+            boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.2)',
         }),
         zoomStyle: Object.freeze({
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
         }),
-        zoomLabelStyle: Object.freeze({
-            textTransform: 'uppercase',
-            paddingLeft: '5px',
-        }),
         areaStyle: Object.freeze({
             fontWeight: 400,
+            borderRadius: 0,
         }),
         dividerStyle: {
             width: '0px',
@@ -43,7 +40,7 @@ const zoomStyles = theme =>
         },
     });
 
-function ZoomToSearchControl({
+function SearchControls({
     zoomToSearch,
     boundary,
     toggleZoom,
@@ -51,6 +48,8 @@ function ZoomToSearchControl({
     clearDrawFilter,
     classes,
 }) {
+    const location = useLocation();
+
     const boundaryButton =
         boundary == null ? (
             <Button
@@ -74,23 +73,38 @@ function ZoomToSearchControl({
                 REMOVE CUSTOM AREA
             </Button>
         );
+
+    const zoomControl = (
+        <div id="zoom-search" className={classes.zoomStyle}>
+            <Button
+                variant="text"
+                checked={zoomToSearch}
+                onClick={() => toggleZoom(!zoomToSearch)}
+                disableRipple
+                fullWidth
+                className={classes.areaStyle}
+                style={
+                    zoomToSearch
+                        ? { backgroundColor: '#F0FAF2', fontWeight: 900 }
+                        : {}
+                }
+            >
+                Zoom to Search
+            </Button>
+        </div>
+    );
+
+    if (location?.pathname?.includes(facilitiesRoute)) {
+        return (
+            <div className={classes.controlsStyle}>
+                {zoomControl}
+                <div className={classes.dividerStyle} />
+                <div>{boundaryButton}</div>
+            </div>
+        );
+    }
     return (
         <div className={classes.controlsStyle}>
-            <div id="zoom-search" className={classes.zoomStyle}>
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={zoomToSearch}
-                            onChange={e => toggleZoom(e.target.checked)}
-                            value="zoom-checkbox"
-                            color="primary"
-                        />
-                    }
-                    className={classes.zoomLabelStyle}
-                    label="Zoom to Search"
-                />
-            </div>
-            <div className={classes.dividerStyle} />
             <div>{boundaryButton}</div>
         </div>
     );
@@ -112,11 +126,11 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-ZoomToSearchControl.defaultProps = {
+SearchControls.defaultProps = {
     zoomToSearch: true,
 };
 
-ZoomToSearchControl.propTypes = {
+SearchControls.propTypes = {
     toggleZoom: PropTypes.func.isRequired,
     zoomToSearch: PropTypes.bool,
 };
@@ -124,4 +138,4 @@ ZoomToSearchControl.propTypes = {
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withStyles(zoomStyles)(ZoomToSearchControl));
+)(withStyles(zoomStyles)(SearchControls));

--- a/src/app/src/components/SidebarWithErrorBoundary.jsx
+++ b/src/app/src/components/SidebarWithErrorBoundary.jsx
@@ -9,6 +9,7 @@ import {
 
 import FacilityDetailsSidebar from './FacilityDetailSidebar';
 import FilterSidebar from './FilterSidebar';
+import HomepageSidebar from './HomepageSidebar';
 
 export default class SidebarWithErrorBoundary extends Component {
     state = { hasError: false };
@@ -42,7 +43,7 @@ export default class SidebarWithErrorBoundary extends Component {
                     key={JSON.stringify(this.state.hasError)}
                     exact
                     path={mainRoute}
-                    component={FilterSidebar}
+                    component={HomepageSidebar}
                 />
             </Switch>
         );

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -65,6 +65,7 @@ function VectorTileFacilitiesMap({
     isEmbedded,
     mapStyle = 'silver',
     navigateToFacilities,
+    isMobile,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
@@ -117,7 +118,7 @@ function VectorTileFacilitiesMap({
             ref={mapRef}
             center={initialCenter}
             zoom={initialZoom}
-            scrollWheelZoom={!isEmbedded}
+            scrollWheelZoom={!isEmbedded && !isMobile}
             minZoom={minimumZoom}
             renderer={L.canvas()}
             style={mapComponentStyles.mapContainerStyles}
@@ -217,6 +218,7 @@ function mapStateToProps({
         facilitiesSidebarTabSearch: { resetButtonClickCount },
         zoomToSearch,
         drawFilterActive,
+        window: { innerWidth: windowInnerWidth },
     },
     clientInfo: { fetched, countryCode },
     facilities: {
@@ -239,6 +241,7 @@ function mapStateToProps({
         boundary,
         isEmbedded,
         mapStyle: config.map_style,
+        isMobile: windowInnerWidth < 600,
     };
 }
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -14,7 +14,12 @@ import VectorTileGridLegend from './VectorTileGridLegend';
 import SearchControls from './SearchControls';
 import PolygonalSearchControl from './PolygonalSearchControl';
 
-import { COUNTRY_CODES, SILVER_MAP_STYLE } from '../util/constants';
+import {
+    COUNTRY_CODES,
+    SILVER_MAP_STYLE,
+    facilitiesRoute,
+    mainRoute,
+} from '../util/constants';
 
 import { makeFacilityDetailLink } from '../util/util';
 
@@ -59,6 +64,7 @@ function VectorTileFacilitiesMap({
     boundary,
     isEmbedded,
     mapStyle = 'silver',
+    navigateToFacilities,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
@@ -161,7 +167,11 @@ function VectorTileFacilitiesMap({
                     zoomLevel={currentMapZoomLevel}
                 />
             )}
-            {drawFilterActive && <PolygonalSearchControl />}
+            {drawFilterActive && (
+                <PolygonalSearchControl
+                    navigateToFacilities={navigateToFacilities}
+                />
+            )}
 
             {boundary != null && (
                 <GeoJSON
@@ -234,8 +244,14 @@ function mapStateToProps({
 
 function mapDispatchToProps(
     dispatch,
-    { history: { push }, match: { params } },
+    { history: { push, replace, location }, match: { params } },
 ) {
+    const navigateToFacilities = () => {
+        if (location?.pathname === mainRoute) {
+            replace(`${facilitiesRoute}/${location?.search}`);
+        }
+        return noop();
+    };
     const visitFacility = oarID => {
         if (oarID && oarID !== params?.oarID) {
             dispatch(resetSingleFacility());
@@ -250,6 +266,7 @@ function mapDispatchToProps(
             visitFacility(oarID);
         },
         handleFacilityClick: visitFacility,
+        navigateToFacilities,
     };
 }
 

--- a/src/app/src/reducers/FiltersReducer.js
+++ b/src/app/src/reducers/FiltersReducer.js
@@ -18,6 +18,7 @@ import {
     updateCombineContributorsFilterOption,
     updateBoundaryFilter,
     resetAllFilters,
+    resetDrawerFilters,
     updateAllFilters,
 } from '../actions/filters';
 
@@ -135,6 +136,16 @@ export default createReducer(
                         ? state.contributors
                         : initialState.contributors,
                 },
+            }),
+        [resetDrawerFilters]: state =>
+            update(initialState, {
+                facilityFreeTextQuery: { $set: state.facilityFreeTextQuery },
+                contributors: {
+                    $set: state.contributors,
+                },
+                countries: { $set: state.countries },
+                combineContributors: { $set: state.combineContributors },
+                lists: { $set: state.lists },
             }),
         [updateAllFilters]: (_state, payload) => payload,
         [completeFetchContributorOptions]: maybeSetFromQueryString(

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -7,10 +7,29 @@
   flex-direction: column;
 }
 
+#sidebar-container {
+  background: #F9F7F7;
+  box-shadow: 2px 0 4px rgba(0,0,0,.15);
+  z-index: 1;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  max-width: 100%;
+  overflow: scroll;
+}
+
 @media (min-width: 600px) {
   #panel-container {
     width: 360px;
     max-width: 100%;
+    flex: none;
+  }
+
+  #sidebar-container {
+    max-width: 50%;
     flex: none;
   }
 

--- a/src/app/src/styles/css/header.css
+++ b/src/app/src/styles/css/header.css
@@ -286,13 +286,12 @@ button.app-header-button {
     width: 100%;
     text-transform: uppercase;
     position: absolute;
-    top: 100%;
-    left: -200%;
     z-index: 1;
     background: #F9F7F7;
     color: #191919;
     opacity: 0;
-    height: 100%
+    height: 100%;
+    left: 0;
 }
 .mobile-nav__item {
     border-top: 0.0625rem solid #0D1128;

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -92,6 +92,21 @@ export const filterSidebarStyles = Object.freeze({
     }),
 });
 
+export const makeFilterStyles = theme =>
+    Object.freeze({
+        inputLabelStyle: Object.freeze({
+            fontFamily: theme.typography.fontFamily,
+            fontSize: '16px',
+            fontWeight: 500,
+            color: '#000',
+            transform: 'translate(0, -8px) scale(1)',
+            paddingBottom: '0.5rem',
+        }),
+        selectStyle: Object.freeze({
+            fontFamily: theme.typography.fontFamily,
+        }),
+    });
+
 export const claimAFacilityFormStyles = Object.freeze({
     textFieldStyles: Object.freeze({
         width: '95%',

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -879,7 +879,7 @@ export const getEmbeddedMapSrc = ({ contributor, timestamp }) => {
           })
         : querystring.stringify({ contributors: contributor, embed: 1 });
 
-    return window.location.href.replace('settings', `?${qs}`);
+    return window.location.href.replace('settings', `facilities?${qs}`);
 };
 
 // This must be kept in sync with renderEmbeddedMap in EmbeddedMapConfig.jsx

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -11,6 +11,15 @@ import { filtersPropType } from '../util/propTypes';
 
 import { createQueryStringFromSearchFilters } from '../util/util';
 
+import { facilitiesRoute } from '../util/constants';
+
+const getCleanPathname = pathname => {
+    if (pathname && pathname[pathname.length - 1] === '/') {
+        return pathname.slice(0, pathname.length - 1);
+    }
+    return pathname;
+};
+
 export default function withQueryStringSync(WrappedComponent) {
     const componentWithWrapper = class extends Component {
         componentDidMount() {
@@ -34,7 +43,12 @@ export default function withQueryStringSync(WrappedComponent) {
             // In that case, `path` will be `/facilities` and `pathname` will be
             // `/facilities/hello-world`. In other cases -- `/` and `/facilities` -- these paths
             // will match.
-            const fetchFacilitiesOnMount = pathname === path;
+            //
+            // Furthermore, limits fetching facilities to the facilities route.
+            const cleanPathname = getCleanPathname(pathname);
+            const isFacilitiesRoute = path.includes(facilitiesRoute);
+            const fetchFacilitiesOnMount =
+                cleanPathname === path && isFacilitiesRoute;
 
             if (vectorTileFeatureIsActive) {
                 return hydrateFiltersFromQueryString(


### PR DESCRIPTION
## Overview

Adds the new homepage, including:
- Creating the new homepage layout
- Separating the homepage from the /facilities route
- Updating the filter styles
- Hiding the 'Zoom to Search' button on the homepage
- Updating the embedded map src URL to point to /facilities

Connects #2047 

## Demo

<img width="1431" alt="Screen Shot 2022-08-26 at 8 35 55 AM" src="https://user-images.githubusercontent.com/21046714/186922623-8557d397-5fb4-4cad-bd32-bcb8241fe0c3.png">
<img width="712" alt="Screen Shot 2022-08-26 at 9 44 43 AM" src="https://user-images.githubusercontent.com/21046714/186922641-2dedacd4-b68c-48ba-8f0a-2997bd610e6b.png">
<img width="697" alt="Screen Shot 2022-08-26 at 9 45 04 AM" src="https://user-images.githubusercontent.com/21046714/186922651-18ac909c-4f46-431c-9e5e-0651b18bb9d8.png">
<img width="1429" alt="Screen Shot 2022-08-26 at 9 45 29 AM" src="https://user-images.githubusercontent.com/21046714/186922665-3dfd3cd1-7320-4be1-900c-76735664d35b.png">
<img width="1429" alt="Screen Shot 2022-08-26 at 9 45 50 AM" src="https://user-images.githubusercontent.com/21046714/186922674-26aa25b8-2028-4f50-8d3b-ab2ad7d7b236.png">
<img width="1425" alt="Screen Shot 2022-08-26 at 9 46 08 AM" src="https://user-images.githubusercontent.com/21046714/186922687-05e0df1c-5c1f-439b-86e2-8aa6d3ae2246.png">

## Notes

Some items that were intentionally excluded from this task (due to scope):

- The contributor search tab and tab bar
- Newsletter bar
- New footer
- Any updated filter behaviors
- The new 'autosuggest' search functionality
- Header changes / Google translate changes (aside from a header bug-fix)

We considered updating the /facilities page to default to the Facilities tab showing instead of the Search tab, but the search wasn't running well consistently with that change; I believe fully testing that will be better handled in #2049.

## Testing Instructions

* Run `./scripts/server`
* Visit [the homepage](http://localhost:6543/) and compare to [the wireframes](https://www.figma.com/file/FGVrJYElirWCQyR7nBehF0/OAR?node-id=24%3A25)
     * Note particularly that the 'Zoom to Search' control should be hidden. 
     * The filters should be highlighted in purple when selected, and the selected items should be green 'pills'.
     * Also view the page in mobile sizing and confirm mobile view appears as expected. 
* Run searches for the main filters. You should be taken to the /facilities page with the filters set. 
* Return to [the homepage](http://localhost:6543/). Select a contributor, and then open the drawer by clicking 'more filters'.
     * The drawer should contain all of the other filters. 
     * Setting the filters should update the number in the 'more filters' button.
     * Clicking 'reset' in the drawer should only reset the drawer filters. 
     * The drawer should display correctly in mobile view. 
* Click Search. 
     * The contributor previously selected should have their name displayed in the filter, not their id. 
     * Any selected 'more filters' should be selected and work as expected. 
* Toggle the 'Zoom to Search' button and confirm it works as before. 
* Return to [the homepage](http://localhost:6543/) and use 'Draw Custom Area'  search. You should be taken directly to the '/facilities' page. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
