### PR TITLE
Fix embedded map styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Support mediaQueryList event listener in older Safari [#2303](https://github.com/open-apparel-registry/open-apparel-registry/pull/2303)
 - Handle additional merge errors [#2299](https://github.com/open-apparel-registry/open-apparel-registry/pull/2299)
+- Fix embedded map styling [#2298](https://github.com/open-apparel-registry/open-apparel-registry/pull/2298)
 
 ### Security
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -4,10 +4,13 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 import Routes from './Routes';
 import { fetchEmbedConfig } from './actions/embeddedMap';
-import { OARColor } from './util/constants';
+import { OARColor, OARSecondaryColor, OARActionColor } from './util/constants';
 import EmbeddedMapUnauthorized from './components/EmbeddedMapUnauthorized';
 
 import './App.css';
+
+const configOrDefault = (configColor, defaultColor) =>
+    !configColor || configColor === OARColor ? defaultColor : configColor;
 
 function App({
     embed,
@@ -35,6 +38,21 @@ function App({
                         main: config.color || OARColor,
                         coloredBackground:
                             config.color === OARColor ? '#c7d2fa' : '',
+                    },
+                    secondary: {
+                        main: configOrDefault(config.color, OARSecondaryColor),
+                    },
+                    action: {
+                        main: configOrDefault(config.color, OARActionColor),
+                        contrastText: 'rgba(0, 0, 0, 0.87)',
+                        dark: configOrDefault(
+                            config.color,
+                            'rgb(178, 144, 44)',
+                        ),
+                        light: configOrDefault(
+                            config.color,
+                            'rgb(255, 216, 101)',
+                        ),
                     },
                 },
             }),

--- a/src/app/src/components/Button.jsx
+++ b/src/app/src/components/Button.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 class Button extends PureComponent {
     render() {
-        const { onClick, text, Icon, disabled, style } = this.props;
+        const { onClick, text, Icon, disabled, style, className } = this.props;
 
         return (
             <MaterialButton
@@ -19,6 +19,7 @@ class Button extends PureComponent {
                 }}
                 variant="contained"
                 color="primary"
+                className={className}
             >
                 <div style={{ display: 'flex' }}>
                     {Icon && <Icon />}

--- a/src/app/src/components/Button.jsx
+++ b/src/app/src/components/Button.jsx
@@ -4,7 +4,15 @@ import PropTypes from 'prop-types';
 
 class Button extends PureComponent {
     render() {
-        const { onClick, text, Icon, disabled, style, className } = this.props;
+        const {
+            onClick,
+            text,
+            Icon,
+            disabled,
+            style,
+            className,
+            color,
+        } = this.props;
 
         return (
             <MaterialButton
@@ -22,7 +30,7 @@ class Button extends PureComponent {
                 className={className}
             >
                 <div style={{ display: 'flex' }}>
-                    {Icon && <Icon />}
+                    {Icon && <Icon color={color} />}
                     {text}
                 </div>
             </MaterialButton>

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -5,6 +5,7 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Tooltip from '@material-ui/core/Tooltip';
+import { withStyles } from '@material-ui/core/styles';
 
 import { toast } from 'react-toastify';
 
@@ -12,16 +13,33 @@ import downloadFacilities from '../actions/downloadFacilities';
 import DownloadIcon from './DownloadIcon';
 import ArrowDropDownIcon from './ArrowDropDownIcon';
 
-const downloadFacilitiesStyles = Object.freeze({
-    listHeaderButtonStyles: Object.freeze({
-        height: '45px',
-        margin: '5px 0',
-    }),
-    buttonText: Object.freeze({
-        marginLeft: '0.2rem',
-        marginRight: '0.6rem',
-    }),
-});
+const downloadFacilitiesStyles = theme =>
+    Object.freeze({
+        listHeaderButtonStyles: Object.freeze({
+            height: '45px',
+            margin: '5px 0',
+            backgroundColor: theme.palette.action.main,
+            fontSize: '16px',
+            fontWeight: 900,
+            lineHeight: '20px',
+            '&:hover': {
+                backgroundColor: theme.palette.action.dark,
+            },
+        }),
+        buttonText: Object.freeze({
+            marginLeft: '0.2rem',
+            marginRight: '0.6rem',
+        }),
+        downloadTooltip: {
+            fontSize: '0.875rem',
+            fontFamily: theme.typography.fontFamily,
+        },
+        buttonContent: {
+            display: 'flex',
+            alignItems: 'center',
+            textTransform: 'none',
+        },
+    });
 
 function DownloadFacilitiesButton({
     /* from state */
@@ -33,6 +51,7 @@ function DownloadFacilitiesButton({
     allowLargeDownloads,
     disabled,
     setLoginRequiredDialogIsOpen,
+    classes,
 }) {
     const [requestedDownload, setRequestedDownload] = useState(false);
     const [anchorEl, setAnchorEl] = React.useState(null);
@@ -67,7 +86,7 @@ function DownloadFacilitiesButton({
                 allowLargeDownloads ? (
                     ''
                 ) : (
-                    <p style={{ fontSize: '0.875rem' }}>
+                    <p className={classes.downloadTooltip}>
                         Downloads are supported only for searches resulting in
                         10,000 facilities or less.
                     </p>
@@ -79,30 +98,16 @@ function DownloadFacilitiesButton({
                 <Button
                     disabled={disabled}
                     variant="outlined"
-                    styles={downloadFacilitiesStyles.listHeaderButtonStyles}
+                    className={classes.listHeaderButtonStyles}
                     aria-owns={anchorEl ? 'download-menu' : undefined}
                     aria-haspopup="true"
                     onClick={handleClick}
-                    style={{
-                        backgroundColor: '#FFCF3F',
-                        fontSize: '16px',
-                        fontWeight: 900,
-                        lineHeight: '20px',
-                    }}
                 >
-                    <div
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            textTransform: 'none',
-                        }}
-                    >
+                    <div className={classes.buttonContent}>
                         <DownloadIcon
                             color={disabled ? 'rgba(0, 0, 0, 0.26)' : '#1C1B1F'}
                         />
-                        <span style={downloadFacilitiesStyles.buttonText}>
-                            Download
-                        </span>
+                        <span className={classes.buttonText}>Download</span>
                         <ArrowDropDownIcon
                             color={disabled ? 'rgba(0, 0, 0, 0.26)' : '#1C1B1F'}
                         />
@@ -152,4 +157,6 @@ function mapStateToProps({
     };
 }
 
-export default connect(mapStateToProps)(DownloadFacilitiesButton);
+export default connect(mapStateToProps)(
+    withStyles(downloadFacilitiesStyles)(DownloadFacilitiesButton),
+);

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Tooltip from '@material-ui/core/Tooltip';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, withTheme } from '@material-ui/core/styles';
 
 import { toast } from 'react-toastify';
 
@@ -19,6 +19,7 @@ const downloadFacilitiesStyles = theme =>
             height: '45px',
             margin: '5px 0',
             backgroundColor: theme.palette.action.main,
+            color: theme.palette.getContrastText(theme.palette.action.main),
             fontSize: '16px',
             fontWeight: 900,
             lineHeight: '20px',
@@ -52,9 +53,14 @@ function DownloadFacilitiesButton({
     disabled,
     setLoginRequiredDialogIsOpen,
     classes,
+    theme,
 }) {
     const [requestedDownload, setRequestedDownload] = useState(false);
     const [anchorEl, setAnchorEl] = React.useState(null);
+
+    const actionContrastText = theme.palette.getContrastText(
+        theme.palette.action.main,
+    );
 
     useEffect(() => {
         if (requestedDownload && logDownloadError) {
@@ -105,11 +111,19 @@ function DownloadFacilitiesButton({
                 >
                     <div className={classes.buttonContent}>
                         <DownloadIcon
-                            color={disabled ? 'rgba(0, 0, 0, 0.26)' : '#1C1B1F'}
+                            color={
+                                disabled
+                                    ? 'rgba(0, 0, 0, 0.26)'
+                                    : actionContrastText
+                            }
                         />
                         <span className={classes.buttonText}>Download</span>
                         <ArrowDropDownIcon
-                            color={disabled ? 'rgba(0, 0, 0, 0.26)' : '#1C1B1F'}
+                            color={
+                                disabled
+                                    ? 'rgba(0, 0, 0, 0.26)'
+                                    : actionContrastText
+                            }
                         />
                     </div>
                 </Button>
@@ -158,5 +172,5 @@ function mapStateToProps({
 }
 
 export default connect(mapStateToProps)(
-    withStyles(downloadFacilitiesStyles)(DownloadFacilitiesButton),
+    withTheme()(withStyles(downloadFacilitiesStyles)(DownloadFacilitiesButton)),
 );

--- a/src/app/src/components/EmbeddedFooter.jsx
+++ b/src/app/src/components/EmbeddedFooter.jsx
@@ -14,7 +14,7 @@ const EmbeddedFooter = () => (
                 src={logo}
                 alt="Powered by Open Supply Hub"
                 width="150"
-                style={{ margin: '8px' }}
+                style={{ margin: '8px 24px' }}
             />
         </a>
     </footer>

--- a/src/app/src/components/EmbeddedMapFieldsConfig.jsx
+++ b/src/app/src/components/EmbeddedMapFieldsConfig.jsx
@@ -292,7 +292,7 @@ function EmbeddedMapFieldsConfig({
                             Choose which fields to display on your map (the
                             number of fields you are able to display corresponds
                             to your Embedded Map package). Facility name,
-                            address, and OS Hub ID will always be included.
+                            address, and OS ID will always be included.
                         </Typography>
                         {errors?.embed_fields && (
                             <Typography style={{ color: 'red' }}>

--- a/src/app/src/components/EmbeddedMapThemeConfig.jsx
+++ b/src/app/src/components/EmbeddedMapThemeConfig.jsx
@@ -111,7 +111,7 @@ function EmbeddedMapThemeConfig({
                             />
                             <FormControlLabel
                                 value={OARColor}
-                                label="OS Hub Blue"
+                                label="OS Hub Green"
                                 style={styles.radioItem}
                                 control={
                                     <Radio
@@ -120,7 +120,7 @@ function EmbeddedMapThemeConfig({
                                         value={OARColor}
                                         name="theme-color"
                                         inputProps={{
-                                            'aria-label': 'OS Hub Blue',
+                                            'aria-label': 'OS Hub Green',
                                         }}
                                         style={styles.radio}
                                     />

--- a/src/app/src/components/FacilityDetailsContent.jsx
+++ b/src/app/src/components/FacilityDetailsContent.jsx
@@ -82,6 +82,7 @@ const detailsStyles = theme =>
         link: {
             color: theme.palette.primary.main,
             paddingLeft: theme.spacing.unit * 2,
+            fontFamily: theme.typography.fontFamily,
         },
     });
 

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -72,6 +72,20 @@ const filterSidebarStyles = theme =>
         filterDrawerHeader: {
             fontFamily: theme.typography.fontFamily,
         },
+        filterButton: {
+            backgroundColor: theme.palette.action.main,
+            color: '#000',
+            fontWeight: 900,
+        },
+        tab: {
+            backgroundColor: theme.palette.secondary,
+            borderColor: '#000',
+            borderStyle: 'solid',
+            borderWidth: 1,
+            // omit shared border
+            borderRightWidth: 0,
+            fontWeight: 800,
+        },
     });
 
 class FilterSidebar extends Component {
@@ -113,7 +127,7 @@ class FilterSidebar extends Component {
     }
 
     render() {
-        const { fetchingFeatureFlags, classes } = this.props;
+        const { fetchingFeatureFlags, classes, secondaryColor } = this.props;
 
         const renderHeader = ({ multiLine }) =>
             this.props.facilitiesCount > 0 && (
@@ -169,18 +183,12 @@ class FilterSidebar extends Component {
                                         LIST
                                     </div>
                                 }
-                                style={{
-                                    backgroundColor:
-                                        this.props.activeFilterSidebarTab === 0
-                                            ? '#FFA6D0'
-                                            : '#fff',
-                                    borderColor: '#000',
-                                    borderStyle: 'solid',
-                                    borderWidth: 1,
-                                    // omit shared border
-                                    borderRightWidth: 0,
-                                    fontWeight: 800,
-                                }}
+                                className={classes.tab}
+                                style={
+                                    this.props.activeFilterSidebarTab === 0
+                                        ? {}
+                                        : { backgroundColor: '#fff' }
+                                }
                             />
                             <Tab
                                 label={
@@ -197,7 +205,7 @@ class FilterSidebar extends Component {
                                 style={{
                                     backgroundColor:
                                         this.props.activeFilterSidebarTab === 1
-                                            ? '#FFA6D0'
+                                            ? secondaryColor
                                             : '#fff',
                                     borderColor: '#000',
                                     borderStyle: 'solid',
@@ -211,11 +219,7 @@ class FilterSidebar extends Component {
                                 onClick={() =>
                                     this.props.toggleFilterModal(true)
                                 }
-                                style={{
-                                    backgroundColor: '#FFCF3F',
-                                    color: '#000',
-                                    fontWeight: 900,
-                                }}
+                                className={classes.filterButton}
                                 text="FILTERS"
                             />
                         </Tabs>

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -46,11 +46,32 @@ import FacilitiesIcon from './FacilitiesIcon';
 
 const filterSidebarStyles = theme =>
     Object.freeze({
-        searchTab: Object.freeze({
-            '*': {
-                fontFamily: theme.typography.fontFamily,
-            },
-        }),
+        header: {
+            padding: '24px',
+            fontFamily: theme.typography.fontFamily,
+        },
+        headerText: {
+            fontWeight: 900,
+            fontSize: '44px',
+            margin: 0,
+            lineHeight: '48px',
+            fontFamily: theme.typography.fontFamily,
+        },
+        resultsSpan: { fontWeight: 800 },
+        filterDrawer: {
+            backgroundColor: '#fff',
+            height: '100%',
+        },
+        filterDrawerContents: {
+            alignItems: 'center',
+            paddingLeft: '1em',
+            paddingRight: '1em',
+            display: 'flex',
+            justifyContent: 'space-between',
+        },
+        filterDrawerHeader: {
+            fontFamily: theme.typography.fontFamily,
+        },
     });
 
 class FilterSidebar extends Component {
@@ -92,7 +113,23 @@ class FilterSidebar extends Component {
     }
 
     render() {
-        const { fetchingFeatureFlags } = this.props;
+        const { fetchingFeatureFlags, classes } = this.props;
+
+        const renderHeader = ({ multiLine }) =>
+            this.props.facilitiesCount > 0 && (
+                <div className={`${classes.header} results-height-subtract`}>
+                    <h1 className={classes.headerText}>
+                        <FacilityIcon /> Facilities
+                    </h1>
+                    {multiLine ? (
+                        <span className={classes.resultsSpan}>
+                            {`${this.props.facilitiesCount} results`}
+                        </span>
+                    ) : (
+                        `${this.props.facilitiesCount} results`
+                    )}
+                </div>
+            );
 
         if (fetchingFeatureFlags) {
             return <CircularProgress />;
@@ -184,28 +221,8 @@ class FilterSidebar extends Component {
                         </Tabs>
                         {this.props.activeFilterSidebarTab === 0 && (
                             <Grid item sm={12}>
-                                {this.props.facilitiesCount > 0 && (
-                                    <div
-                                        className="results-height-subtract"
-                                        style={{
-                                            padding: '24px',
-                                        }}
-                                    >
-                                        <h1
-                                            style={{
-                                                fontWeight: 900,
-                                                fontSize: '44px',
-                                                margin: 0,
-                                                lineHeight: '48px',
-                                            }}
-                                        >
-                                            <FacilityIcon /> Facilities
-                                        </h1>
-                                        <span style={{ fontWeight: 800 }}>
-                                            {`${this.props.facilitiesCount} results`}
-                                        </span>
-                                    </div>
-                                )}
+                                {renderHeader({ multiLine: true })}
+
                                 <FeatureFlag
                                     flag={VECTOR_TILE}
                                     alternative={
@@ -236,26 +253,7 @@ class FilterSidebar extends Component {
                 </Hidden>
                 <Hidden mdDown>
                     <Grid item sm={12} md={4}>
-                        {this.props.facilitiesCount > 0 && (
-                            <div
-                                className="results-height-subtract"
-                                style={{
-                                    padding: '24px',
-                                }}
-                            >
-                                <h1
-                                    style={{
-                                        fontWeight: 900,
-                                        fontSize: '44px',
-                                        margin: 0,
-                                        lineHeight: '48px',
-                                    }}
-                                >
-                                    <FacilityIcon /> Facilities
-                                </h1>
-                                {`${this.props.facilitiesCount} results`}
-                            </div>
-                        )}
+                        {renderHeader({})}
                         <FeatureFlag
                             flag={VECTOR_TILE}
                             alternative={
@@ -270,22 +268,11 @@ class FilterSidebar extends Component {
                     open={this.props.filterModalOpen}
                     onClose={() => this.props.toggleFilterModal(false)}
                 >
-                    <div
-                        style={{
-                            backgroundColor: '#fff',
-                            height: '100%',
-                        }}
-                    >
-                        <div
-                            style={{
-                                alignItems: 'center',
-                                paddingLeft: '1em',
-                                paddingRight: '1em',
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                            }}
-                        >
-                            <h1>Filters</h1>
+                    <div className={classes.filterDrawer}>
+                        <div className={classes.filterDrawerContents}>
+                            <h1 className={classes.filterDrawerHeader}>
+                                Filters
+                            </h1>
                             <IconButton
                                 onClick={() =>
                                     this.props.toggleFilterModal(false)

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -9,6 +9,7 @@ import {
     Tab,
     Tabs,
     withStyles,
+    withTheme,
 } from '@material-ui/core';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import CloseIcon from '@material-ui/icons/Close';
@@ -74,16 +75,18 @@ const filterSidebarStyles = theme =>
         },
         filterButton: {
             backgroundColor: theme.palette.action.main,
-            color: '#000',
+            '&:hover': {
+                backgroundColor: theme.palette.action.dark,
+            },
+            color: theme.palette.secondary.contrastText,
             fontWeight: 900,
         },
         tab: {
-            backgroundColor: theme.palette.secondary,
+            backgroundColor: theme.palette.secondary.main,
+            color: theme.palette.secondary.contrastText,
             borderColor: '#000',
             borderStyle: 'solid',
             borderWidth: 1,
-            // omit shared border
-            borderRightWidth: 0,
             fontWeight: 800,
         },
     });
@@ -127,7 +130,12 @@ class FilterSidebar extends Component {
     }
 
     render() {
-        const { fetchingFeatureFlags, classes, secondaryColor } = this.props;
+        const { fetchingFeatureFlags, classes, theme } = this.props;
+
+        const actionContrastText = theme.palette.getContrastText(
+            theme.palette.action.main,
+        );
+        const tabContrastText = theme.palette.secondary.contrastText;
 
         const renderHeader = ({ multiLine }) =>
             this.props.facilitiesCount > 0 && (
@@ -179,15 +187,29 @@ class FilterSidebar extends Component {
                                             alignItems: 'center',
                                         }}
                                     >
-                                        <FacilitiesIcon />
+                                        <FacilitiesIcon
+                                            color={
+                                                this.props
+                                                    .activeFilterSidebarTab ===
+                                                    0 && tabContrastText
+                                            }
+                                        />
                                         LIST
                                     </div>
                                 }
                                 className={classes.tab}
                                 style={
                                     this.props.activeFilterSidebarTab === 0
-                                        ? {}
-                                        : { backgroundColor: '#fff' }
+                                        ? {
+                                              // omit shared border
+                                              borderRightWidth: 0,
+                                          }
+                                        : {
+                                              backgroundColor: '#fff',
+                                              color: '#000',
+                                              // omit shared border
+                                              borderRightWidth: 0,
+                                          }
                                 }
                             />
                             <Tab
@@ -198,24 +220,30 @@ class FilterSidebar extends Component {
                                             alignItems: 'center',
                                         }}
                                     >
-                                        <MapIcon />
+                                        <MapIcon
+                                            color={
+                                                this.props
+                                                    .activeFilterSidebarTab ===
+                                                    1 && tabContrastText
+                                            }
+                                        />
                                         MAP
                                     </div>
                                 }
-                                style={{
-                                    backgroundColor:
-                                        this.props.activeFilterSidebarTab === 1
-                                            ? secondaryColor
-                                            : '#fff',
-                                    borderColor: '#000',
-                                    borderStyle: 'solid',
-                                    borderWidth: 1,
-                                    fontWeight: 800,
-                                }}
+                                className={classes.tab}
+                                style={
+                                    this.props.activeFilterSidebarTab === 1
+                                        ? {}
+                                        : {
+                                              backgroundColor: '#fff',
+                                              color: '#000',
+                                          }
+                                }
                             />
                             <div style={{ padding: '10px' }} />
                             <Button
                                 Icon={FilterIcon}
+                                color={actionContrastText}
                                 onClick={() =>
                                     this.props.toggleFilterModal(true)
                                 }
@@ -347,6 +375,8 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withStyles(filterSidebarStyles)(
-    connect(mapStateToProps, mapDispatchToProps)(FilterSidebar),
+export default withTheme()(
+    withStyles(filterSidebarStyles)(
+        connect(mapStateToProps, mapDispatchToProps)(FilterSidebar),
+    ),
 );

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -15,6 +15,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
+import { withStyles } from '@material-ui/core/styles';
 import get from 'lodash/get';
 import InfiniteAnyHeight from 'react-infinite-any-height';
 import noop from 'lodash/noop';
@@ -46,15 +47,17 @@ import BadgeClaimed from './BadgeClaimed';
 import CopyLinkIcon from './CopyLinkIcon';
 import { useResultListHeight } from '../util/useHeightSubtract';
 
-const facilitiesTabStyles = Object.freeze({
+const makeFacilitiesTabStyles = theme => ({
     noResultsTextStyles: Object.freeze({
         margin: '30px',
+        fontFamily: theme.typography.fontFamily,
     }),
     linkStyles: Object.freeze({
         color: '#191919',
         flexDirection: 'column',
         display: 'flex',
         textDecoration: 'none',
+        fontFamily: theme.typography.fontFamily,
     }),
     listItemStyles: Object.freeze({
         wordWrap: 'anywhere',
@@ -62,6 +65,7 @@ const facilitiesTabStyles = Object.freeze({
         alignItems: 'start',
         maxWidth: '750px',
         minWidth: '310px',
+        fontFamily: theme.typography.fontFamily,
     }),
     listHeaderStyles: Object.freeze({
         backgroundColor: COLOURS.WHITE,
@@ -91,6 +95,7 @@ const facilitiesTabStyles = Object.freeze({
         fontWeight: 'bold',
         padding: '0 5px',
         marginTop: '5px',
+        fontFamily: theme.typography.fontFamily,
     }),
 });
 
@@ -108,6 +113,7 @@ function FilterSidebarFacilitiesTab({
     },
     handleScroll,
     scrollTop,
+    classes,
 }) {
     const [loginRequiredDialogIsOpen, setLoginRequiredDialogIsOpen] = useState(
         false,
@@ -151,14 +157,14 @@ function FilterSidebarFacilitiesTab({
                 <div className="control-panel__body">
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         An error prevented fetching facilities
                     </Typography>
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         <Button
@@ -185,7 +191,7 @@ function FilterSidebarFacilitiesTab({
                 <div className="control-panel__body">
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         No facilities matching this search
@@ -207,17 +213,12 @@ function FilterSidebarFacilitiesTab({
         : 0;
 
     const listHeaderInsetComponent = (
-        <div
-            style={facilitiesTabStyles.listHeaderStyles}
-            className="results-height-subtract"
-        >
+        <div className={`${classes.listHeaderStyles} results-height-subtract`}>
             <Typography variant="subheading" align="center">
-                <div style={facilitiesTabStyles.titleRowStyles}>
+                <div className={classes.titleRowStyles}>
                     {downloadingCSV ? (
-                        <div style={facilitiesTabStyles.listHeaderButtonStyles}>
-                            <div
-                                style={facilitiesTabStyles.downloadLabelStyles}
-                            >
+                        <div className={classes.listHeaderButtonStyles}>
+                            <div className={classes.downloadLabelStyles}>
                                 Downloading...
                             </div>
                             <LinearProgress
@@ -279,7 +280,7 @@ function FilterSidebarFacilitiesTab({
     const loadingElement = facilities.length !== facilitiesCount && (
         <Fragment>
             <Divider />
-            <ListItem style={facilitiesTabStyles.listItemStyles}>
+            <ListItem className={classes.listItemStyles}>
                 <ListItemText primary="Loading more facilities..." />
             </ListItem>
         </Fragment>
@@ -314,14 +315,12 @@ function FilterSidebarFacilitiesTab({
                             }) => (
                                 <div
                                     key={osID}
-                                    style={facilitiesTabStyles.listItemStyles}
+                                    className={classes.listItemStyles}
                                 >
                                     <Divider />
                                     <ListItem
                                         key={osID}
-                                        style={
-                                            facilitiesTabStyles.listItemStyles
-                                        }
+                                        className={classes.listItemStyles}
                                     >
                                         <Link
                                             to={{
@@ -337,9 +336,7 @@ function FilterSidebarFacilitiesTab({
                                                 osID,
                                                 search,
                                             )}
-                                            style={
-                                                facilitiesTabStyles.linkStyles
-                                            }
+                                            className={classes.linkStyles}
                                         >
                                             <span
                                                 style={{
@@ -397,8 +394,8 @@ function FilterSidebarFacilitiesTab({
                                                 flag={REPORT_A_FACILITY}
                                             >
                                                 <div
-                                                    style={
-                                                        facilitiesTabStyles.closureRibbon
+                                                    className={
+                                                        classes.closureRibbon
                                                     }
                                                 >
                                                     Closed facility
@@ -513,5 +510,8 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default withRouter(
-    connect(mapStateToProps, mapDispatchToProps)(FilterSidebarFacilitiesTab),
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    )(withStyles(makeFacilitiesTabStyles)(FilterSidebarFacilitiesTab)),
 );

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -49,7 +49,7 @@ import { useResultListHeight } from '../util/useHeightSubtract';
 
 const makeFacilitiesTabStyles = theme => ({
     noResultsTextStyles: Object.freeze({
-        margin: '30px',
+        margin: '30px !important',
         fontFamily: theme.typography.fontFamily,
     }),
     linkStyles: Object.freeze({

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -100,6 +100,7 @@ const filterSidebarSearchTabStyles = theme =>
             '&:hover': {
                 backgroundColor: theme.palette.action.dark,
             },
+            color: theme.palette.getContrastText(theme.palette.action.main),
         },
         ...filterSidebarStyles,
     });

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -80,6 +80,7 @@ const filterSidebarSearchTabStyles = theme =>
             color: theme.palette.primary.main,
             paddingTop: '0.5rem',
             paddingBottom: '0.5rem',
+            paddingLeft: '24px',
             textDecoration: 'none',
             lineHeight: '17px',
             '&:hover': {

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -31,8 +31,6 @@ import { fetchFacilities } from '../actions/facilities';
 
 import { recordSearchTabResetButtonClick } from '../actions/ui';
 
-import COLOURS from '../util/COLOURS';
-
 import {
     contributorOptionsPropType,
     contributorTypeOptionsPropType,
@@ -96,6 +94,12 @@ const filterSidebarSearchTabStyles = theme =>
             minWidth: '36px',
             minHeight: '36px',
         }),
+        actionButton: {
+            backgroundColor: theme.palette.action.main,
+            '&:hover': {
+                backgroundColor: theme.palette.action.dark,
+            },
+        },
         ...filterSidebarStyles,
     });
 
@@ -151,12 +155,7 @@ function FilterSidebarSearchTab({
         <Button
             variant="contained"
             type="submit"
-            className={classes.font}
-            style={{
-                boxShadow: 'none',
-                backgroundColor: COLOURS.NAVIGATION,
-                color: COLOURS.NEAR_BLACK,
-            }}
+            className={`${classes.font} ${classes.actionButton}`}
             onClick={() => searchForFacilities(vectorTileFlagIsActive)}
             disabled={fetchingOptions}
             fullWidth
@@ -172,7 +171,7 @@ function FilterSidebarSearchTab({
             onClick={() => resetFilters(embed)}
             disableRipple
             className={classes.reset}
-            color="primary"
+            color="secondary"
             disabled={fetchingOptions}
         >
             <i className={`${classes.icon} fas fa-fw fa-undo`} />

--- a/src/app/src/components/Filters/ContributorFilter.jsx
+++ b/src/app/src/components/Filters/ContributorFilter.jsx
@@ -1,14 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { func, string, bool } from 'prop-types';
 import { connect } from 'react-redux';
-import IconButton from '@material-ui/core/IconButton';
-import Popover from '@material-ui/core/Popover';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import InfoIcon from '@material-ui/icons/Info';
 
 import ShowOnly from '../ShowOnly';
 import StyledSelect from './StyledSelect';
+import ContributorTooltip from './ContributorTooltip';
 
 import {
     contributorOptionsPropType,
@@ -20,25 +18,6 @@ import {
     updateListFilter,
     updateCombineContributorsFilterOption,
 } from '../../actions/filters';
-
-const styles = {
-    popover: {
-        fontSize: '15px',
-        padding: '10px',
-        lineHeight: '22px',
-        maxWidth: '320px',
-        margin: '0 14px',
-    },
-    popoverLineItem: {
-        marginBottom: '6px',
-    },
-    popoverHeading: {
-        fontWeight: 'bold',
-    },
-    icon: {
-        color: 'rgba(0, 0, 0, 0.38)',
-    },
-};
 
 const CONTRIBUTORS = 'CONTRIBUTORS';
 const LISTS = 'LISTS';
@@ -58,67 +37,18 @@ function ContributorFilter({
     updateList,
     contributorListBottomMargin,
 }) {
-    const [
-        contributorPopoverAnchorEl,
-        setContributorPopoverAnchorEl,
-    ] = useState(null);
-
-    const contributorInfoPopoverContent = (
-        <div style={styles.popover}>
-            <p style={styles.popoverHeading}>
-                Do you want to see only facilities which these contributors
-                share? If so, tick this box.
-            </p>
-            <p>
-                There are now two ways to filter a Contributor search on OS Hub:
-            </p>
-            <ol>
-                <li style={styles.popoverLineItem}>
-                    You can search for all the facilities of multiple
-                    contributors. This means that the results would show all of
-                    the facilities contributed to OS Hub by, for example, BRAC
-                    University or Clarks. Some facilities might have been
-                    contributed by BRAC University but not by Clarks, or
-                    vice-versa.
-                </li>
-                <li style={styles.popoverLineItem}>
-                    By checking the “Show only shared facilities” box, this
-                    adjusts the search logic to “AND”. This means that your
-                    results will show only facilities contributed by BOTH BRAC
-                    University AND Clarks (as well as potentially other
-                    contributors). In this way, you can more quickly filter to
-                    show the specific Contributor overlap you are interested in.
-                </li>
-            </ol>
-        </div>
-    );
-
     return (
-        <div>
+        <div className="form__field">
             <ShowOnly when={!embed}>
                 <StyledSelect
-                    label={
-                        <div style={{ display: 'flex' }}>
-                            <p>Data Contributor</p>
-                            <ShowOnly
-                                when={contributors && contributors.length > 1}
-                            >
-                                <IconButton
-                                    onClick={
-                                        // eslint-disable-next-line no-confusing-arrow
-                                        e =>
-                                            contributorPopoverAnchorEl
-                                                ? null
-                                                : setContributorPopoverAnchorEl(
-                                                      e.currentTarget,
-                                                  )
-                                    }
-                                >
-                                    <InfoIcon />
-                                </IconButton>
-                            </ShowOnly>
-                        </div>
-                    }
+                    label="Data Contributor"
+                    renderIcon={() => (
+                        <ShowOnly
+                            when={contributors && contributors.length > 1}
+                        >
+                            <ContributorTooltip />
+                        </ShowOnly>
+                    )}
                     name={CONTRIBUTORS}
                     options={contributorOptions || []}
                     value={contributors}
@@ -138,23 +68,6 @@ function ContributorFilter({
                             }
                             label="Show only shared facilities"
                         />
-
-                        <Popover
-                            id="contributor-info-popover"
-                            anchorOrigin={{
-                                vertical: 'center',
-                                horizontal: 'right',
-                            }}
-                            transformOrigin={{
-                                vertical: 'center',
-                                horizontal: 'left',
-                            }}
-                            open={!!contributorPopoverAnchorEl}
-                            anchorEl={contributorPopoverAnchorEl}
-                            onClick={() => setContributorPopoverAnchorEl(null)}
-                        >
-                            {contributorInfoPopoverContent}
-                        </Popover>
                     </div>
                 </ShowOnly>
             </ShowOnly>

--- a/src/app/src/components/Filters/ContributorTooltip.jsx
+++ b/src/app/src/components/Filters/ContributorTooltip.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
+import InfoIcon from '@material-ui/icons/Info';
+
+function arrowGenerator(color) {
+    return {
+        '&[x-placement*="right"] $arrow': {
+            left: 0,
+            marginLeft: '-0.95em',
+            height: '3em',
+            width: '1em',
+            '&::before': {
+                borderWidth: '1em 1em 1em 0',
+                borderColor: `transparent ${color} transparent transparent`,
+            },
+        },
+    };
+}
+
+const styles = theme => ({
+    arrow: {
+        position: 'absolute',
+        fontSize: 6,
+        width: '3em',
+        height: '3em',
+        '&::before': {
+            content: '""',
+            margin: 'auto',
+            display: 'block',
+            width: 0,
+            height: 0,
+            borderStyle: 'solid',
+        },
+    },
+    htmlPopper: arrowGenerator('#dadde9'),
+    htmlTooltip: {
+        backgroundColor: '#ffffff',
+        color: 'rgba(0, 0, 0, 0.87)',
+        maxWidth: 220,
+        fontSize: theme.typography.pxToRem(12),
+        border: '1px solid #dadde9',
+        '& b': {
+            fontWeight: theme.typography.fontWeightMedium,
+        },
+    },
+    popover: {
+        fontSize: '15px',
+        padding: '10px',
+        lineHeight: '22px',
+        maxWidth: '320px',
+        margin: '0 14px',
+    },
+    popoverLineItem: {
+        marginBottom: '6px',
+    },
+    popoverHeading: {
+        fontWeight: 'bold',
+    },
+    icon: {
+        color: 'rgba(0, 0, 0, 0.38)',
+        paddingLeft: '0.5rem',
+    },
+});
+
+class CustomizedTooltips extends React.Component {
+    state = {
+        arrowRef: null,
+    };
+
+    handleArrowRef = node => {
+        this.setState({
+            arrowRef: node,
+        });
+    };
+
+    render() {
+        const { classes } = this.props;
+
+        return (
+            <Tooltip
+                enterTouchDelay={0}
+                leaveTouchDelay={5000}
+                placement="right"
+                classes={{
+                    popper: classes.htmlPopper,
+                    tooltip: classes.htmlTooltip,
+                }}
+                PopperProps={{
+                    popperOptions: {
+                        modifiers: {
+                            arrow: {
+                                enabled: Boolean(this.state.arrowRef),
+                                element: this.state.arrowRef,
+                            },
+                        },
+                    },
+                }}
+                title={
+                    <React.Fragment>
+                        <div style={styles.popover}>
+                            <p style={styles.popoverHeading}>
+                                Do you want to see only facilities which these
+                                contributors share? If so, tick this box.
+                            </p>
+                            <p>
+                                There are now two ways to filter a Contributor
+                                search on OS Hub:
+                            </p>
+                            <ol>
+                                <li style={styles.popoverLineItem}>
+                                    You can search for all the facilities of
+                                    multiple contributors. This means that the
+                                    results would show all of the facilities
+                                    contributed to OS Hub by, for example, BRAC
+                                    University or Clarks. Some facilities might
+                                    have been contributed by BRAC University but
+                                    not by Clarks, or vice-versa.
+                                </li>
+                                <li style={styles.popoverLineItem}>
+                                    By checking the “Show only shared
+                                    facilities” box, this adjusts the search
+                                    logic to “AND”. This means that your results
+                                    will show only facilities contributed by
+                                    BOTH BRAC University AND Clarks (as well as
+                                    potentially other contributors). In this
+                                    way, you can more quickly filter to show the
+                                    specific Contributor overlap you are
+                                    interested in.
+                                </li>
+                            </ol>
+                        </div>
+                    </React.Fragment>
+                }
+            >
+                <InfoIcon className={classes.icon} fontSize="inherit" />
+            </Tooltip>
+        );
+    }
+}
+
+CustomizedTooltips.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(CustomizedTooltips);

--- a/src/app/src/components/Filters/CountryNameFilter.jsx
+++ b/src/app/src/components/Filters/CountryNameFilter.jsx
@@ -19,11 +19,7 @@ function CountryNameFilter({
     return (
         <div className="form__field">
             <StyledSelect
-                label={
-                    <div style={{ display: 'flex' }}>
-                        <p>Country Name</p>
-                    </div>
-                }
+                label="Country Name"
                 name={COUNTRIES}
                 options={countryOptions || []}
                 value={countries}

--- a/src/app/src/components/Filters/StyledSelect.jsx
+++ b/src/app/src/components/Filters/StyledSelect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { string, bool } from 'prop-types';
+import { string, bool, func } from 'prop-types';
 import InputLabel from '@material-ui/core/InputLabel';
 import ReactSelect from 'react-select';
 import { withStyles } from '@material-ui/core/styles';
@@ -43,7 +43,15 @@ const makeSelectFilterStyles = color => {
     };
 };
 
-function StyledSelect({ name, label, color, creatable, classes, ...rest }) {
+function StyledSelect({
+    name,
+    label,
+    color,
+    creatable,
+    classes,
+    renderIcon,
+    ...rest
+}) {
     const selectFilterStyles = makeSelectFilterStyles(color);
     return (
         <>
@@ -52,7 +60,7 @@ function StyledSelect({ name, label, color, creatable, classes, ...rest }) {
                 htmlFor={name}
                 className={classes.inputLabelStyle}
             >
-                {label}
+                {label} {renderIcon()}
             </InputLabel>
             {creatable ? (
                 <CreatableInputOnly
@@ -96,12 +104,14 @@ function StyledSelect({ name, label, color, creatable, classes, ...rest }) {
 
 StyledSelect.defaultProps = {
     creatable: false,
+    renderIcon: () => {},
 };
 
 StyledSelect.propTypes = {
     name: string.isRequired,
     label: string.isRequired,
     creatable: bool,
+    renderIcon: func,
 };
 
 function mapStateToProps({ embeddedMap: { config } }) {

--- a/src/app/src/components/Filters/TextSearchFilter.jsx
+++ b/src/app/src/components/Filters/TextSearchFilter.jsx
@@ -5,9 +5,11 @@ import TextField from '@material-ui/core/TextField';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import SearchIcon from '@material-ui/icons/Search';
+import InputLabel from '@material-ui/core/InputLabel';
 import { withStyles } from '@material-ui/core/styles';
 
 import { updateFacilityFreeTextQueryFilter } from '../../actions/filters';
+import { makeFilterStyles } from '../../util/styles';
 
 import {
     getValueFromEvent,
@@ -15,22 +17,6 @@ import {
 } from '../../util/util';
 
 import { DEFAULT_SEARCH_TEXT } from '../../util/constants';
-
-const filterStyles = Object.freeze({
-    searchInput: Object.freeze({
-        backgroundColor: '#fff',
-        paddingLeft: 0,
-        borderRadius: 0,
-    }),
-    notchedOutline: {
-        borderRadius: 0,
-    },
-    inputLabelStyle: {
-        fontSize: '18px',
-        fontWeight: 700,
-        color: '#000',
-    },
-});
 
 const FACILITIES = 'FACILITIES';
 
@@ -41,10 +27,17 @@ function TextSearchFilter({
     submitFormOnEnterKeyPress,
     classes,
     searchLabel,
+    marginTop,
 }) {
     return (
-        <div>
-            <p style={filterStyles.inputLabelStyle}>{searchLabel}</p>
+        <div className="form__field" style={{ marginTop }}>
+            <InputLabel
+                shrink={false}
+                htmlFor={FACILITIES}
+                className={classes.inputLabelStyle}
+            >
+                {searchLabel}
+            </InputLabel>
             <TextField
                 id={FACILITIES}
                 placeholder="e.g. ABC Textiles Limited"
@@ -92,6 +85,7 @@ function mapStateToProps({
         facilityFreeTextQuery,
         searchLabel: embed ? config.text_search_label : DEFAULT_SEARCH_TEXT,
         embedExtendedFields: config.extended_fields,
+        marginTop: embed ? '36px' : 0,
     };
 }
 
@@ -109,4 +103,4 @@ function mapDispatchToProps(dispatch, { searchForFacilities }) {
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(withStyles(filterStyles)(TextSearchFilter));
+)(withStyles(makeFilterStyles)(TextSearchFilter));

--- a/src/app/src/components/HomepageSidebarSearch.jsx
+++ b/src/app/src/components/HomepageSidebarSearch.jsx
@@ -283,7 +283,7 @@ function FilterSidebarSearchTab({
                         <CountryNameFilter />
                     </Grid>
                 </Grid>
-                <ShowOnly when={!embed || embedExtendedFields.length}>
+                <ShowOnly when={!embed || embedExtendedFields?.length}>
                     {expandButton}
                 </ShowOnly>
                 <div className={classes.buttonGroup}>

--- a/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/NonVectorTileFilterSidebarFacilitiesTab.jsx
@@ -13,6 +13,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Divider from '@material-ui/core/Divider';
+import { withStyles } from '@material-ui/core/styles';
 import get from 'lodash/get';
 import InfiniteAnyHeight from 'react-infinite-any-height';
 import includes from 'lodash/includes';
@@ -66,16 +67,19 @@ const sortFacilitiesAlphabeticallyByName = data =>
             },
         );
 
-const facilitiesTabStyles = Object.freeze({
+const makeFacilitiesTabStyles = theme => ({
     noResultsTextStyles: Object.freeze({
+        fontFamily: theme.typography.fontFamily,
         margin: '30px',
     }),
     linkStyles: Object.freeze({
         display: 'flex',
         textDecoration: 'none',
+        fontFamily: theme.typography.fontFamily,
     }),
     listItemStyles: Object.freeze({
         wordWrap: 'anywhere',
+        fontFamily: theme.typography.fontFamily,
     }),
     listHeaderStyles: Object.freeze({
         backgroundColor: COLOURS.WHITE,
@@ -104,6 +108,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
     returnToSearchTab,
     filterText,
     updateFilterText,
+    classes,
 }) {
     const [loginRequiredDialogIsOpen, setLoginRequiredDialogIsOpen] = useState(
         false,
@@ -131,14 +136,14 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                 <div className="control-panel__body">
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         An error prevented fetching facilities
                     </Typography>
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         <Button
@@ -165,14 +170,14 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                 <div className="control-panel__body">
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         No facilities to display
                     </Typography>
                     <Typography
                         variant="body1"
-                        style={facilitiesTabStyles.noResultsTextStyles}
+                        className={classes.noResultsTextStyles}
                         align="center"
                     >
                         <Button
@@ -214,12 +219,9 @@ function NonVectorTileFilterSidebarFacilitiesTab({
     );
 
     const listHeaderInsetComponent = (
-        <div
-            style={facilitiesTabStyles.listHeaderStyles}
-            className="results-height-subtract"
-        >
+        <div className={`${classes.listHeaderStyles} results-height-subtract`}>
             <Typography variant="subheading" align="center">
-                <div style={facilitiesTabStyles.titleRowStyles}>
+                <div className={classes.titleRowStyles}>
                     {headerDisplayString}
                     <FeatureFlag
                         flag={ALLOW_LARGE_DOWNLOADS}
@@ -244,7 +246,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                     </FeatureFlag>
                 </div>
             </Typography>
-            <div style={facilitiesTabStyles.listHeaderTextSearchStyles}>
+            <div className={classes.listHeaderTextSearchStyles}>
                 <label htmlFor={SEARCH_TERM_INPUT}>Filter results</label>
                 <ControlledTextInput
                     id={SEARCH_TERM_INPUT}
@@ -282,9 +284,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                                     <Divider />
                                     <ListItem
                                         key={osID}
-                                        style={
-                                            facilitiesTabStyles.listItemStyles
-                                        }
+                                        className={classes.listItemStyles}
                                     >
                                         <Link
                                             to={{
@@ -296,9 +296,7 @@ function NonVectorTileFilterSidebarFacilitiesTab({
                                                 },
                                             }}
                                             href={makeFacilityDetailLink(osID)}
-                                            style={
-                                                facilitiesTabStyles.linkStyles
-                                            }
+                                            className={classes.linkStyles}
                                         >
                                             <ListItemText
                                                 primary={`${name} - ${countryName}`}
@@ -408,4 +406,4 @@ function mapDispatchToProps(dispatch) {
 export default connect(
     mapStateToProps,
     mapDispatchToProps,
-)(NonVectorTileFilterSidebarFacilitiesTab);
+)(withStyles(makeFacilitiesTabStyles)(NonVectorTileFilterSidebarFacilitiesTab));

--- a/src/app/src/util/constants.jsx
+++ b/src/app/src/util/constants.jsx
@@ -588,6 +588,8 @@ export const PPE_FIELD_NAMES = Object.freeze([
 export const OARFont = "'Darker Grotesque',sans-serif";
 export const OARColor = '#8428FA';
 export const SelectedMarkerColor = '#FFCF3F';
+export const OARActionColor = '#FFCF3F';
+export const OARSecondaryColor = '#FFA6D0';
 
 // A CSS size value that is used to set a lower bound on the iframe height
 // when the width is set to 100%

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -106,6 +106,14 @@ export const makeFilterStyles = theme =>
         selectStyle: Object.freeze({
             fontFamily: theme.typography.fontFamily,
         }),
+        searchInput: Object.freeze({
+            backgroundColor: '#fff',
+            paddingLeft: 0,
+            borderRadius: 0,
+        }),
+        notchedOutline: {
+            borderRadius: 0,
+        },
     });
 
 export const claimAFacilityFormStyles = Object.freeze({

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -99,8 +99,9 @@ export const makeFilterStyles = theme =>
             fontSize: '18px',
             fontWeight: 700,
             color: '#000',
-            transform: 'translate(0, -8px) scale(1)',
-            paddingBottom: '0.5rem',
+            padding: '0.5rem 0',
+            display: 'flex',
+            alignContent: 'center',
         }),
         selectStyle: Object.freeze({
             fontFamily: theme.typography.fontFamily,


### PR DESCRIPTION
## Overview

The embedded map custom styles weren't applied to all relevant elements when creating the new layout. Applies the custom color/font where applicable, and also tweaks a few small UI style issues. 

Connects Client 115

## Demo

<img width="1405" alt="Screen Shot 2022-11-03 at 12 09 11 PM" src="https://user-images.githubusercontent.com/21046714/199788907-e27f84c5-e2fe-4cd1-bbf3-994a92ba1318.png">

<img width="492" alt="Screen Shot 2022-11-03 at 12 34 24 PM" src="https://user-images.githubusercontent.com/21046714/199788924-bc60b8d7-10aa-4645-9fe9-49f299d3233d.png">

With Contrast Text:
<img width="1408" alt="Screen Shot 2022-11-03 at 2 29 09 PM" src="https://user-images.githubusercontent.com/21046714/199805228-d9f5cb79-ed03-4680-b1f3-4e3df306e516.png">
<img width="497" alt="Screen Shot 2022-11-03 at 2 29 22 PM" src="https://user-images.githubusercontent.com/21046714/199805239-8054cfeb-a83d-4d7e-8d23-832df5eaa1e5.png">

## Notes

I preferred using the `theme` over pulling in props for custom color/font where possible, to simplify style adjustments later if needed (since the `theme` object is in one place, vs many mapStateToProps). 

Currently, we have three main colors in the app: purple, pink, and yellow. The purple was previously set to be the primary color, so I've left that, and added the pink as secondary, and the yellow as 'action' (since it mostly appears in actionable items, like the search button). The custom type ('action') doesn't have the same power as the built-in primary/secondary color schemes, but is still useful as a variable that can be accessed via theming throughout the app. 

We only allow users to select one color in embedded map config, so in embed mode I've set all the colors to the config color.  However, if we decide to allow users to set multiple colors in the future, it should be fairly simple to apply that via the theme object. 

## Testing Instructions

* Run `./scripts/server`
* View [the homepage](http://localhost:6543/) at full width and mobile. Select two contributors, and view the tooltip for the contributors filter. Note font, color, and alignment throughout.
* View [the facilities page](http://localhost:6543/facilities) at full with and mobile. On mobile, open the filters drawer. Select two contributors, and view the tooltip for the contributors filter. Note font, color, and alignment throughout.
* Go to user embed settings. Note that text should read, 'OS ID' and not 'OS Hub ID'. 
* Set up an embedded map with a very noticeable color and font. Set a field to be searchable, and update the search text. 
* View [the embedded facilities page](http://localhost:6543/facilities?contributors=2&embed=1) at full width and mobile. On mobile, open the filters drawer. Note the alignment of the 'powered by' button. Note font, color, and alignment throughout.
* Test the embedded map again with a user with lowest embed permissions, and the map color set to 'black'.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
