### PR TITLE
Add subscribe link to footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Add subscribe link to footer [#2300](https://github.com/open-apparel-registry/open-apparel-registry/pull/2300)
 
 ### Changed
 - Update Youtube link [#2305](https://github.com/open-apparel-registry/open-apparel-registry/pull/2305)

--- a/src/app/src/util/constants.jsx
+++ b/src/app/src/util/constants.jsx
@@ -813,15 +813,19 @@ export const EmbeddedMapInfoLink = `${InfoLink}/${InfoPaths.embeddedMap}`;
 
 export const FooterLinks = [
     { label: 'Donate', href: DONATE_LINK },
-    { label: 'Privacy Policy', href: `${InfoLink}/${InfoPaths.privacyPolicy}` },
+    {
+        label: 'Subscribe',
+        href: 'https://share.hsforms.com/1bQwXClZUTjihXk3wt1SX2Abujql',
+    },
     { label: 'FAQs', href: `${InfoLink}/${InfoPaths.faqs}` },
+    { label: 'Privacy Policy', href: `${InfoLink}/${InfoPaths.privacyPolicy}` },
+    { label: 'Media Hub', href: `${InfoLink}/${InfoPaths.mediaHub}` },
     {
         label: 'Terms of Service',
         href: `${InfoLink}/${InfoPaths.termsOfService}`,
     },
-    { label: 'Media Hub', href: `${InfoLink}/${InfoPaths.mediaHub}` },
-    { label: 'Contact Us', href: `${InfoLink}/${InfoPaths.contactUs}` },
     { label: 'Reporting Line', href: 'https://opensupplyhub.allvoices.co/' },
+    { label: 'Contact Us', href: `${InfoLink}/${InfoPaths.contactUs}` },
 ];
 
 export const SocialMediaLinks = [


### PR DESCRIPTION
## Overview

This PR adds a subscribe link to the footer.

Connects #2284 

## Notes

Due to the grid nature of the footer links (rather than column), the order of links needed to be rearranged.

## Testing Instructions

* http://localhost:6543/
  * [x] Ensure "Subscribe" link is at the top right of the footer links
  * [x] Ensure link goes to https://share.hsforms.com/1bQwXClZUTjihXk3wt1SX2Abujql

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
