### PR TITLE
Provision an ElastiCache memcached cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add facility details page [#2115](https://github.com/open-apparel-registry/open-apparel-registry/pull/2115)
 - Added API throttling w/ customizable rates per user [#2125](https://github.com/open-apparel-registry/open-apparel-registry/pull/2125)
 - Add interactive map to facility details [#2145](https://github.com/open-apparel-registry/open-apparel-registry/pull/2145)
+- Provision an ElastiCache memcached cluster [#2138](https://github.com/open-apparel-registry/open-apparel-registry/pull/2138)
 
 ### Changed
 

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -70,7 +70,7 @@ data "template_file" "default_job_definition" {
     batch_job_def_name               = "job${local.short}Default"
     log_group_name                   = "log${local.short}Batch"
     cache_host                       = aws_route53_record.cache.name
-    cache_port                       = module.cache.port
+    cache_port                       = var.ec_memcached_port
   }
 }
 
@@ -158,7 +158,7 @@ data "template_file" "notifications_job_definition" {
     batch_job_def_name               = "job${local.short}Notifications"
     log_group_name                   = "log${local.short}Batch"
     cache_host                       = aws_route53_record.cache.name
-    cache_port                       = module.cache.port
+    cache_port                       = var.ec_memcached_port
   }
 }
 

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -69,6 +69,8 @@ data "template_file" "default_job_definition" {
     batch_job_queue_name             = "queue${local.short}Default"
     batch_job_def_name               = "job${local.short}Default"
     log_group_name                   = "log${local.short}Batch"
+    cache_host                       = aws_route53_record.cache.name
+    cache_port                       = module.cache.port
   }
 }
 
@@ -155,6 +157,8 @@ data "template_file" "notifications_job_definition" {
     batch_job_queue_name             = "queue${local.short}Notifications"
     batch_job_def_name               = "job${local.short}Notifications"
     log_group_name                   = "log${local.short}Batch"
+    cache_host                       = aws_route53_record.cache.name
+    cache_port                       = module.cache.port
   }
 }
 

--- a/deployment/terraform/cache.tf
+++ b/deployment/terraform/cache.tf
@@ -1,4 +1,17 @@
 #
