### PR TITLE
Disable zoom to search on facility detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Disable zoom to search on facility detail page [#2250](https://github.com/open-apparel-registry/open-apparel-registry/pull/2250)
+
 ### Security
 
 ## [73-OSHUB] 2022-10-14

--- a/src/app/src/components/Map.jsx
+++ b/src/app/src/components/Map.jsx
@@ -62,6 +62,7 @@ class Map extends Component {
                                             <VectorTileFacilitiesMap
                                                 {...props}
                                                 disableZoom
+                                                disableZoomToSearch
                                             />
                                         )}
                                     />

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -67,6 +67,7 @@ function VectorTileFacilitiesMap({
     navigateToFacilities,
     isMobile,
     disableZoom,
+    disableZoomToSearch,
 }) {
     const mapRef = useUpdateLeafletMapImperatively(resetButtonClickCount, {
         osID,
@@ -78,7 +79,7 @@ function VectorTileFacilitiesMap({
         ),
         isVectorTileMap: true,
         extent,
-        zoomToSearch,
+        zoomToSearch: disableZoomToSearch ? false : zoomToSearch,
         boundary,
     });
 


### PR DESCRIPTION
## Overview

When browsing directly to a facility details page we do not want any facilities search that runs to zoom the map to the extent of that search.

Connects #2245
Connects #2267

## Testing Instructions

**NOTE** There is a race condition that prevented us from noticing this in development. Adding a delay to the fetch action makes the issue repeatably reproducible.

```diff
﻿﻿﻿diff --git a/src/app/src/actions/facilities.js b/src/app/src/actions/facilities.js
index 58daf438..3f17874d 100644
--- a/src/app/src/actions/facilities.js
+++ b/src/app/src/actions/facilities.js
@@ -75,13 +75,15 @@ export function fetchFacilities({
                 return data;
             })
             .then(data => {
-                dispatch(completeFetchFacilities(data));
-                if (activateFacilitiesTab) {
-                    dispatch(toggleFilterModal(false));
-                }
-                if (isFunction(onSuccess)) {
-                    onSuccess(data);
-                }
+                setTimeout(() => {
+                    dispatch(completeFetchFacilities(data));
+                    if (activateFacilitiesTab) {
+                        dispatch(toggleFilterModal(false));
+                    }
+                    if (isFunction(onSuccess)) {
+                        onSuccess(data);
+                    }
+                }, 2000);
             })
             .catch(err => {
                 dispatch(
```

* Check out `ogr/develop`, browse a facility details page directly and verity that the map zooms to the whole world after the artificial delay.
* Check out this branch and verity that it resolves the zooming issue.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
