### PR TITLE
Add interactive map to facility details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add the new homepage [#2085](https://github.com/open-apparel-registry/open-apparel-registry/pull/2085)
 - Add facility details page [#2115](https://github.com/open-apparel-registry/open-apparel-registry/pull/2115)
 - Added API throttling w/ customizable rates per user [#2125](https://github.com/open-apparel-registry/open-apparel-registry/pull/2125)
+- Add interactive map to facility details [#2145](https://github.com/open-apparel-registry/open-apparel-registry/pull/2145)
 
 ### Changed
 

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -548,7 +548,6 @@ hr {
   max-width: 100%;
   flex: none;
   margin: 30px auto 0;
-  border-radius: 5px;
 }
 
 .word-break {

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -75,6 +75,7 @@ function FacilitiesMap({
     },
     isEmbedded,
     isMobile,
+    disableZoom,
 }) {
     const mapRef = useRef(null);
 
@@ -238,7 +239,7 @@ function FacilitiesMap({
             center={initialCenter}
             zoom={initialZoom}
             minZoom={minimumZoom}
-            scrollWheelZoom={!isEmbedded && !isMobile}
+            scrollWheelZoom={!isEmbedded && !isMobile && !disableZoom}
             renderer={L.canvas()}
             style={mapComponentStyles.mapContainerStyles}
             zoomControl={false}

--- a/src/app/src/components/FacilityDetailsContent.jsx
+++ b/src/app/src/components/FacilityDetailsContent.jsx
@@ -12,6 +12,7 @@ import List from '@material-ui/core/List';
 import FacilityDetailsClosureStatus from './FacilityDetailsClosureStatus';
 import FacilityDetailsClaimFlag from './FacilityDetailsClaimFlag';
 import FacilityDetailsCoreFields from './FacilityDetailsCoreFields';
+import FacilityDetailsInteractiveMap from './FacilityDetailsInteractiveMap';
 import FacilityDetailsLocationFields from './FacilityDetailsLocationFields';
 import FacilityDetailsGeneralFields from './FacilityDetailsGeneralFields';
 import FacilityDetailsContributors from './FacilityDetailsContributors';
@@ -242,6 +243,7 @@ const FacilityDetailsContent = ({
                     claimFacility={claimFacility}
                     isClosed={data.properties.is_closed}
                 />
+                <FacilityDetailsInteractiveMap />
                 <FacilityDetailsLocationFields
                     data={data}
                     filterByUniqueField={filterByUniqueField}

--- a/src/app/src/components/FacilityDetailsGeneralFields.jsx
+++ b/src/app/src/components/FacilityDetailsGeneralFields.jsx
@@ -25,8 +25,6 @@ const locationFieldsStyles = theme =>
             justifyContent: 'center',
             borderTop: '2px solid #F9F7F7',
             borderBottom: '2px solid #F9F7F7',
-            flexDirection: 'column',
-            alignItems: 'center',
         },
         contentContainer: {
             width: '100%',
@@ -164,49 +162,51 @@ const FacilityDetailsLocationFields = ({
 
     return (
         <div className={classes.root}>
-            <Grid container className={classes.contentContainer}>
-                <Grid item xs={12} md={6}>
-                    <FacilityDetailsItem
-                        label="Name"
-                        {...nameField}
-                        additionalContent={otherNames}
-                        embed={embed}
-                    />
-                </Grid>
-                <Grid item xs={12} md={6}>
-                    <FacilityDetailsItem
-                        label="Sector"
-                        {...sectorField}
-                        additionalContent={otherSectors}
-                        embed={embed}
-                    />
-                </Grid>
-                {embed
-                    ? renderEmbedFields()
-                    : EXTENDED_FIELD_TYPES.map(renderExtendedField)}
-                <FeatureFlag flag={REPORT_A_FACILITY}>
-                    <ShowOnly when={!!activityReport}>
+            <div className={classes.contentContainer}>
+                <Grid container>
+                    <Grid item xs={12} md={6}>
                         <FacilityDetailsItem
-                            label="Status"
-                            {...activityReport}
-                            additionalContent={otherActivityReports}
-                            additionalContentText="status"
-                            additionalContentTextPlural="statuses"
+                            label="Name"
+                            {...nameField}
+                            additionalContent={otherNames}
                             embed={embed}
                         />
-                    </ShowOnly>
-                </FeatureFlag>
-            </Grid>
-            <Grid container className={classes.contentContainer}>
-                <FeatureFlag flag={CLAIM_A_FACILITY}>
-                    <ShowOnly when={!!data.properties.claim_info}>
-                        <FacilityDetailsClaimedInfo
-                            data={data.properties.claim_info}
-                            formatListItem={formatIfListAndRemoveDuplicates}
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <FacilityDetailsItem
+                            label="Sector"
+                            {...sectorField}
+                            additionalContent={otherSectors}
+                            embed={embed}
                         />
-                    </ShowOnly>
-                </FeatureFlag>
-            </Grid>
+                    </Grid>
+                    {embed
+                        ? renderEmbedFields()
+                        : EXTENDED_FIELD_TYPES.map(renderExtendedField)}
+                    <FeatureFlag flag={REPORT_A_FACILITY}>
+                        <ShowOnly when={!!activityReport}>
+                            <FacilityDetailsItem
+                                label="Status"
+                                {...activityReport}
+                                additionalContent={otherActivityReports}
+                                additionalContentText="status"
+                                additionalContentTextPlural="statuses"
+                                embed={embed}
+                            />
+                        </ShowOnly>
+                    </FeatureFlag>
+                </Grid>
+                <Grid container>
+                    <FeatureFlag flag={CLAIM_A_FACILITY}>
+                        <ShowOnly when={!!data.properties.claim_info}>
+                            <FacilityDetailsClaimedInfo
+                                data={data.properties.claim_info}
+                                formatListItem={formatIfListAndRemoveDuplicates}
+                            />
+                        </ShowOnly>
+                    </FeatureFlag>
+                </Grid>
+            </div>
         </div>
     );
 };

--- a/src/app/src/components/FacilityDetailsInteractiveMap.jsx
+++ b/src/app/src/components/FacilityDetailsInteractiveMap.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+
+import Map from './Map';
+
+const locationFieldsStyles = theme =>
+    Object.freeze({
+        root: {
+            color: '#191919',
+            display: 'flex',
+            justifyContent: 'center',
+            borderTop: '2px solid #F9F7F7',
+            borderBottom: '2px solid #F9F7F7',
+        },
+        contentContainer: {
+            width: '320px',
+            height: '200px',
+            padding: theme.spacing.unit * 3,
+            [theme.breakpoints.up('sm')]: {
+                width: '385px',
+                maxWidth: '100%',
+            },
+            [theme.breakpoints.up('md')]: {
+                width: '100%',
+                maxWidth: '1072px',
+                height: '457px',
+                maxHeight: '100%',
+            },
+        },
+    });
+
+const FacilityDetailsInteractiveMap = ({ classes }) => (
+    <div className={classes.root}>
+        <div className={`${classes.contentContainer}`}>
+            <Map />
+        </div>
+    </div>
+);
+
+export default withStyles(locationFieldsStyles)(FacilityDetailsInteractiveMap);

--- a/src/app/src/components/FacilityDetailsLocationFields.jsx
+++ b/src/app/src/components/FacilityDetailsLocationFields.jsx
@@ -20,8 +20,14 @@ const locationFieldsStyles = theme =>
         contentContainer: {
             width: '100%',
             maxWidth: '1072px',
-            paddingLeft: theme.spacing.unit * 3,
-            paddingBottom: theme.spacing.unit * 3,
+            padding: theme.spacing.unit * 3,
+        },
+        mapContainer: {
+            display: 'flex',
+            justifyContent: 'center',
+            [theme.breakpoints.up('md')]: {
+                display: 'block',
+            },
         },
     });
 
@@ -59,8 +65,11 @@ const FacilityDetailsLocationFields = ({
     return (
         <div className={classes.root}>
             <Grid container className={classes.contentContainer}>
-                <Grid item xs={12} md={6}>
-                    <FacilityDetailsStaticMap data={data} />
+                <Grid item xs={12} md={6} className={classes.mapContainer}>
+                    <FacilityDetailsStaticMap
+                        data={data}
+                        style={{ margin: 0 }}
+                    />
                 </Grid>
                 <Grid item xs={12} md={6}>
                     <FacilityDetailsItem

--- a/src/app/src/components/FacilityDetailsStaticMap.jsx
+++ b/src/app/src/components/FacilityDetailsStaticMap.jsx
@@ -26,6 +26,7 @@ function FacilityDetailsStaticMap({
     clientInfoFetched,
     baseURL,
     countryCode,
+    style = {},
 }) {
     return (
         <ShowOnly when={clientInfoFetched}>
@@ -38,6 +39,7 @@ function FacilityDetailsStaticMap({
                 })}
                 alt={`Facility ${name} at latitude ${lat} and longitude ${lng}`}
                 className="facility-detail_map"
+                style={style}
             />
         </ShowOnly>
     );

--- a/src/app/src/components/Map.jsx
+++ b/src/app/src/components/Map.jsx
@@ -51,11 +51,23 @@ class Map extends Component {
                                 <FeatureFlag
                                     flag={VECTOR_TILE}
                                     alternative={
-                                        <Route component={FacilitiesMap} />
+                                        <Route
+                                            render={props => (
+                                                <FacilitiesMap
+                                                    {...props}
+                                                    disableZoom
+                                                />
+                                            )}
+                                        />
                                     }
                                 >
                                     <Route
-                                        component={VectorTileFacilitiesMap}
+                                        render={props => (
+                                            <VectorTileFacilitiesMap
+                                                {...props}
+                                                disableZoom
+                                            />
+                                        )}
                                     />
                                 </FeatureFlag>
                             )}

--- a/src/app/src/components/SearchControls.jsx
+++ b/src/app/src/components/SearchControls.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
@@ -11,7 +11,7 @@ import { updateBoundaryFilter } from '../actions/filters';
 
 import { fetchFacilities } from '../actions/facilities';
 
-import { facilitiesRoute } from '../util/constants';
+import { facilitiesRoute, mainRoute } from '../util/constants';
 
 const zoomStyles = theme =>
     Object.freeze({
@@ -48,8 +48,6 @@ function SearchControls({
     clearDrawFilter,
     classes,
 }) {
-    const location = useLocation();
-
     const boundaryButton =
         boundary == null ? (
             <Button
@@ -94,19 +92,29 @@ function SearchControls({
         </div>
     );
 
-    if (location?.pathname?.includes(facilitiesRoute)) {
-        return (
-            <div className={classes.controlsStyle}>
-                {zoomControl}
-                <div className={classes.dividerStyle} />
-                <div>{boundaryButton}</div>
-            </div>
-        );
-    }
     return (
-        <div className={classes.controlsStyle}>
-            <div>{boundaryButton}</div>
-        </div>
+        <Switch>
+            <Route
+                exact
+                path={facilitiesRoute}
+                render={() => (
+                    <div className={classes.controlsStyle}>
+                        {zoomControl}
+                        <div className={classes.dividerStyle} />
+                        <div>{boundaryButton}</div>
+                    </div>
+                )}
+            />
+            <Route
+                exact
+                path={mainRoute}
+                render={() => (
+                    <div className={classes.controlsStyle}>
+                        <div>{boundaryButton}</div>
+                    </div>
+                )}
+            />
+        </Switch>
     );
 }
 

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -66,6 +66,7 @@ function VectorTileFacilitiesMap({
     mapStyle = 'silver',
     navigateToFacilities,
     isMobile,
+    disableZoom,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         oarID,
@@ -118,7 +119,7 @@ function VectorTileFacilitiesMap({
             ref={mapRef}
             center={initialCenter}
             zoom={initialZoom}
-            scrollWheelZoom={!isEmbedded && !isMobile}
+            scrollWheelZoom={!isEmbedded && !isMobile && !disableZoom}
             minZoom={minimumZoom}
             renderer={L.canvas()}
             style={mapComponentStyles.mapContainerStyles}


### PR DESCRIPTION
## Overview

Adds an interactive map to the facility details. 

Connects #2076 

## Demo

<img width="494" alt="Screen Shot 2022-09-15 at 9 17 55 AM" src="https://user-images.githubusercontent.com/21046714/190414505-21488bb6-1813-416c-a801-588ee852b026.png">
<img width="550" alt="Screen Shot 2022-09-15 at 9 17 40 AM" src="https://user-images.githubusercontent.com/21046714/190414519-1779c84b-c4b2-4889-b7d1-93dc0539abb3.png">

## Testing Instructions

* Run `./scripts/server`
* Visit a facility's details
* Confirm that the map doesn't zoom on mouse scroll and has no zoom/boundary buttons
* View the map in mobile
* View the map on the homepage and the facility search page and confirm it works as before

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
