### PR TITLE
Rename makecsvs to makedata and add stub SQL mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Replace font and global colors [#2077](https://github.com/open-apparel-registry/open-apparel-registry/pull/2077)
 - Change map marker #[2089](https://github.com/open-apparel-registry/open-apparel-registry/pull/2089)
 - Speed up XLSX parsing by using iteration [#2086](https://github.com/open-apparel-registry/open-apparel-registry/pull/2086)
+- Rename makecsvs to makedata and add stub SQL mode [#2108](https://github.com/open-apparel-registry/open-apparel-registry/pull/2108)
 
 ### Deprecated
 

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -125,8 +125,8 @@ class Command(BaseCommand):
             # TODO Consider useing different contributor IDs
             source_insert = (
                 "INSERT INTO api_source "
-                "(id, source_type, is_active, is_public, create, created_at, updated_at, contributor_id) "
-                "VALUES ({source_id}, 'SINGLE', 't', 't', 't', '{created_at}', '{updated_at}', 1) "
+                "(id, source_type, is_active, is_public, \"create\", created_at, updated_at, contributor_id) "
+                "VALUES ({source_id}, 'SINGLE', 't', 't', 't', '{created_at}', '{updated_at}', 1);\n"
             )
             source_copy_header = (
                 'COPY api_source '
@@ -142,7 +142,7 @@ class Command(BaseCommand):
             list_item_insert = (
                 "INSERT INTO api_facilitylistitem "
                 "(id, row_index, raw_data, status, processing_results, name, address, country_code, geocoded_point, geocoded_address, created_at, updated_at, source_id, clean_address, clean_name, sector) "
-                "VALUES ({source_id}, 0, '', 'MATCHED', '{{}}', '{name}', '{address}', '{country}', {location}, '{address}', '{created_at}', '{updated_at}', '{source_id}, '{clean_address}, '{clean_name}, '{sector}')\n"
+                "VALUES ({source_id}, 0, '', 'MATCHED', '{{}}', '{name}', '{address}', '{country}', {location}, '{address}', '{created_at}', '{updated_at}', {source_id}, '{clean_address}', '{clean_name}', '{sector}');\n"
             )
             list_item_copy_header = (
                 "COPY api_facilitylistitem "
@@ -156,7 +156,7 @@ class Command(BaseCommand):
             facility_insert = (
                 "INSERT INTO api_facility "
                 "(id, name, address, country_code, location, created_at, updated_at, created_from_id, has_inexact_coordinates) "
-                "VALUES ('{oar_id}', '{name}', '{address}', '{country}', {location}, '{created_at}', '{updated_at}', {created_from_id}, '{has_inexact_coordinates}')\n")
+                "VALUES ('{oar_id}', '{name}', '{address}', '{country}', {location}, '{created_at}', '{updated_at}', {created_from_id}, '{has_inexact_coordinates}');\n")
             facility_copy_header = (
                 "COPY api_facility "
                 "(id, name, address, country_code, location, created_at, updated_at, created_from_id, has_inexact_coordinates) "

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -68,12 +68,16 @@ class Command(BaseCommand):
         rows = []
         with open(csv_file) as f:
             for row in csv.DictReader(f):
+                try:
+                    sector = row['sector']
+                except KeyError:
+                    sector = 'Apparel'
                 rows.append(
                     {
                         'country': row['country_code'],
                         'name': row['name'],
                         'address': row['address'],
-                        'sector': row['sector'],
+                        'sector': sector,
                         'lat': row['lat'],
                         'lng': row['lng'],
                     }

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -123,13 +123,12 @@ class Command(BaseCommand):
         if make_sql:
             now = timezone.now().isoformat()
 
-            # TODO Consider useing different contributor IDs
             source_insert = (
                 "INSERT INTO api_source "
                 "(id, source_type, is_active, is_public, \"create\", "
                 "created_at, updated_at, contributor_id) "
                 "VALUES ({source_id}, 'SINGLE', 't', 't', 't', "
-                "'{created_at}', '{updated_at}', 1);\n"
+                "'{created_at}', '{updated_at}', {contributor_id});\n"
             )
             source_copy_header = (
                 'COPY api_source '
@@ -138,7 +137,8 @@ class Command(BaseCommand):
                 'FROM stdin;\n'
             )
             source_copy = (
-                '{source_id}\tSINGLE\tt\tt\tt\t{created_at}\t{updated_at}\t1\n'
+                '{source_id}\tSINGLE\tt\tt\tt\t{created_at}\t{updated_at}\t'
+                '{contributor_id}\n'
             )
 
             # TODO Consider generating multiple line items that match to each
@@ -233,6 +233,7 @@ class Command(BaseCommand):
                     new_row['match_id'] = idval
                     new_row['clean_address'] = clean(new_row['address'])
                     new_row['clean_name'] = clean(new_row['name'])
+                    new_row['contributor_id'] = random.randrange(2, 99)
                     yield new_row
                     idval += 1
 

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -66,6 +66,10 @@ class Command(BaseCommand):
         random.seed(8675309)
 
         rows = []
+
+        def clean(text):
+            return text.replace('\n', '')
+
         with open(csv_file) as f:
             for row in csv.DictReader(f):
                 try:
@@ -74,9 +78,9 @@ class Command(BaseCommand):
                     sector = 'Apparel'
                 rows.append(
                     {
-                        'country': row['country_code'],
-                        'name': row['name'],
-                        'address': row['address'],
+                        'country': clean(row['country_code']),
+                        'name': clean(row['name']),
+                        'address': clean(row['address']),
                         'sector': sector,
                         'lat': row['lat'],
                         'lng': row['lng'],

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -204,6 +204,14 @@ class Command(BaseCommand):
                 '{updated_at}\t{oar_id}\t{list_item_id}\tt\n'
             )
 
+            update_query = (
+                'UPDATE api_facilitylistitem '
+                'SET facility_id = api_facility.id '
+                'FROM api_facility '
+                'WHERE api_facilitylistitem.id >= 100000000 '
+                'AND created_from_id = api_facilitylistitem.id;\n'
+            )
+
             def prepare(rows):
                 idval = 100000000
                 for row in rows:
@@ -228,20 +236,21 @@ class Command(BaseCommand):
                     yield new_row
                     idval += 1
 
-            # TODO Create a post load update that sets facility_id on
-            # api_facilitylistitem
             s_c_file = os.path.join(out_dir, 'sources_copy.sql')
             i_c_file = os.path.join(out_dir, 'facilitylistitems_copy.sql')
             f_c_file = os.path.join(out_dir, 'facilities_copy.sql')
             m_c_file = os.path.join(out_dir, 'facilitymatches_copy.sql')
+            u_file = os.path.join(out_dir, 'facility_to_item_update.sql')
             with open(f_c_file, 'w') as f_c, \
                  open(s_c_file, 'w') as s_c, \
                  open(i_c_file, 'w') as i_c, \
-                 open(m_c_file, 'w') as m_c:
+                 open(m_c_file, 'w') as m_c, \
+                 open(u_file, 'w') as u:
                 s_c.write(source_copy_header)
                 i_c.write(list_item_copy_header)
                 f_c.write(facility_copy_header)
                 m_c.write(match_copy_header)
+                u.write(update_query)
                 for row in prepare(rows):
                     s_c.write(source_copy.format(**row))
                     i_c.write(list_item_copy.format(**row))

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -189,7 +189,7 @@ class Command(BaseCommand):
                 "INSERT INTO api_facilitymatch "
                 "(id, results, confidence, status, created_at, updated_at, "
                 "facility_id, facility_list_item_id, is_active) "
-                "VALUES ({match_id}, {{}}, 98.76, 'AUTOMATIC', "
+                "VALUES ({match_id}, '{{}}', 98.76, 'AUTOMATIC', "
                 "'{created_at}', '{updated_at}', '{oar_id}', "
                 "{list_item_id}, 't');\n"
             )

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -2,6 +2,8 @@ import csv
 import os
 import random
 from django.core.management.base import BaseCommand
+from django.utils import timezone
+from api.oar_id import make_oar_id
 
 
 # Taken from https://stackoverflow.com/a/312464
@@ -58,10 +60,7 @@ class Command(BaseCommand):
         file_count = options['filecount']
         row_count = options['rowcount']
         out_dir = options['outdir']
-        output_sql = options['sql']
-
-        if output_sql:
-            raise Exception('NOT YET IMPLEMENTED')
+        make_sql = options['sql']
 
         random.seed(8675309)
 
@@ -78,6 +77,7 @@ class Command(BaseCommand):
                     sector = 'Apparel'
                 rows.append(
                     {
+                        'oar_id': make_oar_id(row['country_code']),
                         'country': clean(row['country_code']),
                         'name': clean(row['name']),
                         'address': clean(row['address']),
@@ -96,11 +96,37 @@ class Command(BaseCommand):
             max_file_row = len(rows) - 1
             for _ in range(len(rows), row_count):
                 new_row = rows[random.randint(0, max_file_row)].copy()
+                new_row['oar_id'] = make_oar_id(new_row['country_code'])
                 new_row['name'] = shuffle_words(new_row['name'])
                 new_row['address'] = shuffle_words(new_row['address'])
                 rows.append(new_row)
 
         random.shuffle(rows)
+
+        if make_sql:
+            # TODO: Use COPY rather than INSERT
+            now = timezone.now().isoformat()
+            facility_insert = (
+                "INSERT INTO api_facility "
+                "(id, name, address, country_code, location, created_at, updated_at, created_from_id, has_inexact_coordinates) "
+                "VALUES ('{oar_id}', '{name}', '{address}', '{country}', {location}, '{created_at}', '{updated_at}', {created_from_id}, '{has_inexact_coordinates}')\n")
+            def prepare(rows):
+                for row in rows:
+                    new_row = row.copy()
+                    for col in ('name', 'address'):
+                        new_row[col] = new_row[col].replace("'", "''")
+                    new_row['location'] = 'ST_SetSRID(ST_POINT({lng}, {lat}),4326)'.format(**new_row)
+                    new_row['created_at'] = now
+                    new_row['updated_at'] = now
+                    new_row['has_inexact_coordinates'] = 'f'
+                    # TODO FIX LIST ITEM ID GENERATION
+                    new_row['created_from_id'] = '1'
+                    yield new_row
+            inserts = [facility_insert.format(**row) for row in prepare(rows)]
+            out_file = os.path.join(out_dir, 'facilities.sql')
+            with open(out_file, 'w') as f:
+                f.writelines(inserts)
+            return
 
         chunk_size = len(rows) // file_count
         for i, chunk in enumerate(chunks(rows, chunk_size)):

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -12,17 +12,21 @@ def chunks(lst, n):
 
 
 class Command(BaseCommand):
-    help = 'Take a downloaded facility CSV and make uploadable CSVs'
+    help = (
+        'Take a downloaded facility CSV from OAR and make uploadable CSVs or '
+        'SQL scripts. NOTE this has not been updated to use the new OS Hub CSV '
+        'format.'
+    )
 
     def add_arguments(self, parser):
         parser.add_argument('csvfile',
-                            help='Path to a CSV downloaded from OS Hub')
+                            help='Path to a CSV downloaded from OAR')
 
         parser.add_argument(
             '-f',
             '--filecount',
             type=int,
-            help='The total number of files to create',
+            help='For CSV output, the total number of files to create',
             default=1,
         )
 
@@ -30,7 +34,7 @@ class Command(BaseCommand):
             '-r',
             '--rowcount',
             type=int,
-            help='The total number of rows to create',
+            help='The total number of facilities to create',
             default=1,
         )
 
@@ -41,11 +45,23 @@ class Command(BaseCommand):
             default='./',
         )
 
+        parser.add_argument(
+            '-s',
+            '--sql',
+            help='Generate SQL scripts',
+            action='store_true',
+            default=False
+        )
+
     def handle(self, *args, **options):
         csv_file = options['csvfile']
         file_count = options['filecount']
         row_count = options['rowcount']
         out_dir = options['outdir']
+        output_sql = options['sql']
+
+        if output_sql:
+            raise Exception('NOT YET IMPLEMENTED')
 
         random.seed(8675309)
 

--- a/src/django/api/management/commands/makedata.py
+++ b/src/django/api/management/commands/makedata.py
@@ -19,8 +19,8 @@ def chunks(lst, n):
 class Command(BaseCommand):
     help = (
         'Take a downloaded facility CSV from OAR and make uploadable CSVs or '
-        'SQL scripts. NOTE this has not been updated to use the new OS Hub CSV '
-        'format.'
+        'SQL scripts. NOTE this has not been updated to use the new OS Hub '
+        'CSV format.'
     )
 
     def add_arguments(self, parser):
@@ -78,6 +78,7 @@ class Command(BaseCommand):
             return text
 
         oar_ids = set()
+
         def new_oar_id(country_code):
             new_id = make_oar_id(country_code)
             while new_id in oar_ids:
@@ -125,12 +126,15 @@ class Command(BaseCommand):
             # TODO Consider useing different contributor IDs
             source_insert = (
                 "INSERT INTO api_source "
-                "(id, source_type, is_active, is_public, \"create\", created_at, updated_at, contributor_id) "
-                "VALUES ({source_id}, 'SINGLE', 't', 't', 't', '{created_at}', '{updated_at}', 1);\n"
+                "(id, source_type, is_active, is_public, \"create\", "
+                "created_at, updated_at, contributor_id) "
+                "VALUES ({source_id}, 'SINGLE', 't', 't', 't', "
+                "'{created_at}', '{updated_at}', 1);\n"
             )
             source_copy_header = (
                 'COPY api_source '
-                '(id, source_type, is_active, is_public, "create", created_at, updated_at, contributor_id) '
+                '(id, source_type, is_active, is_public, "create", '
+                'created_at, updated_at, contributor_id) '
                 'FROM stdin;\n'
             )
             source_copy = (
@@ -141,42 +145,63 @@ class Command(BaseCommand):
             # facility to more closely simulate real data
             list_item_insert = (
                 "INSERT INTO api_facilitylistitem "
-                "(id, row_index, raw_data, status, processing_results, name, address, country_code, geocoded_point, geocoded_address, created_at, updated_at, source_id, clean_address, clean_name, sector) "
-                "VALUES ({source_id}, 0, '', 'MATCHED', '{{}}', '{name}', '{address}', '{country}', {location}, '{address}', '{created_at}', '{updated_at}', {source_id}, '{clean_address}', '{clean_name}', '{sector}');\n"
+                "(id, row_index, raw_data, status, processing_results, name, "
+                "address, country_code, geocoded_point, geocoded_address, "
+                "created_at, updated_at, source_id, clean_address, "
+                "clean_name, sector) "
+                "VALUES ({source_id}, 0, '', 'MATCHED', '{{}}', '{name}', "
+                "'{address}', '{country}', {location}, '{address}', "
+                "'{created_at}', '{updated_at}', {source_id}, "
+                "'{clean_address}', '{clean_name}', '{sector}');\n"
             )
             list_item_copy_header = (
                 "COPY api_facilitylistitem "
-                "(id, row_index, raw_data, status, processing_results, name, address, country_code, geocoded_point, geocoded_address, created_at, updated_at, source_id, clean_address, clean_name, sector) "
+                "(id, row_index, raw_data, status, processing_results, name, "
+                "address, country_code, geocoded_point, geocoded_address, "
+                "created_at, updated_at, source_id, clean_address, "
+                "clean_name, sector) "
                 "FROM stdin;\n"
             )
             list_item_copy = (
-                '{source_id}\t0\t\tMATCHED\t{{}}\t{name}\t{address}\t{country}\t{hexewkb}\t{address}\t{created_at}\t{updated_at}\t{source_id}\t{clean_address}\t{clean_name}\t{sector}\n'
+                '{source_id}\t0\t\tMATCHED\t{{}}\t{name}\t{address}\t'
+                '{country}\t{hexewkb}\t{address}\t{created_at}\t{updated_at}\t'
+                '{source_id}\t{clean_address}\t{clean_name}\t{sector}\n'
             )
 
             facility_insert = (
                 "INSERT INTO api_facility "
-                "(id, name, address, country_code, location, created_at, updated_at, created_from_id, has_inexact_coordinates) "
-                "VALUES ('{oar_id}', '{name}', '{address}', '{country}', {location}, '{created_at}', '{updated_at}', {created_from_id}, '{has_inexact_coordinates}');\n")
+                "(id, name, address, country_code, location, created_at, "
+                "updated_at, created_from_id, has_inexact_coordinates) "
+                "VALUES ('{oar_id}', '{name}', '{address}', '{country}', "
+                "{location}, '{created_at}', '{updated_at}', "
+                "{created_from_id}, '{has_inexact_coordinates}');\n")
             facility_copy_header = (
                 "COPY api_facility "
-                "(id, name, address, country_code, location, created_at, updated_at, created_from_id, has_inexact_coordinates) "
+                "(id, name, address, country_code, location, created_at, "
+                "updated_at, created_from_id, has_inexact_coordinates) "
                 "FROM stdin;\n")
             facility_copy = (
-                '{oar_id}\t{name}\t{address}\t{country}\t{hexewkb}\t{created_at}\t{updated_at}\t{created_from_id}\t{has_inexact_coordinates}\n')
-
+                '{oar_id}\t{name}\t{address}\t{country}\t{hexewkb}\t'
+                '{created_at}\t{updated_at}\t{created_from_id}\t'
+                '{has_inexact_coordinates}\n')
 
             match_insert = (
                 "INSERT INTO api_facilitymatch "
-                "(id, results, confidence, status, created_at, updated_at, facility_id, facility_list_item_id, is_active) "
-                "VALUES ({match_id}, {{}}, 98.76, 'AUTOMATIC', '{created_at}', '{updated_at}', '{oar_id}', {list_item_id}, 't');\n"
+                "(id, results, confidence, status, created_at, updated_at, "
+                "facility_id, facility_list_item_id, is_active) "
+                "VALUES ({match_id}, {{}}, 98.76, 'AUTOMATIC', "
+                "'{created_at}', '{updated_at}', '{oar_id}', "
+                "{list_item_id}, 't');\n"
             )
             match_copy_header = (
                 'COPY api_facilitymatch '
-                '(id, results, confidence, status, created_at, updated_at, facility_id, facility_list_item_id, is_active) '
+                '(id, results, confidence, status, created_at, updated_at, '
+                'facility_id, facility_list_item_id, is_active) '
                 'FROM stdin;\n'
             )
             match_copy = (
-                '{match_id}\t{{}}\t98.76\tAUTOMATIC\t{created_at}\t{updated_at}\t{oar_id}\t{list_item_id}\tt\n'
+                '{match_id}\t{{}}\t98.76\tAUTOMATIC\t{created_at}\t'
+                '{updated_at}\t{oar_id}\t{list_item_id}\tt\n'
             )
 
             def prepare(rows):
@@ -185,8 +210,12 @@ class Command(BaseCommand):
                     new_row = row.copy()
                     for col in ('name', 'address'):
                         new_row[col] = new_row[col].replace("'", "''")
-                    new_row['location'] = 'ST_SetSRID(ST_POINT({lng}, {lat}),4326)'.format(**new_row)
-                    new_row['hexewkb'] = GEOSGeometry('POINT ({lng} {lat})'.format(**new_row), srid=4326).hexewkb.decode('ascii')
+                    new_row['location'] = \
+                        'ST_SetSRID(ST_POINT({lng}, {lat}),4326)' \
+                        .format(**new_row)
+                    new_row['hexewkb'] = \
+                        GEOSGeometry('POINT ({lng} {lat})'.format(**new_row),
+                                     srid=4326).hexewkb.decode('ascii')
                     new_row['created_at'] = now
                     new_row['updated_at'] = now
                     new_row['has_inexact_coordinates'] = 'f'
@@ -199,12 +228,16 @@ class Command(BaseCommand):
                     yield new_row
                     idval += 1
 
-            # TODO Create a post load update that sets facility_id on api_facilitylistitem
+            # TODO Create a post load update that sets facility_id on
+            # api_facilitylistitem
             s_c_file = os.path.join(out_dir, 'sources_copy.sql')
             i_c_file = os.path.join(out_dir, 'facilitylistitems_copy.sql')
             f_c_file = os.path.join(out_dir, 'facilities_copy.sql')
             m_c_file = os.path.join(out_dir, 'facilitymatches_copy.sql')
-            with open(f_c_file, 'w') as f_c, open(s_c_file, 'w') as s_c, open(i_c_file, 'w') as i_c, open(m_c_file, 'w') as m_c:
+            with open(f_c_file, 'w') as f_c, \
+                 open(s_c_file, 'w') as s_c, \
+                 open(i_c_file, 'w') as i_c, \
+                 open(m_c_file, 'w') as m_c:
                 s_c.write(source_copy_header)
                 i_c.write(list_item_copy_header)
                 f_c.write(facility_copy_header)
@@ -223,7 +256,10 @@ class Command(BaseCommand):
             i_file = os.path.join(out_dir, 'facilitylistitems.sql')
             f_file = os.path.join(out_dir, 'facilities.sql')
             m_file = os.path.join(out_dir, 'facilitymatches.sql')
-            with open(f_file, 'w') as f, open(s_file, 'w') as s, open(i_file, 'w') as i, open(m_file, 'w') as m:
+            with open(f_file, 'w') as f, \
+                 open(s_file, 'w') as s, \
+                 open(i_file, 'w') as i, \
+                 open(m_file, 'w') as m:
                 for row in prepare(rows):
                     s.write(source_insert.format(**row))
                     i.write(list_item_insert.format(**row))


### PR DESCRIPTION
## Overview

Repurpose the previous makecsvs tool to also generate SQL scripts suitable for quickly loading a large volume of data to key tables for testing key application features.

Connects #1975

## Demo
```
$ ./scripts/manage makedata -r 100000 -s oar-export.csv
$ ./scripts/console django
root@346c8ec3e4cc:/usr/local/src# export PGUSER=openapparelregistry
root@346c8ec3e4cc:/usr/local/src# export PGHOST=database
root@346c8ec3e4cc:/usr/local/src# export PGPASSWORD=openapparelregistry
root@346c8ec3e4cc:/usr/local/src# psql < sources_copy.sql
COPY 100000
root@346c8ec3e4cc:/usr/local/src# psql < facilitylistitems_copy.sql
COPY 100000
root@346c8ec3e4cc:/usr/local/src# psql < facilities_copy.sql
COPY 100000
root@346c8ec3e4cc:/usr/local/src# psql < facilitymatches_copy.sql
COPY 100000
root@346c8ec3e4cc:/usr/local/src# psql < facility_to_item_update.sql
UPDATE 100000
```

```
$ time ./scripts/manage index_facilities
Creating open-supply-hub_django_run ... done
Indexing all facilities...

real	40m29.508s
user	0m1.028s
sys	0m0.983s
```

## Notes

The tool was not updated to use the new multi-line CSV format and it currently only compatible with CSV files with one line per facility. You will need to increase the timeout or run `resetdb` after loading data.

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index c683ebba..90d9593d 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     command:
       - "-b :8081"
       - "--reload"
-      - "--timeout=90"
+      - "--timeout=600"
       - "--access-logfile=-"
       - "--error-logfile=-"
       - "--log-level=debug"

````

The script generates both SQL scripts that use individual `INSERT`  statements and SQL scripts that use `COPY`. The `INSERT` style is dramatically slower and was only left has a helpful debugging tool at low data volume.

## Testing Instructions

**NOTE** Loading this volume of data will cause the gunicon service to timeout during dedupe training. 

* Get a CSV exported from OAR production (one named `facilities-prd-2022-02-22.csv` is available in the "Data" folder in the shared Google Drive for this project)
* Copy the CSV to `src/django`
* Run `./scripts/manage makedata -r 100000 -s the-data-file.csv` and verify that 8 SQL scripts are created
* Run `./scripts/server`
* Refer to the "Demo" section above to see how the scripts can be loaded into the database
* Verify the scripts run successfully

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
