### PR TITLE
Allow admins to set superuser status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update list match confirm / rejection to be done by admins [#2030](https://github.com/open-apparel-registry/open-apparel-registry/pull/2030)
 - Update moderation UI to trigger batch processing [#2048](https://github.com/open-apparel-registry/open-apparel-registry/pull/2048)
 - Create a log group for AWS Batch jobs [#2060](https://github.com/open-apparel-registry/open-apparel-registry/pull/2060)
+- Allow admins to set superuser status [#2095](https://github.com/open-apparel-registry/open-apparel-registry/pull/2095)
 
 ### Deprecated
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -45,7 +45,7 @@ admin_site = ApiAdminSite()
 class OarUserAdmin(UserAdmin):
     exclude = ('last_name', 'date_joined', 'first_name', 'username')
     fieldsets = (
-        (None, {'fields': ('email', 'is_staff', 'is_active',
+        (None, {'fields': ('email', 'is_staff', 'is_superuser', 'is_active',
                            'should_receive_newsletter',
                            'has_agreed_to_terms_of_service',
                            'groups')}),


### PR DESCRIPTION
## Overview

Allow admins to set superuser status

Connects #2094

## Demo

![2022-08-24 14 00 01](https://user-images.githubusercontent.com/17363/186523029-426f24aa-e9ee-4e64-8a37-8e96bf2b0a90.gif)

## Testing Instructions

* Browse http://localhost:8081/admin/, log in as c1@example.com and verify that you can set the superuser permission on other suers

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] ~If this PR applies to both OAR and OGR a companion PR has been created~
