### PR TITLE
Update the Python and Rollbar versions used for lamba functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Dont duplicate check items with parsing errors [#2073](https://github.com/open-apparel-registry/open-apparel-registry/pull/2073)
 - Fix list URL construction when running as a Batch job [#2066](https://github.com/open-apparel-registry/open-apparel-registry/pull/2066)
 - Fix getLangFromTranslateElement function [#2097](https://github.com/open-apparel-registry/open-apparel-registry/pull/2097)
+- Update the Python and Rollber versions used for lamba functions [#2120](https://github.com/open-apparel-registry/open-apparel-registry/pull/2120)
 
 ### Security
 

--- a/deployment/terraform/lambda-functions/alert_batch_failures/requirements.txt
+++ b/deployment/terraform/lambda-functions/alert_batch_failures/requirements.txt
@@ -1,1 +1,1 @@
-rollbar==0.14.6
+rollbar==0.16.3

--- a/deployment/terraform/lambda-functions/alert_sfn_failures/requirements.txt
+++ b/deployment/terraform/lambda-functions/alert_sfn_failures/requirements.txt
@@ -1,1 +1,1 @@
-rollbar==0.14.6
+rollbar==0.16.3

--- a/deployment/terraform/lambda.tf
+++ b/deployment/terraform/lambda.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "alert_batch_failures" {
   description   = "Function to alert on AWS Batch Job Failures."
   role          = aws_iam_role.alert_batch_failures.arn
   handler       = "alert_batch_failures.handler"
-  runtime       = "python3.6"
+  runtime       = "python3.8"
   timeout       = 10
   memory_size   = 128
 
@@ -72,7 +72,7 @@ resource "aws_lambda_function" "alert_sfn_failures" {
   description   = "Function to alert on AWS Step Functions Failures."
   role          = aws_iam_role.alert_sfn_failures.arn
   handler       = "alert_sfn_failures.handler"
-  runtime       = "python3.6"
+  runtime       = "python3.8"
   timeout       = 10
   memory_size   = 128
 
@@ -88,4 +88,3 @@ resource "aws_lambda_function" "alert_sfn_failures" {
     Environment = var.environment
   }
 }
-


### PR DESCRIPTION
## Overview

On September 1 2022 our terraform provisioning began failing with the following message

>The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions.

The lambda functions are used to post errors to Rollbar. The latest version of the Rollbar library only lists support up to Python 3.8, so we use that rather than the version recommended in the error message.

Connects #2116

## Demo

After deploying this branch to OS Hub staging I submitted a list and canceled the parse job through the AWS batch console. The failed job notifications appeared in Rollbar

<img width="582" alt="Screen Shot 2022-09-02 at 10 18 04 AM" src="https://user-images.githubusercontent.com/17363/188206292-f73f074b-8348-4937-9b9d-918941b7d090.png">


## Notes

I felt confident about the version upgrades because the What's New documentation for Python 3.7 and 3.8 did not mention any breaking syntax changes that applied to our lambda code and the CHANGELOG for the Rollbar library did not mention any backward incompatible changes.

## Testing Instructions

This was tested on OS Hub staging. See the Demo section above.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
