### PR TITLE
Support mediaQueryList event listener in older Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Support mediaQueryList event listener in older Safari [#2303](https://github.com/open-apparel-registry/open-apparel-registry/pull/2303)
+
 ### Security
 
 ## [75-OSHUB] 2022-11-01

--- a/src/app/src/components/Navbar/Navbar.jsx
+++ b/src/app/src/components/Navbar/Navbar.jsx
@@ -21,10 +21,18 @@ export default function Navbar() {
         const handleMediaChange = e => setMobileMode(e.matches);
         const mediaQueryList = window.matchMedia(breakpoint);
 
-        mediaQueryList.addEventListener('change', handleMediaChange);
+        if (typeof mediaQueryList.addEventListener === 'function') {
+            mediaQueryList.addEventListener('change', handleMediaChange);
+        } else {
+            mediaQueryList.addListener(handleMediaChange);
+        }
 
         return () => {
-            mediaQueryList.removeEventListener('change', handleMediaChange);
+            if (typeof mediaQueryList.addEventListener === 'function') {
+                mediaQueryList.removeEventListener('change', handleMediaChange);
+            } else {
+                mediaQueryList.removeListener(handleMediaChange);
+            }
         };
     }, []);
 


### PR DESCRIPTION
## Overview

Older Safari and Mobile Safari versions have `addListener` instead of `addEventListener` and `removeListener` instead of `removeEventListener`.

Reference:
https://github.com/chakra-ui/chakra-ui/pull/5474

Connects #2294

## Demo

Using an iOS 13 iPhone via BrowserStack

### Before

<img width="304" alt="Screen Shot 2022-11-04 at 2 27 26 PM" src="https://user-images.githubusercontent.com/17363/200077556-7bea8ae4-7ed5-4ec7-af0f-1cdf29e1037b.png">

### After

<img width="304" alt="Screen Shot 2022-11-04 at 2 27 54 PM" src="https://user-images.githubusercontent.com/17363/200077639-4a32e06d-eaef-4dd1-b863-9905c94b0036.png">

## Testing Instructions

- Compare this branch to `ogr/develop` when browsing on iOS 13

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
