### PR TITLE
Fix initial page load layout issue

### DIFF
--- a/src/app/src/components/HomepageSidebarSearch.jsx
+++ b/src/app/src/components/HomepageSidebarSearch.jsx
@@ -142,7 +142,16 @@ function FilterSidebarSearchTab({
 
     if (fetchingOptions) {
         return (
-            <div className="control-panel__content">
+            <div
+                className="control-panel__content"
+                style={{
+                    minWidth: '50vw',
+                    minHeight: '90vh',
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                }}
+            >
                 <CircularProgress />
             </div>
         );

--- a/src/app/src/styles/css/Map.css
+++ b/src/app/src/styles/css/Map.css
@@ -9,7 +9,7 @@
   align-items: flex-start;
 
   max-width: 100%;
-  overflow: scroll;
+  overflow: auto;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Overview

Loading the homepage for the first time can result in some odd looking page layouts. This PR sets a fixed height and width on the loading sidebar so the page renders closer to how it will eventually look. 

Connects #2231 

## Notes

There is still a flash of a loading circle in the beginning. I believe this is do to the loading of feature flags from the database. Also, since the map is not rendered before this, these changes do fix the map loading glitch.

This PR also sets the overflow on the sidebar to auto.

## Testing Instructions

* Open a private window (no cache)
* Go to http://localhost:6543/
* See that page load looks good

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
