### PR TITLE
Handle additional merge errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Support mediaQueryList event listener in older Safari [#2303](https://github.com/open-apparel-registry/open-apparel-registry/pull/2303)
+- Handle additional merge errors [#2299](https://github.com/open-apparel-registry/open-apparel-registry/pull/2299)
 
 ### Security
 

--- a/src/django/api/management/commands/fix_merged_rejections.py
+++ b/src/django/api/management/commands/fix_merged_rejections.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from api.models import FacilityMatch, HistoricalFacilityMatch
+from api.models import FacilityMatch, HistoricalFacilityMatch, FacilityListItem
 from api.constants import ProcessingAction
 
 
@@ -18,11 +18,42 @@ class Command(BaseCommand):
         if dry_run:
             print('== DRY RUN - SKIPPING ALL SAVES')
 
-        count = 0
         now = str(timezone.now())
+
+        def update_list_item(item, facility_id):
+            if item:
+                item.facility_id = facility_id
+                item.processing_results.append({
+                    'action': ProcessingAction.UNDO_MERGE,
+                    'started_at': now,
+                    'error': False,
+                    'finished_at': now,
+                })
+                if not dry_run:
+                    item.save()
+                    print(f'item,save,{item.pk}')
+                else:
+                    print(f'item,dry,{item.pk}')
+
+        def update_match(hist_match, prev_record, note=''):
+            try:
+                match = FacilityMatch.objects.get(pk=hist_match.id)
+                if not dry_run:
+                    match.status = prev_record.status
+                    match.changeReason = 'Fixing incorrect merge'
+                    match.save()
+                    print(f'match,save,{match.pk},{note}')
+                else:
+                    print(f'match,dry,{match.pk},{note}')
+            except FacilityMatch.DoesNotExist:
+                print(f'match,missing,{hist_match.id},{note}')
+
+        count = 0
+        no_valid_matches = set()
+        multiple_valid_matches = set()
         for hist_match in HistoricalFacilityMatch.objects.filter(
             status='MERGED'
-        ).iterator():
+        ).order_by('history_date').iterator():
             try:
                 prev_record = hist_match.prev_record
                 if prev_record and prev_record.status in ['REJECTED',
@@ -33,42 +64,17 @@ class Command(BaseCommand):
                         .filter(facility_list_item_id=list_item.id,
                                 status__in=['AUTOMATIC', 'CONFIRMED'])
                     if len(valid_matches) > 1:
-                        print(
-                            'Multiple valid matches for list item {}'.format(
-                                list_item.id
-                            ))
+                        multiple_valid_matches.add(list_item.id)
                     elif len(valid_matches) < 1:
-                        print(
-                            'No valid matches found for list item {}'.format(
-                                list_item.id
-                            ))
+                        no_valid_matches.add(list_item.id)
                     else:
                         valid_match = valid_matches[0]
                         if list_item:
-                            list_item.facility_id = valid_match.facility_id
-                            list_item.processing_results.append({
-                                'action': ProcessingAction.UNDO_MERGE,
-                                'started_at': now,
-                                'error': False,
-                                'finished_at': now,
-                            })
-                            if not dry_run:
-                                list_item.save()
-                                print(f'item,save,{list_item.pk}')
-                            else:
-                                print(f'item,dry,{list_item.pk}')
+                            update_list_item(list_item,
+                                             valid_match.facility_id)
 
-                        try:
-                            match = FacilityMatch.objects.get(pk=hist_match.id)
-                            if not dry_run:
-                                match.status = prev_record.status
-                                match.changeReason = 'Fixing merge rejection'
-                                match.save()
-                                print(f'match,save,{match.pk}')
-                            else:
-                                print(f'match,dry,{match.pk}')
-                        except FacilityMatch.DoesNotExist:
-                            print(f'match,missing,{hist_match.id}')
+                        update_match(hist_match, prev_record)
+
                         count = count + 1
 
             except Exception as e:
@@ -76,4 +82,67 @@ class Command(BaseCommand):
                 # but not break the loop
                 print(f'match,error,{hist_match.id},{e}')
 
+        print(f'handling items with no valid matches,{no_valid_matches}')
+        for item_id in no_valid_matches:
+            try:
+                hist_matches = HistoricalFacilityMatch.objects.filter(
+                     facility_list_item_id=item_id,
+                     status='MERGED'
+                ).order_by('history_date')
+
+                valid_match = None
+                all_items_invalid = True
+                for hist_match in hist_matches:
+                    prev_match = hist_match.prev_record
+                    if prev_match:
+                        status = prev_match.status
+                        if status in ['AUTOMATIC', 'CONFIRMED']:
+                            # This match was merged through normal channels.
+                            # The list item should point to its facility.
+                            valid_match = prev_match
+                            all_items_invalid = False
+                        elif status not in ['REJECTED', 'PENDING']:
+                            # This match has items that are neither definitely
+                            # valid or definitely invalid.
+                            all_items_invalid = False
+
+                if valid_match:
+                    item = None
+                    try:
+                        item = FacilityListItem.objects.get(pk=item_id)
+                        update_list_item(item,
+                                         valid_match.facility_id)
+                        for hist_match in hist_matches:
+                            prev_record = hist_match.prev_record
+                            if prev_record and prev_record.status in [
+                                    'REJECTED', 'PENDING']:
+                                update_match(hist_match,
+                                             hist_match.prev_record,
+                                             'undo_merged_with_valid')
+                        count = count + 1
+                    except FacilityListItem.DoesNotExist:
+                        print(f'item,missing,{item_id}')
+                elif all_items_invalid:
+                    try:
+                        item = FacilityListItem.objects.get(pk=item_id)
+                        update_list_item(item, None)
+                        for hist_match in hist_matches:
+                            prev_record = hist_match.prev_record
+                            if prev_record and prev_record.status in [
+                                    'REJECTED', 'PENDING']:
+                                update_match(hist_match,
+                                             hist_match.prev_record,
+                                             'undo_all_invalid_merged')
+                        count = count + 1
+                    except FacilityListItem.DoesNotExist:
+                        print(f'item,missing,{item_id}')
+                else:
+                    print('No valid matches for list item {}'.format(
+                            item_id
+                         ))
+            except Exception as e:
+                # In case of an error, we should review/fix the match manually,
+                # but not break the loop
+                print(f'match,error,{hist_match.id},{e}')
+        print(f'Multiple valid matches for {multiple_valid_matches}')
         print('{} items adjusted'.format(count))


### PR DESCRIPTION
## Overview

Updates the merge error correction script to handle additional faulty merge cases, such as instances where all matches for an overwritten item were pending.

I ran this via a test branch on staging and it succeeded with a minimal number of items to be manually fixed (there's no way to get around needing to manually update items where there are multiple possible valid matches, and a few items no valid matches don't seem to fall under either of the additional cases and should be investigated/adjusted manually if needed). 

Connects #2233

## Testing Instructions

* A test branch should be currently live on staging, or can be rerun to make it live `ogr/test/handle-more-merge-errors`
* Run `./scripts/manage ecsmanage fix_merged_rejections --dry-run` to see the script run on staging
* Confirm that the results seem reasonable

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
