### PR TITLE
Add a banner soliciting donations until the end of 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Add subscribe link to footer [#2300](https://github.com/open-apparel-registry/open-apparel-registry/pull/2300)
+- Add a banner soliciting donations untile the end of 2022 [#2318](https://github.com/open-apparel-registry/open-apparel-registry/pull/2318)
 
 ### Changed
 - Update Youtube link [#2305](https://github.com/open-apparel-registry/open-apparel-registry/pull/2305)

--- a/src/app/src/components/Navbar/Navbar.jsx
+++ b/src/app/src/components/Navbar/Navbar.jsx
@@ -5,6 +5,7 @@ import '../../styles/css/header.scss';
 import { MobileNavbarItems, NavbarItems } from '../../util/constants';
 import Logo from './Logo';
 import BurgerButton from './BurgerButton';
+import NavbarQ42022Banner from './NavbarQ42022Banner';
 import GoogleTranslateBar from './GoogleTranslateBar';
 import MenuClickHandlerContext from './MenuClickHandlerContext';
 
@@ -154,6 +155,7 @@ export default function Navbar() {
 
     return (
         <>
+            <NavbarQ42022Banner />
             <GoogleTranslateBar />
             <MenuClickHandlerContext.Provider value={createMenuClickHandler}>
                 {Header}

--- a/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
+++ b/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import '../../styles/css/navbarQ42022Banner.css';
 
-const expirationTime = new Date('Jan 1 2023 00:00:00 GMT-0000').getTime();
+const expirationTime = new Date('Jan 31 2023 00:00:00 GMT-0000').getTime();
 
 export default function NavbarQ42022Banner() {
     const isExpired = new Date().getTime() > expirationTime;

--- a/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
+++ b/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import '../../styles/css/navbarQ42022Banner.css';
+
+const expirationTime = new Date('Jan 1 2023 00:00:00 GMT-0000').getTime();
+
+export default function NavbarQ42022Banner() {
+    const isExpired = new Date().getTime() > expirationTime;
+    return isExpired ? null : (
+        <div
+            style={{
+                fontFamily: 'Darker Grotesque',
+                width: '100%',
+                backgroundColor: 'black',
+                color: '#FCCF3F',
+                textAlign: 'center',
+            }}
+        >
+            <div style={{ padding: '0.5em 0.5em 0 0.5em' }}>
+                We’re fundraising! Help us maintain OS Hub as a free platform,
+                accessible to all, by{' '}
+                <a
+                    className="banner-link"
+                    href="https://givebutter.com/opensupplyhub2022"
+                >
+                    donating to our campaign
+                </a>
+                .
+            </div>
+        </div>
+    );
+}

--- a/src/app/src/styles/css/navbarQ42022Banner.css
+++ b/src/app/src/styles/css/navbarQ42022Banner.css
@@ -1,0 +1,7 @@
+a.banner-link,
+a.banner-link:link,
+a.banner-link:hover,
+a.banner-link:visited,
+a.banner-link:active {
+    color: #FCCF3F;
+}


### PR DESCRIPTION
## Overview

We were asked to quickly add an deploy a banner link that would only last through the end of 2022.

Connects #2317

## Demo

<img width="1280" alt="Screen Shot 2022-11-22 at 4 05 29 PM" src="https://user-images.githubusercontent.com/17363/203439134-f2c1084e-8ae4-4c50-a8b3-4ad97bf444df.png">

<img width="450" alt="Screen Shot 2022-11-22 at 4 05 43 PM" src="https://user-images.githubusercontent.com/17363/203439144-68d2983b-1e4c-47a5-9c2a-2c1cdcd9cc66.png">

## Notes

The styling was specified in the comments of #2317

## Testing Instructions

* Verify that message looks good at all browser widths
* Change the expiration date to 2022 and verify that the banner is no longer shown and the layout is not disturbed

```diff
﻿﻿﻿diff --git a/src/app/src/components/Navbar/NavbarQ42022Banner.jsx b/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
index f785f15c..f48a8b8a 100644
--- a/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
+++ b/src/app/src/components/Navbar/NavbarQ42022Banner.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import '../../styles/css/navbarQ42022Banner.css';
 
-const expirationTime = new Date('Jan 1 2023 00:00:00 GMT-0000').getTime();
+const expirationTime = new Date('Jan 1 2022 00:00:00 GMT-0000').getTime();
 
 export default function NavbarQ42022Banner() {
     const isExpired = new Date().getTime() > expirationTime;
```

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
