### PR TITLE
Fix removed list item filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix loging when checking for existing Hubspot contac [#2259](https://github.com/open-apparel-registry/open-apparel-registry/pull/2259)
 - Fix map not appearing at medium widths [#2263](https://github.com/open-apparel-registry/open-apparel-registry/pull/2263/files)
 - Exclude rejected match items from merge transfer [#2261](https://github.com/open-apparel-registry/open-apparel-registry/pull/2261)
+- Fix removed list filtering [#2266](https://github.com/open-apparel-registry/open-apparel-registry/pull/2266)
 
 ### Security
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3210,7 +3210,9 @@ class FacilityListViewSet(viewsets.ModelViewSet):
                         Q(status='CONFIRMED_MATCH') &
                         ~Q(facility__created_from_id=F('id')) &
                         ~Q(facilitymatch__is_active=False)),
-            FacilityListItem.REMOVED: Q(facilitymatch__is_active=False),
+            FacilityListItem.REMOVED: Q(
+                        Q(facilitymatch__is_active=False) |
+                        Q(status=FacilityListItem.ITEM_REMOVED)),
         }
 
         def make_q_from_status(status):


### PR DESCRIPTION
## Overview

There are now two types of removed items: ones that are removed after processing (which are indicated by having no active matches), and ones that are removed prior to processing (which are indicated by the 'ITEM_REMOVED' status). Adjust the filtering for the list details page to include both types when filtering by 'REMOVED'.

Connects #2258 

## Demo

<img width="1303" alt="Screen Shot 2022-10-25 at 8 31 33 AM" src="https://user-images.githubusercontent.com/21046714/197773581-7ecc61ce-9fcf-4d8a-8366-a4911e8fd540.png">

## Testing Instructions

* Run `./scripts/server` and upload a list, but do NOT fully process it.
* Run `./scripts/manage batch_process -l {list_id} -a parse`
* Choose a parsed item and use the 'remove' button to remove it
* Run `./tools/batch_process {list_id}`
* Remove another item from the list with the 'remove' button
* Apply the 'REMOVE' filter, and you should see both removed items. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
