### PR TITLE
Exclude rejected match items from merge transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Disable zoom to search on facility detail page [#2250](https://github.com/open-apparel-registry/open-apparel-registry/pull/2250)
 - Fix loging when checking for existing Hubspot contac [#2259](https://github.com/open-apparel-registry/open-apparel-registry/pull/2259)
 - Fix map not appearing at medium widths [#2263](https://github.com/open-apparel-registry/open-apparel-registry/pull/2263/files)
+- Exclude rejected match items from merge transfer [#2261](https://github.com/open-apparel-registry/open-apparel-registry/pull/2261)
 
 ### Security
 
@@ -1320,7 +1321,7 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 - Initial release.
 
 [unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/73-OSHUB...HEAD
-[73-OSHUB]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/73-OSHUB
+[73-oshub]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/73-OSHUB
 [66]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/66
 [65]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/65
 [64]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/64

--- a/src/django/api/constants.py
+++ b/src/django/api/constants.py
@@ -26,6 +26,7 @@ class ProcessingAction:
     MOVE_FACILITY = 'move_facility'
     NOTIFY_COMPLETE = 'notify_complete'
     ITEM_REMOVED = 'item_removed'
+    UNDO_MERGE = 'undo_merge'
 
 
 class FacilitiesQueryParams:

--- a/src/django/api/management/commands/fix_merged_rejections.py
+++ b/src/django/api/management/commands/fix_merged_rejections.py
@@ -1,0 +1,79 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from api.models import FacilityMatch, HistoricalFacilityMatch
+from api.constants import ProcessingAction
+
+
+class Command(BaseCommand):
+    help = ('Reset incorrectly merged facility list items.')
+
+    def add_arguments(self, parser):
+        parser.add_argument('-d', '--dry-run', action='store_true',
+                            default=False, help='Do not save cahnges')
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+
+        if dry_run:
+            print('== DRY RUN - SKIPPING ALL SAVES')
+
+        count = 0
+        now = str(timezone.now())
+        for hist_match in HistoricalFacilityMatch.objects.filter(
+            status='MERGED'
+        ).iterator():
+            try:
+                prev_record = hist_match.prev_record
+                if prev_record and prev_record.status in ['REJECTED',
+                                                          'PENDING']:
+                    list_item = prev_record.facility_list_item
+                    valid_matches = FacilityMatch \
+                        .objects \
+                        .filter(facility_list_item_id=list_item.id,
+                                status__in=['AUTOMATIC', 'CONFIRMED'])
+                    if len(valid_matches) > 1:
+                        print(
+                            'Multiple valid matches for list item {}'.format(
+                                list_item.id
+                            ))
+                    elif len(valid_matches) < 1:
+                        print(
+                            'No valid matches found for list item {}'.format(
+                                list_item.id
+                            ))
+                    else:
+                        valid_match = valid_matches[0]
+                        if list_item:
+                            list_item.facility_id = valid_match.facility_id
+                            list_item.processing_results.append({
+                                'action': ProcessingAction.UNDO_MERGE,
+                                'started_at': now,
+                                'error': False,
+                                'finished_at': now,
+                            })
+                            if not dry_run:
+                                list_item.save()
+                                print(f'item,save,{list_item.pk}')
+                            else:
+                                print(f'item,dry,{list_item.pk}')
+
+                        try:
+                            match = FacilityMatch.objects.get(pk=hist_match.id)
+                            if not dry_run:
+                                match.status = prev_record.status
+                                match.changeReason = 'Fixing merge rejection'
+                                match.save()
+                                print(f'match,save,{match.pk}')
+                            else:
+                                print(f'match,dry,{match.pk}')
+                        except FacilityMatch.DoesNotExist:
+                            print(f'match,missing,{hist_match.id}')
+                        count = count + 1
+
+            except Exception as e:
+                # In case of an error, we should review/fix the match manually,
+                # but not break the loop
+                print(f'match,error,{hist_match.id},{e}')
+
+        print('{} items adjusted'.format(count))


### PR DESCRIPTION
## Overview

List items can produce multiple matches, each linked to a different facility. When these matches are PENDING or REJECTED, the list item will point to a different facility than the match, as the list item will have additional valid match(es) linked to that different facility.

When merging facilities, we were previously incorrectly updating PENDING and REJECTED matches' list items to point at the target facility, when instead they should have been left alone, as the list items don't belong to the merged facility.

Also adds a management command to run once to fix list items which were impacted by this bug.

Connects #2233 

## Testing Instructions

On `ogr/develop`:
* Go to http://localhost:6543/dashboard/lists and find a list with a pending match. 
* Note the suggested matched facility's ID. (We will now refer to this as Facility A.)
* Reject the pending match. (If there are multiple pending matches for the list item, reject them all.)
* A new facility will be created from the list item. (We will now refer to this as Facility B). Open this in a new tab. You should see that it has an assigned sector.
* In the original tab, go to http://localhost:6543/dashboard/mergefacilities
* Get another facility ID (Facility C) and set this as the target facility. Set the merge facility to Facility A. Complete the merge. 
* Visit Facility C and confirm that Facility A has been merged into it. 
* Visit Facility B and note that it no longer has a sector. 

On this branch:
* Repeat the above steps with new facilities (Facility A-2, B-2, C-2). Facility B-2 should NOT lose its sector(s).
* Visit Facility B and note that it still has no sector.
* Run `./scripts/manage fix_merged_rejections --dry-run`. You should see that 1 item will be adjusted. 
* Run `./scripts/manage fix_merged_rejections`. One item should be adjusted. 
* Visit Facility B and note that it has its sector back. 

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
