### PR TITLE
Use 'pending' as default status filter on dashboard lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Use 'pending' as the default status filter on the dashboard list page [#2109](https://github.com/open-apparel-registry/open-apparel-registry/pull/2109)
 - Suppress "pure-python SequenceMatcher" warning [#2011](https://github.com/open-apparel-registry/open-apparel-registry/pull/2011)
 - Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
 - Fix processing_type_facility_type_unmatched [#1875](https://github.com/open-apparel-registry/open-apparel-registry/pull/1875)

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -46,6 +46,7 @@ import {
     DEFAULT_PAGE,
     DEFAULT_ROWS_PER_PAGE,
     ENTER_KEY,
+    facilityListStatusChoicesEnum,
     facilityListItemStatusChoicesEnum,
     facilityListItemErrorStatuses,
     facilityListSummaryStatusMessages,
@@ -395,7 +396,7 @@ export const getTokenFromQueryString = qs => {
 export const dashboardListParamsDefaults = Object.freeze({
     contributor: null,
     matchResponsibility: matchResponsibilityEnum.MODERATOR,
-    status: facilityListItemStatusChoicesEnum.MATCHED,
+    status: facilityListStatusChoicesEnum.PENDING,
 });
 
 export const getDashboardListParamsFromQueryString = qs => {


### PR DESCRIPTION
## Overview

This PR sets the default filter for /dashboard/lists to 'pending'.

Connects #2082

## Demo

Note the URL's lack of a `status` query parameter:
<img width="1549" alt="image" src="https://user-images.githubusercontent.com/1977405/187543369-8af38230-9e6e-4594-acde-452ca9bfa511.png">

## Notes

Looks like perhaps the wrong enum was used when setting the default; that should be rectified here.

## Testing Instructions

Navigate to the dashboard's list filter page and verify that `pending` is the default filter. Check the network tab to be sure that the appropriate query parameter appears (`status=PENDING`)

## Checklist

- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
