### PR TITLE
Hide navigation elements on account settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rename Jenkinsfile.release for OSH [#2211](https://github.com/open-apparel-registry/open-apparel-registry/pull/2211)
 - Terminology updates [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
 - Change claim wizard header color [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
+- Hide nav links on My Account - Settings page [#2212](https://github.com/open-apparel-registry/open-apparel-registry/pull/2212)
 
 ### Deprecated
 

--- a/src/app/src/components/UserProfile.jsx
+++ b/src/app/src/components/UserProfile.jsx
@@ -214,26 +214,28 @@ class UserProfile extends Component {
                 }}
             >
                 {title}
-                <div>
-                    <a
-                        href={`/facilities?contributors=${profile.contributorId}`}
-                        rel="noopener noreferrer"
-                        style={{
-                            backgroundColor: '#FFCF3F',
-                            color: '#000',
-                            fontSize: '18px',
-                            fontWeight: '900',
-                            lineHeight: '20px',
-                            textDecoration: 'none',
-                            padding: '16px',
-                            gap: '8px',
-                            display: 'flex',
-                        }}
-                    >
-                        <MapIcon />
-                        View map of facilities
-                    </a>
-                </div>
+                <ShowOnly when={!isEditableProfile}>
+                    <div>
+                        <a
+                            href={`/facilities?contributors=${profile.contributorId}`}
+                            rel="noopener noreferrer"
+                            style={{
+                                backgroundColor: '#FFCF3F',
+                                color: '#000',
+                                fontSize: '18px',
+                                fontWeight: '900',
+                                lineHeight: '20px',
+                                textDecoration: 'none',
+                                padding: '16px',
+                                gap: '8px',
+                                display: 'flex',
+                            }}
+                        >
+                            <MapIcon />
+                            View map of facilities
+                        </a>
+                    </div>
+                </ShowOnly>
             </div>
         );
 
@@ -309,22 +311,24 @@ class UserProfile extends Component {
         return (
             <AppOverflow>
                 <div style={{ backgroundColor: '#F9F7F7' }}>
-                    <Button
-                        style={{
-                            backgroundColor: 'transparent',
-                            color: '#8428FA',
-                            fontSize: '18px',
-                            fontWeight: '700',
-                            lineHeight: '18px',
-                            letterSpacing: '0.5px',
-                            textTransform: 'none',
-                        }}
-                        Icon={ArrowBack}
-                        text="Back to search results"
-                        onClick={() => {
-                            push(facilitiesRoute);
-                        }}
-                    />
+                    <ShowOnly when={!isEditableProfile}>
+                        <Button
+                            style={{
+                                backgroundColor: 'transparent',
+                                color: '#8428FA',
+                                fontSize: '18px',
+                                fontWeight: '700',
+                                lineHeight: '18px',
+                                letterSpacing: '0.5px',
+                                textTransform: 'none',
+                            }}
+                            Icon={ArrowBack}
+                            text="Back to search results"
+                            onClick={() => {
+                                push(facilitiesRoute);
+                            }}
+                        />
+                    </ShowOnly>
                     <AppGrid
                         title={titleBar}
                         style={profileStyles.appGridContainer}


### PR DESCRIPTION
## Overview

This PR hides the navigation elements on the Account Settings page. 

Connects #2196 

## Demo

<img width="1160" alt="Screen Shot 2022-10-03 at 6 08 20 PM" src="https://user-images.githubusercontent.com/8356789/193701595-0c7571e6-1ec3-4d68-ac61-1514656813b4.png">

## Testing Instructions

* Go to My Account > Settings
* Verify there are no nav buttons "View map of facilities" and "Back to search results"
* Go to a user profile page from a facility
* The nav buttons should be visible

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
