### PR TITLE
Include Unspecified in the sectors API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Allow default batch job memory and vCPU count to be set by vars [#2257](https://github.com/open-apparel-registry/open-apparel-registry/pull/2257)
 - Copy changes [#2265](https://github.com/open-apparel-registry/open-apparel-registry/pull/2265)
+- Include Unspecified in the sectors API response [#2272](https://github.com/open-apparel-registry/open-apparel-registry/pull/2272)
 
 ### Deprecated
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -748,8 +748,6 @@ def sectors(request):
             .distinct()
         )
 
-    submitted_sectors.discard('Unspecified')
-
     return Response(sorted(list(submitted_sectors)))
 
 


### PR DESCRIPTION
## Overview

We had previously filtered this default option out but the OS Hub team requests that it be available to enable searching for facilities with an unspecified secgtor via the UI.

Connects #2269

## Demo

<img width="330" alt="Screen Shot 2022-10-26 at 9 46 11 AM" src="https://user-images.githubusercontent.com/17363/198086238-de203942-6cd0-408d-949c-d1f8149c39fd.png">


## Testing Instructions

* Upload and `./tools/atch_process`  [azavea-no-sector.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/9872021/azavea-no-sector.csv) to create a facility record with no sector
* Browse http://localhost:6543/facilities and verify that "Unspecified" appears in the Sector dropdown

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
