### PR TITLE
Add an `activate()` method to TrainedModel

### DIFF
--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -13,7 +13,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.aggregates.general import ArrayAgg
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.db import models, transaction
+from django.db import models, transaction, connection
 from django.db.models.constraints import UniqueConstraint
 from django.db.models.expressions import Subquery, OuterRef
 from django.db.models import F, Q, ExpressionWrapper, Func
@@ -2943,6 +2943,14 @@ class TrainedModelManager(models.Manager):
         return self.get_active().id
 
 
+class NoTrainedModel(Exception):
+        pass
+
+
+class ModelAlreadyActive(Exception):
+        pass
+
+
 class TrainedModel(models.Model):
     class Meta():
         constraints = [UniqueConstraint(name='unique_is_active',
@@ -2958,6 +2966,30 @@ class TrainedModel(models.Model):
                    'dedupe model')
     )
     objects = TrainedModelManager()
+
+    def activate(self):
+        if self.pk is None:
+            raise NoTrainedModel()
+        if self.is_active:
+            raise ModelAlreadyActive()
+        if self.activated_at is not None:
+            raise ModelAlreadyActive()
+        with transaction.atomic():
+            prev_active_version_id = TrainedModel.objects.get_active_version_id()
+            TrainedModel.objects.update(is_active=False)
+            self.is_active = True
+            self.activated_at = timezone.now()
+            self.save()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                        ALTER TABLE dedupe_indexed_records RENAME TO dedupe_indexed_records_{prev_active_version_id};
+                        ALTER TABLE dedupe_indexed_records_{active_version_id} RENAME TO dedupe_indexed_records;
+                        """.format({
+                                "prev_active_version_id": prev_active_version_id, "active_version_id": self.pk,
+                            })
+                )
+        return prev_active_version_id
 
 
 post_save.connect(FacilityClaim.post_save, sender=FacilityClaim)

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -2985,7 +2985,7 @@ class TrainedModel(models.Model):
                     """
                         ALTER TABLE dedupe_indexed_records RENAME TO dedupe_indexed_records_{prev_active_version_id};
                         ALTER TABLE dedupe_indexed_records_{active_version_id} RENAME TO dedupe_indexed_records;
-                        """.format({
+                        """.format(**{
                                 "prev_active_version_id": prev_active_version_id, "active_version_id": self.pk,
                             })
                 )

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -2943,7 +2943,7 @@ class TrainedModelManager(models.Manager):
         return self.get_active().id
 
 
-class NoTrainedModel(Exception):
+class TrainedModelNotSaved(Exception):
         pass
 
 
@@ -2969,7 +2969,7 @@ class TrainedModel(models.Model):
 
     def activate(self):
         if self.pk is None:
-            raise NoTrainedModel()
+            raise TrainedModelNotSaved()
         if self.is_active:
             raise ModelAlreadyActive()
         if self.activated_at is not None:


### PR DESCRIPTION
## Overview

This pull request adds a method to activate a model, and replaces the current index table with one generated alongside that model. There is some error handling to prevent activating a model more than once.

We also rename the table named `dedupe_indexed_records_MODELID` to `dedupe_indexed_records`, and rename the previous one to `dedupe_indexed_records_PREVIOUS_MODELID`. This ensures the index table and model remain in sync.

This branch has been rebased against `ogr/feature/cs/dedupe_upgrade_take2`

Connects #2036

## Testing Instructions

* run `./scripts/resetdb`. This run will finish with the following error, but that's expected because this script has not been updated for the new model training workflow yet:
`api.models.DoesNotExist: TrainedModel matching query does not exist.`
* run `./scripts/manage train_model`
* run `./scripts/manage train_model` a second time
* run `./scripts/manage shell_plus`
* inside the python shell, run these python statements sequentially:
```
t = TrainedModel.objects.get(pk=1)
t.is_active = True
t.activated_at = timezone.now()
t.save()
```
Now we have activated our first model
* still inside the python shell, run these statements sequentially:
```
t = TrainedModel.objects.get(pk=2)
t.activate()
```
The activate method will return a `1`, the ID of the previous model
* run `./scripts/manage dbshell`
* run the query below to see the trained models, and confirm that the output is similar to what is below
```
openapparelregistry=# select id, created_at,is_active,activated_at from api_trainedmodel;
 id |          created_at           | is_active |         activated_at
----+-------------------------------+-----------+-------------------------------
  1 | 2022-09-02 17:26:39.173469+00 | f         | 2022-09-02 17:35:37.264595+00
  2 | 2022-09-02 17:33:14.906307+00 | t         | 2022-09-02 17:36:31.086324+00
(2 rows)
```
* run the query below to confirm that there is data in the index table
```
openapparelregistry=# select * from dedupe_indexed_records limit 2;
 id | block_key |    record_id    |                                                                       record_data

----+-----------+-----------------+--------------------------------------------------------------------------------------
--------------------------------------------------------------------
  1 | wenzhou:0 | CN20222454TBCB2 | {"country": "cn", "name": "wenzhou jietu(aolun) shoes factory", "address": "no.8 shua
ngbao west road ouhai economic developm p.c. 325014 wenzhou china"}
  2 | no8sh:1   | CN20222454TBCB2 | {"country": "cn", "name": "wenzhou jietu(aolun) shoes factory", "address": "no.8 shua
ngbao west road ouhai economic developm p.c. 325014 wenzhou china"}
(2 rows)
```

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
