### PR TITLE
Non-apparel facility_type_processing_type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgrade Google Analytics to gtag.js [#2221](https://github.com/open-apparel-registry/open-apparel-registry/pull/2221)
 - Update Contribute page copy [#2226](https://github.com/open-apparel-registry/open-apparel-registry/pull/2226)
 - Update info site URL to opensupplyhub.org [#2214](https://github.com/open-apparel-registry/open-apparel-registry/pull/2214)
+- Non-apparel facility_type_processing_type handling [#2232](https://github.com/open-apparel-registry/open-apparel-registry/pull/2232)
 
 ### Deprecated
 

--- a/src/django/api/extended_fields.py
+++ b/src/django/api/extended_fields.py
@@ -20,7 +20,8 @@ def extract_int_range_value(value):
 MAX_PRODUCT_TYPE_COUNT = 50
 
 
-def get_facility_and_processing_type_extendfield_value(field, field_value):
+def get_facility_and_processing_type_extendfield_value(field,
+                                                       field_value, sector):
     values = field_value
 
     if isinstance(field_value, str):
@@ -31,7 +32,7 @@ def get_facility_and_processing_type_extendfield_value(field, field_value):
     results = []
 
     for value in deduped_values:
-        result = get_facility_and_processing_type(value)
+        result = get_facility_and_processing_type(value, sector)
         results.append(result)
 
     return {
@@ -92,7 +93,7 @@ def create_extendedfield(field, field_value, item, contributor):
         elif (field == ExtendedField.FACILITY_TYPE or
               field == ExtendedField.PROCESSING_TYPE):
             field_value = get_facility_and_processing_type_extendfield_value(
-                field, field_value
+                field, field_value, item.sector
             )
 
         ExtendedField.objects.create(
@@ -211,7 +212,7 @@ def create_extendedfields_for_claim(claim):
                                     ExtendedField.FACILITY_TYPE]:
                 field_value = (
                     get_facility_and_processing_type_extendfield_value(
-                        extended_field, field_value
+                        extended_field, field_value, claim.sector
                     )
                 )
             elif extended_field == ExtendedField.PRODUCT_TYPE:

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -1482,7 +1482,9 @@ class FacilityManager(models.Manager):
         if len(facility_types):
             standard_facility_types = []
             for facility_type in facility_types:
-                standard_type = get_facility_and_processing_type(facility_type)
+                standard_type = get_facility_and_processing_type(
+                    facility_type, ['Apparel']
+                )
                 if standard_type[0] is not None:
                     standard_facility_types.append(standard_type[2])
             facilities_qs = facilities_qs.filter(
@@ -1493,7 +1495,7 @@ class FacilityManager(models.Manager):
             standard_processing_types = []
             for processing_type in processing_types:
                 standard_type = get_facility_and_processing_type(
-                    processing_type
+                    processing_type, ['Apparel']
                 )
                 if standard_type[0] is not None:
                     standard_processing_types.append(standard_type[3])


### PR DESCRIPTION
## Overview

Facilities with 'Apparel' as one of their sectors are considered to
be in the Apparel sector.

The taxonomy was created for the apparel sector.
Facilities outside of that sector shouldn't be assigned a
facility_type, and any submitted facility_type_processing_type
should be applied as a processing_type without matching to the
taxonomy.

Connects #2224 

## Demo

<img width="1173" alt="Screen Shot 2022-10-11 at 4 43 55 PM" src="https://user-images.githubusercontent.com/21046714/195195907-578f42b9-7506-46d7-8fbd-571bebe9aaca.png">

## Testing Instructions

* Run `./scripts/server`
* Submit and process [facilities.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9759680/facilities.csv)
     * "AARTHI A1 HOME TRENDS PRIVATE" and "Azavea" are in Apparel and should have a processing_type and facility_type, matched to the taxonomy
     * "Alpine Apparels Pvt Ltd Plot 18 And 25" and "Alpine Apparels Pvt Ltd" and not in Apparel. They should have no facility_type, and the processing_type should be cleaned up a little but essentially left as-is.
* Submit a facility via API.
```
{
    "sector_product_type": "Miniatures",
    "country": "China",
    "name": "Tiny Inc.",
    "address": "No.808,the third industry park,Guoyuan Town,Nantong 226500.",
    "facility_type_processing_type": "'dollhouses'|Model/ Cars|Final Product Assembly"
}
```
     * Tiny Inc. is not in Apparel. It should have no facility_type, and the processing_type should be cleaned up a little but essentially left as-is.
* Use the facilities search, filtering by facility_type or processing_type, and confirm that the search returns the expected facilities. 

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
