### PR TITLE
Fixup recent UX changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix list URL construction when running as a Batch job [#2066](https://github.com/open-apparel-registry/open-apparel-registry/pull/2066)
 - Fix getLangFromTranslateElement function [#2097](https://github.com/open-apparel-registry/open-apparel-registry/pull/2097)
 - Update the Python and Rollber versions used for lamba functions [#2120](https://github.com/open-apparel-registry/open-apparel-registry/pull/2120)
+- Fixup recent UX changes [#2141](https://github.com/open-apparel-registry/open-apparel-registry/pull/2141)
 
 ### Security
 

--- a/src/app/src/Routes.jsx
+++ b/src/app/src/Routes.jsx
@@ -17,7 +17,6 @@ import LoginForm from './components/LoginForm';
 import UserProfile from './components/UserProfile';
 import Contribute from './components/Contribute';
 import Homepage from './components/Homepage';
-import MapAndSidebar from './components/MapAndSidebar';
 import FacilityLists from './components/FacilityLists';
 import FacilityListItems from './components/FacilityListItems';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -32,7 +31,7 @@ import ClaimedFacilities from './components/ClaimedFacilities';
 import SurveyDialogNotification from './components/SurveyDialogNotification';
 import Settings from './components/Settings';
 import ExternalRedirect from './components/ExternalRedirect';
-import FacilityDetails from './components/FacilityDetails';
+import Facilities from './components/Facilities';
 
 import { sessionLogin } from './actions/auth';
 import { fetchFeatureFlags } from './actions/featureFlags';
@@ -51,7 +50,6 @@ import {
     listsRoute,
     facilityListItemsRoute,
     facilitiesRoute,
-    facilityDetailsRoute,
     profileRoute,
     dashboardRoute,
     claimFacilityRoute,
@@ -120,9 +118,7 @@ class Routes extends Component {
                                         <FeatureFlag
                                             flag={CLAIM_A_FACILITY}
                                             alternative={
-                                                <Route
-                                                    component={MapAndSidebar}
-                                                />
+                                                <Route component={Facilities} />
                                             }
                                         >
                                             <Route component={ClaimFacility} />
@@ -143,30 +139,8 @@ class Routes extends Component {
                                     )}
                                 />
                                 <Route
-                                    path={facilityDetailsRoute}
-                                    render={() => {
-                                        if (fetchingFeatureFlags) {
-                                            return <CircularProgress />;
-                                        }
-
-                                        return (
-                                            <Route
-                                                component={FacilityDetails}
-                                            />
-                                        );
-                                    }}
-                                />
-                                <Route
                                     path={facilitiesRoute}
-                                    render={() => {
-                                        if (fetchingFeatureFlags) {
-                                            return <CircularProgress />;
-                                        }
-
-                                        return (
-                                            <Route component={MapAndSidebar} />
-                                        );
-                                    }}
+                                    component={Facilities}
                                 />
                                 <Route
                                     exact

--- a/src/app/src/actions/ui.js
+++ b/src/app/src/actions/ui.js
@@ -22,3 +22,5 @@ export const toggleZoomToSearch = createAction('TOGGLE_ZOOM_TO_SEARCH');
 export const showDrawFilter = createAction('SHOW_DRAW_FILTER');
 
 export const setGDPROpen = createAction('SET_GDPR_OPEN');
+
+export const reportListScroll = createAction('REPORT_LIST_SCROLL');

--- a/src/app/src/components/Facilities.jsx
+++ b/src/app/src/components/Facilities.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Route, Switch } from 'react-router-dom';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+import FacilityDetails from './FacilityDetails';
+import MapAndSidebar from './MapAndSidebar';
+
+import withQueryStringSync from '../util/withQueryStringSync';
+import { facilitiesRoute, facilityDetailsRoute } from '../util/constants';
+
+const Facilities = ({ fetchingFeatureFlags }) => {
+    if (fetchingFeatureFlags) {
+        return <CircularProgress />;
+    }
+
+    return (
+        <Switch>
+            <Route path={facilityDetailsRoute} component={FacilityDetails} />
+            <Route path={facilitiesRoute} component={MapAndSidebar} />
+        </Switch>
+    );
+};
+
+function mapStateToProps({ featureFlags: { fetching: fetchingFeatureFlags } }) {
+    return { fetchingFeatureFlags };
+}
+
+export default connect(mapStateToProps)(withQueryStringSync(Facilities));

--- a/src/app/src/components/FacilityDetails.jsx
+++ b/src/app/src/components/FacilityDetails.jsx
@@ -3,16 +3,11 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import ArrowBack from '@material-ui/icons/ArrowBackIos';
-import get from 'lodash/get';
 
 import FacilityDetailsContent from './FacilityDetailsContent';
 
-import { resetSingleFacility, fetchFacilities } from '../actions/facilities';
-import withQueryStringSync from '../util/withQueryStringSync';
-import {
-    facilitiesRoute,
-    FACILITIES_REQUEST_PAGE_SIZE,
-} from '../util/constants';
+import { resetSingleFacility } from '../actions/facilities';
+import { facilitiesRoute } from '../util/constants';
 
 const facilityDetailsStyles = theme => ({
     container: {
@@ -39,13 +34,7 @@ const facilityDetailsStyles = theme => ({
     },
 });
 
-function FacilityDetails({
-    classes,
-    clearFacility,
-    searchForFacilities,
-    vectorTileFlagIsActive,
-    history: { push },
-}) {
+function FacilityDetails({ classes, clearFacility, history: { push } }) {
     return (
         <div className={classes.container}>
             <div className={classes.buttonContainer}>
@@ -54,7 +43,6 @@ function FacilityDetails({
                     className={classes.backButton}
                     onClick={() => {
                         clearFacility();
-                        searchForFacilities(vectorTileFlagIsActive);
                         push(facilitiesRoute);
                     }}
                 >
@@ -67,31 +55,17 @@ function FacilityDetails({
     );
 }
 
-function mapStateToProps({ filters, featureFlags, embeddedMap: { embed } }) {
-    const vectorTileFlagIsActive = get(
-        featureFlags,
-        'flags.vector_tile',
-        false,
-    );
-
-    return { filters, vectorTileFlagIsActive, embedded: !!embed };
+function mapStateToProps({ filters, embeddedMap: { embed } }) {
+    return { filters, embedded: !!embed };
 }
 
 function mapDispatchToProps(dispatch) {
     return {
         clearFacility: () => dispatch(resetSingleFacility()),
-        searchForFacilities: vectorTilesAreActive =>
-            dispatch(
-                fetchFacilities({
-                    pageSize: vectorTilesAreActive
-                        ? FACILITIES_REQUEST_PAGE_SIZE
-                        : 50,
-                }),
-            ),
     };
 }
 
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withStyles(facilityDetailsStyles)(withQueryStringSync(FacilityDetails)));
+)(withStyles(facilityDetailsStyles)(FacilityDetails));

--- a/src/app/src/components/FacilityDetailsClaimedInfo.jsx
+++ b/src/app/src/components/FacilityDetailsClaimedInfo.jsx
@@ -9,9 +9,9 @@ import FacilityDetailsItem from './FacilityDetailsItem';
 
 import { addProtocolToWebsiteURLIfMissing } from '../util/util';
 
-const ClaimInfoSection = ({ label, value }) =>
+const ClaimInfoSection = ({ label, value, fullWidth }) =>
     trim(value) && (
-        <Grid item xs={12} md={6}>
+        <Grid item xs={12} md={fullWidth ? 12 : 6}>
             <FacilityDetailsItem label={label} primary={value} isFromClaim />
         </Grid>
     );
@@ -25,10 +25,6 @@ export default function FacilityDetailsClaimedInfo({ data, formatListItem }) {
 
     const facilitySection = (
         <>
-            <ClaimInfoSection
-                label="Description"
-                value={facility.description}
-            />
             <ClaimInfoSection
                 label="Website"
                 value={
@@ -110,6 +106,11 @@ export default function FacilityDetailsClaimedInfo({ data, formatListItem }) {
         <>
             {facilitySection}
             {officeSection}
+            <ClaimInfoSection
+                label="Description"
+                value={facility.description}
+                fullWidth
+            />
         </>
     );
 }

--- a/src/app/src/components/FacilityDetailsCoreFields.jsx
+++ b/src/app/src/components/FacilityDetailsCoreFields.jsx
@@ -68,6 +68,7 @@ const coreFieldsStyles = theme =>
         },
         osId: {
             marginTop: theme.spacing.unit * 2,
+            fontSize: '18px',
         },
         menuLink: {
             color: 'inherit',

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -40,7 +40,6 @@ import { makeFacilityDetailLink } from '../util/util';
 import COLOURS from '../util/COLOURS';
 
 import { filterSidebarStyles } from '../util/styles';
-import withQueryStringSync from '../util/withQueryStringSync';
 import BadgeClaimed from './BadgeClaimed';
 import CopyLinkIcon from './CopyLinkIcon';
 
@@ -489,11 +488,6 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withQueryStringSync(
-    withRouter(
-        connect(
-            mapStateToProps,
-            mapDispatchToProps,
-        )(FilterSidebarFacilitiesTab),
-    ),
+export default withRouter(
+    connect(mapStateToProps, mapDispatchToProps)(FilterSidebarFacilitiesTab),
 );

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -23,7 +23,7 @@ import CopySearch from './CopySearch';
 import FeatureFlag from './FeatureFlag';
 import DownloadFacilitiesButton from './DownloadFacilitiesButton';
 
-import { toggleFilterModal } from '../actions/ui';
+import { toggleFilterModal, reportListScroll } from '../actions/ui';
 
 import { fetchNextPageOfFacilities } from '../actions/facilities';
 
@@ -103,10 +103,26 @@ function FilterSidebarFacilitiesTab({
     history: {
         location: { search },
     },
+    handleScroll,
+    scrollTop,
 }) {
     const [loginRequiredDialogIsOpen, setLoginRequiredDialogIsOpen] = useState(
         false,
     );
+
+    const [hasScrolled, setHasScrolled] = useState(false);
+    const scrollElements = Array.from(
+        document.getElementsByClassName('infinite-scroll'),
+    );
+    if (!hasScrolled && scrollElements.length) {
+        setHasScrolled(true);
+        // The timeout allows persisted data to be restored before scroll is attemped
+        setTimeout(() => {
+            scrollElements.forEach(x => {
+                x.scrollTo(0, scrollTop);
+            });
+        }, 100);
+    }
 
     if (fetching) {
         return (
@@ -253,7 +269,6 @@ function FilterSidebarFacilitiesTab({
     const nonResultListComponentHeight = Array.from(
         document.getElementsByClassName('results-height-subtract'),
     ).reduce((sum, x) => sum + x.offsetHeight, 0);
-
     const resultListHeight = windowHeight - nonResultListComponentHeight;
 
     const loadingElement = facilities.length !== facilitiesCount && (
@@ -271,6 +286,8 @@ function FilterSidebarFacilitiesTab({
             <div style={filterSidebarStyles.controlPanelContentStyles}>
                 <List component="div">
                     <InfiniteAnyHeight
+                        className="infinite-scroll"
+                        handleScroll={e => handleScroll(e.scrollTop)}
                         containerHeight={resultListHeight}
                         infiniteLoadBeginEdgeOffset={100}
                         isInfiniteLoading={fetching || isInfiniteLoading}
@@ -463,6 +480,7 @@ function mapStateToProps({
     ui: {
         facilitiesSidebarTabSearch: { filterText },
         window: { innerHeight: windowHeight },
+        scrollTop,
     },
     logDownload: { fetching: downloadingCSV },
     facilitiesDownload: {
@@ -478,6 +496,7 @@ function mapStateToProps({
         downloadingCSV,
         windowHeight,
         isInfiniteLoading,
+        scrollTop,
     };
 }
 
@@ -485,6 +504,7 @@ function mapDispatchToProps(dispatch) {
     return {
         returnToSearchTab: () => dispatch(toggleFilterModal()),
         fetchNextPage: () => dispatch(fetchNextPageOfFacilities()),
+        handleScroll: scrollTop => dispatch(reportListScroll(scrollTop)),
     };
 }
 

--- a/src/app/src/components/Homepage.jsx
+++ b/src/app/src/components/Homepage.jsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { Route } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
+import { withStyles } from '@material-ui/core';
 
 import SidebarWithErrorBoundary from './SidebarWithErrorBoundary';
 import FacilitiesMap from './FacilitiesMap';
@@ -13,6 +14,15 @@ import '../styles/css/Map.css';
 import withQueryStringSync from '../util/withQueryStringSync';
 
 import { VECTOR_TILE } from '../util/constants';
+
+const homepageStyles = theme =>
+    Object.freeze({
+        mapSidebarContainer: Object.freeze({
+            [theme.breakpoints.down('md')]: {
+                height: 'auto !important',
+            },
+        }),
+    });
 
 class Homepage extends Component {
     state = { hasError: false };
@@ -29,10 +39,14 @@ class Homepage extends Component {
 
     render() {
         const { hasError } = this.state;
+        const { classes } = this.props;
 
         return (
             <Fragment>
-                <Grid container className="map-sidebar-container">
+                <Grid
+                    container
+                    className={`map-sidebar-container ${classes.mapSidebarContainer}`}
+                >
                     <Grid item sm={12} md={6} id="sidebar-container">
                         <Route component={SidebarWithErrorBoundary} />
                     </Grid>
@@ -61,4 +75,4 @@ class Homepage extends Component {
     }
 }
 
-export default withQueryStringSync(Homepage);
+export default withStyles(homepageStyles)(withQueryStringSync(Homepage));

--- a/src/app/src/components/Map.jsx
+++ b/src/app/src/components/Map.jsx
@@ -9,8 +9,6 @@ import VectorTileFacilitiesMap from './VectorTileFacilitiesMap';
 
 import '../styles/css/Map.css';
 
-import withQueryStringSync from '../util/withQueryStringSync';
-
 import {
     mainRoute,
     facilitiesRoute,
@@ -103,4 +101,4 @@ class Map extends Component {
     }
 }
 
-export default withQueryStringSync(Map);
+export default Map;

--- a/src/app/src/components/Map.jsx
+++ b/src/app/src/components/Map.jsx
@@ -10,7 +10,6 @@ import VectorTileFacilitiesMap from './VectorTileFacilitiesMap';
 import '../styles/css/Map.css';
 
 import {
-    mainRoute,
     facilitiesRoute,
     facilityDetailsRoute,
     VECTOR_TILE,
@@ -64,22 +63,6 @@ class Map extends Component {
                         <Route
                             exact
                             path={facilitiesRoute}
-                            render={() => (
-                                <FeatureFlag
-                                    flag={VECTOR_TILE}
-                                    alternative={
-                                        <Route component={FacilitiesMap} />
-                                    }
-                                >
-                                    <Route
-                                        component={VectorTileFacilitiesMap}
-                                    />
-                                </FeatureFlag>
-                            )}
-                        />
-                        <Route
-                            exact
-                            path={mainRoute}
                             render={() => (
                                 <FeatureFlag
                                     flag={VECTOR_TILE}

--- a/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -35,7 +35,6 @@ import { makeFacilityDetailLink, getValueFromEvent } from '../util/util';
 import COLOURS from '../util/COLOURS';
 
 import { filterSidebarStyles } from '../util/styles';
-import withQueryStringSync from '../util/withQueryStringSync';
 
 const SEARCH_TERM_INPUT = 'SEARCH_TERM_INPUT';
 
@@ -384,9 +383,7 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withQueryStringSync(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    )(NonVectorTileFilterSidebarFacilitiesTab),
-);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(NonVectorTileFilterSidebarFacilitiesTab);

--- a/src/app/src/reducers/UIReducer.js
+++ b/src/app/src/reducers/UIReducer.js
@@ -12,6 +12,7 @@ import {
     showDrawFilter,
     setGDPROpen,
     toggleFilterModal,
+    reportListScroll,
 } from '../actions/ui';
 
 import { completeFetchFacilities } from '../actions/facilities';
@@ -30,6 +31,7 @@ const initialState = Object.freeze({
     zoomToSearch: true,
     drawFilterActive: false,
     gdprOpen: false,
+    scrollTop: 0,
 });
 
 export default createReducer(
@@ -98,6 +100,10 @@ export default createReducer(
             update(state, {
                 gdprOpen: { $set: payload },
             }),
+        [reportListScroll]: (state, payload) =>
+            update(state, { scrollTop: { $set: payload } }),
+        [completeFetchFacilities]: state =>
+            update(state, { scrollTop: { $set: 0 } }),
     },
     initialState,
 );

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -67,6 +67,7 @@ export default function withQueryStringSync(WrappedComponent) {
 
         componentDidUpdate({
             resetButtonClickCount: prevResetButtonClickCount,
+            vectorTileFeatureIsActive: prevVectorTileFeatureIsActive,
         }) {
             const {
                 filters,
@@ -78,6 +79,7 @@ export default function withQueryStringSync(WrappedComponent) {
                 hydrateFiltersFromQueryString,
                 vectorTileFeatureIsActive,
                 embeddedMap: { embed },
+                fetchFacilitiesForCurrentSearch,
             } = this.props;
 
             const newQueryString = `?${createQueryStringFromSearchFilters(
@@ -95,6 +97,10 @@ export default function withQueryStringSync(WrappedComponent) {
                     newQueryString,
                     fetchFacilitiesOnQSChange,
                 );
+            }
+
+            if (!prevVectorTileFeatureIsActive && vectorTileFeatureIsActive) {
+                fetchFacilitiesForCurrentSearch();
             }
 
             if (search === newQueryString) {
@@ -159,6 +165,13 @@ export default function withQueryStringSync(WrappedComponent) {
                       )
                     : null;
             },
+            fetchFacilitiesForCurrentSearch: () =>
+                dispatch(
+                    fetchFacilities({
+                        ...push,
+                        activateFacilitiesTab: false,
+                    }),
+                ),
             clearFacilities: () => dispatch(resetFacilities()),
         };
     }


### PR DESCRIPTION
## Overview

- Increases the font size of the OSHub id on the details page to 18px
- Makes the claim description full-width and moves it to the last spot
- Prevents reloading the facility search when navigating to details and back
- Restores location in list when returning to search from details
     - List location is reset to the top when a new search is completed
     - If the user refreshes the page while on the details page, the search will be rerun and the list location will be reset to the top
- Restores the map in mobile view on the homepage

Connects #2133, #2127

## Demo

![Sep-14-2022 10-32-57](https://user-images.githubusercontent.com/21046714/190183972-aa2c35bf-d407-42a1-93c0-df51145c36fd.gif)

<img width="1238" alt="Screen Shot 2022-09-14 at 10 33 51 AM" src="https://user-images.githubusercontent.com/21046714/190184100-7c1d54da-c5be-4592-953d-9e77c03a3139.png">

## Notes

The scroll-to-location consistently returns the user to approximately the correct location, but sometimes is a little bit off. I've spent some time attempting to tweak it, but I think this is as accurate as we'll get without spending significantly more time on it. 

I based this on Jacob's PR to handle merge conflicts.

## Testing Instructions

* Run `./scripts/server
* View the map on the homepage on mobile
* Run a search
* Scroll the list
* Navigate to a facility, then back using the back button on screen
* Navigate to a facility, then back using the browser back button
* Navigate to a facility with a claim description

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
