### PR TITLE
Header copy and usability changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Update Youtube link [#2305](https://github.com/open-apparel-registry/open-apparel-registry/pull/2305)
+- Header copy and usability changes [#2301](https://github.com/open-apparel-registry/open-apparel-registry/pull/2301)
 
 ### Deprecated
 

--- a/src/app/src/components/Navbar/InternationalMenu.jsx
+++ b/src/app/src/components/Navbar/InternationalMenu.jsx
@@ -49,11 +49,11 @@ function Submenu() {
                     <span>বাংলা</span>
                 </a>
                 <a
-                    className="nav-submenu__link nav-submenu__link--lighter-font-weight"
+                    className="nav-submenu__link nav-submenu__link"
                     href="https://info.opensupplyhub.org/india"
                     target=""
                 >
-                    <span>हिन्दी</span>
+                    <span>India</span>
                 </a>
                 <a
                     className="nav-submenu__link "

--- a/src/app/src/components/Navbar/MainMobileNav.jsx
+++ b/src/app/src/components/Navbar/MainMobileNav.jsx
@@ -58,7 +58,6 @@ function MainMobileNav({
                     <a
                         className="mobile-nav__link"
                         href={`${InfoLink}/${InfoPaths.storiesResources}`}
-                        target="_blank"
                         rel="noreferrer"
                         onClick={handleClose}
                     >

--- a/src/app/src/components/Navbar/MobileInternationalMenu.jsx
+++ b/src/app/src/components/Navbar/MobileInternationalMenu.jsx
@@ -62,7 +62,7 @@ export default function MobileInternationalMenu({
                         href="https://info.opensupplyhub.org/india"
                         target=""
                     >
-                        हिन्दी
+                        India
                     </a>
                 </div>
                 <div className="mobile-nav__item">
@@ -71,7 +71,7 @@ export default function MobileInternationalMenu({
                         href="https://info.opensupplyhub.org/turkey"
                         target=""
                     >
-                        Türk
+                        Türkiye
                     </a>
                 </div>
                 <div className="mobile-nav__item">

--- a/src/app/src/components/Navbar/NavLink.jsx
+++ b/src/app/src/components/Navbar/NavLink.jsx
@@ -12,7 +12,6 @@ export default function NavLink({ label, href, external, mobile = false }) {
             <a
                 className={className}
                 href={href}
-                target="_blank"
                 rel="noreferrer"
                 onClick={createMenuClickHandler()}
             >

--- a/src/app/src/components/Navbar/Navbar.jsx
+++ b/src/app/src/components/Navbar/Navbar.jsx
@@ -50,6 +50,30 @@ export default function Navbar() {
         }
     }, [mobileMode]);
 
+    useEffect(() => {
+        if (activeSubmenu) {
+            const closeHeaderOnOutsideClick = event => {
+                const headerElement = document.getElementById('header');
+                const headerWasClicked = headerElement.contains(event.target);
+
+                if (!headerWasClicked) {
+                    setActiveSubmenu(null);
+                }
+            };
+
+            document.addEventListener('click', closeHeaderOnOutsideClick);
+
+            return () => {
+                document.removeEventListener(
+                    'click',
+                    closeHeaderOnOutsideClick,
+                );
+            };
+        }
+
+        return () => {};
+    }, [activeSubmenu]);
+
     const {
         renderNavItem,
         renderMobileNavItem,

--- a/src/app/src/util/constants.jsx
+++ b/src/app/src/util/constants.jsx
@@ -611,12 +611,12 @@ export const NavbarItems = [
                     label: 'What is OS Hub?',
                     items: [
                         {
-                            type: 'link',
+                            type: 'button',
                             label: 'Introduction',
                             href: InfoLink,
                         },
                         {
-                            type: 'link',
+                            type: 'button',
                             label: 'FAQs',
                             href: `${InfoLink}/${InfoPaths.faqs}`,
                         },


### PR DESCRIPTION
## Overview

This PR implements a few copy and usability changes to the header:

- Close header on click away from header
- Make "Resources" link open in the same tab
- Update copy on the InternationalMenu
- Make the links in the first column of the "How it works" menu buttons

Connects #2296 

## Notes

I've noticed that many of the links in the header/footer have `rel="noreferrer"` attributes. This is just the way they were in the nice and serious design, but maybe the referral information would be useful for gathering usage statistics. 

## Testing Instructions

- [ ] Ensure that clicking off the header/submenu closes the active submenu
- [ ] Ensure that the "Resources" button opens the link in the same tab
- [ ] Ensure that the international menu shows "India" rather than the Hindu equivalent
- [ ] Ensure that the first colum of links in the "How it works" submenu render as buttons instead of links

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
