### PR TITLE
Fix facility download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+- Fix facility download [#2379](https://github.com/open-apparel-registry/open-apparel-registry/pull/2379)
 
 ### Security
 

--- a/src/django/api/helpers.py
+++ b/src/django/api/helpers.py
@@ -69,7 +69,11 @@ def get_list_contributor_field_values(item, fields):
     for f in fields:
         if f['column_name'] in list_fields:
             index = list_fields.index(f['column_name'])
-            f['value'] = try_parse_int_from_float(data_values[index])
+            if 0 <= index < len(data_values):
+                value = data_values[index]
+            else:
+                value = None
+            f['value'] = try_parse_int_from_float(value)
 
     return fields
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -10790,6 +10790,24 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         expected_contributor = 'An Other (API)'
         self.assertEqual(contributor, expected_contributor)
 
+    def test_handle_incomplete_raw_data(self):
+        incomplete_raw_data = '"US","Towel Factory 42","42 Dolphin St"'
+        self.contrib_list_item.raw_data = incomplete_raw_data
+        self.contrib_list_item.save()
+
+        params = 'embed=1&contributors={}&q={}'.format(
+            self.contributor.id, self.contrib_facility.id)
+        response = self.get_facility_download(params)
+        rows = self.get_rows(response)
+
+        self.assertEquals(len(rows), 1)
+
+        expected_base_row = [self.contrib_facility.id, self.date,
+                             'Towel Factory 42', '42 Dolphin St',
+                             'US', 'United States', 0.0, 0.0, 'Apparel',
+                             '', '', '', '', '', '', '', '', 'False']
+        self.assertEquals(rows[0], expected_base_row)
+
 
 class WebhookTests(APITestCase):
     def test_log_event(self):


### PR DESCRIPTION
## Overview

Handles the case when an individual list item's raw data differs in length from the number of headers.

Connects #2369 

## Demo

[facilities.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/10910514/facilities.csv)

## Notes

Based on the way the lists are processed, there really shouldn't be a case where any item has raw data of a different length than the headers. I wanted to identify the source of the damaged data, but when testing out the error in production, the contributor whose list was failing previously didn't throw any errors. I attempted to identify a recent change to their data that might have fixed it, but was unable to. I also loaded several of the user's recent lists into my local database, and wasn't able to replicate the error that way. 

I ended up deleting some of the raw data fields for a list item locally, and was able consistently trigger the error that way. 

## Testing Instructions

On `ogr/develop`:
* Upload a list with custom fields and fully process it. 
* Add the custom fields to your embedded map.
* Use `./scripts/manage shell_plus` to remove the custom fields from the `raw_data` of one of the items in your list.
* Visit your embedded map, and download the facilities. 
      - If you have more than a page worth of facilities, the infinite loop error will be triggered.
      - If you have less than a page of facilities, there will be an error but no infinite loop.

On this branch:
* Attempt to download the same embedded map. It should succeed. 
 
## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
