### PR TITLE
Filter sector options by submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add documentation for AWS debugging [#2176](https://github.com/open-apparel-registry/open-apparel-registry/pull/2176)
 - Add Allow Large Downloads Waffle Switch [#2175](https://github.com/open-apparel-registry/open-apparel-registry/pull/2175)
 - Enable hiding sectors in embed [#2215](https://github.com/open-apparel-registry/open-apparel-registry/pull/2215)
+- Filter sectors by submitted [#2227](https://github.com/open-apparel-registry/open-apparel-registry/pull/2227)
 
 ### Changed
 

--- a/src/app/src/actions/filterOptions.js
+++ b/src/app/src/actions/filterOptions.js
@@ -189,11 +189,21 @@ export function fetchCountryOptions() {
 }
 
 export function fetchSectorOptions() {
-    return dispatch => {
+    return (dispatch, getState) => {
         dispatch(startFetchSectorOptions());
 
+        const {
+            filters: { contributors },
+            embeddedMap: { embed },
+        } = getState();
+
         return apiRequest
-            .get(makeGetSectorsURL())
+            .get(
+                makeGetSectorsURL({
+                    contributor: contributors[0]?.value,
+                    embed,
+                }),
+            )
             .then(({ data }) => mapDjangoChoiceTuplesValueToSelectOptions(data))
             .then(data => dispatch(completeFetchSectorOptions(data)))
             .catch(err =>

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -139,7 +139,10 @@ export const makeGetContributorsURL = () => '/api/contributors/';
 export const makeGetListsURL = () => '/api/contributor-lists/';
 export const makeGetContributorTypesURL = () => '/api/contributor-types/';
 export const makeGetCountriesURL = () => '/api/countries/';
-export const makeGetSectorsURL = () => '/api/sectors/';
+export const makeGetSectorsURL = options =>
+    options && options.embed
+        ? `/api/sectors?contributor=${options.contributor}&embed=${options.embed}`
+        : '/api/sectors/';
 export const makeGetParentCompaniesURL = () => '/api/parent-companies/';
 export const makeGetFacilitiesTypeProcessingTypeURL = () =>
     '/api/facility-processing-types/';


### PR DESCRIPTION
## Overview

The sector select will now only include sectors which are present on active facilities (excluding the 'Undefined' sector value).

In embed mode, the select will only include sectors from list items submitted by the embedded map's contributor, excluding inactive and non-public items.

Connects #2213 

## Demo

Regular
<img width="381" alt="Screen Shot 2022-10-07 at 3 14 38 PM" src="https://user-images.githubusercontent.com/21046714/194637807-5f4b4a59-d40a-4f80-a5cf-3cec48bb9aeb.png">

Embed
<img width="356" alt="Screen Shot 2022-10-07 at 3 17 49 PM" src="https://user-images.githubusercontent.com/21046714/194637824-3eb6695f-ea7b-41be-a2f9-64bbf2f6957d.png">

## Testing Instructions

* As c2@example.com, POST a facility with no sector to create a sector with an Unspecified value.
* As c2@example.com, POST a facility with the sector value 'Health'.
* As c3@example.com, POST a facility with a sector value that none of your facilities have yet.
* Visit the search page. The sector dropdown should contain any sectors that exist on your active facilities, including the unique value you just added, but excluding the Unspecified value.
* Login as c2@example.com and visit your embedded map. You should only see 'Health' and any other sector values submitted by c2@example.com (excluding 'Unspecified'). You shouldn't see the unique value you submitted for c3@example.com. 

## Checklist

- [ ] Ensure that OS Hub staging is available for deployment
- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
