### PR TITLE
Prevent infinite loading on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Handle slow-loading embed config [#2319](https://github.com/open-apparel-registry/open-apparel-registry/pull/2319)
+- Prevent infinite loading on error [#2321](https://github.com/open-apparel-registry/open-apparel-registry/pull/2321)
 
 ### Security
 

--- a/src/app/src/components/ErrorBoundary.jsx
+++ b/src/app/src/components/ErrorBoundary.jsx
@@ -41,8 +41,8 @@ class ErrorBoundary extends Component {
                 <div style={styles.errorContainer}>
                     <h2>Whoops! Something went wrong :(</h2>
                     <p>
-                        Weve recorded the issue and are working on a fix. If
-                        this problem persists, contact support and send along
+                        We&apos;ve recorded the issue and are working on a fix.
+                        If this problem persists, contact support and send along
                         this text:
                     </p>
                     <div style={styles.hash} className="notranslate">

--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -23,6 +23,7 @@ import FilterSidebarSearchTab from './FilterSidebarSearchTab';
 import FilterSidebarFacilitiesTab from './FilterSidebarFacilitiesTab';
 import MapWithHookedHeight from './MapWithHookedHeight';
 import NonVectorTileFilterSidebarFacilitiesTab from './NonVectorTileFilterSidebarFacilitiesTab';
+import SimpleErrorBoundary from './SimpleErrorBoundary';
 
 import { VECTOR_TILE } from '../util/constants';
 
@@ -270,16 +271,17 @@ class FilterSidebar extends Component {
                         </Tabs>
                         {this.props.activeFilterSidebarTab === 0 && (
                             <Grid item sm={12}>
-                                {renderHeader({ multiLine: true })}
-
-                                <FeatureFlag
-                                    flag={VECTOR_TILE}
-                                    alternative={
-                                        <NonVectorTileFilterSidebarFacilitiesTab />
-                                    }
-                                >
-                                    <FilterSidebarFacilitiesTab />
-                                </FeatureFlag>
+                                <SimpleErrorBoundary>
+                                    {renderHeader({ multiLine: true })}
+                                    <FeatureFlag
+                                        flag={VECTOR_TILE}
+                                        alternative={
+                                            <NonVectorTileFilterSidebarFacilitiesTab />
+                                        }
+                                    >
+                                        <FilterSidebarFacilitiesTab />
+                                    </FeatureFlag>
+                                </SimpleErrorBoundary>
                             </Grid>
                         )}
                         {this.props.activeFilterSidebarTab === 1 && (
@@ -290,14 +292,18 @@ class FilterSidebar extends Component {
                                     width: '100%',
                                 }}
                             >
-                                <MapWithHookedHeight />
+                                <SimpleErrorBoundary>
+                                    <MapWithHookedHeight />
+                                </SimpleErrorBoundary>
                             </div>
                         )}
                     </Grid>
                 </Hidden>
                 <Hidden only="xs">
                     <Grid item sm={3} className={classes.searchContainer}>
-                        <FilterSidebarSearchTab />
+                        <SimpleErrorBoundary>
+                            <FilterSidebarSearchTab />
+                        </SimpleErrorBoundary>
                     </Grid>
                 </Hidden>
                 <Hidden only="xs">
@@ -307,15 +313,17 @@ class FilterSidebar extends Component {
                         sm={4}
                         className={classes.resultsContainer}
                     >
-                        {renderHeader({})}
-                        <FeatureFlag
-                            flag={VECTOR_TILE}
-                            alternative={
-                                <NonVectorTileFilterSidebarFacilitiesTab />
-                            }
-                        >
-                            <FilterSidebarFacilitiesTab />
-                        </FeatureFlag>
+                        <SimpleErrorBoundary>
+                            {renderHeader({})}
+                            <FeatureFlag
+                                flag={VECTOR_TILE}
+                                alternative={
+                                    <NonVectorTileFilterSidebarFacilitiesTab />
+                                }
+                            >
+                                <FilterSidebarFacilitiesTab />
+                            </FeatureFlag>
+                        </SimpleErrorBoundary>
                     </Grid>
                 </Hidden>
                 <Modal

--- a/src/app/src/components/SidebarWithErrorBoundary.jsx
+++ b/src/app/src/components/SidebarWithErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Switch, Route } from 'react-router-dom';
+import Grid from '@material-ui/core/Grid';
 
 import { facilitiesRoute, mainRoute } from '../util/constants';
 
@@ -20,6 +21,17 @@ export default class SidebarWithErrorBoundary extends Component {
     }
 
     render() {
+        if (this.state.hasError) {
+            return (
+                <Grid item xs={12} sm={7}>
+                    <h2>Whoops! Something went wrong :(</h2>
+                    <p>
+                        We&apos;ve recorded the issue and are working on a fix.
+                    </p>
+                </Grid>
+            );
+        }
+
         return (
             <Switch>
                 <Route

--- a/src/app/src/components/SimpleErrorBoundary.jsx
+++ b/src/app/src/components/SimpleErrorBoundary.jsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const styles = {
+    errorContainer: {
+        margin: 'auto',
+        boxSizing: 'border-box',
+    },
+};
+
+class SimpleErrorBoundary extends Component {
+    state = {};
+
+    componentDidCatch(error) {
+        this.setState({ error });
+
+        // Report error to Rollbar
+        if (window.Rollbar) {
+            window.Rollbar.error(error);
+        }
+    }
+
+    render() {
+        if (this.state.error) {
+            return (
+                <div style={styles.errorContainer}>
+                    <h2>Whoops! Something went wrong :(</h2>
+                    <p>
+                        We&apos;ve recorded the issue and are working on a fix.
+                    </p>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+SimpleErrorBoundary.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default SimpleErrorBoundary;


### PR DESCRIPTION
## Overview

The sidebar error boundary previously responded to errors by attempting to reload the components which had thrown the error. This resulted in the page infinitely loading.

There are now two levels of error boundaries for the sidebar(s). One handles errors in the filters column and search results column; the other handles errors in the combined sidebar component.

Both levels of error boundary will show an error message instead of the effected component when an error has occurred.

Connects #2314 

## Demo

Error in subsection:
<img width="1035" alt="Screenshot 2022-11-23 at 1 34 03 PM" src="https://user-images.githubusercontent.com/21046714/203635242-25909bbb-26ad-4fe0-a380-5bf0b54c48c2.png">

Error in combined section:
<img width="1157" alt="Screenshot 2022-11-23 at 1 25 41 PM" src="https://user-images.githubusercontent.com/21046714/203635253-e6e91a52-2fcc-4279-89d6-2913f516fea5.png">

## Testing Instructions

* Create an error in the code:
```diff
diff --git a/src/app/src/components/FilterSidebarSearchTab.jsx b/src/app/src/components/FilterSidebarSearchTab.jsx
index 28e0d7ea..4ca73c78 100644
--- a/src/app/src/components/FilterSidebarSearchTab.jsx
+++ b/src/app/src/components/FilterSidebarSearchTab.jsx
@@ -300,7 +300,7 @@ function mapStateToProps({
         facilities: { fetching: fetchingFacilities },
     },
     featureFlags,
-    embeddedMap: { embed, config },
+    embeddedMap: { embed },
 }) {
     const vectorTileFlagIsActive = get(
         featureFlags,
@@ -325,7 +325,7 @@ function mapStateToProps({
         boundary,
         fetchingOptions: fetchingContributors || fetchingCountries,
         embed: !!embed,
-        embedExtendedFields: config.extended_fields,
+        embedExtendedFields: undefined,
     };
 }
```
* Run the app and view an embedded map at desktop and mobile widths. Ensure the error message works and the page doesn't crash.
* Clear that error and add a new error:
```diff
diff --git a/src/app/src/components/FilterSidebar.jsx b/src/app/src/components/FilterSidebar.jsx
index b2e49c1d..5bc26d9f 100644
--- a/src/app/src/components/FilterSidebar.jsx
+++ b/src/app/src/components/FilterSidebar.jsx
@@ -175,18 +175,12 @@ class FilterSidebar extends Component {
             return <CircularProgress />;
         }
 
+        const styleObject = undefined;
+
         return (
             <>
                 <Hidden smUp>
-                    <Grid
-                        item
-                        style={{
-                            alignItems: 'center',
-                            display: 'flex',
-                            width: '100%',
-                            flexDirection: 'column',
-                        }}
-                    >
+                    <Grid item style={styleObject.style}>
                         <Tabs
                             value={this.props.activeFilterSidebarTab}
                             onChange={(_, v) => {
```
* Run the app and view an embedded map at desktop and mobile widths. Ensure the error message works and the page doesn't crash.


## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
