### PR TITLE
Email updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Added data@opensupplyhub.org email [#2373](https://github.com/open-apparel-registry/open-apparel-registry/pull/2373)
 
 ### Changed
 

--- a/deployment/terraform/container_service.tf
+++ b/deployment/terraform/container_service.tf
@@ -149,6 +149,7 @@ data "template_file" "app" {
     oar_client_key                   = var.oar_client_key
     external_domain                  = var.r53_public_hosted_zone
     default_from_email               = var.default_from_email
+    data_from_email                  = var.data_from_email
     notification_email_to            = var.notification_email_to
     hubspot_api_key                  = var.hubspot_api_key
     hubspot_subscription_id          = var.hubspot_subscription_id
@@ -197,6 +198,7 @@ data "template_file" "app_cli" {
     oar_client_key                   = var.oar_client_key
     external_domain                  = var.r53_public_hosted_zone
     default_from_email               = var.default_from_email
+    data_from_email                  = var.data_from_email
     notification_email_to            = var.notification_email_to
     hubspot_api_key                  = var.hubspot_api_key
     hubspot_subscription_id          = var.hubspot_subscription_id

--- a/deployment/terraform/task-definitions/app.json
+++ b/deployment/terraform/task-definitions/app.json
@@ -26,6 +26,7 @@
         { "name": "BATCH_JOB_DEF_NAME", "value": "${batch_job_def_name}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
+        { "name": "DATA_FROM_EMAIL", "value": "${data_from_email}" },
         { "name": "NOTIFICATION_EMAIL_TO", "value": "${notification_email_to}" },
         { "name": "HUBSPOT_API_KEY", "value": "${hubspot_api_key}" },
         { "name": "HUBSPOT_SUBSCRIPTION_ID", "value": "${hubspot_subscription_id}" },

--- a/deployment/terraform/task-definitions/app_cli.json
+++ b/deployment/terraform/task-definitions/app_cli.json
@@ -16,6 +16,7 @@
         { "name": "BATCH_JOB_DEF_NAME", "value": "${batch_job_def_name}" },
         { "name": "DJANGO_SECRET_KEY", "value": "${django_secret_key}" },
         { "name": "DEFAULT_FROM_EMAIL", "value": "${default_from_email}" },
+        { "name": "DATA_FROM_EMAIL", "value": "${data_from_email}" },
         { "name": "NOTIFICATION_EMAIL_TO", "value": "${notification_email_to}" },
         { "name": "HUBSPOT_API_KEY", "value": "${hubspot_api_key}" },
         { "name": "HUBSPOT_SUBSCRIPTION_ID", "value": "${hubspot_subscription_id}" },

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -261,6 +261,9 @@ variable "django_secret_key" {
 variable "default_from_email" {
 }
 
+variable "default_data_email" {
+}
+
 variable "notification_email_to" {
 }
 

--- a/src/app/src/__tests__/utils.tests.js
+++ b/src/app/src/__tests__/utils.tests.js
@@ -1016,7 +1016,7 @@ it('creates params from a query string', () => {
 
 it('creates an email link for reporting a data issue for a facility with a given OS ID', () => {
     const osID = 'osID';
-    const expectedMatch = 'mailto:info@opensupplyhub.org?subject=Reporting a data issue on ID osID';
+    const expectedMatch = 'mailto:data@opensupplyhub.org?subject=Reporting a data issue on ID osID';
 
     expect(makeReportADataIssueEmailLink(osID)).toBe(expectedMatch);
 });
@@ -1525,7 +1525,7 @@ it('creates an API URL for merging two facilties', () => {
     const toMergeID = 'toMergeID';
 
     const expectedURL =
-          '/api/facilities/merge/?target=targetID&merge=toMergeID';
+        '/api/facilities/merge/?target=targetID&merge=toMergeID';
 
     expect(isEqual(
         expectedURL,

--- a/src/app/src/components/ReportFacilityStatusDialog.jsx
+++ b/src/app/src/components/ReportFacilityStatusDialog.jsx
@@ -131,8 +131,8 @@ function ReportFacilityStatusDialog({
                         Please provide information the OS Hub team can use to
                         verify this status change. Should you need to share or
                         attach a document or screenshot, please email it to{' '}
-                        <a href="mailto:info@opensupplyhub.org">
-                            info@opensupplyhub.org
+                        <a href="mailto:data@opensupplyhub.org">
+                            data@opensupplyhub.org
                         </a>{' '}
                         after completing this form.
                     </DialogContentText>

--- a/src/app/src/util/util.js
+++ b/src/app/src/util/util.js
@@ -635,13 +635,13 @@ export const makeSliceArgumentsForTablePagination = (page, rowsPerPage) =>
     Object.freeze([page * rowsPerPage, (page + 1) * rowsPerPage]);
 
 export const makeReportADataIssueEmailLink = osId =>
-    `mailto:info@opensupplyhub.org?subject=Reporting a data issue on ID ${osId}`;
+    `mailto:data@opensupplyhub.org?subject=Reporting a data issue on ID ${osId}`;
 
 export const makeDisputeClaimEmailLink = osId =>
-    `mailto:info@opensupplyhub.org?subject=Disputing a claim of facility ID ${osId}`;
+    `mailto:data@opensupplyhub.org?subject=Disputing a claim of facility ID ${osId}`;
 
 export const makeReportADuplicateEmailLink = osId =>
-    `mailto:info@opensupplyhub.org?subject=Reporting ID ${osId} as a duplicate facility`;
+    `mailto:data@opensupplyhub.org?subject=Reporting ID ${osId} as a duplicate facility`;
 
 export const makeFeatureCollectionFromSingleFeature = feature =>
     Object.freeze({

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -60,7 +60,7 @@ def send_claim_facility_confirmation_email(request, facility_claim):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(claim_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [facility_claim.email],
         html_message=html_template.render(claim_dictionary)
     )
@@ -85,7 +85,7 @@ def send_claim_facility_approval_email(request, facility_claim):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(approval_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [facility_claim.email],
         html_message=html_template.render(approval_dictionary)
     )
@@ -109,7 +109,7 @@ def send_claim_facility_denial_email(request, facility_claim):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(denial_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [facility_claim.email],
         html_message=html_template.render(denial_dictionary)
     )
@@ -133,7 +133,7 @@ def send_claim_facility_revocation_email(request, facility_claim):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(revocation_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [facility_claim.email],
         html_message=html_template.render(revocation_dictionary)
     )
@@ -159,7 +159,7 @@ def send_approved_claim_notice_to_one_contributor(request, claim, contributor):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(notice_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [contributor.admin.email],
         html_message=html_template.render(notice_dictionary)
     )
@@ -209,7 +209,7 @@ def send_claim_update_note_to_one_contributor(request, claim, contributor):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(notice_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [contributor.admin.email],
         html_message=html_template.render(notice_dictionary)
     )
@@ -368,7 +368,7 @@ def notify_facility_list_complete(list_id):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(notification_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [notification_to],
         html_message=html_template.render(notification_dictionary)
     )
@@ -390,7 +390,7 @@ def send_facility_list_rejection_email(request, facility_list):
     send_mail(
         subj_template.render().rstrip(),
         text_template.render(denial_dictionary),
-        settings.DEFAULT_FROM_EMAIL,
+        settings.DATA_FROM_EMAIL,
         [facility_list.source.contributor.admin.email],
         html_message=html_template.render(denial_dictionary)
     )

--- a/src/django/api/templates/mail/claim_facility_approval_body.html
+++ b/src/django/api/templates/mail/claim_facility_approval_body.html
@@ -38,6 +38,6 @@
         <p>
             Best wishes,
         </p>
-        {% include "mail/signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/claim_facility_approval_body.txt
+++ b/src/django/api/templates/mail/claim_facility_approval_body.txt
@@ -16,5 +16,5 @@ You are approved! You can now complete your profile, adding business information
 
 Best wishes,
 
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_denial_body.html
+++ b/src/django/api/templates/mail/claim_facility_denial_body.html
@@ -32,12 +32,12 @@
         <p>
             The claim information is inaccurate. If you believe this denial to be inaccurate,
             you can reach out to the OS Hub team to provide additional, clarifying information at:
-            <a href="mailto:info@opensupplyhub.org">info@opensupplyhub.org</a> The team will review
+            <a href="mailto:data@opensupplyhub.org">data@opensupplyhub.org</a> The team will review
             your claim and get back to you.
         </p>
         <p>
             Best wishes,
         </p>
-        {% include "mail/signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/claim_facility_denial_body.txt
+++ b/src/django/api/templates/mail/claim_facility_denial_body.txt
@@ -12,9 +12,9 @@ Here's the reason for the denial:
 {{ denial_reason }}
 {% endif %}
 
-The claim information is inaccurate. If you believe this denial to be inaccurate, you can reach out to the OS Hub team to provide additional, clarifying information at: info@opensupplyhub.org The team will review your claim and get back to you.
+The claim information is inaccurate. If you believe this denial to be inaccurate, you can reach out to the OS Hub team to provide additional, clarifying information at: data@opensupplyhub.org The team will review your claim and get back to you.
 
 Best wishes,
 
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_revocation_body.html
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.html
@@ -32,12 +32,12 @@
         <p>
             We have discovered your claim is actually inaccurate. If you believe your claim
             should not have been revoked, you can reach out to the OS Hub team to provide additional,
-            clarifying information at: <a href="mailto:info@opensupplyhub.org">info@opensupplyhub.org</a>.
+            clarifying information at: <a href="mailto:data@opensupplyhub.org">data@opensupplyhub.org</a>.
             The team will review your claim and get back to you.
         </p>
         <p>
             Best wishes,
         </p>
-        {% include "mail/signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/claim_facility_revocation_body.txt
+++ b/src/django/api/templates/mail/claim_facility_revocation_body.txt
@@ -12,9 +12,9 @@ Here's the reason it was revoked:
 {{ revocation_reason }}
 {% endif %}
 
-We have discovered your claim is actually inaccurate. If you believe your claim should not have been revoked, you can reach out to the OS Hub team to provide additional, clarifying information at: info@opensupplyhub.org The team will review your claim and get back to you.
+We have discovered your claim is actually inaccurate. If you believe your claim should not have been revoked, you can reach out to the OS Hub team to provide additional, clarifying information at: data@opensupplyhub.org The team will review your claim and get back to you.
 
 Best wishes,
 
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/claim_facility_submitted_body.html
+++ b/src/django/api/templates/mail/claim_facility_submitted_body.html
@@ -55,6 +55,6 @@
         <p>
             Best wishes,
         </p>
-        {% include "mail/signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/claim_facility_submitted_body.txt
+++ b/src/django/api/templates/mail/claim_facility_submitted_body.txt
@@ -20,5 +20,5 @@ We'll review your request to claim the facility and get in touch if we need any 
 
 Best wishes,
 
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/data_team_signature_block.html
+++ b/src/django/api/templates/mail/data_team_signature_block.html
@@ -1,0 +1,3 @@
+<p>
+    OS Hub Data Team
+</p>

--- a/src/django/api/templates/mail/data_team_signature_block.txt
+++ b/src/django/api/templates/mail/data_team_signature_block.txt
@@ -1,0 +1,3 @@
+{% block content %}
+OS Hub Data Team
+{% endblock content %}

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.html
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.html
@@ -36,6 +36,6 @@
         <p>
             Best wishes,
         </p>
-        {% include "mail/signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.txt
+++ b/src/django/api/templates/mail/facility_claim_profile_update_contributor_notice_body.txt
@@ -17,5 +17,5 @@ The following details have been changed:
 {% endif %}
 
 Best wishes,
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/facility_list_complete_body.html
+++ b/src/django/api/templates/mail/facility_list_complete_body.html
@@ -115,11 +115,11 @@
     </ol>
     <p>
       For any questions, feel free to reach out to the OS Hub team:
-      <a href="mailto:info@opensupplyhub.org">info@opensupplyhub.org</a>
+      <a href="mailto:data@opensupplyhub.org">data@opensupplyhub.org</a>
     </p>
     <p>
       All the best,
     </p>
-    {% include "mail/signature_block.html" %}
+    {% include "mail/data_team_signature_block.html" %}
   </body>
 </html>

--- a/src/django/api/templates/mail/facility_list_complete_body.txt
+++ b/src/django/api/templates/mail/facility_list_complete_body.txt
@@ -40,9 +40,9 @@ Once your list is finalized:
 
 If you are a brand or organization uploading a facility list, you can use this suggested text for a message to your suppliers (https://info.opensupplyhub.org/resources/encourage-your-facilities-to-claim-their-profiles), to encourage them to claim their profiles.
 
-For any questions, feel free to reach out to the OS Hub team: info@opensupplyhub.org.
+For any questions, feel free to reach out to the OS Hub team: data@opensupplyhub.org.
 
 All the best,
 
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/api/templates/mail/facility_list_rejection_body.html
+++ b/src/django/api/templates/mail/facility_list_rejection_body.html
@@ -10,8 +10,8 @@
             Hi there,
         </p>
         <p>
-            We’re writing to let you know that your request to upload a dataset to Open Supply Hub was rejected, due to issues with
-            the data in your list. The details of your list are as follows:
+            We’re writing to let you know that your request to upload a data list to Open Supply Hub was rejected.
+            The details of your list are as follows:
         </p>
         <ul>
             <li>
@@ -26,16 +26,15 @@
         </ul>
         {% if rejection_reason|length %}
         <p>
-            Not to worry! Below are details on the data issue(s), as well as guidance on how you can address these issues and
-            get your list approved.
+            Not to worry! Below are details on the reason for rejection, as well as guidance on next steps:
         </p>
         <p>
             {{ rejection_reason }}
         </p>
         {% endif %}
         <p>
-            For any questions, feel free to reach out to the OS Hub team:
-            <a href="mailto:info@opensupplyhub.org">info@opensupplyhub.org</a>.
+            For any questions, feel free to reach out to the OS Hub Data Team:
+            <a href="data@opensupplyhub.org">data@opensupplyhub.org</a>.
             We appreciate your support as we work to maintain a high quality dataset that is open and beneficial to all who need it.
             </p>
             <p>

--- a/src/django/api/templates/mail/facility_list_rejection_body.html
+++ b/src/django/api/templates/mail/facility_list_rejection_body.html
@@ -41,6 +41,6 @@
             <p>
                 All the best,
         </p>
-        {% include "mail/signature_block.html" %}
+        {% include "mail/data_team_signature_block.html" %}
     </body>
 </html>

--- a/src/django/api/templates/mail/facility_list_rejection_body.txt
+++ b/src/django/api/templates/mail/facility_list_rejection_body.txt
@@ -1,19 +1,19 @@
 {% block content %}
 Hi there,
 
-We’re writing to let you know that your request to upload a dataset to Open Supply Hub was rejected, due to issues with the data in your list. The details of your list are as follows:
+We’re writing to let you know that your request to upload a data list to Open Supply Hub was rejected. The details of your list are as follows:
 
 - Facility list: {{ facility_list_name }} created on {{ facility_list_created_at }}
 - Facility list description: {{ facility_list_description }}
 - Facility list URL: {{ facility_list_url }}
 
 {% if rejection_reason|length %}
-Not to worry! Below are details on the data issue(s), as well as guidance on how you can address these issues and get your list approved. 
+Not to worry! Below are details on the reason for rejection, as well as guidance on next steps: 
 
 {{ rejection_reason }}
 {% endif %}
 
-For any questions, feel free to reach out to the OS Hub team: info@opensupplyhub.org. We appreciate your support as we work to maintain a high quality dataset that is open and beneficial to all who need it.
+For any questions, feel free to reach out to the OS Hub Data Team: data@opensupplyhub.org. We appreciate your support as we work to maintain a high quality dataset that is open and beneficial to all who need it.
 
 Best wishes,
 

--- a/src/django/api/templates/mail/facility_list_rejection_body.txt
+++ b/src/django/api/templates/mail/facility_list_rejection_body.txt
@@ -17,5 +17,5 @@ For any questions, feel free to reach out to the OS Hub team: info@opensupplyhub
 
 Best wishes,
 
-{% include "mail/signature_block.txt" %}
+{% include "mail/data_team_signature_block.txt" %}
 {% endblock content %}

--- a/src/django/oar/settings.py
+++ b/src/django/oar/settings.py
@@ -333,6 +333,9 @@ else:
 DEFAULT_FROM_EMAIL = os.getenv(
     'DEFAULT_FROM_EMAIL', 'noreply@staging.opensupplyhub.org')
 
+DATA_FROM_EMAIL = os.getenv(
+    'DATA_FROM_EMAIL', 'data@staging.opensupplyhub.org')
+
 NOTIFICATION_EMAIL_TO = os.getenv(
     'NOTIFICATION_EMAIL_TO', 'notification@example.com')
 


### PR DESCRIPTION
## Overview

This PR does four things:
- Adds env var `DATA_FROM_EMAIL` with value "data@opensupplyhub.org" in development environment 
- Updates the"From" email on data related emails to the `DATA_FROM_EMAIL`
- Updates email on the ReportFacilityStatusDialog to be "data@opensupplyhub.org"
- Updates reject message copy (

Connects #2345 

## Notes

The tfvars file for staging has been updated with the `data_from_email` var, but, as of writing, production has not. 

Though not explicitly asked for in #2345, it seemed like a good idea to the change the email signature for the other emails that would now be coming from data@opensupplyhub.org.

## Testing Instructions

* Trigger the following emails and ensure the console shows the from header as "data@opensupplyhub.org"
  * Processing complete (not sure if this is possible from the UI, does the script show email output?)
  * Reject list (ensure copy is updated as well)
  * Update facility claim profile
  * Approve, deny, revoke, submit claim

* Ensure Report Facility Status Dialog has updated copy

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created