### PR TITLE
Keep list active until replacement is fully matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Copy edits [#2323](https://github.com/open-apparel-registry/open-apparel-registry/pull/2323)
+- Keep list active until replacement is fully matched [#2333](https://github.com/open-apparel-registry/open-apparel-registry/pull/2333)
 
 ### Deprecated
 

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -3022,16 +3022,6 @@ class FacilityListViewSet(viewsets.ModelViewSet):
             source_type=Source.LIST,
             facility_list=new_list)
 
-        if replaces is not None:
-            replaces_source_qs = Source.objects.filter(facility_list=replaces)
-            if replaces_source_qs.exists():
-                for replaced_source in replaces_source_qs:
-                    # Use `save` on the instances rather than calling `update`
-                    # on the queryset to ensure that the custom save logic is
-                    # triggered
-                    replaced_source.is_active = False
-                    replaced_source.save()
-
         items = [FacilityListItem(row_index=idx,
                                   raw_data=row,
                                   sector=[],


### PR DESCRIPTION
## Overview

If the list being replaced is deactivated immediately the contributors facilities will disappear from search results until the new list is fully matched.

Connects #1388

## Testing Instructions

These instructions assume that `./scripts/resetdb` has been run

* Browse http://localhost:6543/ and verify that Factory A appears in the the Data Contributor dropdown. 
* Filter by Factory A and verify there are 73 matching facilities
* Log in as c3@example.com
* Upload [azavea.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10198510/azavea.csv)
 and select the previous list to be replaced
* Browse http://localhost:6543/ and verify that Factory A is still available Data Contributor dropdown and that search still returns 73 facilities.
* Parse and geocode the list
  *  `./scripts/manage batch_process --list-id 16 --action parse`
  *  `./scripts/manage batch_process --list-id 16 --action geocode`
*  Verify that Factory A is still available Data Contributor dropdown and that search still returns 73 facilities.
* Match the list
  *  `./scripts/manage batch_process --list-id 16 --action match`
*  Verify that Factory A is still available Data Contributor dropdown and that search now returns the single azavea facility.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
