### PR TITLE
Fix user profile facility map link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update the Python and Rollber versions used for lamba functions [#2120](https://github.com/open-apparel-registry/open-apparel-registry/pull/2120)
 - Fixup recent UX changes [#2141](https://github.com/open-apparel-registry/open-apparel-registry/pull/2141)
 - Fixed parsing country strings with newline characters [#2195](https://github.com/open-apparel-registry/open-apparel-registry/pull/2195)
+- Fixed user profile facilites map link [#2204](https://github.com/open-apparel-registry/open-apparel-registry/pull/2204)
 
 ### Security
 

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -216,7 +216,7 @@ class UserProfile extends Component {
                 {title}
                 <div>
                     <a
-                        href={`/facilities?contributors=${profile.id}`}
+                        href={`/facilities?contributors=${profile.contributorId}`}
                         rel="noopener noreferrer"
                         style={{
                             backgroundColor: '#FFCF3F',

--- a/src/app/src/reducers/ProfileReducer.js
+++ b/src/app/src/reducers/ProfileReducer.js
@@ -160,6 +160,7 @@ export default createReducer(
                                 profileSummaryFieldsEnum.facilityLists
                             ],
                     },
+                    contributorId: { $set: payload.contributor_id || null },
                 },
                 fetching: { $set: false },
                 error: { $set: null },

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -267,12 +267,14 @@ class UserProfileSerializer(ModelSerializer):
     facility_lists = SerializerMethodField()
     is_verified = SerializerMethodField()
     embed_config = SerializerMethodField()
+    contributor_id = SerializerMethodField()
 
     class Meta:
         model = User
         fields = ('id', 'name', 'description', 'website', 'contributor_type',
                   'other_contributor_type', 'facility_lists', 'is_verified',
-                  'embed_config')
+                  'embed_config', 'contributor_id')
+        read_only_fields = ('contributor_id',)
 
     def get_name(self, user):
         try:


### PR DESCRIPTION
## Overview

Previously the user ID was used in the facility map link. This PR updates the link to use contributor_ids from the user's facility lists.

Connects #2173 

## Notes

I'm not sure if it's possible for a user to be associated with lists from multiple contributor IDs. If not, then the user-profile route should be updated to return the contributor_id at the top level (rather than in the nested facility lists).

## Testing Instructions

* Go to a user profile page
* Click "View map of facilities" button
* The facilities page should load with the appropriate contributor filter applied.
* The correct contributor ID should be in the URL params

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
