### PR TITLE
Update My Account header button style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update search results dropdowns [#2161](https://github.com/open-apparel-registry/open-apparel-registry/pull/2161)
 - Use HubSpot for mailing list [#2166](https://github.com/open-apparel-registry/open-apparel-registry/pull/2166)
 - Add Sector model and update create facility product type/sector parsing [#2157](https://github.com/open-apparel-registry/open-apparel-registry/pull/2157) [#2191](https://github.com/open-apparel-registry/open-apparel-registry/pull/2191)
-- Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167)
+- Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167) [#2022](https://github.com/open-apparel-registry/open-apparel-registry/pull/2202)
 - Filter out fields from inactive lists in facility API response [#2180](https://github.com/open-apparel-registry/open-apparel-registry/pull/2180)
 
 ### Deprecated

--- a/src/app/src/components/Navbar/AuthMenu.jsx
+++ b/src/app/src/components/Navbar/AuthMenu.jsx
@@ -41,7 +41,7 @@ function AuthMenu({
     }
 
     return (
-        <>
+        <div className="auth-menu">
             <button
                 type="button"
                 className="nav-submenu-button"
@@ -72,7 +72,7 @@ function AuthMenu({
                     },
                 ])}
             />
-        </>
+        </div>
     );
 }
 

--- a/src/app/src/styles/css/header.scss
+++ b/src/app/src/styles/css/header.scss
@@ -248,7 +248,8 @@ $pink-500: #FFA6D0;
     &--auth {
       padding-top: calc($gtr / 4);
       padding-bottom: calc($gtr / 4);
-      background-color: #D9D2E9;
+      background-color: $purple-100;
+      line-height: 1.4;
     }
   }
 
@@ -590,6 +591,10 @@ $pink-500: #FFA6D0;
     padding-left: 0;
     padding-top: $gtr;
     list-style: none;
+  }
+
+  .auth-menu .nav-submenu__list {
+    padding-top: 0;
   }
 
   .nav-submenu__list-item {


### PR DESCRIPTION
## Overview

This PR makes minor adjustments to the "My Account" submenu of the header.

Connects #2068

## Demo

<img width="1447" alt="Screen Shot 2022-09-29 at 5 36 56 PM" src="https://user-images.githubusercontent.com/8356789/193302790-ecfbd2df-412d-4c19-b288-11b0a12e5eb6.png">


## Notes

See also #2167 

## Testing Instructions

* Login
* Check "My Account" submenu matches expected style

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
