### PR TITLE
Fix unit tests to wrok with refactored dedupe implementation

### DIFF
--- a/src/django/api/matching.py
+++ b/src/django/api/matching.py
@@ -500,32 +500,6 @@ def text_match_item(country_code, name, threshold=0.5):
                    .order_by('-similarity')
 
 
-def facility_values_to_dedupe_record(facility_dict):
-    """
-    Convert a dictionary with id, country, name, and address keys into a
-    dictionary suitable for training and indexing a Dedupe model.
-
-    Arguments:
-    facility_dict -- A dict with id, country, name, and address key created
-                     from a `Facility` values query.
-
-    Returns:
-    A dictionary with the id as the key and a dictionary of fields
-    as the value.
-    """
-    return {
-        str(facility_dict['id']): {
-            "country": clean(facility_dict['country']),
-            "name": clean(facility_dict['name']),
-            "address": clean(facility_dict['address']),
-        }
-    }
-
-
-class GazetteerCacheTimeoutError(Exception):
-    pass
-
-
 class GazetteerCache:
     """
     A container for holding a single, trained and indexed Gazetteer in memory,

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib import auth
@@ -86,6 +87,17 @@ from api.facility_type_processing_type import (
     get_facility_and_processing_type
 )
 from api.extended_fields import MAX_PRODUCT_TYPE_COUNT
+
+
+# Ensure that a trained and actived model is available for all tests that
+# interact with dedupe or FacilityMatch records (FacilityMatch has a post-save
+# signal handler that updates the traind model index)
+def setUpModule():
+    call_command(
+        'loaddata',
+        'trainedmodel.json',
+        verbosity=0
+    )
 
 
 class FacilityListCreateTest(APITestCase):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -61,7 +61,7 @@ from api.models import (
 
 from api.oar_id import make_oar_id, validate_oar_id
 from api.matching import (match_facility_list_items, GazetteerCache,
-                          sort_exact_matches)
+                          sort_exact_matches, get_canonical_items)
 from api.processing import (parse_facility_list_item,
                             geocode_facility_list_item,
                             reduce_matches, is_string_match,
@@ -1778,11 +1778,7 @@ class DedupeMatchingTests(TestCase):
 
     def setUp(self):
         self.contributor = Contributor.objects.first()
-
-    def tearDown(self):
-        GazetteerCache._gazetter = None
-        GazetteerCache._facility_version = None
-        GazetteerCache._match_version = None
+        GazetteerCache.index(get_canonical_items())
 
     def create_list(self, items, status=FacilityListItem.GEOCODED):
         facility_list = FacilityList(

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -71,8 +71,7 @@ from api.constants import (CsvHeaderField,
 from api.geocoding import geocode_address
 from api.matching import (match_item,
                           exact_match_item,
-                          text_match_item,
-                          GazetteerCacheTimeoutError)
+                          text_match_item)
 from api.helpers import clean
 from api.models import (ContributorWebhook,
                         FacilityList,
@@ -1554,22 +1553,6 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                                     kwargs={'pk': match.pk})
                             result['matches'].append(facility_dict)
 
-        except GazetteerCacheTimeoutError as te:
-            item.status = FacilityListItem.ERROR_MATCHING
-            item.processing_results.append({
-                'action': ProcessingAction.MATCH,
-                'started_at': match_started,
-                'error': True,
-                'message': str(te),
-                'finished_at': str(timezone.now())
-            })
-            item.save()
-            result['status'] = item.status
-            result['message'] = (
-                'A timeout occurred waiting for match results. Training may '
-                'be in progress. Retry your request in a few minutes')
-            return Response(result,
-                            status=status.HTTP_503_SERVICE_UNAVAILABLE)
         except Exception as e:
             item.status = FacilityListItem.ERROR_MATCHING
             item.processing_results.append({


### PR DESCRIPTION
## Overview

Fix tests and remove unused code

Connects #2148

## Demo

```
----------------------------------------------------------------------
Ran 361 tests in 297.576s

OK (skipped=1)
```

## Notes

Tests that interact with dedupe or FacilityMatch need a trained model to be available in the database.

Prior to the dedupe refactoring all of the canonical records were indexed as part of the model training process that ran each time time test were run. Since we are now loading a pre-trained model, the dedupe matching tests need to explicitly index the canonical records.

While fixing tests we identified and removed code that is no longer used.

## Testing Instructions

* Verify that the unit tests pass.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
