### PR TITLE
OS Hub Style Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed parsing country strings with newline characters [#2195](https://github.com/open-apparel-registry/open-apparel-registry/pull/2195)
 - Fixed user profile facilites map link [#2204](https://github.com/open-apparel-registry/open-apparel-registry/pull/2204)
 - Fix parse errors [#2207](https://github.com/open-apparel-registry/open-apparel-registry/pull/2207)
+- OS Hub style fixes [#2222](https://github.com/open-apparel-registry/open-apparel-registry/pull/2222)
 
 ### Security
 

--- a/src/app/src/components/FacilityLists.jsx
+++ b/src/app/src/components/FacilityLists.jsx
@@ -83,7 +83,7 @@ class FacilityLists extends Component {
 
         return (
             <AppOverflow>
-                <AppGrid title="My Lists">
+                <AppGrid title="My Lists" style={{ marginBottom: '100px' }}>
                     <ShowOnly
                         when={!!myFacilitiesRoute && !!facilityLists.length}
                     >

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -57,9 +57,6 @@ const filterSidebarSearchTabStyles = theme =>
             display: 'flex',
             flexDirection: 'column',
         }),
-        topSidebarDiv: Object.freeze({
-            overflowY: 'scroll',
-        }),
         bottomSidebarDiv: Object.freeze({
             paddingBottom: '16px',
             paddingLeft: '24px',
@@ -200,10 +197,8 @@ function FilterSidebarSearchTab({
     return (
         <div className="control-panel__content">
             <div
-                className={`${classes.sidebarDiv} ${classes.topSidebarDiv}`}
-                style={{
-                    height: filterListHeight,
-                }}
+                className={classes.sidebarDiv}
+                style={{ height: filterListHeight }}
             >
                 <div className={classes.filtersDiv}>
                     <TextSearchFilter

--- a/src/app/src/components/Filters/ContributorFilter.jsx
+++ b/src/app/src/components/Filters/ContributorFilter.jsx
@@ -56,6 +56,7 @@ function ContributorFilter({
     listOptions,
     lists,
     updateList,
+    contributorListBottomMargin,
 }) {
     const [
         contributorPopoverAnchorEl,
@@ -165,6 +166,9 @@ function ContributorFilter({
                     style={{
                         marginLeft: embed ? 0 : '16px',
                         marginTop: '12px',
+                        marginBottom: contributorListBottomMargin
+                            ? '24px'
+                            : undefined,
                     }}
                 >
                     <StyledSelect
@@ -184,6 +188,7 @@ function ContributorFilter({
 ContributorFilter.defaultProps = {
     contributorOptions: null,
     listOptions: null,
+    contributorListBottomMargin: false,
 };
 
 ContributorFilter.propTypes = {
@@ -196,6 +201,7 @@ ContributorFilter.propTypes = {
     fetchingFacilities: bool.isRequired,
     fetchingOptions: bool.isRequired,
     fetchingLists: bool.isRequired,
+    contributorListBottomMargin: bool,
 };
 
 function mapStateToProps({

--- a/src/app/src/components/HomepageSidebarSearch.jsx
+++ b/src/app/src/components/HomepageSidebarSearch.jsx
@@ -268,7 +268,7 @@ function FilterSidebarSearchTab({
                 <TextSearchFilter searchForFacilities={searchForFacilities} />
                 <Grid container spacing={8}>
                     <Grid item xs={12} md={6}>
-                        <ContributorFilter />
+                        <ContributorFilter contributorListBottomMargin />
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <CountryNameFilter />

--- a/src/app/src/components/Navbar/MobileNavParent.jsx
+++ b/src/app/src/components/Navbar/MobileNavParent.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useMenuClickHandlerContext } from './MenuClickHandlerContext';
 
 import MobileNavSubmenuColumnSection from './MobileNavSubmenuColumnSection';
 import { BackButtonArrowLeft, MobileSubmenuButtonArrowRight } from './navIcons';
@@ -11,8 +10,6 @@ export default function MobileNavParent({
     setActive,
     setInactive,
 }) {
-    const createMenuClickHandler = useMenuClickHandlerContext();
-
     return (
         <>
             <button
@@ -35,7 +32,7 @@ export default function MobileNavParent({
                 <button
                     type="button"
                     className="mobile-nav-back-button"
-                    onClick={createMenuClickHandler(setInactive)}
+                    onClick={setInactive}
                 >
                     <BackButtonArrowLeft />
                     <span>Back</span>

--- a/src/app/src/styles/css/header.scss
+++ b/src/app/src/styles/css/header.scss
@@ -222,7 +222,7 @@ $pink-500: #FFA6D0;
       left: 0;
       top: 0;
       background: $grey-500;
-      z-index: 1000;
+      z-index: 0;
       transform: scaleY(0);
       transform-origin: bottom;
       transition: all 0.1s;


### PR DESCRIPTION
## Overview

This PR fixes a few small styling issues with the OS Hub UI:

- Hovering over buttons would cause the text to disappear. This turned out to be a `z-index` issue.
- Clicking back on the mobile menu would close the menu
- The contributor list filter does not have a bottom margin on the home page
- The Facilities List page does not have a bottom margin
- The search filters sidebar would sometimes have two scroll bars

Connects #2217 

## Demo

https://user-images.githubusercontent.com/8356789/194412866-3ecba516-c87d-40f0-9dc2-b0b684ee28a4.mov

https://user-images.githubusercontent.com/8356789/194413910-68c7e979-18ea-408b-b3af-2582c1c7f094.mov

<img width="337" alt="Screen Shot 2022-10-06 at 3 37 35 PM" src="https://user-images.githubusercontent.com/8356789/194413800-d9bdb3f3-3bf4-4bb3-ae6e-516e3862c2fd.png">

<img width="1165" alt="Screen Shot 2022-10-06 at 3 39 31 PM" src="https://user-images.githubusercontent.com/8356789/194414116-7a3b7dd0-f455-43da-a9bc-c61b8d68a887.png">

## Testing Instructions

* Hover over menu buttons
* Open a mobile menu and go back
* Check bottom of contributor list filter is not up against search button
  * Check there is no extra space beneath contributor list filter on facilities search page
* Go to My Lists. There should be a margin at the bottom of the page.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
