### PR TITLE
Enable deletion protection for RDS databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Update spelling of TR to Türkiye and accept multiple versions [#2375](https://github.com/open-apparel-registry/open-apparel-registry/pull/2375)
+- Enable deletion protection for RDS databases [#2382](https://github.com/open-apparel-registry/open-apparel-registry/pull/2382)
 
 ### Deprecated
 

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -98,6 +98,7 @@ module "database_enc" {
   storage_encrypted          = var.rds_storage_encrypted
   subnet_group               = aws_db_subnet_group.default.name
   parameter_group            = aws_db_parameter_group.default.name
+  deletion_protection        = var.rds_deletion_protection
 
   alarm_cpu_threshold                = var.rds_cpu_threshold_percent
   alarm_disk_queue_threshold         = var.rds_disk_queue_threshold

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -190,6 +190,10 @@ variable "rds_work_mem" {
   default = "20000"
 }
 
+variable "rds_deletion_protection" {
+  default = true
+}
+
 variable "app_ecs_desired_count" {
   default = "1"
 }


### PR DESCRIPTION
## Overview

We want to be forced to take the extra step of disabling this to avoid accidental deletion of our most valuable resource.

Connects #2376 

## Demo

Running a `plan` on OS Hub staging includes this resource change

```
  # module.database_enc.aws_db_instance.postgresql will be updated in-place
  ~ resource "aws_db_instance" "postgresql" {
      ~ deletion_protection                   = false -> true
        id                                    = "opensupplyhub-enc-stg"
        name                                  = "opensupplyhub"
        tags                                  = {
            "Environment" = "Staging"
            "Name"        = "DatabaseServer"
            "Project"     = "OpenSupplyHub"
        }
        # (59 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

## Testing Instructions

* Verify the change

## Checklist

- [x] `fixup!` commits have been squashed
- [x] CI passes after rebase
- [x] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [x] If this PR applies to both OAR and OGR a companion PR has been created
