### PR TITLE
Update contribute page copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change claim wizard header color [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
 - Hide nav links on My Account - Settings page [#2212](https://github.com/open-apparel-registry/open-apparel-registry/pull/2212)
 - Upgrade Google Analytics to gtag.js [#2221](https://github.com/open-apparel-registry/open-apparel-registry/pull/2221)
+- Update Contribute page copy [#2226](https://github.com/open-apparel-registry/open-apparel-registry/pull/2226)
 
 ### Deprecated
 

--- a/src/app/src/components/Contribute.jsx
+++ b/src/app/src/components/Contribute.jsx
@@ -46,12 +46,12 @@ function ContributeList({ userHasSignedIn, fetchingSessionSignIn }) {
 
     return (
         <AppOverflow>
-            <AppGrid title="Contribute">
+            <AppGrid title="Upload">
                 <Grid container className="margin-bottom-64">
                     <Grid item xs={12}>
                         <p>
-                            Thank you for contributing your data to the Open
-                            Supply Hub.
+                            Thank you for contributing your data to Open Supply
+                            Hub.
                         </p>
 
                         <p>
@@ -62,8 +62,8 @@ function ContributeList({ userHasSignedIn, fetchingSessionSignIn }) {
                             >
                                 Please follow these step-by-step instructions
                             </a>{' '}
-                            to prepare and upload your data to the OS Hub via
-                            CSV or Excel file.
+                            to prepare and upload your data to OS Hub via CSV or
+                            Excel file.
                         </p>
 
                         <p>


### PR DESCRIPTION
## Overview

This PR remove the "the" before OS Hub and updates the page header.

Connects #2225 

## Demo

<img width="728" alt="Screen Shot 2022-10-07 at 1 47 48 PM" src="https://user-images.githubusercontent.com/8356789/194629049-ad7cc835-b2f8-4f04-94dc-8cb71a98bcc7.png">

## Testing Instructions

* Log in
* Click "Upload Data"
* Verify header and copy are correct and have no typos

## Checklist

- [x] Ensure that OS Hub staging is available for deployment
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
