### PR TITLE
Update the Python and Rollber versions used for lamba functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix getLangFromTranslateElement function [#2096](https://github.com/open-apparel-registry/open-apparel-registry/pull/2096)
+- Update the Python and Rollber versions used for lamba functions [#2121](https://github.com/open-apparel-registry/open-apparel-registry/pull/2121/files)
+]
 
 ### Security
 

--- a/deployment/terraform/lambda-functions/alert_batch_failures/requirements.txt
+++ b/deployment/terraform/lambda-functions/alert_batch_failures/requirements.txt
@@ -1,1 +1,1 @@
-rollbar==0.14.6
+rollbar==0.16.3

--- a/deployment/terraform/lambda-functions/alert_sfn_failures/requirements.txt
+++ b/deployment/terraform/lambda-functions/alert_sfn_failures/requirements.txt
@@ -1,1 +1,1 @@
-rollbar==0.14.6
+rollbar==0.16.3

--- a/deployment/terraform/lambda.tf
+++ b/deployment/terraform/lambda.tf
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "alert_batch_failures" {
   description      = "Function to alert on AWS Batch Job Failures."
   role             = "${aws_iam_role.alert_batch_failures.arn}"
   handler          = "alert_batch_failures.handler"
-  runtime          = "python3.6"
+  runtime          = "python3.8"
   timeout          = 10
   memory_size      = 128
 
@@ -67,7 +67,7 @@ resource "aws_lambda_function" "alert_sfn_failures" {
   description      = "Function to alert on AWS Step Functions Failures."
   role             = "${aws_iam_role.alert_sfn_failures.arn}"
   handler          = "alert_sfn_failures.handler"
-  runtime          = "python3.6"
+  runtime          = "python3.8"
   timeout          = 10
   memory_size      = 128
 


### PR DESCRIPTION
## Overview

NOTE: This is the same change as #2120 targeted at the `develop` branch

On September 1 2022 our terraform provisioning began failing with the following message

> The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9) while creating or updating functions.

The lambda functions are used to post errors to Rollbar. The latest version of the Rollbar library only lists support up to Python 3.8, so we use that rather than the version recommended in the error message.

Connects #2116

## Notes

I felt confident about the version upgrades because the What's New documentation for Python 3.7 and 3.8 did not mention any breaking syntax changes that applied to our lambda code and the CHANGELOG for the Rollbar library did not mention any backward incompatible changes.

## Demo

<img width="540" alt="Screen Shot 2022-09-02 at 11 45 32 AM" src="https://user-images.githubusercontent.com/17363/188218179-0ede7b73-58f5-4f5f-b7d4-20143b145507.png">

## Testing Instructions

This was tested on staging by pushing a test branch, submitting a list, then cancelling the jobs via the AWS Batch console. See the demo screenshot above.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
