### PR TITLE
Show components with no query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167) [#2022](https://github.com/open-apparel-registry/open-apparel-registry/pull/2202)
 - Filter out fields from inactive lists in facility API response [#2180](https://github.com/open-apparel-registry/open-apparel-registry/pull/2180)
 - Update site footer with OS Hub styling [#2189](https://github.com/open-apparel-registry/open-apparel-registry/pull/2189)
-- Updated withQueryStringSync to render only after query params are hydrated [#2205](https://github.com/open-apparel-registry/open-apparel-registry/pull/2205)
+- Updated withQueryStringSync to render only after query params are hydrated [#2205](https://github.com/open-apparel-registry/open-apparel-registry/pull/2205) [#2223](https://github.com/open-apparel-registry/open-apparel-registry/pull/2223)
 - Rename Jenkinsfile.release for OSH [#2211](https://github.com/open-apparel-registry/open-apparel-registry/pull/2211)
 - Terminology updates [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
 - Change claim wizard header color [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)

--- a/src/app/src/util/withQueryStringSync.jsx
+++ b/src/app/src/util/withQueryStringSync.jsx
@@ -63,6 +63,8 @@ export default function withQueryStringSync(WrappedComponent) {
                 }
 
                 this.setState({ finishedInitialHydrate: true });
+            } else if (!search) {
+                this.setState({ finishedInitialHydrate: true });
             } else {
                 replace(
                     `?${createQueryStringFromSearchFilters(filters, embed)}`,


### PR DESCRIPTION
## Overview

Recent changes to the `withQueryStringSync` function prevented components that use it from rendering if the query parameters have not hydrated. If a component does not have query parameters, it would be stuck in the loading state.

Connects #2173 

## Testing Instructions

* Go to https://localhost:6543/facilities directly
* Filter components/page should load

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
