### PR TITLE
Fix map not appearing at medium widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Disable zoom to search on facility detail page [#2250](https://github.com/open-apparel-registry/open-apparel-registry/pull/2250)
 - Fix loging when checking for existing Hubspot contac [#2259](https://github.com/open-apparel-registry/open-apparel-registry/pull/2259)
+- Fix map not appearing at medium widths [#2263](https://github.com/open-apparel-registry/open-apparel-registry/pull/2263/files)
 
 ### Security
 

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -20,7 +20,7 @@ import FilterIcon from './FilterIcon';
 import FeatureFlag from './FeatureFlag';
 import FilterSidebarSearchTab from './FilterSidebarSearchTab';
 import FilterSidebarFacilitiesTab from './FilterSidebarFacilitiesTab';
-import Map from './Map';
+import MapWithHookedHeight from './MapWithHookedHeight';
 import NonVectorTileFilterSidebarFacilitiesTab from './NonVectorTileFilterSidebarFacilitiesTab';
 
 import { VECTOR_TILE } from '../util/constants';
@@ -224,7 +224,7 @@ class FilterSidebar extends Component {
                                     width: '100%',
                                 }}
                             >
-                                <Map />
+                                <MapWithHookedHeight />
                             </div>
                         )}
                     </Grid>

--- a/src/app/src/components/MapWithHookedHeight.jsx
+++ b/src/app/src/components/MapWithHookedHeight.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Map from './Map';
+import { useMapHeight } from '../util/useHeightSubtract';
+
+const MapWithHookedHeight = () => {
+    const mapHeight = useMapHeight();
+    return <Map height={mapHeight} />;
+};
+
+export default MapWithHookedHeight;


### PR DESCRIPTION
## Overview

When we introduced the new footer we included a `useMapHeight` hook that would provide a calculated value for the `Map` component. The `Map` component created in `MapAndSidebar` made use of this hook but the `Map` component created in `FilterSidebar` did not, resulting in the map not appearing at medium scree widths.

Connects #2260

## Demo

NOTE the demo includes a know Leaflet exception that does not affect behavior when deployed

https://user-images.githubusercontent.com/17363/197303510-84d38dde-b36d-47de-9546-e745151751b2.mp4

## Testing Instructions

* Verify that the map displays correctly at all widths on the facilities page and the homepage and facility details pages are unaffected.
 
## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
