### PR TITLE
Don't return fields for inactive lists in Facility API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use HubSpot for mailing list [#2166](https://github.com/open-apparel-registry/open-apparel-registry/pull/2166)
 - Add Sector model and update create facility product type/sector parsing [#2157](https://github.com/open-apparel-registry/open-apparel-registry/pull/2157) [#2191](https://github.com/open-apparel-registry/open-apparel-registry/pull/2191)
 - Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167)
+- Filter out fields from inactive lists in facility API response [#2180](https://github.com/open-apparel-registry/open-apparel-registry/pull/2180)
 
 ### Deprecated
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1630,12 +1630,18 @@ class Facility(PPEMixin):
         }
 
     def extended_fields(self, contributor_id=None):
-        active_items = self.facilitymatch_set \
+        active_matches = self.facilitymatch_set \
                            .filter(status__in=[FacilityMatch.AUTOMATIC,
                                                FacilityMatch.CONFIRMED,
                                                FacilityMatch.MERGED]) \
                            .filter(is_active=True) \
                            .values_list('facility_list_item')
+
+        active_sources = self.facilitylistitem_set \
+                             .filter(source__is_active=True) \
+                             .values_list('id')
+
+        active_items = active_matches.intersection(active_sources)
 
         base_qs = ExtendedField.objects \
                                .filter(facility=self)

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth import password_validation
 from django.urls import reverse
-from django.db.models import Count
+from django.db.models import Count, Q
 from rest_framework.serializers import (BooleanField,
                                         CharField,
                                         ChoiceField,
@@ -1889,10 +1889,14 @@ class ExtendedFieldListSerializer(ModelSerializer):
                                   self.should_display_contributor(instance))
 
     def get_value_count(self, instance):
-        return ExtendedField.objects.filter(facility=instance.facility) \
+        from_claim = Q(facility_list_item=None)
+        from_active_list = Q(facility_list_item__source__is_active=True)
+        vals = ExtendedField.objects.filter(facility=instance.facility) \
                                     .filter(field_name=instance.field_name) \
                                     .filter(value=instance.value) \
+                                    .filter(from_claim | from_active_list) \
                                     .count()
+        return vals
 
     def get_is_from_claim(self, instance):
         return instance.facility_list_item is None

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -1024,6 +1024,8 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         queryset = Facility \
             .objects \
             .filter_by_query_params(request.query_params) \
+            .prefetch_related('facilitymatch_set', 'facilitylistitem_set',
+                              'facilitylistitem_set__source') \
             .order_by('name')
 
         page_queryset = self.paginate_queryset(queryset)


### PR DESCRIPTION
## Overview

Updates the `FacilitySerializer` & `Facility.extended_fields` method to no longer return extended fields from lists that are no longer active (the `source` for the list has `is_active` set to `False`). We also no longer use those fields in ordering based on number of identical values (the `value_count` property).

Connects to #2129

## Notes

This worked out to be more complicated than I expected initially - many of our unit tests didn't set `FacilityListItem.facility`, which I had to fix to support the additional query added to `Facility.extended_fields`

## Testing Instructions

* `scripts/server`

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
