### PR TITLE
Fix parse errors (OSHub)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixup recent UX changes [#2141](https://github.com/open-apparel-registry/open-apparel-registry/pull/2141)
 - Fixed parsing country strings with newline characters [#2195](https://github.com/open-apparel-registry/open-apparel-registry/pull/2195)
 - Fixed user profile facilites map link [#2204](https://github.com/open-apparel-registry/open-apparel-registry/pull/2204)
+- Fix parse errors [#2207](https://github.com/open-apparel-registry/open-apparel-registry/pull/2207)
 
 ### Security
 

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -73,8 +73,16 @@ def get_product_type_extendedfield_value(field_value):
     }
 
 
+def all_values_empty(value):
+    if value is not None and isinstance(value, list):
+        values = [v for v in value if v is not None and v != ""]
+        return len(values) == 0
+    return False
+
+
 def create_extendedfield(field, field_value, item, contributor):
-    if field_value is not None and field_value != "":
+    if field_value is not None and field_value != "" \
+            and not all_values_empty(field_value):
         if field == ExtendedField.NUMBER_OF_WORKERS:
             field_value = extract_int_range_value(field_value)
         elif field == ExtendedField.PARENT_COMPANY:

--- a/src/django/api/facility_type_processing_type.py
+++ b/src/django/api/facility_type_processing_type.py
@@ -438,6 +438,9 @@ def get_facility_and_processing_type(facility_or_processing_type):
     # Assign a default value to field_type
     field_type = PROCESSING_TYPE
 
+    if cleaned_input is None:
+        return (None, None, None, None)
+
     # Try for exact match
     processing_type = ALL_PROCESSING_TYPES.get(cleaned_input)
     facility_type = ALL_FACILITY_TYPES.get(cleaned_input)


### PR DESCRIPTION
 ## Overview

Duplicate pointed at OS Hub for [#2206](https://github.com/open-apparel-registry/open-apparel-registry/pull/2206).

In a recently uploaded list on OAR staging, several items failed to parse. 

When a facility type or processing type is submitted with a pipe as
the final character, it creates an empty string as the final
value in the array. When we attempted to process the empty string,
it was cleaned to a None value, which threw an error. Empty strings are
now processed as 'No match' or (None, None, None, None).

Also, when a list of items is provided as an extended field value, if all
items in the array are empty strings, don't make the extended field.
This prevents a completely blank extended field from being created. 
These were being created for `product_type` for some items in the
failed list. 

Connects #[104](https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/104)

## Demo
<img width="1340" alt="Screen Shot 2022-10-03 at 11 44 06 AM" src="https://user-images.githubusercontent.com/21046714/193650314-4f621e9d-06c3-450e-87c3-823e052a888a.png">


## Notes

I marked the empty string as "No match" instead of filtering it out to keep the number of items consistent between the raw and processed data. 

## Testing Instructions

* Run `./scripts/server` and sign in as c2@example.com. 
* Contribute [parse_failure_items.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9699922/items.csv). Upload should succeed.
* Run `./tools/batch_process {list_id}`. The list should parse successfully. 
* In the items from the list, there should be no blank `product_type` field, and the `processing_type`/`facility_type` fields should show the correct values from the CSV. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
