### PR TITLE
Change map marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Create a log group for AWS Batch jobs [#2060](https://github.com/open-apparel-registry/open-apparel-registry/pull/2060)
 - Allow admins to set superuser status [#2095](https://github.com/open-apparel-registry/open-apparel-registry/pull/2095)
 - Replace font and global colors [#2077](https://github.com/open-apparel-registry/open-apparel-registry/pull/2077)
+- Change map marker #[2089](https://github.com/open-apparel-registry/open-apparel-registry/pull/2089)
 
 ### Deprecated
 

--- a/src/app/src/components/VectorTileFacilitiesLayer.jsx
+++ b/src/app/src/components/VectorTileFacilitiesLayer.jsx
@@ -12,7 +12,7 @@ import isEqual from 'lodash/isEqual';
 import intersection from 'lodash/intersection';
 import sortBy from 'lodash/sortBy';
 
-import { OARColor } from '../util/constants';
+import { SelectedMarkerColor } from '../util/constants';
 import FacilitiesMapPopup from './FacilitiesMapPopup';
 
 import {
@@ -26,9 +26,9 @@ const VectorGrid = withLeaflet(VectorGridDefault);
 const createMarkerIcon = (color = '#838BA5') => {
     const fill = color.replace('#', '%23');
     return L.icon({
-        iconUrl: `data:image/svg+xml;utf8,<svg fill="${fill}" height="506" viewBox="0 0 384 506" width="384" xmlns="http://www.w3.org/2000/svg"><path d="m0 192c0-106.039 85.961-192 192-192s192 85.961 192 192c0 70.692667-64 175.359373-192 314.00012-128-138.640747-192-243.307453-192-314.00012zm192 80c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"/></svg>`,
-        iconSize: [30, 40],
-        iconAnchor: [15, 40],
+        iconUrl: `data:image/svg+xml;utf8,<svg width="32" height="42" viewBox="0 0 32 42" fill="${fill}" xmlns="http://www.w3.org/2000/svg"><path d="M19.5393 13.3319L19.5381 13.3307C18.5694 12.3481 17.3722 11.8399 16 11.8399C14.6277 11.8399 13.4309 12.3482 12.4633 13.3313C11.4952 14.3149 11 15.5239 11 16.9039C11 18.2838 11.495 19.4922 12.4633 20.4746C13.4307 21.4588 14.6275 21.9679 16 21.9679C17.3728 21.9679 18.5701 21.4587 19.5387 20.4746C20.5058 19.492 21 18.2835 21 16.9039C21 15.5244 20.5059 14.3156 19.5393 13.3319ZM4.80844 27.8042L4.80822 27.8039C2.22372 23.9245 1 20.434 1 17.3103C1 12.4608 2.52552 8.69462 5.50969 5.89893L5.50984 5.89878C8.54893 3.05045 12.032 1.64795 16 1.64795C19.968 1.64795 23.4511 3.05045 26.4902 5.89878L26.4903 5.89893C29.4745 8.69462 31 12.4608 31 17.3103C31 20.4341 29.7768 23.9247 27.1937 27.8041C24.7177 31.5218 20.9973 35.5748 16 39.9617C11.0028 35.5748 7.28309 31.5218 4.80844 27.8042Z" fill="${fill}" stroke="%230D1128" stroke-width="2"/></svg>`,
+        iconSize: [32, 42],
+        iconAnchor: [16, 42],
     });
 };
 
@@ -378,7 +378,8 @@ function mapStateToProps({
         tileCacheKey,
         fetching,
         resetButtonClickCount,
-        iconColor: config.color || OARColor,
+        iconColor:
+            config.selectedMarkerColor || config.color || SelectedMarkerColor,
     };
 }
 

--- a/src/app/src/reducers/EmbeddedMapReducer.js
+++ b/src/app/src/reducers/EmbeddedMapReducer.js
@@ -1,7 +1,7 @@
 import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
-import { OARFont, OARColor } from '../util/constants';
+import { OARFont, OARColor, SelectedMarkerColor } from '../util/constants';
 
 import {
     setEmbeddedMapStatus,
@@ -14,6 +14,7 @@ import { completeSubmitLogOut } from '../actions/auth';
 
 const initialConfig = Object.freeze({
     color: OARColor,
+    selectedMarkerColor: SelectedMarkerColor,
     contributor: null,
     font: OARFont,
 });

--- a/src/app/src/util/constants.js
+++ b/src/app/src/util/constants.js
@@ -584,6 +584,7 @@ export const PPE_FIELD_NAMES = Object.freeze([
 
 export const OARFont = "'Darker Grotesque',sans-serif";
 export const OARColor = '#8428FA';
+export const SelectedMarkerColor = '#FFCF3F';
 
 // A CSS size value that is used to set a lower bound on the iframe height
 // when the width is set to 100%


### PR DESCRIPTION
NOTE this is based on the `feature/jm/2059-color-font-updates` branch

## Overview

The new marker SVG was exported from the Figma document.

Previously the selected marker color and main theme color were the same. In the new design they are different, so we also make a change to the marker color override handling that is possible in embedded maps.

Connects #2059

## Demo

### Main Map

![2022-08-24 11 41 50](https://user-images.githubusercontent.com/17363/186500896-307b7d5a-9605-4677-b345-7df644680012.gif)


### Embed with Custom Color
<img width="1255" alt="Screen Shot 2022-08-24 at 11 53 43 AM" src="https://user-images.githubusercontent.com/17363/186501081-fb1c50ec-a5a0-4811-87aa-f002bca9ecb6.png">

## Testing Instructions

* Zoom in on an area with multiple markers and verify the new marker design and selection color
* Log in as c3@example.com
* Browse http://localhost:6543/settings, select the Embed tab and configure an embed
  * Set a custom color
  * Select the Silver basemap
  * Check the 100% width box
* Verify that the custom color is uses as the selected marker color.  

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
