### PR TITLE
Revise embed CSV/XLSX download format and content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated Google Maps API version to 3.51 [#2361](https://github.com/open-apparel-registry/open-apparel-registry/pull/2361)
 - Updated approval workflow [#2363](https://github.com/open-apparel-registry/open-apparel-registry/pull/2362)
+- Revise embed CSV/XLSX download format and content [#2365](https://github.com/open-apparel-registry/open-apparel-registry/pull/2365)
 
 ### Deprecated
 

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -928,7 +928,9 @@ class FacilityDownloadSerializer(Serializer):
         if is_embed_mode:
             contributor_id = get_embed_contributor_id(self)
             facility_matches = facility_matches.filter(
-                facility_list_item__source__contributor_id=contributor_id)
+                facility_list_item__source__contributor_id=contributor_id,
+                facility_list_item__source__is_active=True,
+                is_active=True)
 
         facility_matches = facility_matches.order_by('-created_at')
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -10704,7 +10704,7 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
                              'data one', '', '', '', '', '', '', '', 'False']
         self.assertEquals(rows[0], expected_base_row)
 
-    def test_private_source_is_anonymized(self):
+    def test_inactive_source_is_anonymized(self):
         list_item = self.create_additional_list_item()
         list_item.source.is_active = False
         list_item.source.save()
@@ -10720,7 +10720,7 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         contributor = rows[1][self.contributor_column_index]
         self.assertEquals(contributor, 'An Other (API)')
 
-    def test_inactive_source_is_anonymized(self):
+    def test_private_source_is_anonymized(self):
         list_item = self.create_additional_list_item()
         list_item.source.is_public = False
         list_item.source.save()


### PR DESCRIPTION
Revise the embed mode CSV/XLSX downloads to only include active list items and only include one row per facility

Connects #2135
Connects #2329 

## Demo

File downloaded from http://localhost:6543/facilities?contributors=2
[facilities-normal.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10701467/facilities-normal.csv)

File downloaded from http://localhost:6543/facilities?contributors=2&embed=1
[facilities-embed-contributor.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10701469/facilities-embed-contributor.csv)

## Notes

This PR satisfies request 2 in #2329 by changing CSV downloads in embed mode to have a single row per facility

## Testing Instructions

### Setup

- `./scripts/resetdb`
- Log in as c3@example.com
- Contribute [embed-test-1.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10702573/embed-test-1.csv)
- `./scripts/manage batch_process --action parse --list-id 16`
- In a separate browser session log in as c1@example.com
	- Browse http://localhost:6543/lists/16 and approve the list
	- Browse http://localhost:8081/admin/api/contributor/2/change/ 
		- Set a `Contrib type`
		- Set `Embed level` to Embed Deluxe / Custom Embed 
		- Save
- `./tools/batch_process 16`
- In the original browser session, contribute [embed-test-2.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10702577/embed-test-2.csv), **selecting embed-test-1 as the list to replace**
-  `./scripts/manage batch_process --action parse --list-id 17`
- In the admin browser session browse http://localhost:6543/lists/17 and approve the list
-  `./tools/batch_process 17`
- In the original browser session search for "CHIA HER INDUSTRIAL" and submit a claim for the facility
- Log in as c2@example.com, search for "BO HSING ENTERPRISE" and submit a claim for the facility.
- In the admin browser session browse http://localhost:6543/dashboard/claims and approve both the claims
- In the original browser session log back in as c3@example.com
- Browse http://localhost:6543/claimed and edit the profile 
	- Set the name to "CHIA HER INDUSTRIAL CLAIMED C3"
	- Set the product types to "C3 PRODUCT TYPE" 
	- Set number of workers to 9999
	- Save
- Log in as c2@example.com
- Browse http://localhost:6543/claimed and edit the profile 
	- Set the name to "BO HSING ENTERPRISE CLAIMED C2"
	- Set the product types to "C2 PRODUCT TYPE" 
	-  Set number of workers to 8888
- Log in as c3@example.com
- Contribute [embed-test-3.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10702578/embed-test-3.csv), **selecting embed-test-2 as the list to replace**
- `./scripts/manage batch_process --action parse --list-id 18`
- In the admin browser session browse http://localhost:6543/lists/18 and approve the list
-  `./tools/batch_process 18`
- In the original browser session contribute [embed-test-4.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10702579/embed-test-4.csv),  **selecting embed-test-3 as the list to replace**
- `./scripts/manage batch_process --action parse --list-id 19`
- In the admin browser session browse http://localhost:6543/lists/19 and approve the list
-  `./tools/batch_process 19`
-  In the original browser session contribute [embed-test-B.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10702584/embed-test-B.csv) **but DO NOT select a replacement list**
- `./scripts/manage batch_process --action parse --list-id 20`
- In the admin browser session browse http://localhost:6543/lists/20 and approve the list
-  `./tools/batch_process 20`
- In the original browser session browse http://localhost:6543/settings, select the embed tab, enable the `building_color` custom field, and check the `100% width` box, verifying that the embed preview loads

### Test

- Browse http://localhost:6543/facilities?contributors=2
	- Download the results
	- Verify that there are multiple lines for facilities that appeared in multiple files
	- Verify the name, product type, and number_of_workers from claims appear for both BO HSING ENTERPRISE and CHIA HER INDUSTRIAL
- Browse http://localhost:6543/facilities?contributors=2&embed=1
	- Download the results
	- Verify there is a single line per facility
	- Verify the building_color field is set for 3 facilities
	- Verify the name, product type, and number_of_workers from claims appear for CHIA HER INDUSTRIAL (claimed by the embed contributor) but not for BO HSING ENTERPRISE (claimed by a different contributor)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
