### PR TITLE
Update Youtube link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Update Youtube link [#2305](https://github.com/open-apparel-registry/open-apparel-registry/pull/2305)
 
 ### Deprecated
 

--- a/src/app/src/util/constants.jsx
+++ b/src/app/src/util/constants.jsx
@@ -877,7 +877,7 @@ export const SocialMediaLinks = [
                 />
             </svg>
         ),
-        href: 'https://www.youtube.com/channel/UCZ8Qn5HvFHX453JfI4dhYpA',
+        href: 'https://www.youtube.com/channel/UCy-66mcBwX2wlUM6kvKUrGw',
     },
     {
         label: 'Github',


### PR DESCRIPTION
## Overview

This PR updates the Youtube link. The old channel was deleted when migrating to the new email address.

Connects #2304 

## Testing Instructions

- http://localhost:6543/
- Click Youtube link on the footer and make sure it goes to right place

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
