### PR TITLE
Update terminology, claim wizard color (#2143, #2131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update site footer with OS Hub styling [#2189](https://github.com/open-apparel-registry/open-apparel-registry/pull/2189)
 - Updated withQueryStringSync to render only after query params are hydrated [#2205](https://github.com/open-apparel-registry/open-apparel-registry/pull/2205)
 - Rename Jenkinsfile.release for OSH [#2211](https://github.com/open-apparel-registry/open-apparel-registry/pull/2211)
+- Terminology updates [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
+- Change claim wizard header color [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
 
 ### Deprecated
 

--- a/src/app/src/components/ClaimedFacilitiesDetailsSidebar.jsx
+++ b/src/app/src/components/ClaimedFacilitiesDetailsSidebar.jsx
@@ -45,7 +45,7 @@ export default function ClaimedFacilitiesDetailsSidebar({ facilityDetails }) {
                 </Typography>
             </div>
             <div style={claimedFacilitiesDetailsSidebarStyles.sectionStyles}>
-                <Typography variant="title">Contributors</Typography>
+                <Typography variant="title">Organizations</Typography>
                 <ul
                     style={claimedFacilitiesDetailsSidebarStyles.bodyTextStyles}
                 >

--- a/src/app/src/components/ContributorWebhookForm.jsx
+++ b/src/app/src/components/ContributorWebhookForm.jsx
@@ -66,6 +66,10 @@ function ContributorWebhookForm({
                 saveWebhook(form);
             }}
         >
+            <p>
+                This feature is in development. Notification logic can be
+                created but events will not be sent at this time.
+            </p>
             <div>
                 <div className="form__field">
                     <label

--- a/src/app/src/components/DashboardApiBlocks.jsx
+++ b/src/app/src/components/DashboardApiBlocks.jsx
@@ -27,7 +27,7 @@ const styles = {
 };
 
 const currentDate = moment();
-const ALL_CONTRIBUTORS = { value: '', label: 'All Contributors' };
+const ALL_CONTRIBUTORS = { value: '', label: 'All Organizations' };
 
 function DashboardApiBlocks({
     dashboardApiBlocks: { apiBlocks },
@@ -88,7 +88,7 @@ function DashboardApiBlocks({
                                 name={CONTRIBUTORS}
                                 classNamePrefix="select"
                                 options={contributors}
-                                placeholder="Select a contributor..."
+                                placeholder="Select an organization..."
                                 value={contributor}
                                 onChange={c => setContributor(c)}
                                 disabled={apiBlocks.fetching}

--- a/src/app/src/components/DashboardApiBlocksTable.jsx
+++ b/src/app/src/components/DashboardApiBlocksTable.jsx
@@ -60,7 +60,7 @@ function DashboardApiBlocksTable({
                 <TableHead>
                     <TableRow>
                         <TableCell>Date Created</TableCell>
-                        <TableCell>Contributor</TableCell>
+                        <TableCell>Organization</TableCell>
                         <TableCell>In Effect Until</TableCell>
                         <TableCell padding="dense">Count Limit</TableCell>
                         <TableCell padding="dense">Actual Count</TableCell>

--- a/src/app/src/components/DashboardClaimsListTable.jsx
+++ b/src/app/src/components/DashboardClaimsListTable.jsx
@@ -51,7 +51,7 @@ function DashboardClaimsListTable({ data, history: { push } }) {
                     <TableRow>
                         <TableCell padding="dense">Claim ID</TableCell>
                         <TableCell>Facility Name</TableCell>
-                        <TableCell>Contributor Name</TableCell>
+                        <TableCell>Organization Name</TableCell>
                         <TableCell padding="dense">Created</TableCell>
                         <TableCell padding="dense">Last Updated</TableCell>
                         <TableCell padding="dense">Status</TableCell>

--- a/src/app/src/components/DashboardLists.jsx
+++ b/src/app/src/components/DashboardLists.jsx
@@ -233,7 +233,7 @@ function DashboardLists({
         <Paper style={styles.container}>
             <div style={styles.filterRow}>
                 <div style={styles.filter}>
-                    <label htmlFor={CONTRIBUTORS}>Contributor</label>
+                    <label htmlFor={CONTRIBUTORS}>Organization</label>
                     <ReactSelect
                         id={CONTRIBUTORS}
                         name={CONTRIBUTORS}

--- a/src/app/src/components/DashboardUpdateFacilityLocationCard.jsx
+++ b/src/app/src/components/DashboardUpdateFacilityLocationCard.jsx
@@ -189,7 +189,7 @@ export default function DashboardUpdateLocationCard({
                             isClearable
                             id="contributors"
                             name="contributors"
-                            placeholder="Contributor (optional)"
+                            placeholder="Organization (optional)"
                             className="basic-multi-select notranslate"
                             classNamePrefix="select"
                             options={contributorOptions}

--- a/src/app/src/components/FacilityDetailsContributors.jsx
+++ b/src/app/src/components/FacilityDetailsContributors.jsx
@@ -85,7 +85,7 @@ const FacilityDetailsContributors = ({ classes, contributors }) => {
                         {visibleContributors.length === 1
                             ? 'organization has'
                             : 'organizations have'}{' '}
-                        contributed data for this facility
+                        uploaded data for this facility
                     </span>
                 </Button>
             </div>
@@ -94,7 +94,7 @@ const FacilityDetailsContributors = ({ classes, contributors }) => {
                     <>
                         <GroupIcon />{' '}
                         <span className={classes.buttonText}>
-                            Contributors ({visibleContributors.length})
+                            Organizations ({visibleContributors.length})
                         </span>
                     </>
                 }

--- a/src/app/src/components/FacilityDetailsItem.jsx
+++ b/src/app/src/components/FacilityDetailsItem.jsx
@@ -39,8 +39,8 @@ const FacilityDetailsItem = ({
     embed,
     isVerified,
     isFromClaim,
-    additionalContentText = 'contribution',
-    additionalContentTextPlural = 'contributions',
+    additionalContentText = 'entry',
+    additionalContentTextPlural = 'entries',
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const hasAdditionalContent = !embed && !!additionalContent?.length;

--- a/src/app/src/components/Filters/ContributorFilter.jsx
+++ b/src/app/src/components/Filters/ContributorFilter.jsx
@@ -99,7 +99,7 @@ function ContributorFilter({
                 <StyledSelect
                     label={
                         <div style={{ display: 'flex' }}>
-                            <p>Contributor</p>
+                            <p>Data Contributor</p>
                             <ShowOnly
                                 when={contributors && contributors.length > 1}
                             >

--- a/src/app/src/components/Settings.jsx
+++ b/src/app/src/components/Settings.jsx
@@ -21,7 +21,7 @@ import { convertFeatureFlagsObjectToListOfActiveFlags } from '../util/util';
 const PROFILE_TAB = 'Profile';
 const EMBED_TAB = 'Embed';
 const TOKEN_TAB = 'Tokens';
-const NOTIFICATIONS_TAB = 'Notifications';
+const NOTIFICATIONS_TAB = 'API Notifications';
 
 const getTabs = ({ fetchingFlags, activeFeatureFlags }) => {
     if (fetchingFlags || !includes(activeFeatureFlags, EMBEDDED_MAP_FLAG)) {

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -189,7 +189,7 @@ class UserProfile extends Component {
                         textTransform: 'uppercase',
                     }}
                 >
-                    Contributor
+                    Organization
                 </h3>
                 <h2 style={profileStyles.titleStyles}>
                     {!isEditableProfile && profile.name}

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -31,11 +31,7 @@
 
 .panel-header {
   color: white;
-  background-color: #3d2f8c;  /* Old browsers */
-  background: -moz-linear-gradient(-45deg, #003de5 0%, #7964ff 100%); /* FF3.6-15 */
-  background: -webkit-linear-gradient(-45deg, #003de5 0%,#7964ff 100%); /* Chrome10-25,Safari5.1-6 */
-  background: linear-gradient(135deg, #003de5 0%,#7964ff 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#003de5', endColorstr='#7964ff',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
+  background-color: #8428FA; 
   padding: 20px 16px;
 }
 

--- a/src/app/src/util/constants.jsx
+++ b/src/app/src/util/constants.jsx
@@ -163,23 +163,23 @@ const accountEmailField = Object.freeze({
 
 const accountNameField = Object.freeze({
     id: registrationFieldsEnum.name,
-    label: 'Contributor Name',
+    label: 'Organization Name',
     type: inputTypesEnum.text,
     required: true,
-    hint: `If you are uploading a supplier list on behalf of the organisation
-you work for, you should add the organisation name here, not your personal name.
-Your contributor name will appear publicly on all facilities that you upload as
+    hint: `If you are uploading a supplier list on behalf of the organization
+you work for, you should add the organization name here, not your personal name.
+Your organization name will appear publicly on all facilities that you upload as
 the data source for each facility contributed.`,
     modelFieldName: 'name',
 });
 
 const accountDescriptionField = Object.freeze({
     id: registrationFieldsEnum.description,
-    label: 'Description',
+    label: 'Organization Description',
     type: inputTypesEnum.text,
     required: true,
-    hint: `Enter a description of the contributor. This will appear in your
-public contributor profile.`,
+    hint: `Enter a description of the organization. This will appear in your
+public organization profile.`,
     modelFieldName: 'description',
 });
 
@@ -194,7 +194,7 @@ const accountWebsiteField = Object.freeze({
 
 const accountContributorTypeField = Object.freeze({
     id: registrationFieldsEnum.contributorType,
-    label: 'Contributor Type',
+    label: 'Organization Type',
     type: inputTypesEnum.select,
     options: contributorTypeOptions,
     required: true,

--- a/src/django/api/templates/mail/facility_list_complete_body.html
+++ b/src/django/api/templates/mail/facility_list_complete_body.html
@@ -10,37 +10,40 @@
             Hi there,
         </p>
         <p>
-            Thanks for submitting {{ list_name }} to the Open Supply Hub. The list has now been processed by our system and the results are available here: <a href="{{ list_url }}">{{ list_url }}</a>.
+            Thank you for submitting {{ list_name }} to Open Supply Hub. This list has been approved by the OS Hub team and has completed processing. This means that all facilities from the list that did not require additional verification by our team are now live on OS Hub. The admin view of your list is now available here: <a href="{{ list_url }}">{{ list_url }}</a>.
         </p>
-        <strong>What next?</strong>
-        <strong>Reviewing your upload: </strong>
+        <p><strong>What's next?</strong></p>
+        <p><strong>For You:</strong></p>
         <ol>
             <li>
-                <strong> Check for and Resolve Errors:</strong> Some entries in your list may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. You can read the <a href="https://info.openapparel.org/faqs#processing-data-in-the-oar">Processing data in the OS Hub section of our FAQs</a> for more information on error types and how to resolve them. Once you have pin-pointed the cause of the error, update your facility information in your Excel/CSV file and re-upload your FULL list to the OS Hub again (uploading one facility at a time results in multiple lists that are harder to manage).
+                <strong> Check for and Resolve Errors: </strong> Some entries in your list may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. Check out <a href="http://info.opensupplyhub.org/faqs">our FAQs</a> for more information on error types and how to resolve them. Once you have pin-pointed the cause of the error, update your facility information in your Excel/CSV file and re-upload your FULL list to the OS Hub again (uploading one facility at a time results in multiple lists that are harder to manage in the future).
             </li>
             <li>
-                <strong> Confirm or Reject Potential Matches: </strong> In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool. Once you have resolved any errors in your list, next we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I meant to do on the confirm / reject page?” question of our <a href="https://info.openapparel.org/faqs#uploading-to-the-oar">FAQ page</a>.
-            </li>
-            <li>
-                <strong> Data Points Beyond Name and Address: </strong> If you uploaded additional data points beyond facility name and address, you will now be able to see them by searching or downloading your contribution from the Open Supply Hub.
+                <strong> NOTE: Data Points Beyond Name and Address </strong> If you uploaded additional data points beyond facility name and address, note that you won’t be able to see these data points in your admin view – but don’t worry, they are there. You can confirm that we’ve received them by selecting the “Download submitted file” from the admin view of your list (linked above) or by searching/downloading your list in <a href="https://www.opensupplyhub.org/">Open Supply Hub</a>.
             </li>
         </ol>
-        <strong>Once your list is uploaded and cleaned: </strong>
+        <strong>Behind the Scenes:</strong>
         <ol>
             <li>
-                <strong> See who else is connected with your facilities/suppliers: </strong>Once you have contributed to the OS Hub, check out your facility profiles to see which other companies and organizations are connected with the facilities you uploaded. What collaborations could you explore working on together?
+                <strong> Finalizing facility matches: </strong> If some of the facilities you uploaded aren’t yet showing up in your public-facing list on OS Hub and are appearing as a “Potential Match” in your admin view, this means our algorithm flagged them to be checked by a human, to confirm whether or not they match an existing facility in the database. This helps us accurately address more nuanced matching cases and maintain a higher level of data quality in OS Hub. The OS Hub team is now working through these instances in your list. If you would prefer to complete this step yourself, instead of our Data Moderation team, please reach out to <a href="mailto:info@opensupplyhub.org">info@opensupplyhub.org</a>.You can see each facility’s current match status here: <a href="{{ list_url }}">{{ list_url }}</a>.
+            </li>
+        </ol>
+        <strong> Once your list is finalized: </strong>
+        <ol>
+            <li>
+                <strong> See who else is connected with your facilities/suppliers: </strong>Once you have uploaded data  to OS Hub, check out your facility profiles to see which other companies and organizations are connected with the facilities you uploaded. What collaborations could you explore working on together? If you want to search for facilities that you share with a specific contributor, you can use our contributor search feature – be sure to check the “show only shared facilities” option.
             </li>
             <li>
-                <strong>Share your OS Hub contribution: </strong>Link directly to your facility/supplier data on the OS Hub from your website, so your users can easily search and navigate through your list. <a href="https://info.openapparel.org/stories-resources/assets-for-oar-stakeholders">These free graphics are available</a> for use to point users to your OS Hub contribution on your website, LinkedIn profile, and/or on social media. You can also display your facility/supplier data as an <a href="https://info.openapparel.org/embedded-map">interactive map, embedded on your website</a>.
+                <strong>Share your OS Hub contribution: </strong>Link directly to your facility/supplier data on the OS Hub from your website, so your users can easily search and navigate through your list. <a href="https://info.opensupplyhub.org/stories-resources/assets-for-stakeholders">These free graphics are available</a> for use to point users to your OS Hub contribution on your website, LinkedIn profile, and/or on social media. You can also display your facility/supplier data as an <a href="https://info.opensupplyhub.org/embedded-map">interactive map, embedded on your website</a>.
             </li>
             <li>
-                <strong>Encourage your facilities/suppliers to claim their profiles or claim your facility, if you are the owner: </strong>By claiming their facilities on the OS Hub, facility owners or senior management can provide facility location data straight from the source, as well as add additional details to their profiles, including MOQs, lead times, certifications, and more.
+                <strong>Encourage your facilities/suppliers to claim their profiles or claim your facility, if you are the owner: </strong>By claiming their facilities on OS Hub, facility owners or senior management can provide facility location data straight from the source, as well as add additional details to their profiles, including MOQs, lead times, certifications, and more.
                 <br/>
-                If you are a brand or organization uploading a facility list, you can find suggested text for <a href="https://info.openapparel.org/stories-resources/encourage-your-facilities-to-claim-their-profiles">a message to your suppliers here</a>, to encourage them to claim their profiles.</li>
+                If you are a brand or organization uploading a facility list, you can find suggested text for <a href="https://info.opensupplyhub.org/stories-resources/encourage-your-facilities-to-claim-their-profiles">a message to your suppliers here</a>, to encourage them to claim their profiles.</li>
             </li>
         </ol>
         <p>
-            For any questions, feel free to reach out to the OS Hub team: <a href="mailto:info@openapparel.org">info@openapparel.org</a>
+            For any questions, feel free to reach out to the OS Hub team: <a href="mailto:info@opensupplyhub.org">info@opensupplyhub.org</a>
         </p>
         <p>
             All the best,

--- a/src/django/api/templates/mail/facility_list_complete_body.txt
+++ b/src/django/api/templates/mail/facility_list_complete_body.txt
@@ -1,29 +1,31 @@
 {% block content %}
 Hi there,
 
-Thanks for submitting {{ list_name }} to the Open Supply Hub. The list has now been processed by our system and the results are available here: {{list_url}}.
+Thank you for submitting {{ list_name }} to Open Supply Hub. This list has been approved by the OS Hub team and has completed processing. This means that all facilities from the list that did not require additional verification by our team are now live on OS Hub. The admin view of your list is now available here: {{list_url}}.
 
-What next?
+What’s next? 
 
-Reviewing your upload:
+For You:
 
-1. Check for and Resolve Errors: Some entries in your list may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. You can read the Processing data in the OS Hub section of our FAQs (https://info.openapparel.org/faqs#processing-data-in-the-oar) for more information on error types and how to resolve them. Once you have pin-pointed the cause of the error, update your facility information in your Excel/CSV file and re-upload your FULL list to the OS Hub again (uploading one facility at a time results in multiple lists that are harder to manage).
+Check for and Resolve Errors: Some entries in your list may have generated an error message. You can review these entries to see whether it’s caused by an error in data entry, such as a country name being mis-spelled, or whether our geo-coder is unable to plot the facility due to the address lacking sufficient details. Check out our FAQs for more information on error types and how to resolve them. Once you have pin-pointed the cause of the error, update your facility information in your Excel/CSV file and re-upload your FULL list to the OS Hub again (uploading one facility at a time results in multiple lists that are harder to manage in the future).
 
-2. Confirm or Reject Potential Matches: In some cases, our algorithm wasn’t certain whether to identify a facility as a match, or whether to create a new entity in the tool. Once you have resolved any errors in your list, next we ask you to filter your list by “Potential matches” and confirm or reject the options presented to you. For more information on this process, see the “What am I meant to do on the confirm / reject page?” question of our FAQ page (https://info.openapparel.org/faqs#uploading-to-the-oar).
+NOTE: Data Points Beyond Name and Address: If you uploaded additional data points beyond facility name and address, note that you won’t be able to see these data points in your admin view – but don’t worry, they are there. You can confirm that we’ve received them by selecting the “Download submitted file” from the admin view of your list (linked above) or by searching/downloading your list in Open Supply Hub.
 
-3. Data Points Beyond Name and Address: If you uploaded additional data points beyond facility name and address, you will now be able to see them by searching or downloading your contribution from the Open Supply Hub.
+Behind the Scenes:
 
-Once your list is uploaded and cleaned:
+Finalizing facility matches: If some of the facilities you uploaded aren’t yet showing up in your public-facing list on OS Hub and are appearing as a “Potential Match” in your admin view, this means our algorithm flagged them to be checked by a human, to confirm whether or not they match an existing facility in the database. This helps us accurately address more nuanced matching cases and maintain a higher level of data quality in OS Hub. The OS Hub team is now working through these instances in your list. If you would prefer to complete this step yourself, instead of our Data Moderation team, please reach out to info@opensupplyhub.org.You can see each facility’s current match status here:  {{list_url}}.
 
-1. See who else is connected with your facilities/suppliers: Once you have contributed to the OS Hub, check out your facility profiles to see which other companies and organizations are connected with the facilities you uploaded. What collaborations could you explore working on together?
+Once your list is finalized:
 
-2. Share your OS Hub contribution: Link directly to your facility/supplier data on the OS Hub from your website, so your users can easily search and navigate through your list. These free graphics are available (https://info.openapparel.org/stories-resources/assets-for-oar-stakeholders) for use to point users to your OS Hub contribution on your website, LinkedIn profile, and/or on social media. You can also display your facility/supplier data as an interactive map, embedded on your website (https://info.openapparel.org/embedded-map).
+1. See who else is connected with your facilities/suppliers: Once you have uploaded data  to OS Hub, check out your facility profiles to see which other companies and organizations are connected with the facilities you uploaded. What collaborations could you explore working on together? If you want to search for facilities that you share with a specific contributor, you can use our contributor search feature – be sure to check the “show only shared facilities” option.
 
-3. Encourage your facilities/suppliers to claim their profiles or claim your facility, if you are the owner: By claiming their facilities on the OS Hub, facility owners or senior management can provide facility location data straight from the source, as well as add additional details to their profiles, including MOQs, lead times, certifications, and more.
+2. Share your OS Hub contribution: Link directly to your facility/supplier data on the OS Hub from your website, so your users can easily search and navigate through your list. These free graphics are available for use to point users to your OS Hub contribution on your website, LinkedIn profile, and/or on social media. You can also display your facility/supplier data as an interactive map, embedded on your website.
 
-If you are a brand or organization uploading a facility list, you can find suggested text for a message to your suppliers here (https://info.openapparel.org/stories-resources/encourage-your-facilities-to-claim-their-profiles), to encourage them to claim their profiles.
+3. Encourage your facilities/suppliers to claim their profiles or claim your facility, if you are the owner: By claiming their facilities on OS Hub, facility owners or senior management can provide facility location data straight from the source, as well as add additional details to their profiles, including MOQs, lead times, certifications, and more.
 
-For any questions, feel free to reach out to the OS Hub team: info@openapparel.org.
+If you are a brand or organization uploading a facility list, you can find suggested text for a message to your suppliers here, to encourage them to claim their profiles.
+
+For any questions, feel free to reach out to the OS Hub team: info@opensupplyhub.org.
 
 All the best,
 


### PR DESCRIPTION
## Overview

A lot of the old copy refers to open apparel instead of open supply hub. Also, the claim wizard heading needs to reflect the new branding.

Connects #2143 and #2131 

## Notes

* [This document](https://docs.google.com/document/d/1l-cECNgAR5EfUzkpKLLiQBRiH6GdgsPpVoxZzoCXQ_c/edit) got a suggested change yesterday. I'm not sure if I should update to the newer copy.
* The links ended up in [this ticket](https://app.zenhub.com/workspaces/civic-apps-5c8fabc1177a1c1f6672f901/issues/open-apparel-registry/open-apparel-registry/2183) but I already had those changes made. Should I break them out to a separate PR?


## Testing Instructions

* Verify that the copy looks as it should based on the issue
* Verify that a claim facility page like [this](http://localhost:6543/facilities/US2022270A42PQM/claim) has a purple header instead of a blue to purple gradient header

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
