### PR TITLE
Speed up XLSX parsing by using iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow admins to set superuser status [#2095](https://github.com/open-apparel-registry/open-apparel-registry/pull/2095)
 - Replace font and global colors [#2077](https://github.com/open-apparel-registry/open-apparel-registry/pull/2077)
 - Change map marker #[2089](https://github.com/open-apparel-registry/open-apparel-registry/pull/2089)
+- Speed up XLSX parsing by using iteration [#2086](https://github.com/open-apparel-registry/open-apparel-registry/pull/2086)
 
 ### Deprecated
 

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -89,12 +89,20 @@ def parse_xlsx(file, request):
                     if cell.row != 1:
                         cell.value = format_percent(cell.value)
 
-        header = ','.join([format_cell_value(cell.value) for cell in ws[1]])
+        ws_rows = ws.rows
+        # Useing `next` will consome the row so that iteration of the data rows
+        # will skipt the header row
+        first_row = next(ws_rows)
+        header = ','.join(
+            [format_cell_value(cell.value) for cell in first_row])
 
-        rows = ['"{}"'.format(
-            '","'.join([format_cell_value(cell.value) for cell in ws[idx]]))
-                for idx in range(2, ws.max_row + 1)
-                if any(cell.value is not None for cell in ws[idx])]
+        def format_row(row):
+            return '"{}"'.format(
+                '","'.join([format_cell_value(cell.value) for cell in row]))
+
+        rows = [format_row(row)
+                for row in ws_rows
+                if any(cell.value is not None for cell in row)]
 
         return header, rows
     except Exception:


### PR DESCRIPTION
## Overview

Uploading large XLSX files was failing due to the fact that the initial processing was taking longer than the 30 second CloudFront timeout.

This commit improves performance by using iteration of the workbook rows rather than indexing.

This implementation is based on https://stackoverflow.com/a/35824345

Connects #2040

## Testing Instructions


* Log in as c3@example.com
* Contribute [Test List 10k With Percent Fields.xlsx](https://github.com/open-apparel-registry/open-apparel-registry/files/9428247/Test.List.10k.With.Percent.Fields.xlsx)  Note the list ID
* Run the parse action

```
> ./scripts/manage batch_process --list-id {id}  --action parse
Creating open-supply-hub_django_run ... done
parse: 9486 successes
parse: 514 failures
```

* Check the raw data for a line and verify that the percent fields were read in correctly.

```
openapparelregistry=# select max(id) from api_facilitylistitem;
  max
-------
 30932
(1 row)

openapparelregistry=# select raw_data from api_facilitylistitem where id = 30932;
                                                       raw_data
-----------------------------------------------------------------------------------------------------------------------
 "Multi-category","China","Test Facility Name 10000","Fu Ao Industrial, Xi Niu Bei Management                         +
 District, Dongguan, Guangdong, China","68%","","1%","","","","","","","","","","","","","","","","","","","","","",""
(1 row)
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
