### PR TITLE
Change header color in staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Update openapparel.org references [#2281](https://github.com/open-apparel-registry/open-apparel-registry/pull/2281)
+- Change header banner color in staging [#2285](https://github.com/open-apparel-registry/open-apparel-registry/pull/2285)
 
 ### Deprecated
 

--- a/src/app/src/components/Navbar/Navbar.jsx
+++ b/src/app/src/components/Navbar/Navbar.jsx
@@ -55,9 +55,15 @@ export default function Navbar() {
         mobileMode ? ' mobile-nav-is-active' : ''
     }`;
 
+    const isStaging = window.ENVIRONMENT.ENVIRONMENT === 'staging';
+
     const Header = (
         <header className={headerClassName} id="header">
-            <div className="header__main">
+            <div
+                className={`header__main${
+                    isStaging ? ' header__main--staging' : ''
+                }`}
+            >
                 <Logo />
                 <nav className="nav" id="nav" role="navigation">
                     {NavbarItems.map(item => {

--- a/src/app/src/styles/css/header.scss
+++ b/src/app/src/styles/css/header.scss
@@ -284,6 +284,35 @@ $pink-500: #FFA6D0;
     }
   }
 
+  .header__main--staging {
+    background: $purple-500;
+
+    .nav-link:hover {
+      color: white;
+    }
+
+    .nav-item:hover,
+    .nav-submenu-is-active {
+
+      .nav-submenu-button,
+      .nav-submenu-button__arrow {
+        color: white !important;
+
+        path {
+          fill: white !important;
+        }
+
+        &::after {
+          background-color: white;
+        }
+      }
+    }
+
+    .nav-item .nav-submenu-button--language svg.nav-submenu-button__international path:first-child {
+      fill: none !important;
+    }
+  }
+
   .header__home {
     text-decoration: none;
     display: flex;


### PR DESCRIPTION
## Overview

This PR updates the color of the header while in staging.

Connects #2270 

## Demo

<img width="1472" alt="Screen Shot 2022-10-28 at 4 48 47 PM" src="https://user-images.githubusercontent.com/8356789/198738646-926e820d-50e2-4131-befd-3b6871f0127b.png">

## Testing Instructions

This requires some code modification to test: In Nabar.jsx, set `isStaging` directly to `true`.
- http://localhost:6543/
- See that banner is correct shade of purple
- Resize to mobile menu and ensure header is still purple

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
