### PR TITLE
Update batch AMI Id to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 
 - Updated Node to version 14 [#1986](https://github.com/open-apparel-registry/open-apparel-registry/pull/1986)
+- Updated Batch AMI ID to latest version [#2190](https://github.com/open-apparel-registry/open-apparel-registry/pull/2190)
 
 ## [66] - 2022-05-12
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -281,7 +281,7 @@ variable "batch_notifications_ce_spot_fleet_bid_percentage" {
 variable "batch_ami_id" {
   # Latest ECS-optimized Amazon Linux AMI in eu-west-1
   # See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-  default = "ami-00921cd1ce43d567a"
+  default = "ami-002e2fef4b94f8fd0"
 }
 
 variable "batch_default_ce_min_vcpus" {


### PR DESCRIPTION
## Overview

Update the AMI ID used for batch processing to the latest available.

Connects #1947 

## Demo

![image](https://user-images.githubusercontent.com/4432106/192880254-8fd354dd-2f9a-4aa5-af7d-28d05be96552.png)

## Notes

I needed to also update the `terraform.tfvars` file on S3 for Open Supply Hub staging - I have *not yet* updated the same variable on OS Hub production, OAR staging or OAR production.

## Testing Instructions

(I've already done this on OS Hub staging)
* Verify that the batch job queue on AWS references the new AMI ID
* Upload a CSV and verify that it makes it to the parsing step

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
