### PR TITLE
Only include approved lists in the facility-lists API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Copy edits [#2323](https://github.com/open-apparel-registry/open-apparel-registry/pull/2323)
 - Keep list active until replacement is fully matched [#2333](https://github.com/open-apparel-registry/open-apparel-registry/pull/2333)
+- Only include approved lists in the facility-lists API [#2336](https://github.com/open-apparel-registry/open-apparel-registry/pull/2336)
 
 ### Deprecated
 

--- a/src/django/api/management/commands/processfixtures.py
+++ b/src/django/api/management/commands/processfixtures.py
@@ -1,6 +1,8 @@
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
+from api.models import FacilityList
+
 
 class Command(BaseCommand):
     help = 'Run all processing steps on data loaded from fixtures'
@@ -26,6 +28,9 @@ class Command(BaseCommand):
         start_id = options['startid']
         end_id = options['endid']
         for list_id in range(start_id, end_id):
+            FacilityList.objects\
+                        .filter(pk=list_id)\
+                        .update(status=FacilityList.APPROVED)
             for action in ('parse', 'geocode', 'match'):
                 call_command('batch_process',
                              '--list-id', list_id,

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -4249,9 +4249,11 @@ class FacilityActivityReportViewSet(viewsets.GenericViewSet):
 
 class ContributorFacilityListViewSet(viewsets.ReadOnlyModelViewSet):
     """
-    View active Facility Lists filtered by Contributor.
+    View Facility Lists that are both active and approved filtered by
+    Contributor.
     """
-    queryset = FacilityList.objects.filter(source__is_active=True)
+    queryset = FacilityList.objects.filter(source__is_active=True,
+                                           status=FacilityList.APPROVED)
 
     @swagger_auto_schema(manual_parameters=[openapi.Parameter(
         'contributors',


### PR DESCRIPTION
## Overview

Lists that are not approved will have active facility matches so we want toexclude non-approved lists from the the API used to populate the list filter dropdown.

We also update the `processfixtures` management command. The command is used for loading development data and all the lists processed by this command should have their status set to APPROVED to more closely match the real production process.

Connects #2335 

## Testing Instructions

* Run `./scripts/resetdb` and verify that it completes without error
* Log in as c3@example.com
* Browse http://localhost:6543/contribute
* In "Select a list to replace" choose "Summer 2019 Compliance List" and upload 
[azavea.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10231597/azavea.csv)
* Browse http://localhost:6543/, select Factory A from the "Data Contributor" filter and verify that the "Contributor List" dropdown does not contain the new "azavea" list
* Run the parse step on the new list
  * `./scripts/manage batch_process --list-id 16 --action parse`
* In a separate browser session log in as c1@example.com
  * Browse http://localhost:6543/dashboard/lists/ and select the pending "azavea" list
  * Approve the list
* Back in the original browser session refresh http://localhost:6543/, select Factory A from the "Data Contributor" filter and verify that the "Contributor List" dropdown now contains both lists.
* Finish processing the new list
  * `./scripts/manage batch_process --list-id 16 --action geocode`
  * `./scripts/manage batch_process --list-id 16 --action match`
* Back in the original browser session refresh http://localhost:6543/, select Factory A from the "Data Contributor" filter and verify that the "Contributor List" dropdown now contains just the "azavea" list

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
