### PR TITLE
Fix getLangFromTranslateElement function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Set pagination_class on ApiBlockViewSet to None [#2057](https://github.com/open-apparel-registry/open-apparel-registry/pull/2057)
 - Dont duplicate check items with parsing errors [#2073](https://github.com/open-apparel-registry/open-apparel-registry/pull/2073)
 - Fix list URL construction when running as a Batch job [#2066](https://github.com/open-apparel-registry/open-apparel-registry/pull/2066)
+- Fix getLangFromTranslateElement function [#2097](https://github.com/open-apparel-registry/open-apparel-registry/pull/2097)
 
 ### Security
 

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -101,7 +101,7 @@
         var defaultLanguage = 'en';
         function getLangFromTranslateElement(translateElement) {
             const innerText = translateElement?.M?.innerText?.slice(0, -2);
-            const shortNameDict = translateElement?.B;
+            const shortNameDict = translateElement?.C;
             if (!innerText || !shortNameDict) return defaultLanguage;
             for (const [key, value] of Object.entries(shortNameDict)) {
                 if (value.toLowerCase().trim() == innerText.toLowerCase().trim()) {


### PR DESCRIPTION


## Overview

On August 18 2022 we began seeing exceptions raised out of this function logged to Rollbar. We suspect Google deployed an update that caused the minified parameter names to change.

This is the same fix as #2096 applied to the `ogr/develop` branch.

Connects #2070

## Testing Instructions

* Browse http://localhost:6543/ and verify that exceptions are not raised in the devtools console
* Verify that selecting different languages changes the 2-letter code label on the dropdown menu
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
