### PR TITLE
Check facility query string for aliased OS ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--  Added load balance check for cloudfront auth header [#2364](https://github.com/open-apparel-registry/open-apparel-registry/pull/2364)
+- Added load balance check for cloudfront auth header [#2364](https://github.com/open-apparel-registry/open-apparel-registry/pull/2364)
+- Check facility query string for aliased OS ID [#2366](https://github.com/open-apparel-registry/open-apparel-registry/pull/2366)
 
 ### Changed
 

--- a/src/django/api/models.py
+++ b/src/django/api/models.py
@@ -32,7 +32,7 @@ from api.constants import (
     MatchResponsibility
 )
 from api.countries import COUNTRY_CHOICES
-from api.os_id import make_os_id
+from api.os_id import make_os_id, string_matches_os_id_format
 from api.constants import (Affiliations, Certifications, FacilitiesQueryParams)
 from api.helpers import (prefix_a_an,
                          get_single_contributor_field_values,
@@ -1424,7 +1424,16 @@ class FacilityManager(models.Manager):
 
         facilities_qs = FacilityIndex.objects.all()
 
+        if id is None and string_matches_os_id_format(free_text_query):
+            id = free_text_query
+            free_text_query = None
+
         if id is not None:
+            try:
+                id = FacilityAlias.objects.get(pk=id).facility_id
+            except FacilityAlias.DoesNotExist:
+                pass
+
             facilities_qs = facilities_qs.filter(id=id)
 
         if free_text_query is not None:

--- a/src/django/api/os_id.py
+++ b/src/django/api/os_id.py
@@ -1,5 +1,6 @@
 import base32_crockford
 import random
+import re
 
 from django.utils import timezone
 
@@ -77,3 +78,10 @@ def validate_os_id(raw_id, raise_on_invalid=True):
         else:
             return False
     return True
+
+
+os_id_regex = re.compile('[A-Z]{2}[0-9]{7}[A-Z0-9]{6}')
+
+
+def string_matches_os_id_format(string):
+    return os_id_regex.match(string or '') is not None

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -7742,6 +7742,10 @@ class FacilitySearchTest(FacilityAPITestCaseBase):
         self.list_item_two_b.facility = self.facility_two
         self.list_item_two_b.save()
 
+        self.alias = FacilityAlias.objects.create(
+            facility=self.facility_two,
+            os_id='US1234567ABCDEF')
+
         self.base_url = reverse('facility-list')
         self.contributor_or_url = self.base_url + \
             '?contributors={}&contributors={}'
@@ -7808,6 +7812,22 @@ class FacilitySearchTest(FacilityAPITestCaseBase):
                 self.contributor.id,
                 self.contributor_two.id))
         self.assert_response_count(response, 0)
+
+    def test_search_aliased_id(self):
+        response = self.client.get(
+            '{}?q={}'.format(
+                self.base_url,
+                self.alias.os_id
+            )
+        )
+
+        self.assert_response_count(response, 1)
+
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            self.alias.facility.id,
+            response_json['features'][0]['id']
+        )
 
 
 class ListWithoutSourceTest(TestCase):


### PR DESCRIPTION
## Overview

This PR adds checks to the facility search logic. If the query string matches the regex patter of an OS ID, the facility alias table is searched. If a match is found, the `id` parameter is overwritten with the aliased ID.

Connects #1847 

## Notes

Additionally, if the query string matches the OS ID regex pattern, the query string parameter is cleared so as not to conflict with the ID queryset filter. This means that if someone inteneded to search for a string that matches the pattern, but is not actually an OS ID, they would not see the expected results. Since the OS ID regex pattern is pretty specific, this seems unlikely to occur.

## Testing Instructions

- `./scripts/manage test api.tests.FacilitySearchTest`
---

* Create a facility alias in the `api_facilityalias` table
* Search for that facility alias id
  * [ ] Ensure the aliases facility shows up in the list

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
