### PR TITLE
Handle medium viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support mediaQueryList event listener in older Safari [#2303](https://github.com/open-apparel-registry/open-apparel-registry/pull/2303)
 - Handle additional merge errors [#2299](https://github.com/open-apparel-registry/open-apparel-registry/pull/2299)
 - Fix embedded map styling [#2298](https://github.com/open-apparel-registry/open-apparel-registry/pull/2298)
+- Handle medium viewport [#2308](https://github.com/open-apparel-registry/open-apparel-registry/pull/2308)
 
 ### Security
 

--- a/src/app/src/App.jsx
+++ b/src/app/src/App.jsx
@@ -30,6 +30,15 @@ function App({
     const theme = useMemo(
         () =>
             createMuiTheme({
+                breakpoints: {
+                    values: {
+                        xs: 0,
+                        sm: 700,
+                        md: 900,
+                        lg: 1280,
+                        xl: 1920,
+                    },
+                },
                 typography: {
                     fontFamily: config.font,
                 },

--- a/src/app/src/components/DownloadFacilitiesButton.jsx
+++ b/src/app/src/components/DownloadFacilitiesButton.jsx
@@ -18,6 +18,7 @@ const downloadFacilitiesStyles = theme =>
         listHeaderButtonStyles: Object.freeze({
             height: '45px',
             margin: '5px 0',
+            marginRight: '1em',
             backgroundColor: theme.palette.action.main,
             color: theme.palette.getContrastText(theme.palette.action.main),
             fontSize: '16px',

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -89,6 +89,17 @@ const filterSidebarStyles = theme =>
             borderWidth: 1,
             fontWeight: 800,
         },
+        searchContainer: {
+            minWidth: '200px',
+        },
+        resultsContainer: {
+            [theme.breakpoints.up('sm')]: {
+                minWidth: '250px',
+            },
+            [theme.breakpoints.up('md')]: {
+                minWidth: '320px',
+            },
+        },
     });
 
 class FilterSidebar extends Component {
@@ -279,12 +290,17 @@ class FilterSidebar extends Component {
                     </Grid>
                 </Hidden>
                 <Hidden only="xs">
-                    <Grid item sm={3}>
+                    <Grid item sm={3} className={classes.searchContainer}>
                         <FilterSidebarSearchTab />
                     </Grid>
                 </Hidden>
                 <Hidden only="xs">
-                    <Grid item xs={12} sm={4}>
+                    <Grid
+                        item
+                        xs={12}
+                        sm={4}
+                        className={classes.resultsContainer}
+                    >
                         {renderHeader({})}
                         <FeatureFlag
                             flag={VECTOR_TILE}

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -159,7 +159,7 @@ class FilterSidebar extends Component {
 
         return (
             <>
-                <Hidden lgUp>
+                <Hidden smUp>
                     <Grid
                         item
                         style={{
@@ -278,13 +278,13 @@ class FilterSidebar extends Component {
                         )}
                     </Grid>
                 </Hidden>
-                <Hidden mdDown>
-                    <Grid item md={3}>
+                <Hidden only="xs">
+                    <Grid item sm={3}>
                         <FilterSidebarSearchTab />
                     </Grid>
                 </Hidden>
-                <Hidden mdDown>
-                    <Grid item sm={12} md={4}>
+                <Hidden only="xs">
+                    <Grid item xs={12} sm={4}>
                         {renderHeader({})}
                         <FeatureFlag
                             flag={VECTOR_TILE}

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -50,6 +50,12 @@ const filterSidebarStyles = theme =>
         header: {
             padding: '24px',
             fontFamily: theme.typography.fontFamily,
+            [theme.breakpoints.up('sm')]: {
+                padding: '12px 24px',
+            },
+            [theme.breakpoints.up('md')]: {
+                padding: '24px',
+            },
         },
         headerText: {
             fontWeight: 900,

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -76,8 +76,16 @@ const makeFacilitiesTabStyles = theme => ({
     titleRowStyles: Object.freeze({
         display: 'flex',
         alignItems: 'center',
-        padding: '6px 1rem',
+        padding: '0 1rem',
         justifyContent: 'space-around',
+        [theme.breakpoints.up('sm')]: {
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+        },
+        [theme.breakpoints.up('md')]: {
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
     }),
     listHeaderButtonStyles: Object.freeze({
         height: '45px',
@@ -97,6 +105,18 @@ const makeFacilitiesTabStyles = theme => ({
         marginTop: '5px',
         fontFamily: theme.typography.fontFamily,
     }),
+    copyLinkButton: {
+        height: '45px',
+        fontSize: '16px',
+        fontWeight: '900',
+        lineWeight: '20px',
+    },
+    copyLinkButtonContent: {
+        display: 'flex',
+        alignItems: 'center',
+        textTransform: 'none',
+        whiteSpace: 'nowrap',
+    },
 });
 
 function FilterSidebarFacilitiesTab({
@@ -214,66 +234,53 @@ function FilterSidebarFacilitiesTab({
 
     const listHeaderInsetComponent = (
         <div className={`${classes.listHeaderStyles} results-height-subtract`}>
-            <Typography variant="subheading" align="center">
-                <div className={classes.titleRowStyles}>
-                    {downloadingCSV ? (
-                        <div className={classes.listHeaderButtonStyles}>
-                            <div className={classes.downloadLabelStyles}>
-                                Downloading...
-                            </div>
-                            <LinearProgress
-                                variant="determinate"
-                                value={progress}
-                            />
+            <div className={classes.titleRowStyles}>
+                {downloadingCSV ? (
+                    <div className={classes.listHeaderButtonStyles}>
+                        <div className={classes.downloadLabelStyles}>
+                            Downloading...
                         </div>
-                    ) : (
-                        <FeatureFlag
-                            flag={ALLOW_LARGE_DOWNLOADS}
-                            alternative={
-                                <DownloadFacilitiesButton
-                                    disabled={
-                                        facilitiesCount >=
-                                        FACILITIES_DOWNLOAD_DEFAULT_LIMIT
-                                    }
-                                    setLoginRequiredDialogIsOpen={
-                                        setLoginRequiredDialogIsOpen
-                                    }
-                                />
-                            }
-                        >
+                        <LinearProgress
+                            variant="determinate"
+                            value={progress}
+                        />
+                    </div>
+                ) : (
+                    <FeatureFlag
+                        flag={ALLOW_LARGE_DOWNLOADS}
+                        alternative={
                             <DownloadFacilitiesButton
-                                allowLargeDownloads
+                                disabled={
+                                    facilitiesCount >=
+                                    FACILITIES_DOWNLOAD_DEFAULT_LIMIT
+                                }
                                 setLoginRequiredDialogIsOpen={
                                     setLoginRequiredDialogIsOpen
                                 }
                             />
-                        </FeatureFlag>
-                    )}
-                    <CopySearch>
-                        <Button
-                            variant="outlined"
-                            onClick={noop}
-                            style={{
-                                fontSize: '16px',
-                                fontWeight: '900',
-                                lineWeight: '20px',
-                                marginLeft: '1em',
-                            }}
-                        >
-                            <div
-                                style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    textTransform: 'none',
-                                }}
-                            >
-                                <CopyLinkIcon />
-                                Copy Link
-                            </div>
-                        </Button>
-                    </CopySearch>
-                </div>
-            </Typography>
+                        }
+                    >
+                        <DownloadFacilitiesButton
+                            allowLargeDownloads
+                            setLoginRequiredDialogIsOpen={
+                                setLoginRequiredDialogIsOpen
+                            }
+                        />
+                    </FeatureFlag>
+                )}
+                <CopySearch>
+                    <Button
+                        variant="outlined"
+                        onClick={noop}
+                        className={classes.copyLinkButton}
+                    >
+                        <div className={classes.copyLinkButtonContent}>
+                            <CopyLinkIcon />
+                            Copy Link
+                        </div>
+                    </Button>
+                </CopySearch>
+            </div>
         </div>
     );
 

--- a/src/app/src/components/FilterSidebarFacilitiesTab.jsx
+++ b/src/app/src/components/FilterSidebarFacilitiesTab.jsx
@@ -66,6 +66,12 @@ const makeFacilitiesTabStyles = theme => ({
         maxWidth: '750px',
         minWidth: '310px',
         fontFamily: theme.typography.fontFamily,
+        [theme.breakpoints.up('sm')]: {
+            minWidth: '240px',
+        },
+        [theme.breakpoints.up('md')]: {
+            minWidth: '310px',
+        },
     }),
     listHeaderStyles: Object.freeze({
         backgroundColor: COLOURS.WHITE,

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -101,6 +101,7 @@ const filterSidebarSearchTabStyles = theme =>
                 backgroundColor: theme.palette.action.dark,
             },
             color: theme.palette.getContrastText(theme.palette.action.main),
+            flex: 1,
         },
         ...filterSidebarStyles,
     });
@@ -160,7 +161,6 @@ function FilterSidebarSearchTab({
             className={`${classes.font} ${classes.actionButton}`}
             onClick={() => searchForFacilities(vectorTileFlagIsActive)}
             disabled={fetchingOptions}
-            fullWidth
         >
             Search
         </Button>
@@ -214,8 +214,9 @@ function FilterSidebarSearchTab({
 
             <div
                 className={`${classes.sidebarDiv} ${classes.bottomSidebarDiv} filter-list-subtract`}
+                style={{ maxHeight: '120px' }}
             >
-                <div className="form__action" style={{ marginBottom: '40px' }}>
+                <div style={{ margin: '6px 0', display: 'flex' }}>
                     {searchResetButtonGroup()}
                 </div>
                 <ShowOnly when={!embed || embedExtendedFields.length}>

--- a/src/app/src/components/Filters/StyledSelect.jsx
+++ b/src/app/src/components/Filters/StyledSelect.jsx
@@ -11,7 +11,7 @@ import { OARColor } from '../../util/constants';
 import ArrowDropDownIcon from '../ArrowDropDownIcon';
 import CreatableInputOnly from '../CreatableInputOnly';
 
-const makeSelectFilterStyles = color => {
+const makeSelectFilterStyles = (color, windowWidth) => {
     const themeColor = color || OARColor;
     return {
         multiValue: provided => ({
@@ -40,6 +40,11 @@ const makeSelectFilterStyles = color => {
                 },
             };
         },
+        clearIndicator: provided => ({
+            ...provided,
+            padding:
+                windowWidth > 699 && windowWidth < 900 ? 0 : provided.padding,
+        }),
     };
 };
 
@@ -50,9 +55,10 @@ function StyledSelect({
     creatable,
     classes,
     renderIcon,
+    windowWidth,
     ...rest
 }) {
-    const selectFilterStyles = makeSelectFilterStyles(color);
+    const selectFilterStyles = makeSelectFilterStyles(color, windowWidth);
     return (
         <>
             <InputLabel
@@ -114,9 +120,15 @@ StyledSelect.propTypes = {
     renderIcon: func,
 };
 
-function mapStateToProps({ embeddedMap: { config } }) {
+function mapStateToProps({
+    embeddedMap: { config },
+    ui: {
+        window: { innerWidth },
+    },
+}) {
     return {
         color: config?.color,
+        windowWidth: innerWidth,
     };
 }
 

--- a/src/app/src/components/Filters/TextSearchFilter.jsx
+++ b/src/app/src/components/Filters/TextSearchFilter.jsx
@@ -51,7 +51,10 @@ function TextSearchFilter({
                 }}
                 InputProps={{
                     endAdornment: (
-                        <InputAdornment position="end">
+                        <InputAdornment
+                            position="end"
+                            className={classes.searchAdornment}
+                        >
                             <IconButton
                                 aria-label={searchLabel}
                                 onClick={searchForFacilities}

--- a/src/app/src/components/Map.jsx
+++ b/src/app/src/components/Map.jsx
@@ -33,8 +33,8 @@ class Map extends Component {
         return (
             <Grid
                 item
-                sm={12}
-                md={7}
+                xs={12}
+                sm={7}
                 className="map-container"
                 style={this.props.height ? { height: this.props.height } : {}}
             >

--- a/src/app/src/components/MapAndSidebar.jsx
+++ b/src/app/src/components/MapAndSidebar.jsx
@@ -17,7 +17,7 @@ function MapAndSidebar() {
         <Fragment>
             <Grid container className="map-sidebar-container">
                 <Route component={SidebarWithErrorBoundary} />
-                <Hidden mdDown>
+                <Hidden only="xs">
                     <Map height={mapHeight} />
                 </Hidden>
             </Grid>

--- a/src/app/src/components/SearchControls.jsx
+++ b/src/app/src/components/SearchControls.jsx
@@ -16,13 +16,20 @@ import { facilitiesRoute, mainRoute } from '../util/constants';
 const zoomStyles = theme =>
     Object.freeze({
         controlsStyle: Object.freeze({
-            background: 'white',
             fontFamily: theme.typography.fontFamily,
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            borderRadius: '0',
-            boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.2)',
+            [theme.breakpoints.up('sm')]: {
+                maxWidth: '235px',
+                flexDirection: 'column',
+                alignItems: 'flex-start',
+            },
+            [theme.breakpoints.up('md')]: {
+                maxWidth: '320px',
+                flexDirection: 'row',
+                alignItems: 'center',
+            },
         }),
         zoomStyle: Object.freeze({
             display: 'flex',
@@ -32,11 +39,21 @@ const zoomStyles = theme =>
         areaStyle: Object.freeze({
             fontWeight: 400,
             borderRadius: 0,
+            background: 'white',
+            '&:hover': {
+                background: 'white',
+            },
         }),
         dividerStyle: {
             width: '0px',
             height: '32px',
             borderLeft: '1px solid rgba(0, 0, 0, 0.3)',
+            [theme.breakpoints.up('sm')]: {
+                display: 'none',
+            },
+            [theme.breakpoints.up('md')]: {
+                display: 'block',
+            },
         },
     });
 

--- a/src/app/src/util/styles.js
+++ b/src/app/src/util/styles.js
@@ -110,10 +110,14 @@ export const makeFilterStyles = theme =>
             backgroundColor: '#fff',
             paddingLeft: 0,
             borderRadius: 0,
+            paddingRight: 0,
         }),
-        notchedOutline: {
+        notchedOutline: Object.freeze({
             borderRadius: 0,
-        },
+        }),
+        searchAdornment: Object.freeze({
+            padding: 0,
+        }),
     });
 
 export const claimAFacilityFormStyles = Object.freeze({


### PR DESCRIPTION
## Overview

We had only a mobile layout and a desktop layout, and were switching to the mobile layout at medium-width screens, which particularly negatively impacted the embedded map preview. Decreases the breakpoint at which we leave the desktop view to 900px, and adjusts the view from 700px-899px to prevent overflow. Finally, switches to mobile view when under 700px.

Connects Client 114

## Demo

700px
<img width="729" alt="700px" src="https://user-images.githubusercontent.com/21046714/201404120-fddffaa4-065a-4425-9823-2dca264df237.png">

900px
<img width="909" alt="900px" src="https://user-images.githubusercontent.com/21046714/201404153-b65aec7b-83c9-403c-854b-93da2e87e33d.png">

Embedded preview
<img width="1214" alt="Embed Preview" src="https://user-images.githubusercontent.com/21046714/201404174-e2a217ec-c261-46af-aace-641203e2d847.png">

## Testing Instructions

* Run `./scripts/server`.
* Use developer tools to view the map at: 1100px; 900px; 700px; and 500px. 
* Confirm the site is useable and visually appealing at each size. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
