### PR TITLE
Fix logging when checking for existing Hubspot contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Disable zoom to search on facility detail page [#2250](https://github.com/open-apparel-registry/open-apparel-registry/pull/2250)
+- Fix loging when checking for existing Hubspot contac [#2259](https://github.com/open-apparel-registry/open-apparel-registry/pull/2259)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -227,7 +227,7 @@ def add_user_to_mailing_list(email, name, contrib_type):
                           data=new_contact)
 
         # Raise error for error statuses other than existing contact
-        contact_already_exists = r.status_code != 409
+        contact_already_exists = r.status_code == 409
         if not contact_already_exists:
             r.raise_for_status()
 


### PR DESCRIPTION

## Overview

The boolean comparison was mistakenly inverted. If we get a 409 when attempting to create a contact then that contact already exists and we want to continue with subscibing them to the list.

Connects https://github.com/open-apparel-registry/open-apparel-registry-clients/issues/105

## Testing Instructions

* Verify that my interpretation of the logic is correct

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
