### PR TITLE
Update the facility list content when there are no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rename makecsvs to makedata and add stub SQL mode [#2108](https://github.com/open-apparel-registry/open-apparel-registry/pull/2108)
 - Update facility lists for contributor workflow updates [#2050](https://github.com/open-apparel-registry/open-apparel-registry/issues/2050)
 - Update facility details content [#2126](https://github.com/open-apparel-registry/open-apparel-registry/pull/2126)
-- Search/Filtering/Results UX Updates [#2110](https://github.com/open-apparel-registry/open-apparel-registry/pull/2110)
+- Search/Filtering/Results UX Updates [#2110](https://github.com/open-apparel-registry/open-apparel-registry/pull/2110) [#2159](https://github.com/open-apparel-registry/open-apparel-registry/pull/2159)
 - Delete matched facilities from created contributer [#2153](https://github.com/open-apparel-registry/open-apparel-registry/pull/2153)
 
 ### Deprecated

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -184,7 +184,7 @@ class FilterSidebar extends Component {
                         </Tabs>
                         {this.props.activeFilterSidebarTab === 0 && (
                             <Grid item sm={12} md={3}>
-                                {this.props.facilitiesCount && (
+                                {this.props.facilitiesCount > 0 && (
                                     <div
                                         className="results-height-subtract"
                                         style={{
@@ -234,7 +234,7 @@ class FilterSidebar extends Component {
                 </Hidden>
                 <Hidden mdDown>
                     <Grid item sm={12} md={4}>
-                        {this.props.facilitiesCount && (
+                        {this.props.facilitiesCount > 0 && (
                             <div
                                 className="results-height-subtract"
                                 style={{

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -183,20 +183,7 @@ function FilterSidebarFacilitiesTab({
                         style={facilitiesTabStyles.noResultsTextStyles}
                         align="center"
                     >
-                        No facilities to display
-                    </Typography>
-                    <Typography
-                        variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
-                        align="center"
-                    >
-                        <Button
-                            onClick={returnToSearchTab}
-                            variant="outlined"
-                            color="secondary"
-                        >
-                            Search for facilities
-                        </Button>
+                        No facilities matching this search
                     </Typography>
                 </div>
             </div>


### PR DESCRIPTION

## Overview

Previously a "0" was being rendered because React will still render zero even though it is falsy

We remove the "Search for facilties" button because it is a left over when when filters and results always appeared in separate tabs.

Connects #2049

## Demo

### Before
<img width="753" alt="Screen Shot 2022-09-21 at 11 33 18 AM" src="https://user-images.githubusercontent.com/17363/191583460-49fe1b85-d4ea-46fb-959d-048152e9ee70.png">

### After

<img width="747" alt="Screen Shot 2022-09-21 at 11 37 26 AM" src="https://user-images.githubusercontent.com/17363/191584287-e8600462-0dc5-4842-801a-21ab6431bb1f.png">

## Testing Instructions

* Browse http://localhost:6543/facilities?q=DOESNOTMATCHANYTHING and verify the results content

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
