### PR TITLE
Add management command to replace oar_id in JSON fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add managemnt command to replace oar_id in JSON fields [#2251](https://github.com/open-apparel-registry/open-apparel-registry/pull/2251)
+
 ### Changed
 
 ### Deprecated

--- a/src/django/api/management/commands/replace_oar_id.py
+++ b/src/django/api/management/commands/replace_oar_id.py
@@ -1,0 +1,61 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from api.models import FacilityListItem, FacilityMatch
+
+
+class Command(BaseCommand):
+    help = ('Replace references to oar_id in item processing_results and '
+            'match results')
+
+    def add_arguments(self, parser):
+        parser.add_argument('-d', '--dry-run', action='store_true',
+                            default=False, help='Do not save cahnges')
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+
+        if dry_run:
+            print('== DRY RUN - SKIPPING ALL SAVES')
+
+        print('-- PROCESSING ITEMS')
+
+        filters = (
+            Q(processing_results__contains=[{"action": "move_facility"}])
+            | Q(processing_results__contains=[{"action": "merge_facility"}])
+            | Q(processing_results__contains=[{"action": "split_facility"}])
+        )
+
+        for item in FacilityListItem.objects.filter(filters).iterator():
+            did_update_key = False
+            for result in item.processing_results:
+                if 'previous_facility_oar_id' in result:
+                    result['previous_facility_os_id'] = \
+                        result.pop('previous_facility_oar_id')
+                    did_update_key = True
+                if 'merged_oar_id' in result:
+                    result['merged_os_id'] = \
+                        result.pop('merged_oar_id')
+                    did_update_key = True
+            if did_update_key:
+                if not dry_run:
+                    item.save()
+                    print(f'item,save,{item.pk}')
+                else:
+                    print(f'item,dry,{item.pk}')
+            else:
+                print(f'item,skip,{item.pk}')
+
+        print('-- PROCESSING MATCHES')
+
+        matches = FacilityMatch.objects.filter(
+            results__has_key='split_from_oar_id')
+
+        for match in matches.iterator():
+            match.results['split_from_os_id'] = \
+                match.results.pop('split_from_oar_id')
+            if not dry_run:
+                match.save()
+                print(f'match,save,{match.pk}')
+            else:
+                print(f'match,dry,{match.pk}')


### PR DESCRIPTION
## Overview

The `FacilityListItem` and `FacilityMatch` models both have JSON fields which can contain keys that reference oar_id rather than os_id. Splitting a facility was failing with an error due to the code expecting a key name containing os_id.

Despite the fact that it is a one time operation, we wrote this as a management command rather than a data migration to facilitate testing with a "dry run" option.

Connects #2246
Connects #2252

## Testing Instructions

### Setup

In `./scripts/manage shell_plus` add some test data and leave the shell open

```
i = FacilityListItem.objects.all().first()
i.processing_results.append({'action': 'merge_facility', 'merged_oar_id': 'ZXY987'})
i.processing_results.append({'action': 'move_facility', 'previous_facility_oar_id': 'ABC123'})
i.processing_results.append({'action': 'split_facility', 'previous_facility_oar_id': 'DDD434'})
i.save()

m = FacilityMatch.objects.all().first()
m.status['split_from_oar_id'] = 'HHH888'
m.save()
```

### Test

- Run ` ./scripts/manage replace_oar_id --dry-run` and verify that it prints a single item and a singly match to the console  with "dry" in the message
- In the Django shell verify that the changes to the key names were not saved
```
i.i.refresh_from_db()
i.processing_results

m.refresh_from_db()
m.results
```
- Run ` ./scripts/manage replace_oar_id` and verify that it prints a single item and a singly match to the console with "save" in the message
- Run ` ./scripts/manage replace_oar_id` and verify  that it does not print any items or matches
- In the Django shell verify that the key names have been changed
```
i.i.refresh_from_db()
i.processing_results

m.refresh_from_db()
m.results
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
