### PR TITLE
Don't create an empty product_types extended field when parsing CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated OAR ID to OS ID [#2163](https://github.com/open-apparel-registry/open-apparel-registry/pull/2163)
 - Update search results dropdowns [#2161](https://github.com/open-apparel-registry/open-apparel-registry/pull/2161)
 - Use HubSpot for mailing list [#2166](https://github.com/open-apparel-registry/open-apparel-registry/pull/2166)
-- Add Sector model and update create facility product type/sector parsing [#2157](https://github.com/open-apparel-registry/open-apparel-registry/pull/2157)
+- Add Sector model and update create facility product type/sector parsing [#2157](https://github.com/open-apparel-registry/open-apparel-registry/pull/2157) [#2191](https://github.com/open-apparel-registry/open-apparel-registry/pull/2191)
 - Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167)
 
 ### Deprecated

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -187,11 +187,12 @@ def parse_facility_list_item(item):
 
         parser = CsvRowSectorProductTypeParser(fields, values)
         item.sector = parser.sectors
-        if 'product_type' in fields:
-            values[fields.index('product_type')] = parser.product_types
-        else:
-            fields.append('product_type')
-            values.append(parser.product_types)
+        if len(parser.product_types) > 0:
+            if 'product_type' in fields:
+                values[fields.index('product_type')] = parser.product_types
+            else:
+                fields.append('product_type')
+                values.append(parser.product_types)
 
         if CsvHeaderField.COUNTRY in fields:
             item.country_code = get_country_code(

--- a/src/django/api/processing.py
+++ b/src/django/api/processing.py
@@ -193,6 +193,13 @@ def parse_facility_list_item(item):
             else:
                 fields.append('product_type')
                 values.append(parser.product_types)
+        else:
+            # In this case the parse found that all of the product_type values
+            # for the item were actually sectors. Setting None instead of an
+            # empty list ensures that we do not create an extended field for
+            # product_type
+            if 'product_type' in fields:
+                values[fields.index('product_type')] = None
 
         if CsvHeaderField.COUNTRY in fields:
             item.country_code = get_country_code(

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -626,6 +626,25 @@ class FacilityListItemParseTest(ProcessingTestCase):
         self.assertEqual(['Apparel'], item.sector)
         self.assertEqual(0, ExtendedField.objects.all().count())
 
+    def test_only_valid_sectors_as_product_type(self):
+        facility_list = FacilityList.objects.create(
+            header="product_type,address,country,name"
+        )
+        source = Source.objects.create(
+            source_type=Source.LIST, facility_list=facility_list,
+            contributor=self.contributor
+        )
+        item = FacilityListItem.objects.create(
+            row_index=1,
+            sector=[],
+            raw_data="Apparel,1234 main st,ChInA,Shirts!",
+            source=source
+        )
+        parse_facility_list_item(item)
+        self.assert_successful_parse_results(item)
+        self.assertEqual(['Apparel'], item.sector)
+        self.assertEqual(0, ExtendedField.objects.all().count())
+
 
 class UserTokenGenerationTest(TestCase):
     def setUp(self):

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -607,6 +607,25 @@ class FacilityListItemParseTest(ProcessingTestCase):
             'raw_values': [' Toys', 'Games']
         }, ef.value)
 
+    def test_sector_product_type_parsing_with_only_sector(self):
+        facility_list = FacilityList.objects.create(
+            header="sector_product_type,address,country,name"
+        )
+        source = Source.objects.create(
+            source_type=Source.LIST, facility_list=facility_list,
+            contributor=self.contributor
+        )
+        item = FacilityListItem.objects.create(
+            row_index=1,
+            sector=[],
+            raw_data="Apparel,1234 main st,ChInA,Shirts!",
+            source=source
+        )
+        parse_facility_list_item(item)
+        self.assert_successful_parse_results(item)
+        self.assertEqual(['Apparel'], item.sector)
+        self.assertEqual(0, ExtendedField.objects.all().count())
+
 
 class UserTokenGenerationTest(TestCase):
     def setUp(self):
@@ -8893,6 +8912,25 @@ class SectorTestCase(FacilityAPITestCaseBase):
         facility_index = FacilityIndex.objects.get(id=ef.facility.id)
         self.assertIn(
             self.SECTOR_NON_EXISTANT.lower(), facility_index.product_type)
+
+    @patch('api.geocoding.requests.get')
+    def test_sector_product_type_contains_only_sector(self, mock_get):
+        mock_get.return_value = Mock(ok=True, status_code=200)
+        mock_get.return_value.json.return_value = geocoding_data
+        self.join_group_and_login()
+        response = self.client.post(self.url, json.dumps({
+            'country': "US",
+            'name': "Azavea",
+            'address': "990 Spring Garden St., Philadelphia PA 19123",
+            'sector_product_type':
+            [self.SECTOR_A],
+        }), content_type='application/json')
+        response_data = json.loads(response.content)
+
+        item = FacilityListItem.objects.get(
+            facility_id=response_data['os_id'])
+        self.assertIn(self.SECTOR_A, item.sector)
+        self.assertEqual(0, ExtendedField.objects.all().count())
 
 
 class FacilityAndProcessingTypeAPITest(FacilityAPITestCaseBase):


### PR DESCRIPTION
## Overview

This `len` check alreay existed in the the facility POST API handler but was missing from the CSV parsing.

Connects #2080

## Testing Instructions

* Verify the logic and that the new unit tests pass CI

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
