### PR TITLE
Add facility details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add duplicate status to list filter and item counts [#2061](https://github.com/open-apparel-registry/open-apparel-registry/pull/2061)
 - Add notify management command [#2045](https://github.com/open-apparel-registry/open-apparel-registry/pull/2045)
 - Add the new homepage [#2085](https://github.com/open-apparel-registry/open-apparel-registry/pull/2085)
+- Add facility details page [#2115](https://github.com/open-apparel-registry/open-apparel-registry/pull/2115)
 
 ### Changed
 - Upgrade terraform to 1.1.9 [#2054](https://github.com/open-apparel-registry/open-apparel-registry/pull/2054)

--- a/src/app/src/Routes.jsx
+++ b/src/app/src/Routes.jsx
@@ -32,6 +32,7 @@ import ClaimedFacilities from './components/ClaimedFacilities';
 import SurveyDialogNotification from './components/SurveyDialogNotification';
 import Settings from './components/Settings';
 import ExternalRedirect from './components/ExternalRedirect';
+import FacilityDetails from './components/FacilityDetails';
 
 import { sessionLogin } from './actions/auth';
 import { fetchFeatureFlags } from './actions/featureFlags';
@@ -50,6 +51,7 @@ import {
     listsRoute,
     facilityListItemsRoute,
     facilitiesRoute,
+    facilityDetailsRoute,
     profileRoute,
     dashboardRoute,
     claimFacilityRoute,
@@ -139,6 +141,20 @@ class Routes extends Component {
                                             />
                                         </FeatureFlag>
                                     )}
+                                />
+                                <Route
+                                    path={facilityDetailsRoute}
+                                    render={() => {
+                                        if (fetchingFeatureFlags) {
+                                            return <CircularProgress />;
+                                        }
+
+                                        return (
+                                            <Route
+                                                component={FacilityDetails}
+                                            />
+                                        );
+                                    }}
                                 />
                                 <Route
                                     path={facilitiesRoute}

--- a/src/app/src/components/FacilityDetailSidebar.jsx
+++ b/src/app/src/components/FacilityDetailSidebar.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { Redirect } from 'react-router';
+import { Redirect, withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import get from 'lodash/get';
@@ -55,6 +55,7 @@ const detailsSidebarStyles = theme =>
             flex: 1,
             overflow: 'scroll',
             paddingBottom: '50px',
+            backgroundColor: '#fff',
         },
         label: {
             padding: '12px 24px 6px 24px',
@@ -576,7 +577,9 @@ function mapDispatchToProps(
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(withStyles(detailsSidebarStyles)(FacilityDetailSidebar));
+export default withRouter(
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    )(withStyles(detailsSidebarStyles)(FacilityDetailSidebar)),
+);

--- a/src/app/src/components/FacilityDetails.jsx
+++ b/src/app/src/components/FacilityDetails.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import ArrowBack from '@material-ui/icons/ArrowBackIos';
+import get from 'lodash/get';
+
+import FacilityDetailSidebar from './FacilityDetailSidebar';
+
+import { resetSingleFacility, fetchFacilities } from '../actions/facilities';
+import withQueryStringSync from '../util/withQueryStringSync';
+import {
+    facilitiesRoute,
+    FACILITIES_REQUEST_PAGE_SIZE,
+} from '../util/constants';
+
+const facilityDetailsStyles = theme => ({
+    container: {
+        backgroundColor: '#F9F7F7',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: 0,
+        [theme.breakpoints.up('md')]: {
+            paddingLeft: '4.5rem',
+            paddingRight: '4.5rem',
+        },
+    },
+    buttonContainer: {
+        height: '4.5rem',
+        display: 'flex',
+        justifyContent: 'flex-start',
+        alignItems: 'center',
+    },
+    backButton: {
+        textTransform: 'none',
+        fontWeight: 700,
+    },
+});
+
+function FacilityDetails({
+    classes,
+    clearFacility,
+    searchForFacilities,
+    vectorTileFlagIsActive,
+    history: { push },
+}) {
+    return (
+        <div className={classes.container}>
+            <div className={classes.buttonContainer}>
+                <Button
+                    color="primary"
+                    className={classes.backButton}
+                    onClick={() => {
+                        clearFacility();
+                        searchForFacilities(vectorTileFlagIsActive);
+                        push(facilitiesRoute);
+                    }}
+                >
+                    <ArrowBack />
+                    Back to search results
+                </Button>
+            </div>
+            <FacilityDetailSidebar />
+        </div>
+    );
+}
+
+function mapStateToProps({ filters, featureFlags, embeddedMap: { embed } }) {
+    const vectorTileFlagIsActive = get(
+        featureFlags,
+        'flags.vector_tile',
+        false,
+    );
+
+    return { filters, vectorTileFlagIsActive, embedded: !!embed };
+}
+
+function mapDispatchToProps(dispatch) {
+    return {
+        clearFacility: () => dispatch(resetSingleFacility()),
+        searchForFacilities: vectorTilesAreActive =>
+            dispatch(
+                fetchFacilities({
+                    pageSize: vectorTilesAreActive
+                        ? FACILITIES_REQUEST_PAGE_SIZE
+                        : 50,
+                }),
+            ),
+    };
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withStyles(facilityDetailsStyles)(withQueryStringSync(FacilityDetails)));

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useState } from 'react';
 import { arrayOf, bool, func, number, string } from 'prop-types';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import LinearProgress from '@material-ui/core/LinearProgress';
@@ -93,6 +94,9 @@ function FilterSidebarFacilitiesTab({
     returnToSearchTab,
     fetchNextPage,
     isInfiniteLoading,
+    history: {
+        location: { search },
+    },
 }) {
     const [loginRequiredDialogIsOpen, setLoginRequiredDialogIsOpen] = useState(
         false,
@@ -280,12 +284,16 @@ function FilterSidebarFacilitiesTab({
                                             to={{
                                                 pathname: makeFacilityDetailLink(
                                                     oarID,
+                                                    search,
                                                 ),
                                                 state: {
                                                     panMapToFacilityDetails: true,
                                                 },
                                             }}
-                                            href={makeFacilityDetailLink(oarID)}
+                                            href={makeFacilityDetailLink(
+                                                oarID,
+                                                search,
+                                            )}
                                             style={
                                                 facilitiesTabStyles.linkStyles
                                             }
@@ -413,7 +421,6 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(FilterSidebarFacilitiesTab);
+export default withRouter(
+    connect(mapStateToProps, mapDispatchToProps)(FilterSidebarFacilitiesTab),
+);

--- a/src/app/src/components/SidebarWithErrorBoundary.jsx
+++ b/src/app/src/components/SidebarWithErrorBoundary.jsx
@@ -1,13 +1,8 @@
 import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
 
-import {
-    facilityDetailsRoute,
-    facilitiesRoute,
-    mainRoute,
-} from '../util/constants';
+import { facilitiesRoute, mainRoute } from '../util/constants';
 
-import FacilityDetailsSidebar from './FacilityDetailSidebar';
 import FilterSidebar from './FilterSidebar';
 import HomepageSidebar from './HomepageSidebar';
 
@@ -27,12 +22,6 @@ export default class SidebarWithErrorBoundary extends Component {
     render() {
         return (
             <Switch>
-                <Route
-                    key={JSON.stringify(this.state.hasError)}
-                    exact
-                    path={facilityDetailsRoute}
-                    component={FacilityDetailsSidebar}
-                />
                 <Route
                     key={JSON.stringify(this.state.hasError)}
                     exact

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -578,7 +578,8 @@ export const mapDjangoChoiceTuplesValueToSelectOptions = data =>
 
 export const allListsAreEmpty = (...lists) => negate(some)(lists, size);
 
-export const makeFacilityDetailLink = oarID => `${facilitiesRoute}/${oarID}`;
+export const makeFacilityDetailLink = (oarID, search) =>
+    `${facilitiesRoute}/${oarID}${search || ''}`;
 
 export const makeClaimFacilityLink = oarID =>
     `${facilitiesRoute}/${oarID}/claim`;


### PR DESCRIPTION
## Overview

Pulls the facility details view into a separate page, only adding the
basic routing functionality and some initial framing.

Connects #2074 

## Demo

![Aug-31-2022 16-41-01](https://user-images.githubusercontent.com/21046714/187780959-171402f4-e26d-427b-b445-3ae99e1ae34c.gif)
<img width="402" alt="Screen Shot 2022-08-31 at 5 02 18 PM" src="https://user-images.githubusercontent.com/21046714/187781470-96c858de-a292-40c0-9405-26dc71f70e3a.png">

## Notes

The task says to use a blank page for the route. However, I didn't want to merge a site with a 'broken' facility details page into OSHub staging, since it's being used, so I put the existing facility details page into the new page with something of an initial 'frame' as a placeholder.  

## Testing Instructions

* Run `./scripts/server`
* Search for facilities with at least one filter set. 
* Select a facility and confirm that the facility details load in a new page. 
* View the page in mobile and confirm that mobile styling looks reasonable.
* Use the 'Back to search results' button and confirm that the query string is still present on the search page. 
* Login as c3@example.com, and navigate to the embed tab in the user settings page. Set a height and width for the map. Confirm that you are able to navigate back and forth between search and the facility details without errors within the embedded map. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