+# Security group resources
+#
+resource "aws_security_group" "memcached" {
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sgCacheCluster"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+#
 # Subnet group resources
 #
 resource "aws_elasticache_subnet_group" "memcached" {
@@ -24,23 +37,72 @@ resource "aws_elasticache_parameter_group" "memcached" {
 #
 # ElastiCache resources
 #
-module "cache" {
-  source = "github.com/azavea/terraform-aws-memcached-elasticache?ref=feature%2Fjcw%2F0-12-update"
+resource "aws_elasticache_cluster" "memcached" {
+  lifecycle {
+    create_before_destroy = true
+  }
 
-  vpc_id                 = module.vpc.id
-  cache_identifier       = var.ec_memcached_identifier
-  desired_clusters       = var.ec_memcached_desired_clusters
-  instance_type          = var.ec_memcached_instance_type
+  cluster_id = format(
+    "%.16s-%.4s",
+    lower(var.ec_memcached_identifier),
+    md5(var.ec_memcached_instance_type),
+    )
+  engine                 = "memcached"
   engine_version         = var.ec_memcached_engine_version
-  parameter_group        = aws_elasticache_parameter_group.memcached.name
-  subnet_group           = aws_elasticache_subnet_group.memcached.name
+  node_type              = var.ec_memcached_instance_type
+  num_cache_nodes        = var.ec_memcached_desired_clusters
+  az_mode                = var.ec_memcached_desired_clusters == 1 ? "single-az" : "cross-az"
+  parameter_group_name   = aws_elasticache_parameter_group.memcached.name
+  subnet_group_name      = aws_elasticache_subnet_group.memcached.name
+  security_group_ids     = [aws_security_group.memcached.id]
   maintenance_window     = var.ec_memcached_maintenance_window
   notification_topic_arn = aws_sns_topic.global.arn
+  port                   = var.ec_memcached_port
 
-  alarm_cpu_threshold_percent  = var.ec_memcached_alarm_cpu_threshold_percent
-  alarm_memory_threshold_bytes = var.ec_memcached_alarm_memory_threshold_bytes
-  alarm_actions                = [aws_sns_topic.global.arn]
+  tags = {
+    Name        = "CacheCluster"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
 
-  project     = var.project
-  environment = var.environment
+#
+# CloudWatch resources
+#
+resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
+  alarm_name          = "alarm${local.short}MemcachedCacheClusterCPUUtilization"
+  alarm_description   = "Memcached cluster CPU utilization"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+
+  threshold = var.ec_memcached_alarm_cpu_threshold_percent
+
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.memcached.id
+  }
+
+  alarm_actions = [aws_sns_topic.global.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "cache_memory" {
+  alarm_name          = "alarm${local.short}MemcachedCacheClusterFreeableMemory"
+  alarm_description   = "Memcached cluster freeable memory"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/ElastiCache"
+  period              = "60"
+  statistic           = "Average"
+
+  threshold = var.ec_memcached_alarm_memory_threshold_bytes
+
+  dimensions = {
+    CacheClusterId = aws_elasticache_cluster.memcached.id
+  }
+
+  alarm_actions = [aws_sns_topic.global.arn]
 }

--- a/deployment/terraform/cache.tf
+++ b/deployment/terraform/cache.tf
@@ -1,0 +1,46 @@
+#
+# Subnet group resources
+#
+resource "aws_elasticache_subnet_group" "memcached" {
+  name        = var.ec_memcached_identifier
+  description = "Private subnets for Memcached ElastiCache instances"
+  subnet_ids  = module.vpc.private_subnet_ids
+}
+
+#
+# Parameter group resources
+#
+resource "aws_elasticache_parameter_group" "memcached" {
+  name        = var.ec_memcached_identifier
+  description = "Parameter Group for ElastiCache Memcached"
+  family      = var.ec_memcached_parameter_group_family
+
+  parameter {
+    name  = "max_item_size"
+    value = var.ec_memcached_max_item_size
+  }
+}
+
+#
+# ElastiCache resources
+#
+module "cache" {
+  source = "github.com/azavea/terraform-aws-memcached-elasticache?ref=feature%2Fjcw%2F0-12-update"
+
+  vpc_id                 = module.vpc.id
+  cache_identifier       = var.ec_memcached_identifier
+  desired_clusters       = var.ec_memcached_desired_clusters
+  instance_type          = var.ec_memcached_instance_type
+  engine_version         = var.ec_memcached_engine_version
+  parameter_group        = aws_elasticache_parameter_group.memcached.name
+  subnet_group           = aws_elasticache_subnet_group.memcached.name
+  maintenance_window     = var.ec_memcached_maintenance_window
+  notification_topic_arn = aws_sns_topic.global.arn
+
+  alarm_cpu_threshold_percent  = var.ec_memcached_alarm_cpu_threshold_percent
+  alarm_memory_threshold_bytes = var.ec_memcached_alarm_memory_threshold_bytes
+  alarm_actions                = [aws_sns_topic.global.arn]
+
+  project     = var.project
+  environment = var.environment
+}

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -139,6 +139,8 @@ data "template_file" "app" {
     batch_job_queue_name             = local.batch_job_queue_name
     batch_job_def_name               = local.batch_job_def_name
     log_group_name                   = "log${local.short}App"
+    cache_host                       = aws_route53_record.cache.name
+    cache_port                       = module.cache.port
   }
 }
 
@@ -184,6 +186,8 @@ data "template_file" "app_cli" {
     batch_job_queue_name             = local.batch_job_queue_name
     batch_job_def_name               = local.batch_job_def_name
     log_group_name                   = "log${local.short}AppCLI"
+    cache_host                       = aws_route53_record.cache.name
+    cache_port                       = module.cache.port
   }
 }
 
@@ -238,4 +242,3 @@ resource "aws_cloudwatch_log_group" "cli" {
   name              = "log${local.short}AppCLI"
   retention_in_days = 30
 }
-

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -140,7 +140,7 @@ data "template_file" "app" {
     batch_job_def_name               = local.batch_job_def_name
     log_group_name                   = "log${local.short}App"
     cache_host                       = aws_route53_record.cache.name
-    cache_port                       = module.cache.port
+    cache_port                       = var.ec_memcached_port
   }
 }
 
@@ -187,7 +187,7 @@ data "template_file" "app_cli" {
     batch_job_def_name               = local.batch_job_def_name
     log_group_name                   = "log${local.short}AppCLI"
     cache_host                       = aws_route53_record.cache.name
-    cache_port                       = module.cache.port
+    cache_port                       = var.ec_memcached_port
   }
 }
 

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -23,6 +23,14 @@ resource "aws_route53_record" "database" {
   records = [module.database_enc.hostname]
 }
 
+resource "aws_route53_record" "cache" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "cache.service.${var.r53_private_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "10"
+  records = [module.cache.endpoint]
+}
+
 #
 # Public DNS resources
 #
@@ -90,4 +98,3 @@ resource "aws_route53_record" "ses_dkim" {
   ttl     = "300"
   records = ["${element(aws_ses_domain_dkim.app.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
-

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -28,7 +28,7 @@ resource "aws_route53_record" "cache" {
   name    = "cache.service.${var.r53_private_hosted_zone}"
   type    = "CNAME"
   ttl     = "10"
-  records = [module.cache.endpoint]
+  records = [aws_elasticache_cluster.memcached.cluster_address]
 }
 
 #

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -64,6 +64,16 @@ resource "aws_security_group_rule" "bastion_https_egress" {
   security_group_id = module.vpc.bastion_security_group_id
 }
 
+resource "aws_security_group_rule" "bastion_memcached_egress" {
+  type      = "egress"
+  from_port = module.cache.port
+  to_port   = module.cache.port
+  protocol  = "tcp"
+
+  security_group_id        = module.vpc.bastion_security_group_id
+  source_security_group_id = module.cache.cache_security_group_id
+}
+
 #
 # App ALB security group resources
 #
@@ -122,6 +132,39 @@ resource "aws_security_group_rule" "rds_enc_bastion_ingress" {
 }
 
 #
+# Memcached security group resources
+#
+resource "aws_security_group_rule" "memcached_app_ingress" {
+  type      = "ingress"
+  from_port = module.cache.port
+  to_port   = module.cache.port
+  protocol  = "tcp"
+
+  security_group_id        = module.cache.cache_security_group_id
+  source_security_group_id = aws_security_group.app.id
+}
+
+resource "aws_security_group_rule" "memcached_batch_ingress" {
+  type      = "ingress"
+  from_port = module.cache.port
+  to_port   = module.cache.port
+  protocol  = "tcp"
+
+  security_group_id        = module.cache.cache_security_group_id
+  source_security_group_id = aws_security_group.batch.id
+}
+
+resource "aws_security_group_rule" "memcached_bastion_ingress" {
+  type      = "ingress"
+  from_port = module.cache.port
+  to_port   = module.cache.port
+  protocol  = "tcp"
+
+  security_group_id        = module.cache.cache_security_group_id
+  source_security_group_id = module.vpc.bastion_security_group_id
+}
+
+#
 # ECS container instance security group resources
 #
 resource "aws_security_group_rule" "app_https_egress" {
@@ -165,6 +208,16 @@ resource "aws_security_group_rule" "app_bastion_ingress" {
   source_security_group_id = module.vpc.bastion_security_group_id
 }
 
+resource "aws_security_group_rule" "app_memcached_egress" {
+  type      = "egress"
+  from_port = module.cache.port
+  to_port   = module.cache.port
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.app.id
+  source_security_group_id = module.cache.cache_security_group_id
+}
+
 #
 # Batch container instance security group resources
 #
@@ -198,3 +251,12 @@ resource "aws_security_group_rule" "batch_bastion_ingress" {
   source_security_group_id = module.vpc.bastion_security_group_id
 }
 
+resource "aws_security_group_rule" "batch_memcached_egress" {
+  type      = "egress"
+  from_port = module.cache.port
+  to_port   = module.cache.port
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.batch.id
+  source_security_group_id = module.cache.cache_security_group_id
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -66,12 +66,12 @@ resource "aws_security_group_rule" "bastion_https_egress" {
 
 resource "aws_security_group_rule" "bastion_memcached_egress" {
   type      = "egress"
-  from_port = module.cache.port
-  to_port   = module.cache.port
+  from_port = var.ec_memcached_port
+  to_port   = var.ec_memcached_port
   protocol  = "tcp"
 
   security_group_id        = module.vpc.bastion_security_group_id
-  source_security_group_id = module.cache.cache_security_group_id
+  source_security_group_id = aws_security_group.memcached.id
 }
 
 #
@@ -136,31 +136,31 @@ resource "aws_security_group_rule" "rds_enc_bastion_ingress" {
 #
 resource "aws_security_group_rule" "memcached_app_ingress" {
   type      = "ingress"
-  from_port = module.cache.port
-  to_port   = module.cache.port
+  from_port = var.ec_memcached_port
+  to_port   = var.ec_memcached_port
   protocol  = "tcp"
 
-  security_group_id        = module.cache.cache_security_group_id
+  security_group_id        = aws_security_group.memcached.id
   source_security_group_id = aws_security_group.app.id
 }
 
 resource "aws_security_group_rule" "memcached_batch_ingress" {
   type      = "ingress"
-  from_port = module.cache.port
-  to_port   = module.cache.port
+  from_port = var.ec_memcached_port
+  to_port   = var.ec_memcached_port
   protocol  = "tcp"
 
-  security_group_id        = module.cache.cache_security_group_id
+  security_group_id        = aws_security_group.memcached.id
   source_security_group_id = aws_security_group.batch.id
 }
 
 resource "aws_security_group_rule" "memcached_bastion_ingress" {
   type      = "ingress"
-  from_port = module.cache.port
-  to_port   = module.cache.port
+  from_port = var.ec_memcached_port
+  to_port   = var.ec_memcached_port
   protocol  = "tcp"
 
-  security_group_id        = module.cache.cache_security_group_id
+  security_group_id        = aws_security_group.memcached.id
   source_security_group_id = module.vpc.bastion_security_group_id
 }
 
@@ -210,12 +210,12 @@ resource "aws_security_group_rule" "app_bastion_ingress" {
 
 resource "aws_security_group_rule" "app_memcached_egress" {
   type      = "egress"
-  from_port = module.cache.port
-  to_port   = module.cache.port
+  from_port = var.ec_memcached_port
+  to_port   = var.ec_memcached_port
   protocol  = "tcp"
 
   security_group_id        = aws_security_group.app.id
-  source_security_group_id = module.cache.cache_security_group_id
+  source_security_group_id = aws_security_group.memcached.id
 }
 
 #
@@ -253,10 +253,10 @@ resource "aws_security_group_rule" "batch_bastion_ingress" {
 
 resource "aws_security_group_rule" "batch_memcached_egress" {
   type      = "egress"
-  from_port = module.cache.port
-  to_port   = module.cache.port
+  from_port = var.ec_memcached_port
+  to_port   = var.ec_memcached_port
   protocol  = "tcp"
 
   security_group_id        = aws_security_group.batch.id
-  source_security_group_id = module.cache.cache_security_group_id
+  source_security_group_id = aws_security_group.memcached.id
 }

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -20,7 +20,9 @@
       { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
       { "name": "BATCH_MODE", "value": "True" },
       { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" },
-      { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" }
+      { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" },
+      { "name": "CACHE_HOST", "value": "${cache_host}" },
+      { "name": "CACHE_PORT", "value": "${cache_port}" }
   ],
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/deployment/terraform/job-definitions/notifications.json
+++ b/deployment/terraform/job-definitions/notifications.json
@@ -20,7 +20,9 @@
       { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
       { "name": "BATCH_MODE", "value": "True" },
       { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" },
-      { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" }
+      { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" },
+      { "name": "CACHE_HOST", "value": "${cache_host}" },
+      { "name": "CACHE_PORT", "value": "${cache_port}" }
   ],
   "logConfiguration": {
       "logDriver": "awslogs",

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -35,7 +35,9 @@
         { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
         { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" },
         { "name": "OAR_CLIENT_KEY", "value": "${oar_client_key}" },
-        { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" }
+        { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" },
+        { "name": "CACHE_HOST", "value": "${cache_host}" },
+        { "name": "CACHE_PORT", "value": "${cache_port}" }
     ],
     "portMappings": [
       {

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -25,7 +25,9 @@
         { "name": "ROLLBAR_SERVER_SIDE_ACCESS_TOKEN", "value": "${rollbar_server_side_access_token}" },
         { "name": "REACT_APP_ROLLBAR_CLIENT_SIDE_ACCESS_TOKEN", "value": "${rollbar_client_side_access_token}" },
         { "name": "OAR_CLIENT_KEY", "value": "" },
-        { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" }
+        { "name": "EXTERNAL_DOMAIN", "value": "${external_domain}" },
+        { "name": "CACHE_HOST", "value": "${cache_host}" },
+        { "name": "CACHE_PORT", "value": "${cache_port}" }
     ],
     "logConfiguration": {
         "logDriver": "awslogs",

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -359,6 +359,10 @@ variable "aws_cloudfront_canonical_user_id" {
 
 variable "ec_memcached_identifier" {}
 
+variable "ec_memcached_port" {
+  default = 11211
+}
+
 variable "ec_memcached_parameter_group_family" {
   default = "memcached1.6"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -357,3 +357,37 @@ variable "aws_cloudfront_canonical_user_id" {
   default = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
 }
 
+variable "ec_memcached_identifier" {}
+
+variable "ec_memcached_parameter_group_family" {
+  default = "memcached1.6"
+}
+
+variable "ec_memcached_maintenance_window" {
+  default = "sun:02:30-sun:03:30"
+}
+
+variable "ec_memcached_desired_clusters" {
+  default = 1
+}
+
+variable "ec_memcached_instance_type" {
+  default = "cache.t3.medium"
+}
+
+variable "ec_memcached_engine_version" {
+  default = "1.6.12"
+}
+
+variable "ec_memcached_alarm_cpu_threshold_percent" {
+  default = "75"
+}
+
+variable "ec_memcached_alarm_memory_threshold_bytes" {
+  default = "10000000"
+}
+
+variable "ec_memcached_max_item_size" {
+  # 1MB
+  default = "1048576"
+}

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -16,7 +16,12 @@ Build application for staging or a release.
 if [[ -n "${GIT_COMMIT}" ]]; then
     GIT_COMMIT="${GIT_COMMIT:0:7}"
 else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
+    # TODO A run of cipublish on Jenkins resulted in an image being published
+    # with an 8-character tag. Is this workaround the best solution? This SO
+    # answer indicates that --short does not guarantee a length of 7
+    # https://stackoverflow.com/a/44287003
+    SHORT_SHA="$(git rev-parse --short HEAD)"
+    GIT_COMMIT="${SHORT_SHA:0:7}"
 fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -15,7 +15,12 @@ Publish container images to Elastic Container Registry (ECR).
 if [[ -n "${GIT_COMMIT}" ]]; then
     GIT_COMMIT="${GIT_COMMIT:0:7}"
 else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
+    # TODO A run of cipublish on Jenkins resulted in an image being published
+    # with an 8-character tag. Is this workaround the best solution? This SO
+    # answer indicates that --short does not guarantee a length of 7
+    # https://stackoverflow.com/a/44287003
+    SHORT_SHA="$(git rev-parse --short HEAD)"
+    GIT_COMMIT="${SHORT_SHA:0:7}"
 fi
 
 function amazon_ecr_login() {

--- a/scripts/infra
+++ b/scripts/infra
@@ -16,7 +16,12 @@ Execute Terraform subcommands with remote state management.
 if [[ -n "${GIT_COMMIT}" ]]; then
     GIT_COMMIT="${GIT_COMMIT:0:7}"
 else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
+    # TODO A run of cipublish on Jenkins resulted in an image being published
+    # with an 8-character tag. Is this workaround the best solution? This SO
+    # answer indicates that --short does not guarantee a length of 7
+    # https://stackoverflow.com/a/44287003
+    SHORT_SHA="$(git rev-parse --short HEAD)"
+    GIT_COMMIT="${SHORT_SHA:0:7}"
 fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -354,7 +354,8 @@ STATICFILES_STORAGE = 'spa.storage.SPAStaticFilesStorage'
 WATCHMAN_ERROR_CODE = 503
 WATCHMAN_CHECKS = (
     'watchman.checks.databases',
-    'api.checks.gazetteercache'
+    'watchman.checks.caches',
+    'api.checks.gazetteercache',
 )
 
 # django-ecsmanage

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -269,8 +269,7 @@ MEMCACHED_LOCATION = f"{os.getenv('CACHE_HOST')}:{os.getenv('CACHE_PORT')}"
 if DEBUG:
     CACHE_BACKEND = 'django.core.cache.backends.memcached.PyLibMCCache'
 else:
-    # TODO (GH #2091) use django_elasticache in staging / production
-    CACHE_BACKEND = 'django.core.cache.backends.locmem.LocMemCache'
+    CACHE_BACKEND = 'django_elasticache.memcached.ElastiCache'
 
 CACHES = {
     'default': {

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -7,6 +7,7 @@ defusedxml==0.6.0
 django-amazon-ses==4.0.1
 django-cors-headers==3.13.0
 django-ecsmanage==2.0.1
+django-elasticache==1.0.3
 django-extensions==3.1.4
 django-jsonview==2.0.0
 django-rest-auth[with_social]==0.9.5


### PR DESCRIPTION
## Overview

We are using memcached as a cache backend to enable API request throttling.

This uses a pre-release version of terraform-aws-memcached-elasticache module with suupport for Terraform version 0.12+
https://github.com/azavea/terraform-aws-memcached-elasticache/pull/8

The values for ec_memcached_max_item_size, alarm_cpu_threshold_percent, and alarm_memory_threshold_bytes were copied from the default values. The ec_memcached_maintenance_window was chosen based on a previous project value. ElastiCache requires a minimum 1-hour window.  We chose the lastest version of memcached available at the time of writing.

The cache.t3.medium size was chosen because it offers an ample 3GB of memory and 2 vCPUs at $1.63 a day. We choose 1 cluster node to keep the cluster logic simple since it is not immediately clear if the old django-elasticace library recommended by the AWS docs will still work correctly.

This library has not been updated in 5 years but AWS still mentiones using it in its documentation and web searches for alternatives have not yielded better options.

Connects #2091

## Demo

### Bastion connectivity to cache 

```
$ telnet cache.service.osh.internal 11211
Trying {IP}...
Connected to cache.service.osh.internal.
Escape character is '^]'.
stats
STAT pid 1
STAT uptime 1716
STAT time 1663559021
STAT version 1.6.12
STAT libevent 2.1.11-stable
STAT pointer_size 64
STAT rusage_user 0.074682
STAT rusage_system 0.055924
STAT max_connections 65000
STAT curr_connections 23
STAT total_connections 42
STAT connection_structures 24
STAT response_obj_oom 0
STAT response_obj_count 1
STAT response_obj_bytes 32768
STAT read_buf_count 4
STAT read_buf_bytes 65536
STAT read_buf_bytes_free 16384
STAT read_buf_oom 0
STAT reserved_fds 10
STAT cmd_get 645
STAT cmd_set 645
STAT cmd_flush 0
STAT cmd_touch 0
STAT cmd_config_get 128
STAT cmd_config_set 1
STAT cmd_meta 0
STAT get_hits 645
STAT get_misses 0
STAT get_expired 0
STAT get_flushed 0
STAT delete_misses 0
STAT delete_hits 645
STAT incr_misses 0
STAT incr_hits 0
STAT decr_misses 0
STAT decr_hits 0
STAT cas_misses 0
STAT cas_hits 0
STAT cas_badval 0
STAT touch_hits 0
STAT touch_misses 0
STAT auth_cmds 0
STAT auth_errors 0
STAT bytes_read 168847
STAT bytes_written 218489
STAT limit_maxbytes 3212836864
STAT launch_time_maxbytes 3212836864
STAT accepting_conns 1
STAT listen_disabled_num 0
STAT time_in_listen_disabled_us 0
STAT threads 2
STAT conn_yields 0
STAT hash_power_level 16
STAT hash_bytes 524288
STAT hash_is_expanding 0
STAT curr_config 1
STAT malloc_fails 0
STAT log_worker_dropped 0
STAT log_worker_written 0
STAT log_watcher_skipped 0
STAT log_watcher_sent 0
STAT log_watchers 0
STAT unexpected_napi_ids 0
STAT round_robin_fallback 0
STAT bytes 0
STAT curr_items 0
STAT total_items 645
STAT slab_global_page_pool 0
STAT expired_unfetched 0
STAT evicted_unfetched 0
STAT evictions 0
STAT reclaimed 0
STAT crawler_reclaimed 0
STAT crawler_items_checked 0
STAT lrutail_reflocked 0
END
quit
```

### App task health check includes cache

```
 curl https://{osh-staging}/health-check/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   147  100   147    0     0    176      0 --:--:-- --:--:-- --:--:--   185
{
  "gazetteercache": {
    "ok": true
  },
  "caches": [
    {
      "api_throttling": {
        "ok": true
      }
    },
    {
      "default": {
        "ok": true
      }
    }
  ],
  "databases": [
    {
      "default": {
        "ok": true
      }
    }
  ]
}
```

### Throttle

<img width="845" alt="Screen Shot 2022-09-18 at 8 54 02 PM" src="https://user-images.githubusercontent.com/17363/190947331-60fdf6ae-0c1b-4499-9de6-541b2b47ed8f.png">

## Testing Instructions

A test branch was deployed to staging to verify the deployment and produce the demo output above.

 

## Checklist

- [ ] ~Switch to the release tagged version of https://github.com/azavea/terraform-aws-memcached-elasticache/pull/8~
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
