### PR TITLE
Allow default batch job memory and vCPU count to be set by vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Allow default batch job memory and vCPU count to be set by vars [#2257](https://github.com/open-apparel-registry/open-apparel-registry/pull/2257)
+
 ### Deprecated
 
 ### Removed

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -52,6 +52,8 @@ data "template_file" "default_job_definition" {
 
   vars = {
     image_url                        = "${module.ecr_repository_batch.repository_url}:${var.image_tag}"
+    vcpus                            = var.batch_default_job_vcpus
+    memory                           = var.batch_default_job_memory
     postgres_host                    = aws_route53_record.database.name
     postgres_port                    = module.database_enc.port
     postgres_user                    = var.rds_database_username

--- a/deployment/terraform/job-definitions/default.json
+++ b/deployment/terraform/job-definitions/default.json
@@ -1,7 +1,7 @@
 {
   "image": "${image_url}",
-  "vcpus": 2,
-  "memory": 4096,
+  "vcpus": ${vcpus},
+  "memory": ${memory},
   "command": ["./manage.py", "batch_process", "--list-id" , "Ref::listid", "--action", "Ref::action"],
   "environment": [
       { "name": "AWS_DEFAULT_REGION", "value": "${aws_region}" },

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -284,6 +284,14 @@ variable "batch_ami_id" {
   default = "ami-002e2fef4b94f8fd0"
 }
 
+variable "batch_default_job_vcpus" {
+  default = 2
+}
+
+variable "batch_default_job_memory" {
+  default = 4096
+}
+
 variable "batch_default_ce_min_vcpus" {
   default = "0"
 }


### PR DESCRIPTION
## Overview

Allows changing resources without a code deployment and using different resource allocations in different environments.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/107

## Demo

<img width="539" alt="Screen Shot 2022-10-19 at 12 01 33 PM" src="https://user-images.githubusercontent.com/17363/196780921-cf1a5091-a83e-496a-a86f-829da410ffea.png">

## Testing Instructions

* Edit the default values `batch_default_job_vcpus` and `batch_default_job_memory` values in `variables.tf` so they are different
* `docker-compose -f docker-compose.ci.yml run --rm terraform`
* `bash-5.1# ./scripts/infra plan`
* In the `plan` output find the `aws_batch_job_definition.default` resource and verify that the `memory` and `vcpus` values match what was set in the variables file.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
