### PR TITLE
Update login page copy

### DIFF
--- a/src/app/src/components/LoginForm.jsx
+++ b/src/app/src/components/LoginForm.jsx
@@ -65,8 +65,8 @@ class LoginForm extends Component {
                 <AppGrid title="Log In" style={{ marginBottom: '100px' }}>
                     <Grid item xs={12} sm={7}>
                         <p>
-                            You must be a registered user to contribute to the
-                            Open Supply Hub.
+                            You must be a registered user to contribute to Open
+                            Supply Hub.
                             <br />
                             Don&apos;t have an account?{' '}
                             <Link


### PR DESCRIPTION
## Overview

This PR removes "the" from "the OS Hub" on the login page.

Connects #2235 

## Notes

I missed this in #2237 because "the OS Hub" was split along multiple lines.

## Testing Instructions

* Go to login page
* Ensure that the copy reads "contribute to OS Hub" and not "contribute to the OS Hub"

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
