### PR TITLE
Add load balance check for cloudfront auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+-  Added load balance check for cloudfront auth header [#2364](https://github.com/open-apparel-registry/open-apparel-registry/pull/2364)
+
 ### Changed
 
 - Updated Google Maps API version to 3.51 [#2361](https://github.com/open-apparel-registry/open-apparel-registry/pull/2361)

--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -9,6 +9,11 @@ resource "aws_cloudfront_distribution" "cdn" {
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
     }
+
+    custom_header {
+        name = "X-CloudFront-Auth"
+        value = var.cloudfront_auth_token
+    }
   }
 
   enabled         = true

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -96,8 +96,28 @@ resource "aws_lb_listener" "app" {
   certificate_arn   = module.cert_lb.arn
 
   default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      status_code = 403
+      message_body = "Access denied"
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "cdn_auth" {
+  listener_arn = aws_lb_listener.app.id
+
+  condition {
+    http_header {
+      http_header_name = "X-CloudFront-Auth"
+      values = [var.cloudfront_auth_token]
+    }
+  }
+
+  action {
+    type = "forward"
     target_group_arn = aws_lb_target_group.app.id
-    type             = "forward"
   }
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -35,6 +35,9 @@ variable "r53_public_hosted_zone" {
 variable "cloudfront_price_class" {
 }
 
+variable "cloudfront_auth_token" {
+}
+
 variable "vpc_cidr_block" {
   default = "10.0.0.0/16"
 }


### PR DESCRIPTION
## Overview

This PR adds a rule to the AWS load balancer listener to allow only traffic with the correct `X-CloudFront-Auth` header set. This prevents non-CloudFront clients from reaching the origin.

Connects #2349 

## Notes

Staging and production configuration tfvar files have been updated with `couldfront_auth_token`.

## Testing Instructions

These changes are currently applied in staging and a test branch is currently being built and deployed.

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
