### PR TITLE
Fix Gtag.js script tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed user profile facilites map link [#2204](https://github.com/open-apparel-registry/open-apparel-registry/pull/2204)
 - Fix parse errors [#2207](https://github.com/open-apparel-registry/open-apparel-registry/pull/2207)
 - OS Hub style fixes [#2222](https://github.com/open-apparel-registry/open-apparel-registry/pull/2222)
+- Fix gtag.js script tag [#2229](https://github.com/open-apparel-registry/open-apparel-registry/pull/2229)
 
 ### Security
 

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -60,7 +60,17 @@
             window[disableGAKey] = true;
         }
     </script>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_ANALYTICS_KEY%"></script>
+    <script async id="analytics"></script>
+    <script>
+        if (window.ENVIRONMENT &&
+            window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY &&
+            window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY !== "") {
+            // Import the Google Analytics script. This must occur AFTER the GA key is disabled.
+            var rootGtagUrl = "https://www.googletagmanager.com/gtag/js?id="
+            var analyticsKey = window.ENVIRONMENT.REACT_APP_GOOGLE_ANALYTICS_KEY;
+            document.getElementById('analytics').src = rootGtagUrl + analyticsKey;
+        }
+    </script>
     <!-- End Google Analytics -->
     <!--
       Rollbar Configuration


### PR DESCRIPTION
## Overview

The environment variable for the Google Analytics key wasn't being properly added into the script tag during the build process. This new approach should work to apply the key in all environments.

Connects #2188 

## Testing Instructions

* Do not run `./scripts/server` until directed, or the environment variables won't be applied correctly. 
* Update your `.env` to set `REACT_APP_GOOGLE_ANALYTICS_KEY` equal to the new G-XXXXX (GA4 formatted) id. 
* Change `util.ga.js` line 35 to `if (!environment) {` (to allow analytics to run in development).
* Run `./scripts/server`.
* Visit http://localhost:6543/settings and check if your analytics permissions are on or off. Turn them on (approve them) if they are off. 
* Open the network tab in the developer tools and refresh the page. 
* Search for requests containing the GA4 key. You should see several. In one of the payloads, you should see "User consented to GA tracking".
* There should be a request that looks like https://www.googletagmanager.com/gtag/js?id={ID} with ID being your analytics key
* Click around the site and you will see additional requests. 
* Go back to settings and reject analytics. Refresh the page. 
* Now in the network tab, you should only see two GET requests and no POSTs. Clicking around should send no POST requests with user data. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
