### PR TITLE
Handle slow-loading embed config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Handle slow-loading embed config [#2319](https://github.com/open-apparel-registry/open-apparel-registry/pull/2319)
 
 ### Security
 

--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -219,7 +219,7 @@ function FilterSidebarSearchTab({
                 <div style={{ margin: '6px 0', display: 'flex' }}>
                     {searchResetButtonGroup()}
                 </div>
-                <ShowOnly when={!embed || embedExtendedFields.length}>
+                <ShowOnly when={!embed || embedExtendedFields?.length}>
                     <div className="form__field">
                         <ShowOnly when={!embed}>
                             <div className="form__info">

--- a/src/app/src/reducers/EmbeddedMapReducer.js
+++ b/src/app/src/reducers/EmbeddedMapReducer.js
@@ -18,6 +18,7 @@ const initialConfig = Object.freeze({
     hideSectorData: false,
     contributor: null,
     font: OARFont,
+    extended_fields: [],
 });
 
 const initialState = Object.freeze({


### PR DESCRIPTION
## Overview

When the embed config loads too slowly, an error was thrown because the embedConfig.extended_fields were undefined. Adds an empty extended fields array to the initial state and also handles undefined extended_fields.

Connects #2313 

## Testing Instructions

* Wrap the completeFetchEmbedConfig action in a timeout to slow it down. 
```diff
diff --git a/src/app/src/actions/embeddedMap.js b/src/app/src/actions/embeddedMap.js
index 27d398d7..49ba367d 100644
--- a/src/app/src/actions/embeddedMap.js
+++ b/src/app/src/actions/embeddedMap.js
@@ -39,13 +39,15 @@ export function fetchEmbedConfig(contributorID) {
             .get(makeContributorEmbedConfigURL(contributorID))
             .then(({ data }) => {
                 const { font, color } = data;
-                dispatch(
-                    completeFetchEmbedConfig({
-                        ...data,
-                        font: !font ? OARFont : font,
-                        color: !color ? OARColor : color,
-                    }),
-                );
+                setTimeout(() => {
+                    dispatch(
+                        completeFetchEmbedConfig({
+                            ...data,
+                            font: !font ? OARFont : font,
+                            color: !color ? OARColor : color,
+                        }),
+                    );
+                }, 10000);
             })
             .catch(err =>
                 dispatch(
```
* WARNING: If you do this on develop and then open an embed config, the tab will usually crash!! 
* On this branch, open any embed config and confirm the page doesn't crash

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
