### PR TITLE
Fix diagram links in markdown document

### DIFF
--- a/doc/diagrams/README.md
+++ b/doc/diagrams/README.md
@@ -7,25 +7,25 @@ visualising software architecture](https://c4model.com/)
 
 ## System Context
 
-[png](./System Context Diagram/OS Hub System Context Diagram.drawio.png)
-[svg](./System Context Diagram/OS Hub System Context Diagram.drawio.svg)
-[xml](./System Context Diagram/OS Hub System Context Diagram.drawio.xml)
+[png](./System%20Context%20Diagram/OS%20Hub%20System%20Context%20Diagram.drawio.png)
+[svg](./System%20Context%20Diagram/OS%20Hub%20System%20Context%20Diagram.drawio.svg)
+[xml](./System%20Context%20Diagram/OS%20Hub%20System%20Context%20Diagram.drawio.xml)
 
-![System Context Diagram](./System Context Diagram/OS Hub System Context Diagram.drawio.png)
+![System Context Diagram](./System%20Context%20Diagram/OS%20Hub%20System%20Context%20Diagram.drawio.png)
 
 
 ## Container
 
-[png](./Container Diagram/OS Hub Container Diagram.drawio.png)
-[svg](./Container Diagram/OS Hub Container Diagram.drawio.svg)
-[xml](./Container Diagram/OS Hub Container Diagram.drawio.xml)
+[png](./Container%20Diagram/OS%20Hub%20Container%20Diagram.drawio.png)
+[svg](./Container%20Diagram/OS%20Hub%20Container%20Diagram.drawio.svg)
+[xml](./Container%20Diagram/OS%20Hub%20Container%20Diagram.drawio.xml)
 
-![Container Diagram](./Container Diagram/OS Hub Container Diagram.drawio.png)
+![Container Diagram](./Container%20Diagram/OS%20Hub%20Container%20Diagram.drawio.png)
 
 ## Deployment
 
-[png](./Deployment Diagram/OS Hub Deployment Diagram.drawio.png)
-[svg](./Deployment Diagram/OS Hub Deployment Diagram.drawio.svg)
-[xml](./Deployment Diagram/OS Hub Deployment Diagram.drawio.xml)
+[png](./Deployment%20Diagram/OS%20Hub%20Deployment%20Diagram.drawio.png)
+[svg](./Deployment%20Diagram/OS%20Hub%20Deployment%20Diagram.drawio.svg)
+[xml](./Deployment%20Diagram/OS%20Hub%20Deployment%20Diagram.drawio.xml)
 
-![Deployment Diagram](./Deployment Diagram/OS Hub Deployment Diagram.drawio.png)
+![Deployment Diagram](./Deployment%20Diagram/OS%20Hub%20Deployment%20Diagram.drawio.png)


### PR DESCRIPTION
To render properly on github.com whitespace in markdown links must be escaped.


