### PR TITLE
Update Google Maps API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Updated Google Maps API version to 3.51 [#2361](https://github.com/open-apparel-registry/open-apparel-registry/pull/2361)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/DashboardGeocoder.jsx
+++ b/src/app/src/components/DashboardGeocoder.jsx
@@ -175,7 +175,7 @@ function DashboardGeocoder({ countryOptions, fetchingOptions, getCountries }) {
                             googleMapsLoaderConf={{
                                 KEY: GOOGLE_CLIENT_SIDE_API_KEY,
                                 REGION: country.value || COUNTRY_CODES.default,
-                                VERSION: 3.37,
+                                VERSION: '3.51',
                             }}
                             type="roadmap"
                             continuousWorld

--- a/src/app/src/components/FacilitiesMap.jsx
+++ b/src/app/src/components/FacilitiesMap.jsx
@@ -253,7 +253,7 @@ function FacilitiesMap({
                 googleMapsLoaderConf={{
                     KEY: GOOGLE_CLIENT_SIDE_API_KEY,
                     REGION: countryCode,
-                    VERSION: 3.37,
+                    VERSION: '3.51',
                 }}
                 type="roadmap"
                 continuousWorld

--- a/src/app/src/components/VectorTileFacilitiesMap.jsx
+++ b/src/app/src/components/VectorTileFacilitiesMap.jsx
@@ -136,7 +136,7 @@ function VectorTileFacilitiesMap({
                 googleMapsLoaderConf={{
                     KEY: GOOGLE_CLIENT_SIDE_API_KEY,
                     REGION: countryCode,
-                    VERSION: 3.47,
+                    VERSION: '3.51',
                 }}
                 type="roadmap"
                 styles={mapStyle === 'silver' ? SILVER_MAP_STYLE : null}


### PR DESCRIPTION
## Overview

The current version of the google maps API is retired. This PR updates to the quarterly release scheduled for mid-February.

Connects #2356 

## Testing Instructions

* Ensure `ogr/test/ms/update-google-maps-api-version` is the active branch on staging.
* Go to https://staging.opensupplyhub.org/ and navigate around
  * [x] Ensure map basemap renders correctly (see #1658)
  * [x] Ensure other map features work correctly

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
