### PR TITLE
Fix data from email var name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Added data@opensupplyhub.org email [#2373](https://github.com/open-apparel-registry/open-apparel-registry/pull/2373)
+- Added data@opensupplyhub.org email [#2373](https://github.com/open-apparel-registry/open-apparel-registry/pull/2373) [#2374](https://github.com/open-apparel-registry/open-apparel-registry/pull/2374)
 
 ### Changed
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -261,7 +261,7 @@ variable "django_secret_key" {
 variable "default_from_email" {
 }
 
-variable "default_data_email" {
+variable "data_from_email" {
 }
 
 variable "notification_email_to" {


### PR DESCRIPTION
## Overview

In #2373 I gave the default from email var the wrong name in variables.tf. This PR fixes it.

## Testing Instructions

* Terraform deploy

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
