### PR TITLE
Update og:url meta tag to opensupplyhub.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allow default batch job memory and vCPU count to be set by vars [#2257](https://github.com/open-apparel-registry/open-apparel-registry/pull/2257)
 - Copy changes [#2265](https://github.com/open-apparel-registry/open-apparel-registry/pull/2265)
 - Include Unspecified in the sectors API response [#2272](https://github.com/open-apparel-registry/open-apparel-registry/pull/2272)
+- Update og:url meta tag to opensupplyhub.org [#2276](https://github.com/open-apparel-registry/open-apparel-registry/pull/2276/files)
 
 ### Deprecated
 

--- a/src/app/public/index.html
+++ b/src/app/public/index.html
@@ -37,7 +37,7 @@
     <meta property="og:title" content="Open Supply Hub">
     <meta name="description" content="The Open Supply Hub (OS Hub) is an open source map and database of global apparel facilities, their affiliations and unique OS IDs assigned to each facility.">
     <meta property="og:description" content="The Open Supply Hub (OS Hub) is an open source map and database of global apparel facilities, their affiliations and unique OS IDs assigned to each facility.">
-    <meta property="og:url" content="https://openapparel.org">
+    <meta property="og:url" content="https://opensupplyhub.org">
     <meta property="og:site_name" content="Open Supply Hub">
 
     <!-- Environment Variables -->


### PR DESCRIPTION
## Overview

Update og:url meta tag to opensupplyhub.org

Connects #2140

