### PR TITLE
Update train model command

### DIFF
--- a/src/django/api/management/commands/train_model.py
+++ b/src/django/api/management/commands/train_model.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from api.matching import train_gazetteer, get_model_data
+from api.matching import train_and_activate_gazetteer, get_model_data
 
 
 class Command(BaseCommand):
@@ -8,6 +8,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         messy, canonical = get_model_data()
-
-        gazetter = train_gazetteer(messy, canonical)
-        gazetter.build_index_table(canonical)
+        gazetteer = train_and_activate_gazetteer(messy, canonical)

--- a/src/django/api/management/commands/train_model.py
+++ b/src/django/api/management/commands/train_model.py
@@ -8,4 +8,4 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         messy, canonical = get_model_data()
-        gazetteer = train_and_activate_gazetteer(messy, canonical)
+        train_and_activate_gazetteer(messy, canonical)

--- a/src/django/api/matching.py
+++ b/src/django/api/matching.py
@@ -267,7 +267,6 @@ def train_and_activate_gazetteer(messy, canonical):
     gazetteer.trained_model = active_model
     gazetteer.cleanup_training()
     gazetteer.build_index_table(canonical)
-    #TODO make sure this works
     try:
         prev_active_model_id = active_model.activate()
     except ModelNotActivated:
@@ -279,14 +278,15 @@ def train_and_activate_gazetteer(messy, canonical):
                WHERE NOT EXISTS
                 (SELECT *
                     FROM dedupe_indexed_records d2
-                    WHERE d1.record_id = d2.record_id)""".format(prev_active_model_id)
+                    WHERE d1.record_id = d2.record_id)
+                    """.format(prev_active_model_id)
         )
         while True:
             records = cursor.fetchmany(1000)
             if not records:
                 break
             for record in records:
-                item = {record[0]: json.loads(record[1])    }
+                item = {record[0]: json.loads(record[1])}
                 gazetteer.index(item)
 
 

--- a/src/django/api/matching.py
+++ b/src/django/api/matching.py
@@ -242,10 +242,6 @@ def load_gazetteer():
     return gazetteer
 
 
-class ModelNotActivated(Exception):
-    pass
-
-
 def train_and_activate_gazetteer(messy, canonical):
     fields = [
         {'field': 'country', 'type': 'Exact'},
@@ -267,10 +263,7 @@ def train_and_activate_gazetteer(messy, canonical):
     gazetteer.trained_model = active_model
     gazetteer.cleanup_training()
     gazetteer.build_index_table(canonical)
-    try:
-        prev_active_model_id = active_model.activate()
-    except ModelNotActivated:
-        pass
+    prev_active_model_id = active_model.activate()
     with connection.cursor() as cursor:
         cursor.execute(
             """SELECT record_id, record_data


### PR DESCRIPTION
## Overview

This issue creates a train_and_activate_gazetteer function. We consolidate all code related to creating and training a model into this function, allowing us to clean up other sections of legacy code.

Connects #2037

This PR was originally open as  #2142, which was closed inadvertently.

## Demo
```
$ ./scripts/manage train_model
Creating open-apparel-registry_django_run ... done
reading training from file
Final predicate set:
SimplePredicate: (firstIntegerPredicate, address)
Final predicate set:
TfidfTextSearchPredicate: (0.6, address)
SimplePredicate: (firstTwoTokensPredicate, name)
SimplePredicate: (oneGramFingerprint, name)
using cross validation to find optimum alpha...
optimum alpha: 0.100000, score 0.5003286163666517
Final predicate set:
SimplePredicate: (sameFiveCharStartPredicate, address)
SimplePredicate: (firstTwoTokensPredicate, name)
SimplePredicate: (twoGramFingerprint, name)
$
```

## Notes

## Testing Instructions

* run `./scripts/resetdb`
* run `./scripts/manage train_model`. The debug statements will cause the script to output the model ID of the previous model, pausing to wait for user input before continuing.:
```
9
Press Enter to continue...
```
* Before we continue with this script, open a new tab and run `./scripts/manage dbshell`
* Run the following 3 insert statements.
 **Please Note:** the table name must be updated to reflect the previous model ID from the other tab.
```sql
insert into dedupe_indexed_records_9 (id, block_key, record_id, record_data) values (99996,'azavea','AZ012346','{"country": "us", "name": "azavea", "address": "123 fake street phila pa 19111"}');
```
```sql
insert into dedupe_indexed_records_9 (id, block_key, record_id, record_data) values (99997,'azavea','AZ012347','{"country": "us", "name": "azavea", "address": "123 fake street phila pa 19111"}');
```
```sql
insert into dedupe_indexed_records_9 (id, block_key, record_id, record_data) values (99999,'azavea','AZ012348','{"country": "us", "name": "azavea", "address": "123 fake street phila pa 19111"}');
```
* Switch back to the `train_model` tab, and press enter to continue the script. the rest of the process will commence, and the script will terminate
* Switching to the database tab, run the following query to verify that the timestamp for the active model is correct:
```sql
select id, created_at,is_active,activated_at from api_trainedmodel;
```
* run the query below to confirm that the rows have been added to the current index table:
```sql
select * from dedupe_indexed_records where record_id = 'AZ012346' OR record_id = 'AZ012347' OR record_id = 'AZ012348';
```
This is an example of what the output should look like:
```sql
  id   |  block_key   | record_id |                                   record_data

-------+--------------+-----------+------------------------------------------------------------------------
----------
 66788 | 123fa:0      | AZ012346  | {"country": "us", "name": "azavea", "address": "123 fake street phila p
a 19111"}
 66789 | avazeaveza:2 | AZ012346  | {"country": "us", "name": "azavea", "address": "123 fake street phila p
a 19111"}
 66792 | 123fa:0      | AZ012347  | {"country": "us", "name": "azavea", "address": "123 fake street phila p
a 19111"}
 66793 | avazeaveza:2 | AZ012347  | {"country": "us", "name": "azavea", "address": "123 fake street phila p
a 19111"}
 66796 | 123fa:0      | AZ012348  | {"country": "us", "name": "azavea", "address": "123 fake street phila p
a 19111"}
 66797 | avazeaveza:2 | AZ012348  | {"country": "us", "name": "azavea", "address": "123 fake street phila p
a 19111"}
(6 rows)
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] Remove any DROP commits
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
