### PR TITLE
Separate index table creation

### DIFF
--- a/src/django/api/gazetteer.py
+++ b/src/django/api/gazetteer.py
@@ -179,13 +179,17 @@ class OgrGazetteer(Link, OgrGazetteerMatching):
 
         with connection.cursor() as cursor:
             cursor.execute(
-                """CREATE TABLE IF NOT EXISTS {}
-                (block_key text,
-                record_id varchar(32),
-                record_data text,
-                UNIQUE (block_key, record_id))
                 """
-                .format(table_name)
+                CREATE TABLE IF NOT EXISTS {table_name}
+                    (id SERIAL PRIMARY KEY,
+                    block_key text NOT NULL,
+                    record_id varchar(32) NOT NULL,
+                    record_data text NOT NULL,
+                    UNIQUE (block_key, record_id));
+                CREATE INDEX {table_name}_idx
+                ON {table_name} (block_key, record_id);
+                """
+                .format(table_name=table_name)
             )
             # TODO: Bulk insert for speed?
             # The `target` kwarg is related to index predicates, which we are

--- a/src/django/api/gazetteer.py
+++ b/src/django/api/gazetteer.py
@@ -179,7 +179,12 @@ class OgrGazetteer(Link, OgrGazetteerMatching):
 
         with connection.cursor() as cursor:
             cursor.execute(
-                "CREATE TABLE {} (LIKE dedupe_indexed_records INCLUDING ALL)"
+                """CREATE TABLE IF NOT EXISTS {}
+                (block_key text,
+                record_id varchar(32),
+                record_data text,
+                UNIQUE (block_key, record_id))
+                """
                 .format(table_name)
             )
             # TODO: Bulk insert for speed?


### PR DESCRIPTION
## Overview

When we were creating a new index table for the about-to-be-activated dedupe_indexed_records table, we were previously creating it using CREATE TABLE ... LIKE. This linked some element of the tables together, which complicated deleting previous tables. We're updating it so the table is being created independently.

Connects #2146

## Notes

## Testing Instructions

* train two models by running `./scripts/manage train_model` twice
* run `./scripts/dbshell`
* run the query `select id from api_trainedmodel;` to get the ID of the oldest model
* run the query `drop table dedupe_indexed_records_3;`, replacing 3 with the ID of the oldest trained model to see if it deletes without error

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
