### PR TITLE
Revert download format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+-   Revert to previous download format [#2403](https://github.com/open-apparel-registry/open-apparel-registry/pull/2403)
+
 ### Deprecated
 
 ### Removed
@@ -22,382 +24,389 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [79-OSHUB] 2023-03-23
 
 ### Added
-- Added data@opensupplyhub.org email [#2373](https://github.com/open-apparel-registry/open-apparel-registry/pull/2373) [#2374](https://github.com/open-apparel-registry/open-apparel-registry/pull/2374)
+
+-   Added data@opensupplyhub.org email [#2373](https://github.com/open-apparel-registry/open-apparel-registry/pull/2373) [#2374](https://github.com/open-apparel-registry/open-apparel-registry/pull/2374)
 
 ### Changed
-- Update spelling of TR to Türkiye and accept multiple versions [#2375](https://github.com/open-apparel-registry/open-apparel-registry/pull/2375)
-- Enable deletion protection for RDS databases [#2382](https://github.com/open-apparel-registry/open-apparel-registry/pull/2382)
-- Send clousure report emails from the data@ email addres and change address in email body and claim form [#2389](https://github.com/open-apparel-registry/open-apparel-registry/pull/2389)
+
+-   Update spelling of TR to Türkiye and accept multiple versions [#2375](https://github.com/open-apparel-registry/open-apparel-registry/pull/2375)
+-   Enable deletion protection for RDS databases [#2382](https://github.com/open-apparel-registry/open-apparel-registry/pull/2382)
+-   Send clousure report emails from the data@ email addres and change address in email body and claim form [#2389](https://github.com/open-apparel-registry/open-apparel-registry/pull/2389)
 
 ### Fixed
-- Fix facility download [#2379](https://github.com/open-apparel-registry/open-apparel-registry/pull/2379)
+
+-   Fix facility download [#2379](https://github.com/open-apparel-registry/open-apparel-registry/pull/2379)
 
 ## [78-OSHUB] 2023-02-20
 
 ### Added
 
-- Added load balance check for cloudfront auth header [#2364](https://github.com/open-apparel-registry/open-apparel-registry/pull/2364)
-- Check facility query string for aliased OS ID [#2366](https://github.com/open-apparel-registry/open-apparel-registry/pull/2366)
+-   Added load balance check for cloudfront auth header [#2364](https://github.com/open-apparel-registry/open-apparel-registry/pull/2364)
+-   Check facility query string for aliased OS ID [#2366](https://github.com/open-apparel-registry/open-apparel-registry/pull/2366)
 
 ### Changed
 
-- Updated Google Maps API version to 3.51 [#2361](https://github.com/open-apparel-registry/open-apparel-registry/pull/2361)
-- Updated approval workflow [#2363](https://github.com/open-apparel-registry/open-apparel-registry/pull/2362)
-- Revise embed CSV/XLSX download format and content [#2365](https://github.com/open-apparel-registry/open-apparel-registry/pull/2365)
+-   Updated Google Maps API version to 3.51 [#2361](https://github.com/open-apparel-registry/open-apparel-registry/pull/2361)
+-   Updated approval workflow [#2363](https://github.com/open-apparel-registry/open-apparel-registry/pull/2362)
+-   Revise embed CSV/XLSX download format and content [#2365](https://github.com/open-apparel-registry/open-apparel-registry/pull/2365)
 
 ## [77-OSHUB] 2022-12-15
 
 ### Changed
 
-- Copy edits [#2323](https://github.com/open-apparel-registry/open-apparel-registry/pull/2323)
-- Keep list active until replacement is fully matched [#2333](https://github.com/open-apparel-registry/open-apparel-registry/pull/2333)
-- Only include approved lists in the facility-lists API [#2336](https://github.com/open-apparel-registry/open-apparel-registry/pull/2336)
+-   Copy edits [#2323](https://github.com/open-apparel-registry/open-apparel-registry/pull/2323)
+-   Keep list active until replacement is fully matched [#2333](https://github.com/open-apparel-registry/open-apparel-registry/pull/2333)
+-   Only include approved lists in the facility-lists API [#2336](https://github.com/open-apparel-registry/open-apparel-registry/pull/2336)
 
 ## [76-OSHUB] 2022-11-23
 
 ### Added
-- Add subscribe link to footer [#2300](https://github.com/open-apparel-registry/open-apparel-registry/pull/2300)
-- Add a banner soliciting donations untile the end of 2022 [#2318](https://github.com/open-apparel-registry/open-apparel-registry/pull/2318)
+
+-   Add subscribe link to footer [#2300](https://github.com/open-apparel-registry/open-apparel-registry/pull/2300)
+-   Add a banner soliciting donations untile the end of 2022 [#2318](https://github.com/open-apparel-registry/open-apparel-registry/pull/2318)
 
 ### Changed
-- Update Youtube link [#2305](https://github.com/open-apparel-registry/open-apparel-registry/pull/2305)
-- Header copy and usability changes [#2301](https://github.com/open-apparel-registry/open-apparel-registry/pull/2301)
+
+-   Update Youtube link [#2305](https://github.com/open-apparel-registry/open-apparel-registry/pull/2305)
+-   Header copy and usability changes [#2301](https://github.com/open-apparel-registry/open-apparel-registry/pull/2301)
 
 ### Fixed
 
-- Support mediaQueryList event listener in older Safari [#2303](https://github.com/open-apparel-registry/open-apparel-registry/pull/2303)
-- Handle additional merge errors [#2299](https://github.com/open-apparel-registry/open-apparel-registry/pull/2299)
-- Fix embedded map styling [#2298](https://github.com/open-apparel-registry/open-apparel-registry/pull/2298)
-- Handle medium viewport [#2308](https://github.com/open-apparel-registry/open-apparel-registry/pull/2308)
+-   Support mediaQueryList event listener in older Safari [#2303](https://github.com/open-apparel-registry/open-apparel-registry/pull/2303)
+-   Handle additional merge errors [#2299](https://github.com/open-apparel-registry/open-apparel-registry/pull/2299)
+-   Fix embedded map styling [#2298](https://github.com/open-apparel-registry/open-apparel-registry/pull/2298)
+-   Handle medium viewport [#2308](https://github.com/open-apparel-registry/open-apparel-registry/pull/2308)
 
 ## [75-OSHUB] 2022-11-01
 
 ### Added
-- Add Open Graph preview image and Twitter card info [#2286](https://github.com/open-apparel-registry/open-apparel-registry/pull/2286)
+
+-   Add Open Graph preview image and Twitter card info [#2286](https://github.com/open-apparel-registry/open-apparel-registry/pull/2286)
 
 ### Changed
 
-- Update openapparel.org references [#2281](https://github.com/open-apparel-registry/open-apparel-registry/pull/2281)
-- Change header banner color in staging [#2285](https://github.com/open-apparel-registry/open-apparel-registry/pull/2285)
-- Update various copy and links [#2292](https://github.com/open-apparel-registry/open-apparel-registry/pull/2292)
+-   Update openapparel.org references [#2281](https://github.com/open-apparel-registry/open-apparel-registry/pull/2281)
+-   Change header banner color in staging [#2285](https://github.com/open-apparel-registry/open-apparel-registry/pull/2285)
+-   Update various copy and links [#2292](https://github.com/open-apparel-registry/open-apparel-registry/pull/2292)
 
 ### Fixed
-- Fix broken header and footer links [#2289](https://github.com/open-apparel-registry/open-apparel-registry/pull/2289)
+
+-   Fix broken header and footer links [#2289](https://github.com/open-apparel-registry/open-apparel-registry/pull/2289)
 
 ## [74-OSHUB] 2022-10-26
 
 ### Added
 
-- Add managemnt command to replace oar_id in JSON fields [#2251](https://github.com/open-apparel-registry/open-apparel-registry/pull/2251)
+-   Add managemnt command to replace oar_id in JSON fields [#2251](https://github.com/open-apparel-registry/open-apparel-registry/pull/2251)
 
 ### Changed
 
-- Allow default batch job memory and vCPU count to be set by vars [#2257](https://github.com/open-apparel-registry/open-apparel-registry/pull/2257)
-- Copy changes [#2265](https://github.com/open-apparel-registry/open-apparel-registry/pull/2265)
-- Include Unspecified in the sectors API response [#2272](https://github.com/open-apparel-registry/open-apparel-registry/pull/2272)
-- Update og:url meta tag to opensupplyhub.org [#2276](https://github.com/open-apparel-registry/open-apparel-registry/pull/2276/files)
+-   Allow default batch job memory and vCPU count to be set by vars [#2257](https://github.com/open-apparel-registry/open-apparel-registry/pull/2257)
+-   Copy changes [#2265](https://github.com/open-apparel-registry/open-apparel-registry/pull/2265)
+-   Include Unspecified in the sectors API response [#2272](https://github.com/open-apparel-registry/open-apparel-registry/pull/2272)
+-   Update og:url meta tag to opensupplyhub.org [#2276](https://github.com/open-apparel-registry/open-apparel-registry/pull/2276/files)
 
 ### Fixed
 
-- Disable zoom to search on facility detail page [#2250](https://github.com/open-apparel-registry/open-apparel-registry/pull/2250)
-- Fix loging when checking for existing Hubspot contac [#2259](https://github.com/open-apparel-registry/open-apparel-registry/pull/2259)
-- Fix map not appearing at medium widths [#2263](https://github.com/open-apparel-registry/open-apparel-registry/pull/2263/files)
-- Exclude rejected match items from merge transfer [#2261](https://github.com/open-apparel-registry/open-apparel-registry/pull/2261)
-- Fix removed list filtering [#2266](https://github.com/open-apparel-registry/open-apparel-registry/pull/2266)
+-   Disable zoom to search on facility detail page [#2250](https://github.com/open-apparel-registry/open-apparel-registry/pull/2250)
+-   Fix loging when checking for existing Hubspot contac [#2259](https://github.com/open-apparel-registry/open-apparel-registry/pull/2259)
+-   Fix map not appearing at medium widths [#2263](https://github.com/open-apparel-registry/open-apparel-registry/pull/2263/files)
+-   Exclude rejected match items from merge transfer [#2261](https://github.com/open-apparel-registry/open-apparel-registry/pull/2261)
+-   Fix removed list filtering [#2266](https://github.com/open-apparel-registry/open-apparel-registry/pull/2266)
 
 ## [73-OSHUB] 2022-10-14
 
 ### Added
 
-- Filter facilities by sectors [#1930](https://github.com/open-apparel-registry/open-apparel-registry/pull/1930)
-- Add new Average Match Count, Confirm Reject Counts, and Error Items reports [#1855](https://github.com/open-apparel-registry/open-apparel-registry/pull/1855/commits)
-- Get sector from CSV or API and store on `FacilityListItem` [#1868](https://github.com/open-apparel-registry/open-apparel-registry/pull/1868)
-- Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871) & [#1967](https://github.com/open-apparel-registry/open-apparel-registry/pull/1967)
-- Add sector to FacilityIndex [#1883](https://github.com/open-apparel-registry/open-apparel-registry/pull/1883)
-- Show sectors on facility detail sidebar [#1898](https://github.com/open-apparel-registry/open-apparel-registry/pull/1898)
-- Add sector search controls [#1899](https://github.com/open-apparel-registry/open-apparel-registry/pull/1899)
-- Display claim information [#1905](https://github.com/open-apparel-registry/open-apparel-registry/pull/1905)
-- Create OGR staging environment [#1885](https://github.com/open-apparel-registry/open-apparel-registry/pull/1885)
-- Add sector to Facility Claim [#1934](https://github.com/open-apparel-registry/open-apparel-registry/pull/1934)
-- Added a script to automate restoring an anonymized production snapshot [#1948](https://github.com/open-apparel-registry/open-apparel-registry/pull/1948/commits/b7fecdca30c011a5ef3a8a68971e4ce5fbe8c319)
-- Add Event model [#1995](https://github.com/open-apparel-registry/open-apparel-registry/pull/1995)
-- Add sector to CSV [#1987](https://github.com/open-apparel-registry/open-apparel-registry/pull/1987)
-- Add notifications section to settings page [#2013](https://github.com/open-apparel-registry/open-apparel-registry/pull/2013)
-- Add transfer status to the Adjust Facility Matches interface [#1945](https://github.com/open-apparel-registry/open-apparel-registry/pull/2014)
-- Add facility_location to FacilityClaim [#2012](https://github.com/open-apparel-registry/open-apparel-registry/pull/2012https://github.com/open-apparel-registry/open-apparel-registry/pull/2012)
-- Add webhook event logging utility [#2024](https://github.com/open-apparel-registry/open-apparel-registry/pull/2024)
-- Add AWS Batch resources for delivering notifications [#2026](https://github.com/open-apparel-registry/open-apparel-registry/pull/2026)
-- Ignore duplicate rows [#2032](https://github.com/open-apparel-registry/open-apparel-registry/pull/2032)
-- Add status fields to Facility List [#2015](https://github.com/open-apparel-registry/open-apparel-registry/pull/2025)
-- Add list status to /lists pages [#2044](https://github.com/open-apparel-registry/open-apparel-registry/pull/2044)
-- Add duplicate status to list filter and item counts [#2061](https://github.com/open-apparel-registry/open-apparel-registry/pull/2061)
-- Add notify management command [#2045](https://github.com/open-apparel-registry/open-apparel-registry/pull/2045)
-- Add the new homepage [#2085](https://github.com/open-apparel-registry/open-apparel-registry/pull/2085)
-- Add facility details page [#2115](https://github.com/open-apparel-registry/open-apparel-registry/pull/2115)
-- Added API throttling w/ customizable rates per user [#2125](https://github.com/open-apparel-registry/open-apparel-registry/pull/2125)
-- Add interactive map to facility details [#2145](https://github.com/open-apparel-registry/open-apparel-registry/pull/2145)
-- Provision an ElastiCache memcached cluster [#2138](https://github.com/open-apparel-registry/open-apparel-registry/pull/2138)
-- Store raw list files [#2154](https://github.com/open-apparel-registry/open-apparel-registry/pull/2154)
-- Add documentation for AWS debugging [#2176](https://github.com/open-apparel-registry/open-apparel-registry/pull/2176)
-- Add Allow Large Downloads Waffle Switch [#2175](https://github.com/open-apparel-registry/open-apparel-registry/pull/2175)
-- Enable hiding sectors in embed [#2215](https://github.com/open-apparel-registry/open-apparel-registry/pull/2215)
-- Filter sectors by submitted [#2227](https://github.com/open-apparel-registry/open-apparel-registry/pull/2227)
+-   Filter facilities by sectors [#1930](https://github.com/open-apparel-registry/open-apparel-registry/pull/1930)
+-   Add new Average Match Count, Confirm Reject Counts, and Error Items reports [#1855](https://github.com/open-apparel-registry/open-apparel-registry/pull/1855/commits)
+-   Get sector from CSV or API and store on `FacilityListItem` [#1868](https://github.com/open-apparel-registry/open-apparel-registry/pull/1868)
+-   Add sector choices API endpoint [#1871](https://github.com/open-apparel-registry/open-apparel-registry/pull/1871) & [#1967](https://github.com/open-apparel-registry/open-apparel-registry/pull/1967)
+-   Add sector to FacilityIndex [#1883](https://github.com/open-apparel-registry/open-apparel-registry/pull/1883)
+-   Show sectors on facility detail sidebar [#1898](https://github.com/open-apparel-registry/open-apparel-registry/pull/1898)
+-   Add sector search controls [#1899](https://github.com/open-apparel-registry/open-apparel-registry/pull/1899)
+-   Display claim information [#1905](https://github.com/open-apparel-registry/open-apparel-registry/pull/1905)
+-   Create OGR staging environment [#1885](https://github.com/open-apparel-registry/open-apparel-registry/pull/1885)
+-   Add sector to Facility Claim [#1934](https://github.com/open-apparel-registry/open-apparel-registry/pull/1934)
+-   Added a script to automate restoring an anonymized production snapshot [#1948](https://github.com/open-apparel-registry/open-apparel-registry/pull/1948/commits/b7fecdca30c011a5ef3a8a68971e4ce5fbe8c319)
+-   Add Event model [#1995](https://github.com/open-apparel-registry/open-apparel-registry/pull/1995)
+-   Add sector to CSV [#1987](https://github.com/open-apparel-registry/open-apparel-registry/pull/1987)
+-   Add notifications section to settings page [#2013](https://github.com/open-apparel-registry/open-apparel-registry/pull/2013)
+-   Add transfer status to the Adjust Facility Matches interface [#1945](https://github.com/open-apparel-registry/open-apparel-registry/pull/2014)
+-   Add facility_location to FacilityClaim [#2012](https://github.com/open-apparel-registry/open-apparel-registry/pull/2012https://github.com/open-apparel-registry/open-apparel-registry/pull/2012)
+-   Add webhook event logging utility [#2024](https://github.com/open-apparel-registry/open-apparel-registry/pull/2024)
+-   Add AWS Batch resources for delivering notifications [#2026](https://github.com/open-apparel-registry/open-apparel-registry/pull/2026)
+-   Ignore duplicate rows [#2032](https://github.com/open-apparel-registry/open-apparel-registry/pull/2032)
+-   Add status fields to Facility List [#2015](https://github.com/open-apparel-registry/open-apparel-registry/pull/2025)
+-   Add list status to /lists pages [#2044](https://github.com/open-apparel-registry/open-apparel-registry/pull/2044)
+-   Add duplicate status to list filter and item counts [#2061](https://github.com/open-apparel-registry/open-apparel-registry/pull/2061)
+-   Add notify management command [#2045](https://github.com/open-apparel-registry/open-apparel-registry/pull/2045)
+-   Add the new homepage [#2085](https://github.com/open-apparel-registry/open-apparel-registry/pull/2085)
+-   Add facility details page [#2115](https://github.com/open-apparel-registry/open-apparel-registry/pull/2115)
+-   Added API throttling w/ customizable rates per user [#2125](https://github.com/open-apparel-registry/open-apparel-registry/pull/2125)
+-   Add interactive map to facility details [#2145](https://github.com/open-apparel-registry/open-apparel-registry/pull/2145)
+-   Provision an ElastiCache memcached cluster [#2138](https://github.com/open-apparel-registry/open-apparel-registry/pull/2138)
+-   Store raw list files [#2154](https://github.com/open-apparel-registry/open-apparel-registry/pull/2154)
+-   Add documentation for AWS debugging [#2176](https://github.com/open-apparel-registry/open-apparel-registry/pull/2176)
+-   Add Allow Large Downloads Waffle Switch [#2175](https://github.com/open-apparel-registry/open-apparel-registry/pull/2175)
+-   Enable hiding sectors in embed [#2215](https://github.com/open-apparel-registry/open-apparel-registry/pull/2215)
+-   Filter sectors by submitted [#2227](https://github.com/open-apparel-registry/open-apparel-registry/pull/2227)
 
 ### Changed
 
-- Upgrade terraform to 1.1.9 [#2054](https://github.com/open-apparel-registry/open-apparel-registry/pull/2054)
-- Use autocomplete ordered by name for admin contributors dropdown [#1848](https://github.com/open-apparel-registry/open-apparel-registry/pull/1848)
-- Document parallel OGR workflow in the README [#1851](https://github.com/open-apparel-registry/open-apparel-registry/pull/1851)
-- Update tile load test script and add scripts for hompage load, facility download, and facility POST [#1777](https://github.com/open-apparel-registry/open-apparel-registry/pull/1777)
-- API documentation updates [#1844](https://github.com/open-apparel-registry/open-apparel-registry/pull/1844)
-- Return sector in Facility detail response [#1884](https://github.com/open-apparel-registry/open-apparel-registry/pull/1884) [#1929](https://github.com/open-apparel-registry/open-apparel-registry/pull/1929)
-- Updated logo and colors on top banner, map and search button [#1900](https://github.com/open-apparel-registry/open-apparel-registry/pull/1900) [#1974](https://github.com/open-apparel-registry/open-apparel-registry/pull/1974)
-- Avoid exception when parsing arrays in raw data [#1910](https://github.com/open-apparel-registry/open-apparel-registry/pull/1910)
-- Added option to exclude specified users from anonymization script [#1924](https://github.com/open-apparel-registry/open-apparel-registry/pull/1924)
-- Remove hard coded domain from mail.py [#1931](https://github.com/open-apparel-registry/open-apparel-registry/pull/1931)
-- Rename OAR to OS Hub / Open Apparel Registry to Open Supply Hub [#1935](https://github.com/open-apparel-registry/open-apparel-registry/pull/1935)
-- Update favicon images with OS Hub logo [#1938](https://github.com/open-apparel-registry/open-apparel-registry/pull/1938)
-- Use name prefix and create before destroy for batch compute [#1952](https://github.com/open-apparel-registry/open-apparel-registry/pull/1952)
-- Switched from `django-swagger` to `drf-yasg` [#1951](https://github.com/open-apparel-registry/open-apparel-registry/pull/1951/files)
-- Return anonymized sectors and index them instead of excluding them when items are private or inactive [#1966](https://github.com/open-apparel-registry/open-apparel-registry/pull/1966)
-- Upgrade Django to 3.2, Python to 3.10, as well as other dependencies [#1965](https://github.com/open-apparel-registry/open-apparel-registry/pull/1965/)
-- Update facility download [#1981](https://github.com/open-apparel-registry/open-apparel-registry/pull/1981)
-- Limit parent company dropdown options to other parent companies and allow freeform text entry [#1983](https://github.com/open-apparel-registry/open-apparel-registry/pull/1983)
-- Update "adjust facility matches" dashboard [#2005](https://github.com/open-apparel-registry/open-apparel-registry/pull/2005)
-- Split batch steps [#2028](https://github.com/open-apparel-registry/open-apparel-registry/pull/2028)
-- Update list match confirm / rejection to be done by admins [#2030](https://github.com/open-apparel-registry/open-apparel-registry/pull/2030)
-- Update moderation UI to trigger batch processing [#2048](https://github.com/open-apparel-registry/open-apparel-registry/pull/2048)
-- Create a log group for AWS Batch jobs [#2060](https://github.com/open-apparel-registry/open-apparel-registry/pull/2060)
-- Allow admins to set superuser status [#2095](https://github.com/open-apparel-registry/open-apparel-registry/pull/2095)
-- Replace font and global colors [#2077](https://github.com/open-apparel-registry/open-apparel-registry/pull/2077)
-- Change map marker #[2089](https://github.com/open-apparel-registry/open-apparel-registry/pull/2089)
-- Speed up XLSX parsing by using iteration [#2086](https://github.com/open-apparel-registry/open-apparel-registry/pull/2086)
-- Rename makecsvs to makedata and add stub SQL mode [#2108](https://github.com/open-apparel-registry/open-apparel-registry/pull/2108)
-- Update facility lists for contributor workflow updates [#2050](https://github.com/open-apparel-registry/open-apparel-registry/issues/2050)
-- Update facility details content [#2126](https://github.com/open-apparel-registry/open-apparel-registry/pull/2126)
-- Search/Filtering/Results UX Updates [#2110](https://github.com/open-apparel-registry/open-apparel-registry/pull/2110) [#2159](https://github.com/open-apparel-registry/open-apparel-registry/pull/2159)
-- Delete matched facilities from created contributer [#2153](https://github.com/open-apparel-registry/open-apparel-registry/pull/2153)
-- Update contributor profile UX [#2151](https://github.com/open-apparel-registry/open-apparel-registry/pull/2151)
-- Tweak copy link, download buttons [#2162](https://github.com/open-apparel-registry/open-apparel-registry/pull/2162)
-- Update static map marker to OS Hub style marker [#2169](https://github.com/open-apparel-registry/open-apparel-registry/pull/2169)
-- Updated OAR ID to OS ID [#2163](https://github.com/open-apparel-registry/open-apparel-registry/pull/2163)
-- Update search results dropdowns [#2161](https://github.com/open-apparel-registry/open-apparel-registry/pull/2161)
-- Use HubSpot for mailing list [#2166](https://github.com/open-apparel-registry/open-apparel-registry/pull/2166)
-- Add Sector model and update create facility product type/sector parsing [#2157](https://github.com/open-apparel-registry/open-apparel-registry/pull/2157) [#2191](https://github.com/open-apparel-registry/open-apparel-registry/pull/2191)
-- Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167) [#2022](https://github.com/open-apparel-registry/open-apparel-registry/pull/2202)
-- Filter out fields from inactive lists in facility API response [#2180](https://github.com/open-apparel-registry/open-apparel-registry/pull/2180)
-- Update site footer with OS Hub styling [#2189](https://github.com/open-apparel-registry/open-apparel-registry/pull/2189)
-- Updated withQueryStringSync to render only after query params are hydrated [#2205](https://github.com/open-apparel-registry/open-apparel-registry/pull/2205) [#2223](https://github.com/open-apparel-registry/open-apparel-registry/pull/2223)
-- Rename Jenkinsfile.release for OSH [#2211](https://github.com/open-apparel-registry/open-apparel-registry/pull/2211)
-- Terminology updates [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
-- Change claim wizard header color [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
-- Hide nav links on My Account - Settings page [#2212](https://github.com/open-apparel-registry/open-apparel-registry/pull/2212)
-- Upgrade Google Analytics to gtag.js [#2221](https://github.com/open-apparel-registry/open-apparel-registry/pull/2221)
-- Update Contribute page copy [#2226](https://github.com/open-apparel-registry/open-apparel-registry/pull/2226)
-- Update info site URL to opensupplyhub.org [#2214](https://github.com/open-apparel-registry/open-apparel-registry/pull/2214)
-- Non-apparel facility_type_processing_type handling [#2232](https://github.com/open-apparel-registry/open-apparel-registry/pull/2232)
-- Allow super users to remove list items they don't own [#2228](https://github.com/open-apparel-registry/open-apparel-registry/pull/2228)
-- Allow facility list items to be removed from pending lists [#2228](https://github.com/open-apparel-registry/open-apparel-registry/pull/2228)
-- Update copy text for OS Hub [#2237](https://github.com/open-apparel-registry/open-apparel-registry/pull/2237)
-- Update embedded map footer logo [#2243](https://github.com/open-apparel-registry/open-apparel-registry/pull/2243)
+-   Upgrade terraform to 1.1.9 [#2054](https://github.com/open-apparel-registry/open-apparel-registry/pull/2054)
+-   Use autocomplete ordered by name for admin contributors dropdown [#1848](https://github.com/open-apparel-registry/open-apparel-registry/pull/1848)
+-   Document parallel OGR workflow in the README [#1851](https://github.com/open-apparel-registry/open-apparel-registry/pull/1851)
+-   Update tile load test script and add scripts for hompage load, facility download, and facility POST [#1777](https://github.com/open-apparel-registry/open-apparel-registry/pull/1777)
+-   API documentation updates [#1844](https://github.com/open-apparel-registry/open-apparel-registry/pull/1844)
+-   Return sector in Facility detail response [#1884](https://github.com/open-apparel-registry/open-apparel-registry/pull/1884) [#1929](https://github.com/open-apparel-registry/open-apparel-registry/pull/1929)
+-   Updated logo and colors on top banner, map and search button [#1900](https://github.com/open-apparel-registry/open-apparel-registry/pull/1900) [#1974](https://github.com/open-apparel-registry/open-apparel-registry/pull/1974)
+-   Avoid exception when parsing arrays in raw data [#1910](https://github.com/open-apparel-registry/open-apparel-registry/pull/1910)
+-   Added option to exclude specified users from anonymization script [#1924](https://github.com/open-apparel-registry/open-apparel-registry/pull/1924)
+-   Remove hard coded domain from mail.py [#1931](https://github.com/open-apparel-registry/open-apparel-registry/pull/1931)
+-   Rename OAR to OS Hub / Open Apparel Registry to Open Supply Hub [#1935](https://github.com/open-apparel-registry/open-apparel-registry/pull/1935)
+-   Update favicon images with OS Hub logo [#1938](https://github.com/open-apparel-registry/open-apparel-registry/pull/1938)
+-   Use name prefix and create before destroy for batch compute [#1952](https://github.com/open-apparel-registry/open-apparel-registry/pull/1952)
+-   Switched from `django-swagger` to `drf-yasg` [#1951](https://github.com/open-apparel-registry/open-apparel-registry/pull/1951/files)
+-   Return anonymized sectors and index them instead of excluding them when items are private or inactive [#1966](https://github.com/open-apparel-registry/open-apparel-registry/pull/1966)
+-   Upgrade Django to 3.2, Python to 3.10, as well as other dependencies [#1965](https://github.com/open-apparel-registry/open-apparel-registry/pull/1965/)
+-   Update facility download [#1981](https://github.com/open-apparel-registry/open-apparel-registry/pull/1981)
+-   Limit parent company dropdown options to other parent companies and allow freeform text entry [#1983](https://github.com/open-apparel-registry/open-apparel-registry/pull/1983)
+-   Update "adjust facility matches" dashboard [#2005](https://github.com/open-apparel-registry/open-apparel-registry/pull/2005)
+-   Split batch steps [#2028](https://github.com/open-apparel-registry/open-apparel-registry/pull/2028)
+-   Update list match confirm / rejection to be done by admins [#2030](https://github.com/open-apparel-registry/open-apparel-registry/pull/2030)
+-   Update moderation UI to trigger batch processing [#2048](https://github.com/open-apparel-registry/open-apparel-registry/pull/2048)
+-   Create a log group for AWS Batch jobs [#2060](https://github.com/open-apparel-registry/open-apparel-registry/pull/2060)
+-   Allow admins to set superuser status [#2095](https://github.com/open-apparel-registry/open-apparel-registry/pull/2095)
+-   Replace font and global colors [#2077](https://github.com/open-apparel-registry/open-apparel-registry/pull/2077)
+-   Change map marker #[2089](https://github.com/open-apparel-registry/open-apparel-registry/pull/2089)
+-   Speed up XLSX parsing by using iteration [#2086](https://github.com/open-apparel-registry/open-apparel-registry/pull/2086)
+-   Rename makecsvs to makedata and add stub SQL mode [#2108](https://github.com/open-apparel-registry/open-apparel-registry/pull/2108)
+-   Update facility lists for contributor workflow updates [#2050](https://github.com/open-apparel-registry/open-apparel-registry/issues/2050)
+-   Update facility details content [#2126](https://github.com/open-apparel-registry/open-apparel-registry/pull/2126)
+-   Search/Filtering/Results UX Updates [#2110](https://github.com/open-apparel-registry/open-apparel-registry/pull/2110) [#2159](https://github.com/open-apparel-registry/open-apparel-registry/pull/2159)
+-   Delete matched facilities from created contributer [#2153](https://github.com/open-apparel-registry/open-apparel-registry/pull/2153)
+-   Update contributor profile UX [#2151](https://github.com/open-apparel-registry/open-apparel-registry/pull/2151)
+-   Tweak copy link, download buttons [#2162](https://github.com/open-apparel-registry/open-apparel-registry/pull/2162)
+-   Update static map marker to OS Hub style marker [#2169](https://github.com/open-apparel-registry/open-apparel-registry/pull/2169)
+-   Updated OAR ID to OS ID [#2163](https://github.com/open-apparel-registry/open-apparel-registry/pull/2163)
+-   Update search results dropdowns [#2161](https://github.com/open-apparel-registry/open-apparel-registry/pull/2161)
+-   Use HubSpot for mailing list [#2166](https://github.com/open-apparel-registry/open-apparel-registry/pull/2166)
+-   Add Sector model and update create facility product type/sector parsing [#2157](https://github.com/open-apparel-registry/open-apparel-registry/pull/2157) [#2191](https://github.com/open-apparel-registry/open-apparel-registry/pull/2191)
+-   Update site header with OS Hub styling [#2167](https://github.com/open-apparel-registry/open-apparel-registry/pull/2167) [#2022](https://github.com/open-apparel-registry/open-apparel-registry/pull/2202)
+-   Filter out fields from inactive lists in facility API response [#2180](https://github.com/open-apparel-registry/open-apparel-registry/pull/2180)
+-   Update site footer with OS Hub styling [#2189](https://github.com/open-apparel-registry/open-apparel-registry/pull/2189)
+-   Updated withQueryStringSync to render only after query params are hydrated [#2205](https://github.com/open-apparel-registry/open-apparel-registry/pull/2205) [#2223](https://github.com/open-apparel-registry/open-apparel-registry/pull/2223)
+-   Rename Jenkinsfile.release for OSH [#2211](https://github.com/open-apparel-registry/open-apparel-registry/pull/2211)
+-   Terminology updates [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
+-   Change claim wizard header color [#2194](https://github.com/open-apparel-registry/open-apparel-registry/pull/2194)
+-   Hide nav links on My Account - Settings page [#2212](https://github.com/open-apparel-registry/open-apparel-registry/pull/2212)
+-   Upgrade Google Analytics to gtag.js [#2221](https://github.com/open-apparel-registry/open-apparel-registry/pull/2221)
+-   Update Contribute page copy [#2226](https://github.com/open-apparel-registry/open-apparel-registry/pull/2226)
+-   Update info site URL to opensupplyhub.org [#2214](https://github.com/open-apparel-registry/open-apparel-registry/pull/2214)
+-   Non-apparel facility_type_processing_type handling [#2232](https://github.com/open-apparel-registry/open-apparel-registry/pull/2232)
+-   Allow super users to remove list items they don't own [#2228](https://github.com/open-apparel-registry/open-apparel-registry/pull/2228)
+-   Allow facility list items to be removed from pending lists [#2228](https://github.com/open-apparel-registry/open-apparel-registry/pull/2228)
+-   Update copy text for OS Hub [#2237](https://github.com/open-apparel-registry/open-apparel-registry/pull/2237)
+-   Update embedded map footer logo [#2243](https://github.com/open-apparel-registry/open-apparel-registry/pull/2243)
 
 ### Fixed
 
-- Use 'pending' as the default status filter on the dashboard list page [#2109](https://github.com/open-apparel-registry/open-apparel-registry/pull/2109)
-- Suppress "pure-python SequenceMatcher" warning [#2011](https://github.com/open-apparel-registry/open-apparel-registry/pull/2011)
-- Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
-- Fix processing_type_facility_type_unmatched [#1875](https://github.com/open-apparel-registry/open-apparel-registry/pull/1875)
-- Fix VectorGrid bug [#1928](https://github.com/open-apparel-registry/open-apparel-registry/pull/1928)
-- Exclude null claim sector value when serializing facility details [#1963](https://github.com/open-apparel-registry/open-apparel-registry/pull/1963)
-- Ensure inactive matches have anonymized sectors [#1968](https://github.com/open-apparel-registry/open-apparel-registry/pull/1968)
-- Fix showing anonymous contributors on sidebar [#1994](https://github.com/open-apparel-registry/open-apparel-registry/pull/1994)
-- Replace + character in ISO date string when in batch job name [#2008](https://github.com/open-apparel-registry/open-apparel-registry/pull/2008)
-- Update sectors in FacilityIndex after upload [#2004](https://github.com/open-apparel-registry/open-apparel-registry/pull/2004)
-- Fix delete facility [#2020](https://github.com/open-apparel-registry/open-apparel-registry/pull/2020)
-- Fix facility details sector display [#2029](https://github.com/open-apparel-registry/open-apparel-registry/pull/2029)
-- Set pagination_class on ApiBlockViewSet to None [#2057](https://github.com/open-apparel-registry/open-apparel-registry/pull/2057)
-- Dont duplicate check items with parsing errors [#2073](https://github.com/open-apparel-registry/open-apparel-registry/pull/2073)
-- Fix list URL construction when running as a Batch job [#2066](https://github.com/open-apparel-registry/open-apparel-registry/pull/2066)
-- Fix getLangFromTranslateElement function [#2097](https://github.com/open-apparel-registry/open-apparel-registry/pull/2097)
-- Update the Python and Rollber versions used for lamba functions [#2120](https://github.com/open-apparel-registry/open-apparel-registry/pull/2120)
-- Fixup recent UX changes [#2141](https://github.com/open-apparel-registry/open-apparel-registry/pull/2141)
-- Fixed parsing country strings with newline characters [#2195](https://github.com/open-apparel-registry/open-apparel-registry/pull/2195)
-- Fixed user profile facilites map link [#2204](https://github.com/open-apparel-registry/open-apparel-registry/pull/2204)
-- Fix parse errors [#2207](https://github.com/open-apparel-registry/open-apparel-registry/pull/2207)
-- OS Hub style fixes [#2222](https://github.com/open-apparel-registry/open-apparel-registry/pull/2222)
-- Fix gtag.js script tag [#2229](https://github.com/open-apparel-registry/open-apparel-registry/pull/2229)
-- Fix initial page load layout bug [#2238](https://github.com/open-apparel-registry/open-apparel-registry/pull/2238)
+-   Use 'pending' as the default status filter on the dashboard list page [#2109](https://github.com/open-apparel-registry/open-apparel-registry/pull/2109)
+-   Suppress "pure-python SequenceMatcher" warning [#2011](https://github.com/open-apparel-registry/open-apparel-registry/pull/2011)
+-   Fix geocode error messages to include the status code [#1853](https://github.com/open-apparel-registry/open-apparel-registry/pull/1853)
+-   Fix processing_type_facility_type_unmatched [#1875](https://github.com/open-apparel-registry/open-apparel-registry/pull/1875)
+-   Fix VectorGrid bug [#1928](https://github.com/open-apparel-registry/open-apparel-registry/pull/1928)
+-   Exclude null claim sector value when serializing facility details [#1963](https://github.com/open-apparel-registry/open-apparel-registry/pull/1963)
+-   Ensure inactive matches have anonymized sectors [#1968](https://github.com/open-apparel-registry/open-apparel-registry/pull/1968)
+-   Fix showing anonymous contributors on sidebar [#1994](https://github.com/open-apparel-registry/open-apparel-registry/pull/1994)
+-   Replace + character in ISO date string when in batch job name [#2008](https://github.com/open-apparel-registry/open-apparel-registry/pull/2008)
+-   Update sectors in FacilityIndex after upload [#2004](https://github.com/open-apparel-registry/open-apparel-registry/pull/2004)
+-   Fix delete facility [#2020](https://github.com/open-apparel-registry/open-apparel-registry/pull/2020)
+-   Fix facility details sector display [#2029](https://github.com/open-apparel-registry/open-apparel-registry/pull/2029)
+-   Set pagination_class on ApiBlockViewSet to None [#2057](https://github.com/open-apparel-registry/open-apparel-registry/pull/2057)
+-   Dont duplicate check items with parsing errors [#2073](https://github.com/open-apparel-registry/open-apparel-registry/pull/2073)
+-   Fix list URL construction when running as a Batch job [#2066](https://github.com/open-apparel-registry/open-apparel-registry/pull/2066)
+-   Fix getLangFromTranslateElement function [#2097](https://github.com/open-apparel-registry/open-apparel-registry/pull/2097)
+-   Update the Python and Rollber versions used for lamba functions [#2120](https://github.com/open-apparel-registry/open-apparel-registry/pull/2120)
+-   Fixup recent UX changes [#2141](https://github.com/open-apparel-registry/open-apparel-registry/pull/2141)
+-   Fixed parsing country strings with newline characters [#2195](https://github.com/open-apparel-registry/open-apparel-registry/pull/2195)
+-   Fixed user profile facilites map link [#2204](https://github.com/open-apparel-registry/open-apparel-registry/pull/2204)
+-   Fix parse errors [#2207](https://github.com/open-apparel-registry/open-apparel-registry/pull/2207)
+-   OS Hub style fixes [#2222](https://github.com/open-apparel-registry/open-apparel-registry/pull/2222)
+-   Fix gtag.js script tag [#2229](https://github.com/open-apparel-registry/open-apparel-registry/pull/2229)
+-   Fix initial page load layout bug [#2238](https://github.com/open-apparel-registry/open-apparel-registry/pull/2238)
 
 ### Security
 
-- Updated Node to version 14 [#1986](https://github.com/open-apparel-registry/open-apparel-registry/pull/1986)
-- Updated Batch AMI ID to latest version [#2190](https://github.com/open-apparel-registry/open-apparel-registry/pull/2190)
+-   Updated Node to version 14 [#1986](https://github.com/open-apparel-registry/open-apparel-registry/pull/1986)
+-   Updated Batch AMI ID to latest version [#2190](https://github.com/open-apparel-registry/open-apparel-registry/pull/2190)
 
 ## [66] - 2022-05-12
 
 ### Added
 
-- Add new taxonomy processing types [#1827](https://github.com/open-apparel-registry/open-apparel-registry/pull/1827)
-- Add extended field reports [#1826](https://github.com/open-apparel-registry/open-apparel-registry/pull/1826)
+-   Add new taxonomy processing types [#1827](https://github.com/open-apparel-registry/open-apparel-registry/pull/1827)
+-   Add extended field reports [#1826](https://github.com/open-apparel-registry/open-apparel-registry/pull/1826)
 
 ### Changed
 
-- Mark failing reports with Do Not Open [#1836](https://github.com/open-apparel-registry/open-apparel-registry/pull/1836)
+-   Mark failing reports with Do Not Open [#1836](https://github.com/open-apparel-registry/open-apparel-registry/pull/1836)
 
 ### Fixed
 
-- Handle blank rows and columns in .xlsx [#1837](https://github.com/open-apparel-registry/open-apparel-registry/pull/1837)
+-   Handle blank rows and columns in .xlsx [#1837](https://github.com/open-apparel-registry/open-apparel-registry/pull/1837)
 
 ## [65] - 2022-04-28
 
 ### Changed
 
-- Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
-- Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
-- Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794) [#1800](https://github.com/open-apparel-registry/open-apparel-registry/pull/1800)
-- Use exact match in parent company when creating extended field [#1804](https://github.com/open-apparel-registry/open-apparel-registry/pull/1804)
-- Read percentage as string in Excel [#1811](https://github.com/open-apparel-registry/open-apparel-registry/pull/1811) [#1822](https://github.com/open-apparel-registry/open-apparel-registry/pull/1822)
+-   Update DB anonymization script [#1769](https://github.com/open-apparel-registry/open-apparel-registry/pull/1769)
+-   Update tileer load test script [#1770](https://github.com/open-apparel-registry/open-apparel-registry/pull/1770)
+-   Only show contributed extended fields in embed sidebar search [#1794](https://github.com/open-apparel-registry/open-apparel-registry/pull/1794) [#1800](https://github.com/open-apparel-registry/open-apparel-registry/pull/1800)
+-   Use exact match in parent company when creating extended field [#1804](https://github.com/open-apparel-registry/open-apparel-registry/pull/1804)
+-   Read percentage as string in Excel [#1811](https://github.com/open-apparel-registry/open-apparel-registry/pull/1811) [#1822](https://github.com/open-apparel-registry/open-apparel-registry/pull/1822)
 
 ### Fixed
 
-- Skip rendering embed fields with empty values [#1809](https://github.com/open-apparel-registry/open-apparel-registry/pull/1809)
-- Show the correct submission date for name and address fields [#1810](https://github.com/open-apparel-registry/open-apparel-registry/pull/1810)
+-   Skip rendering embed fields with empty values [#1809](https://github.com/open-apparel-registry/open-apparel-registry/pull/1809)
+-   Show the correct submission date for name and address fields [#1810](https://github.com/open-apparel-registry/open-apparel-registry/pull/1810)
 
 ## [64] - 2022-03-22
 
 ### Changed
 
-- Reduce pageSize when downloading to 10 [#1763](https://github.com/open-apparel-registry/open-apparel-registry/pull/1763)
+-   Reduce pageSize when downloading to 10 [#1763](https://github.com/open-apparel-registry/open-apparel-registry/pull/1763)
 
 ## [63] - 2022-03-21
 
 ### Changed
 
-- Delay loading search field dropdown data [#1731](https://github.com/open-apparel-registry/open-apparel-registry/pull/1731)
-- Exclude details from facility list API by defaut [#1739](https://github.com/open-apparel-registry/open-apparel-registry/pull/1739)
-- Minor UX changes [#1745](https://github.com/open-apparel-registry/open-apparel-registry/pull/1745)
-- Increase database work_mem to 20MB [#1744](https://github.com/open-apparel-registry/open-apparel-registry/pull/1744)
-- Swap copy between My Lists and Individual List page [#1756](https://github.com/open-apparel-registry/open-apparel-registry/pull/1756)
-- Hide raw facility_type values [#1758](https://github.com/open-apparel-registry/open-apparel-registry/pull/1758)
+-   Delay loading search field dropdown data [#1731](https://github.com/open-apparel-registry/open-apparel-registry/pull/1731)
+-   Exclude details from facility list API by defaut [#1739](https://github.com/open-apparel-registry/open-apparel-registry/pull/1739)
+-   Minor UX changes [#1745](https://github.com/open-apparel-registry/open-apparel-registry/pull/1745)
+-   Increase database work_mem to 20MB [#1744](https://github.com/open-apparel-registry/open-apparel-registry/pull/1744)
+-   Swap copy between My Lists and Individual List page [#1756](https://github.com/open-apparel-registry/open-apparel-registry/pull/1756)
+-   Hide raw facility_type values [#1758](https://github.com/open-apparel-registry/open-apparel-registry/pull/1758)
 
 ### Removed
 
-- Remove contribute type counts from dropdown [#1732](https://github.com/open-apparel-registry/open-apparel-registry/pull/1732)
-- Remove product type dropdown from search and claim [#1734](https://github.com/open-apparel-registry/open-apparel-registry/pull/1734)
-- Remove parent company dropdown from search [#1736](https://github.com/open-apparel-registry/open-apparel-registry/pull/1736)
+-   Remove contribute type counts from dropdown [#1732](https://github.com/open-apparel-registry/open-apparel-registry/pull/1732)
+-   Remove product type dropdown from search and claim [#1734](https://github.com/open-apparel-registry/open-apparel-registry/pull/1734)
+-   Remove parent company dropdown from search [#1736](https://github.com/open-apparel-registry/open-apparel-registry/pull/1736)
 
 ### Fixed
 
-- Hide contributor details in embed downloads [#1742](https://github.com/open-apparel-registry/open-apparel-registry/pull/1742)
-- Wrap long filenames in My Lists page [#1756](https://github.com/open-apparel-registry/open-apparel-registry/pull/1756)
-- Fix handling of numeric custom fields [#1757](https://github.com/open-apparel-registry/open-apparel-registry/pull/1757)
-- Filter out invalid facility_types [#1759](https://github.com/open-apparel-registry/open-apparel-registry/pull/1759)
+-   Hide contributor details in embed downloads [#1742](https://github.com/open-apparel-registry/open-apparel-registry/pull/1742)
+-   Wrap long filenames in My Lists page [#1756](https://github.com/open-apparel-registry/open-apparel-registry/pull/1756)
+-   Fix handling of numeric custom fields [#1757](https://github.com/open-apparel-registry/open-apparel-registry/pull/1757)
+-   Filter out invalid facility_types [#1759](https://github.com/open-apparel-registry/open-apparel-registry/pull/1759)
 
 ## [62] - 2022-03-18
 
 ### Added
 
-- Filter by extended fields [#1696](https://github.com/open-apparel-registry/open-apparel-registry/pull/1696)
-- Add extended profile search APIs [#1697](https://github.com/open-apparel-registry/open-apparel-registry/pull/1697)
-- Add an API to return suggested product type choices [#1708](https://github.com/open-apparel-registry/open-apparel-registry/pull/1708)
-- Add extended fields to sidebar [#1710](https://github.com/open-apparel-registry/open-apparel-registry/pull/1710)
+-   Filter by extended fields [#1696](https://github.com/open-apparel-registry/open-apparel-registry/pull/1696)
+-   Add extended profile search APIs [#1697](https://github.com/open-apparel-registry/open-apparel-registry/pull/1697)
+-   Add an API to return suggested product type choices [#1708](https://github.com/open-apparel-registry/open-apparel-registry/pull/1708)
+-   Add extended fields to sidebar [#1710](https://github.com/open-apparel-registry/open-apparel-registry/pull/1710)
 
 ### Changed
 
-- Allow submitting non-taxonomy facility type and processing type [#1705](https://github.com/open-apparel-registry/open-apparel-registry/pull/1705)
-- Update email copy for list completion [#1709](https://github.com/open-apparel-registry/open-apparel-registry/pull/1709)
-- Remove the redundant workers suffix when showing value [#1715](https://github.com/open-apparel-registry/open-apparel-registry/pull/1715/files)
-- Update copy on list pages [#1719](https://github.com/open-apparel-registry/open-apparel-registry/pull/1719)
-- Remove native language name from filter sidebar [#1722](https://github.com/open-apparel-registry/open-apparel-registry/pull/1722)
+-   Allow submitting non-taxonomy facility type and processing type [#1705](https://github.com/open-apparel-registry/open-apparel-registry/pull/1705)
+-   Update email copy for list completion [#1709](https://github.com/open-apparel-registry/open-apparel-registry/pull/1709)
+-   Remove the redundant workers suffix when showing value [#1715](https://github.com/open-apparel-registry/open-apparel-registry/pull/1715/files)
+-   Update copy on list pages [#1719](https://github.com/open-apparel-registry/open-apparel-registry/pull/1719)
+-   Remove native language name from filter sidebar [#1722](https://github.com/open-apparel-registry/open-apparel-registry/pull/1722)
 
 ### Fixed
 
-- Hide inactive contributor associations [#1712](https://github.com/open-apparel-registry/open-apparel-registry/pull/1712)
-- Fix CSV download when extended profile switch is off [#1720](https://github.com/open-apparel-registry/open-apparel-registry/pull/1720)
+-   Hide inactive contributor associations [#1712](https://github.com/open-apparel-registry/open-apparel-registry/pull/1712)
+-   Fix CSV download when extended profile switch is off [#1720](https://github.com/open-apparel-registry/open-apparel-registry/pull/1720)
 
 ## [61] 2022-03-17
 
 ### Fixed
 
-- Move exact_match sorting to server [#1716](https://github.com/open-apparel-registry/open-apparel-registry/pull/1716)
+-   Move exact_match sorting to server [#1716](https://github.com/open-apparel-registry/open-apparel-registry/pull/1716)
 
 ## [60] - 2022-03-03
 
 ### Added
 
-- Include extended fields in CSV/Excel downloads [#1683](https://github.com/open-apparel-registry/open-apparel-registry/pull/1683)
-- Add embed_level to development contributors [#1681](https://github.com/open-apparel-registry/open-apparel-registry/pull/1681)
+-   Include extended fields in CSV/Excel downloads [#1683](https://github.com/open-apparel-registry/open-apparel-registry/pull/1683)
+-   Add embed_level to development contributors [#1681](https://github.com/open-apparel-registry/open-apparel-registry/pull/1681)
 
 ### Changed
 
-- Change production type to Processing type in Django admin [#1679](https://github.com/open-apparel-registry/open-apparel-registry/pull/1679)
-- Combine facility type and production type claim fields [#1678](https://github.com/open-apparel-registry/open-apparel-registry/pull/1678/files)
-- Migrate claim extended fields [#1677](https://github.com/open-apparel-registry/open-apparel-registry/pull/1677)
+-   Change production type to Processing type in Django admin [#1679](https://github.com/open-apparel-registry/open-apparel-registry/pull/1679)
+-   Combine facility type and production type claim fields [#1678](https://github.com/open-apparel-registry/open-apparel-registry/pull/1678/files)
+-   Migrate claim extended fields [#1677](https://github.com/open-apparel-registry/open-apparel-registry/pull/1677)
 
 ### Fixed
 
-- Fix claim showing incorrect parent facility [#1687](https://github.com/open-apparel-registry/open-apparel-registry/pull/1687)
+-   Fix claim showing incorrect parent facility [#1687](https://github.com/open-apparel-registry/open-apparel-registry/pull/1687)
 
 ## [59] - 2022-02-25
 
 ### Added
 
-- Add selecting silver map style to embed config [#1637](https://github.com/open-apparel-registry/open-apparel-registry/pull/1637)
-- Integrate facility/processing type taxonomy into facility claims [#1639](https://github.com/open-apparel-registry/open-apparel-registry/pull/1639)
-- Index extended fields [#1651](https://github.com/open-apparel-registry/open-apparel-registry/pull/1651)
-- Allow searching contributors by name and admin email [#1668](https://github.com/open-apparel-registry/open-apparel-registry/pull/1668)
-- Add support for facility_type_processing_type meta extended field [#1671](https://github.com/open-apparel-registry/open-apparel-registry/pull/1671)
+-   Add selecting silver map style to embed config [#1637](https://github.com/open-apparel-registry/open-apparel-registry/pull/1637)
+-   Integrate facility/processing type taxonomy into facility claims [#1639](https://github.com/open-apparel-registry/open-apparel-registry/pull/1639)
+-   Index extended fields [#1651](https://github.com/open-apparel-registry/open-apparel-registry/pull/1651)
+-   Allow searching contributors by name and admin email [#1668](https://github.com/open-apparel-registry/open-apparel-registry/pull/1668)
+-   Add support for facility_type_processing_type meta extended field [#1671](https://github.com/open-apparel-registry/open-apparel-registry/pull/1671)
 
 ### Changed
 
-- Update final facility_type/processing_type taxonomy [#1644](https://github.com/open-apparel-registry/open-apparel-registry/pull/1644)
-- Modified custom_text handling [#1665](https://github.com/open-apparel-registry/open-apparel-registry/pull/1665)
-- Add two additional types to taxonomy [#1662](https://github.com/open-apparel-registry/open-apparel-registry/pull/1662)
-- Use DEBUGPY env var to conditionally enable debugging [#1675](https://github.com/open-apparel-registry/open-apparel-registry/pull/1675)
+-   Update final facility_type/processing_type taxonomy [#1644](https://github.com/open-apparel-registry/open-apparel-registry/pull/1644)
+-   Modified custom_text handling [#1665](https://github.com/open-apparel-registry/open-apparel-registry/pull/1665)
+-   Add two additional types to taxonomy [#1662](https://github.com/open-apparel-registry/open-apparel-registry/pull/1662)
+-   Use DEBUGPY env var to conditionally enable debugging [#1675](https://github.com/open-apparel-registry/open-apparel-registry/pull/1675)
 
 ### Fixed
 
-- Fix handling of numeric cells in Excel workbooks [#1663](https://github.com/open-apparel-registry/open-apparel-registry/pull/1663)
-- Fix custom text handling when not in embed mode [#1673](https://github.com/open-apparel-registry/open-apparel-registry/pull/1673)
+-   Fix handling of numeric cells in Excel workbooks [#1663](https://github.com/open-apparel-registry/open-apparel-registry/pull/1663)
+-   Fix custom text handling when not in embed mode [#1673](https://github.com/open-apparel-registry/open-apparel-registry/pull/1673)
 
 ### Security
 
-- Bump follow-redirects from 1.14.3 to 1.14.8 in /src/app [#1645](https://github.com/open-apparel-registry/open-apparel-registry/pull/1645)
-- Bump url-parse from 1.5.1 to 1.5.7 in /src/app [#1666](https://github.com/open-apparel-registry/open-apparel-registry/pull/1666)
+-   Bump follow-redirects from 1.14.3 to 1.14.8 in /src/app [#1645](https://github.com/open-apparel-registry/open-apparel-registry/pull/1645)
+-   Bump url-parse from 1.5.1 to 1.5.7 in /src/app [#1666](https://github.com/open-apparel-registry/open-apparel-registry/pull/1666)
 
 ## [58] 2022-02-17
 
 ### Fixed
 
-- [Temporarily fix Google basemap](https://github.com/open-apparel-registry/open-apparel-registry/pull/1658)
+-   [Temporarily fix Google basemap](https://github.com/open-apparel-registry/open-apparel-registry/pull/1658)
 
 ## [57] 2022-02-15
 
 ### Added
 
-- Add closure status to extended profile [#1635](https://github.com/open-apparel-registry/open-apparel-registry/pull/1635)
+-   Add closure status to extended profile [#1635](https://github.com/open-apparel-registry/open-apparel-registry/pull/1635)
 
 ### Changed
 
-- Ignore partial OAR IDs [#1641](https://github.com/open-apparel-registry/open-apparel-registry/pull/1641)
+-   Ignore partial OAR IDs [#1641](https://github.com/open-apparel-registry/open-apparel-registry/pull/1641)
 
 ## [56] 2022-02-10
 
 ### Added
 
-- Add facility/processing type taxonomy and look-up function [#1601](https://github.com/open-apparel-registry/open-apparel-registry/pull/1601)
-- Create product type extended field [#1605](https://github.com/open-apparel-registry/open-apparel-registry/pull/1605)
-- Index custom text [#1607](https://github.com/open-apparel-registry/open-apparel-registry/pull/1607)
-- Create extended field values for processing/facility type [#1616](https://github.com/open-apparel-registry/open-apparel-registry/pull/1616)
-- Add batch_process tool [#1625](https://github.com/open-apparel-registry/open-apparel-registry/pull/1625)
-- Display processing and facility type [#1624](https://github.com/open-apparel-registry/open-apparel-registry/pull/1624)
-- Search custom_text in embedded map [#1629](https://github.com/open-apparel-registry/open-apparel-registry/pull/1629)
+-   Add facility/processing type taxonomy and look-up function [#1601](https://github.com/open-apparel-registry/open-apparel-registry/pull/1601)
+-   Create product type extended field [#1605](https://github.com/open-apparel-registry/open-apparel-registry/pull/1605)
+-   Index custom text [#1607](https://github.com/open-apparel-registry/open-apparel-registry/pull/1607)
+-   Create extended field values for processing/facility type [#1616](https://github.com/open-apparel-registry/open-apparel-registry/pull/1616)
+-   Add batch_process tool [#1625](https://github.com/open-apparel-registry/open-apparel-registry/pull/1625)
+-   Display processing and facility type [#1624](https://github.com/open-apparel-registry/open-apparel-registry/pull/1624)
+-   Search custom_text in embedded map [#1629](https://github.com/open-apparel-registry/open-apparel-registry/pull/1629)
 
 ### Changed
 
-- Update embed facility detail rendering to support extended fields [#1627](https://github.com/open-apparel-registry/open-apparel-registry/pull/1627)
-- Update field handling [#1630](https://github.com/open-apparel-registry/open-apparel-registry/pull/1630)
-- Add an item to the release checklist to avoid deploys during demos [#1633](https://github.com/open-apparel-registry/open-apparel-registry/pull/1633)
+-   Update embed facility detail rendering to support extended fields [#1627](https://github.com/open-apparel-registry/open-apparel-registry/pull/1627)
+-   Update field handling [#1630](https://github.com/open-apparel-registry/open-apparel-registry/pull/1630)
+-   Add an item to the release checklist to avoid deploys during demos [#1633](https://github.com/open-apparel-registry/open-apparel-registry/pull/1633)
 
 ### Deprecated
 
@@ -405,8 +414,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Handle country code geocoding errors [#1619](https://github.com/open-apparel-registry/open-apparel-registry/pull/1619)
-- Fix custom text processing [#1631](https://github.com/open-apparel-registry/open-apparel-registry/pull/1631)
+-   Handle country code geocoding errors [#1619](https://github.com/open-apparel-registry/open-apparel-registry/pull/1619)
+-   Fix custom text processing [#1631](https://github.com/open-apparel-registry/open-apparel-registry/pull/1631)
 
 ### Security
 
@@ -414,422 +423,422 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add extended field handling to facility details [#1593](https://github.com/open-apparel-registry/open-apparel-registry/pull/1593)
-- Add searchability to embed config [#1598](https://github.com/open-apparel-registry/open-apparel-registry/pull/1598)
-- Create parent company extended fields [#1602](https://github.com/open-apparel-registry/open-apparel-registry/pull/1602)
-- Edit search label in embed config [#1604](https://github.com/open-apparel-registry/open-apparel-registry/pull/1604)
+-   Add extended field handling to facility details [#1593](https://github.com/open-apparel-registry/open-apparel-registry/pull/1593)
+-   Add searchability to embed config [#1598](https://github.com/open-apparel-registry/open-apparel-registry/pull/1598)
+-   Create parent company extended fields [#1602](https://github.com/open-apparel-registry/open-apparel-registry/pull/1602)
+-   Edit search label in embed config [#1604](https://github.com/open-apparel-registry/open-apparel-registry/pull/1604)
 
 ### Changed
 
-- Identify exact matches pre-dedupe [#1568](https://github.com/open-apparel-registry/open-apparel-registry/pull/1568)
-- Expand ExtendedField.FIELD_CHOICES [#1595](https://github.com/open-apparel-registry/open-apparel-registry/pull/1595)
+-   Identify exact matches pre-dedupe [#1568](https://github.com/open-apparel-registry/open-apparel-registry/pull/1568)
+-   Expand ExtendedField.FIELD_CHOICES [#1595](https://github.com/open-apparel-registry/open-apparel-registry/pull/1595)
 
 ### Fixed
 
-- Split clean field migration in two and handle real world data [#1571](https://github.com/open-apparel-registry/open-apparel-registry/pull/1571)
-- Fix the Percent Data by Source Type report [#1575](https://github.com/open-apparel-registry/open-apparel-registry/pull/1575)
-- Handle create=false when exact matching [#1594](https://github.com/open-apparel-registry/open-apparel-registry/pull/1594)
-- Fix ExtendedField admin [#1596](https://github.com/open-apparel-registry/open-apparel-registry/pull/1596)
-- Prevent 'clean' field error when parsing [#1600](https://github.com/open-apparel-registry/open-apparel-registry/pull/1600)
+-   Split clean field migration in two and handle real world data [#1571](https://github.com/open-apparel-registry/open-apparel-registry/pull/1571)
+-   Fix the Percent Data by Source Type report [#1575](https://github.com/open-apparel-registry/open-apparel-registry/pull/1575)
+-   Handle create=false when exact matching [#1594](https://github.com/open-apparel-registry/open-apparel-registry/pull/1594)
+-   Fix ExtendedField admin [#1596](https://github.com/open-apparel-registry/open-apparel-registry/pull/1596)
+-   Prevent 'clean' field error when parsing [#1600](https://github.com/open-apparel-registry/open-apparel-registry/pull/1600)
 
 ## [54] 2022-01-05
 
 ### Added
 
-- Update extended fields when matches are adjusted [#1544](https://github.com/open-apparel-registry/open-apparel-registry/pull/1544)
-- Allow prefer contributor name in embed [#1557](https://github.com/open-apparel-registry/open-apparel-registry/pull/1557)
-- Add new facility details sidebar [#1552](https://github.com/open-apparel-registry/open-apparel-registry/pull/1552)
+-   Update extended fields when matches are adjusted [#1544](https://github.com/open-apparel-registry/open-apparel-registry/pull/1544)
+-   Allow prefer contributor name in embed [#1557](https://github.com/open-apparel-registry/open-apparel-registry/pull/1557)
+-   Add new facility details sidebar [#1552](https://github.com/open-apparel-registry/open-apparel-registry/pull/1552)
 
 ### Fixed
 
-- Use newer version of terraform container to avoid CI error [#1566](https://github.com/open-apparel-registry/open-apparel-registry/pull/1566)
-- Add contributor fields to facility downloads [#1565](https://github.com/open-apparel-registry/open-apparel-registry/pull/1565)
-- Fix contributor id bug [#1567](https://github.com/open-apparel-registry/open-apparel-registry/pull/1567)
+-   Use newer version of terraform container to avoid CI error [#1566](https://github.com/open-apparel-registry/open-apparel-registry/pull/1566)
+-   Add contributor fields to facility downloads [#1565](https://github.com/open-apparel-registry/open-apparel-registry/pull/1565)
+-   Fix contributor id bug [#1567](https://github.com/open-apparel-registry/open-apparel-registry/pull/1567)
 
 ## [53] 2021-12-09
 
 ### Added
 
-- Create ExtendedFields [#1527](https://github.com/open-apparel-registry/open-apparel-registry/pull/1527)
-- Include ExtendedFields in Facility Details [#1530](https://github.com/open-apparel-registry/open-apparel-registry/pull/1530)
-- Add extended profile feature flag [#1542](https://github.com/open-apparel-registry/open-apparel-registry/pull/1542)
+-   Create ExtendedFields [#1527](https://github.com/open-apparel-registry/open-apparel-registry/pull/1527)
+-   Include ExtendedFields in Facility Details [#1530](https://github.com/open-apparel-registry/open-apparel-registry/pull/1530)
+-   Add extended profile feature flag [#1542](https://github.com/open-apparel-registry/open-apparel-registry/pull/1542)
 
 ### Fixed
 
-- Fix broken geocoding test [#1546](https://github.com/open-apparel-registry/open-apparel-registry/pull/1546)
-- Correctly position and size embed footer badge [#1547](https://github.com/open-apparel-registry/open-apparel-registry/pull/1547)
+-   Fix broken geocoding test [#1546](https://github.com/open-apparel-registry/open-apparel-registry/pull/1546)
+-   Correctly position and size embed footer badge [#1547](https://github.com/open-apparel-registry/open-apparel-registry/pull/1547)
 
 ## [52] 2021-11-10
 
 ### Added
 
-- Redirect to new info site [#1523](https://github.com/open-apparel-registry/open-apparel-registry/pull/1523)
+-   Redirect to new info site [#1523](https://github.com/open-apparel-registry/open-apparel-registry/pull/1523)
 
 ### Fixed
 
-- Correct info site routes [#1520](https://github.com/open-apparel-registry/open-apparel-registry/pull/1520)
+-   Correct info site routes [#1520](https://github.com/open-apparel-registry/open-apparel-registry/pull/1520)
 
 ## [51] 2021-11-04
 
 ### Added
 
-- Add ExtendedFields model [#1503](https://github.com/open-apparel-registry/open-apparel-registry/pull/1503)
+-   Add ExtendedFields model [#1503](https://github.com/open-apparel-registry/open-apparel-registry/pull/1503)
 
 ### Changed
 
-- Update copy [#1515](https://github.com/open-apparel-registry/open-apparel-registry/pull/1515)
-- Update My Lists link/copy [#1516](https://github.com/open-apparel-registry/open-apparel-registry/pull/1516)
+-   Update copy [#1515](https://github.com/open-apparel-registry/open-apparel-registry/pull/1515)
+-   Update My Lists link/copy [#1516](https://github.com/open-apparel-registry/open-apparel-registry/pull/1516)
 
 ## [50] 2021-10-28
 
 ### Fixed
 
-- Fix 'More' Links [#1505](https://github.com/open-apparel-registry/open-apparel-registry/pull/1505)
+-   Fix 'More' Links [#1505](https://github.com/open-apparel-registry/open-apparel-registry/pull/1505)
 
 ## [49] 2021-10-27
 
 ### Added
 
-- Add warning about inexact facility coordinates [#1488](https://github.com/open-apparel-registry/open-apparel-registry/pull/1488)
-- Add endpoints for info website [#1487](https://github.com/open-apparel-registry/open-apparel-registry/pull/1487)
+-   Add warning about inexact facility coordinates [#1488](https://github.com/open-apparel-registry/open-apparel-registry/pull/1488)
+-   Add endpoints for info website [#1487](https://github.com/open-apparel-registry/open-apparel-registry/pull/1487)
 
 ### Changed
 
-- Update header, footer, and font [#1495](https://github.com/open-apparel-registry/open-apparel-registry/pull/1495)
-- Provide access to info endpoints [#1499](https://github.com/open-apparel-registry/open-apparel-registry/pull/1499)
-- Update and fix links [#1502](https://github.com/open-apparel-registry/open-apparel-registry/pull/1502)
+-   Update header, footer, and font [#1495](https://github.com/open-apparel-registry/open-apparel-registry/pull/1495)
+-   Provide access to info endpoints [#1499](https://github.com/open-apparel-registry/open-apparel-registry/pull/1499)
+-   Update and fix links [#1502](https://github.com/open-apparel-registry/open-apparel-registry/pull/1502)
 
 ## [48] 2021-10-08
 
 ### Added
 
-- Add Geocoding Dashboard [#1469](https://github.com/open-apparel-registry/open-apparel-registry/pull/1469)
-- Redirect to alias for deleted facilities [#1473](https://github.com/open-apparel-registry/open-apparel-registry/pull/1473)
-- Add linkings IDs for relocated facilities [#1474](https://github.com/open-apparel-registry/open-apparel-registry/pull/1474)
-- Add script to merge identified duplicates [#1477](https://github.com/open-apparel-registry/open-apparel-registry/pull/1477)
+-   Add Geocoding Dashboard [#1469](https://github.com/open-apparel-registry/open-apparel-registry/pull/1469)
+-   Redirect to alias for deleted facilities [#1473](https://github.com/open-apparel-registry/open-apparel-registry/pull/1473)
+-   Add linkings IDs for relocated facilities [#1474](https://github.com/open-apparel-registry/open-apparel-registry/pull/1474)
+-   Add script to merge identified duplicates [#1477](https://github.com/open-apparel-registry/open-apparel-registry/pull/1477)
 
 ### Fixed
 
-- Fix delete facility endpoint [#1472](https://github.com/open-apparel-registry/open-apparel-registry/pull/1472)
-- Allow blank new_oar_ids [#1485](https://github.com/open-apparel-registry/open-apparel-registry/pull/1485)
-- Fix invalid country/address combinations [#1482](https://github.com/open-apparel-registry/open-apparel-registry/pull/1482)
+-   Fix delete facility endpoint [#1472](https://github.com/open-apparel-registry/open-apparel-registry/pull/1472)
+-   Allow blank new_oar_ids [#1485](https://github.com/open-apparel-registry/open-apparel-registry/pull/1485)
+-   Fix invalid country/address combinations [#1482](https://github.com/open-apparel-registry/open-apparel-registry/pull/1482)
 
 ### Security
 
-- Bump axios from 0.21.1 to 0.21.2 in /src/app [#1466](https://github.com/open-apparel-registry/open-apparel-registry/pull/1466)
+-   Bump axios from 0.21.1 to 0.21.2 in /src/app [#1466](https://github.com/open-apparel-registry/open-apparel-registry/pull/1466)
 
 ## [47] 2021-09-14
 
 ### Added
 
-- Allow users to transfer matches between facilities [#1464](https://github.com/open-apparel-registry/open-apparel-registry/pull/1464)
+-   Allow users to transfer matches between facilities [#1464](https://github.com/open-apparel-registry/open-apparel-registry/pull/1464)
 
 ## [46] 2021-08-17
 
 ### Added
 
-- Add custom marker colors [#1445](https://github.com/open-apparel-registry/open-apparel-registry/pull/1445)
-- Add facility indexing [#1455](https://github.com/open-apparel-registry/open-apparel-registry/pull/1455)
+-   Add custom marker colors [#1445](https://github.com/open-apparel-registry/open-apparel-registry/pull/1445)
+-   Add facility indexing [#1455](https://github.com/open-apparel-registry/open-apparel-registry/pull/1455)
 
 ### Changed
 
-- Disable scrolling in embed mode [#1437](https://github.com/open-apparel-registry/open-apparel-registry/pull/1437)
-- Update logo and copy [#1449](https://github.com/open-apparel-registry/open-apparel-registry/pull/1449)
+-   Disable scrolling in embed mode [#1437](https://github.com/open-apparel-registry/open-apparel-registry/pull/1437)
+-   Update logo and copy [#1449](https://github.com/open-apparel-registry/open-apparel-registry/pull/1449)
 
 ### Fixed
 
-- Fix mobile header [#1454](https://github.com/open-apparel-registry/open-apparel-registry/pull/1454)
+-   Fix mobile header [#1454](https://github.com/open-apparel-registry/open-apparel-registry/pull/1454)
 
 ## [45] 2021-07-21
 
 ### Added
 
-- Integrate Mailchimp signup [#1412](https://github.com/open-apparel-registry/open-apparel-registry/pull/1412)
-- Close all facilities on a list [#1429](https://github.com/open-apparel-registry/open-apparel-registry/pull/1429)
+-   Integrate Mailchimp signup [#1412](https://github.com/open-apparel-registry/open-apparel-registry/pull/1412)
+-   Close all facilities on a list [#1429](https://github.com/open-apparel-registry/open-apparel-registry/pull/1429)
 
 ### Changed
 
-- Conditionally hide remove button [#1417](https://github.com/open-apparel-registry/open-apparel-registry/pull/1417)
-- Align logout button [#1420](https://github.com/open-apparel-registry/open-apparel-registry/pull/1420)
-- Use contractual limit tracking [#1418](https://github.com/open-apparel-registry/open-apparel-registry/pull/1418)
-- Handle error when splitting match w/o location [#1424](https://github.com/open-apparel-registry/open-apparel-registry/pull/1424)
-- Make period_start_date editable [#1430](https://github.com/open-apparel-registry/open-apparel-registry/pull/1430)
+-   Conditionally hide remove button [#1417](https://github.com/open-apparel-registry/open-apparel-registry/pull/1417)
+-   Align logout button [#1420](https://github.com/open-apparel-registry/open-apparel-registry/pull/1420)
+-   Use contractual limit tracking [#1418](https://github.com/open-apparel-registry/open-apparel-registry/pull/1418)
+-   Handle error when splitting match w/o location [#1424](https://github.com/open-apparel-registry/open-apparel-registry/pull/1424)
+-   Make period_start_date editable [#1430](https://github.com/open-apparel-registry/open-apparel-registry/pull/1430)
 
 ### Fixed
 
-- Anonymize other_locations contributors [#1415](https://github.com/open-apparel-registry/open-apparel-registry/pull/1415)
-- Fix facility detail header [#1419](https://github.com/open-apparel-registry/open-apparel-registry/pull/1419)
-- Fix facility history bug [#1421](https://github.com/open-apparel-registry/open-apparel-registry/pull/1421)
-- Block users without contributors [#1426](https://github.com/open-apparel-registry/open-apparel-registry/pull/1426)
-- Extend geocoding report results [#1428](https://github.com/open-apparel-registry/open-apparel-registry/pull/1428)
+-   Anonymize other_locations contributors [#1415](https://github.com/open-apparel-registry/open-apparel-registry/pull/1415)
+-   Fix facility detail header [#1419](https://github.com/open-apparel-registry/open-apparel-registry/pull/1419)
+-   Fix facility history bug [#1421](https://github.com/open-apparel-registry/open-apparel-registry/pull/1421)
+-   Block users without contributors [#1426](https://github.com/open-apparel-registry/open-apparel-registry/pull/1426)
+-   Extend geocoding report results [#1428](https://github.com/open-apparel-registry/open-apparel-registry/pull/1428)
 
 ## [44] 2021-06-22
 
 ### Added
 
-- Add new admin reports [#1391](https://github.com/open-apparel-registry/open-apparel-registry/pull/1391)
-- Reorder contributor fields [#1398](https://github.com/open-apparel-registry/open-apparel-registry/pull/1398)
-- Add additional new admin reports [#1399](https://github.com/open-apparel-registry/open-apparel-registry/pull/1399)
-- Add cumulative versions of reports [#1405](https://github.com/open-apparel-registry/open-apparel-registry/pull/1405)
+-   Add new admin reports [#1391](https://github.com/open-apparel-registry/open-apparel-registry/pull/1391)
+-   Reorder contributor fields [#1398](https://github.com/open-apparel-registry/open-apparel-registry/pull/1398)
+-   Add additional new admin reports [#1399](https://github.com/open-apparel-registry/open-apparel-registry/pull/1399)
+-   Add cumulative versions of reports [#1405](https://github.com/open-apparel-registry/open-apparel-registry/pull/1405)
 
 ### Changed
 
-- Consolidate contributor type options [#1395](https://github.com/open-apparel-registry/open-apparel-registry/pull/1395)
+-   Consolidate contributor type options [#1395](https://github.com/open-apparel-registry/open-apparel-registry/pull/1395)
 
 ### Fixed
 
-- Correct contributor types [#1397](https://github.com/open-apparel-registry/open-apparel-registry/pull/1397)
-- Set a minimum height when using a 100% width embed [#1401](https://github.com/open-apparel-registry/open-apparel-registry/pull/1401)
+-   Correct contributor types [#1397](https://github.com/open-apparel-registry/open-apparel-registry/pull/1397)
+-   Set a minimum height when using a 100% width embed [#1401](https://github.com/open-apparel-registry/open-apparel-registry/pull/1401)
 
 ### Security
 
-- Bump ws from 6.2.1 to 6.2.2 in /src/app [#1383](https://github.com/open-apparel-registry/open-apparel-registry/pull/1383)
+-   Bump ws from 6.2.1 to 6.2.2 in /src/app [#1383](https://github.com/open-apparel-registry/open-apparel-registry/pull/1383)
 
 ## [43] - 2021-06-11
 
 ### Added
 
-- Conditionally change split operation to revert [#1386](https://github.com/open-apparel-registry/open-apparel-registry/pull/1386)
+-   Conditionally change split operation to revert [#1386](https://github.com/open-apparel-registry/open-apparel-registry/pull/1386)
 
 ### Changed
 
-- Update claim a facility [#1385](https://github.com/open-apparel-registry/open-apparel-registry/pull/1385)
+-   Update claim a facility [#1385](https://github.com/open-apparel-registry/open-apparel-registry/pull/1385)
 
 ### Fixed
 
-- Remove state flag from useUpdateLeafletMapImperatively to avoid loop [#1393](https://github.com/open-apparel-registry/open-apparel-registry/pull/1393)
-- Pass request as context to FacilitySerializer [#1396](https://github.com/open-apparel-registry/open-apparel-registry/pull/1396)
+-   Remove state flag from useUpdateLeafletMapImperatively to avoid loop [#1393](https://github.com/open-apparel-registry/open-apparel-registry/pull/1393)
+-   Pass request as context to FacilitySerializer [#1396](https://github.com/open-apparel-registry/open-apparel-registry/pull/1396)
 
 ## [42] - 2021-06-02
 
 ### Added
 
-- Download facilities list as Excel [#1293](https://github.com/open-apparel-registry/open-apparel-registry/pull/1293)
-- Add scripts/console [#1295](https://github.com/open-apparel-registry/open-apparel-registry/pull/1295)
-- Notify contributors when lists complete processing [#1290](https://github.com/open-apparel-registry/open-apparel-registry/pull/1290)
-- Add Settings Page [#1290](https://github.com/open-apparel-registry/open-apparel-registry/pull/1298)
-- Add Back Button to Facility Claims [#1307](https://github.com/open-apparel-registry/open-apparel-registry/pull/1307)
-- Add models to persist embed config [#1304](https://github.com/open-apparel-registry/open-apparel-registry/pull/1304)
-- Add API to get nonstandard fields for contributor [#1321](https://github.com/open-apparel-registry/open-apparel-registry/pull/1321)
-- Add new admin reports [#1326](https://github.com/open-apparel-registry/open-apparel-registry/pull/1326)
-- Connect embed section of settings page to API [#1329](https://github.com/open-apparel-registry/open-apparel-registry/pull/1329)
-- Show custom facility fields when in embed mode [#1341](https://github.com/open-apparel-registry/open-apparel-registry/pull/1341)
-- Add NonstandardFields model [#1340](https://github.com/open-apparel-registry/open-apparel-registry/pull/1340)
-- Enable custom styles [#1348](https://github.com/open-apparel-registry/open-apparel-registry/pull/1348)
-- Add contributor embed level field [#1349](https://github.com/open-apparel-registry/open-apparel-registry/pull/1349)
-- Add full-width embedded map support [#1352](https://github.com/open-apparel-registry/open-apparel-registry/pull/1352)
-- Embedded map settings changes [#1353](https://github.com/open-apparel-registry/open-apparel-registry/pull/1353)
-- Disable PPE search in embed mode [#1364](https://github.com/open-apparel-registry/open-apparel-registry/pull/1364)
-- Enable the default embed map custom fields by default [#1365](https://github.com/open-apparel-registry/open-apparel-registry/pull/1365)
-- Allow IFrames [#1367](https://github.com/open-apparel-registry/open-apparel-registry/pull/1367)
-- Prevent embedded map use without authorization [#1370](https://github.com/open-apparel-registry/open-apparel-registry/pull/1370)
-- Show messages when the embed config is incomplete [#1376](https://github.com/open-apparel-registry/open-apparel-registry/pull/1376)
-- Download and map changes for embed mode [#1378](https://github.com/open-apparel-registry/open-apparel-registry/pull/1378)
-- Use contributor ID rather than user ID when building embed code [#1380](https://github.com/open-apparel-registry/open-apparel-registry/pull/1380)
-- Disable claim a facility in embed mode [#1382](https://github.com/open-apparel-registry/open-apparel-registry/pull/1382)
+-   Download facilities list as Excel [#1293](https://github.com/open-apparel-registry/open-apparel-registry/pull/1293)
+-   Add scripts/console [#1295](https://github.com/open-apparel-registry/open-apparel-registry/pull/1295)
+-   Notify contributors when lists complete processing [#1290](https://github.com/open-apparel-registry/open-apparel-registry/pull/1290)
+-   Add Settings Page [#1290](https://github.com/open-apparel-registry/open-apparel-registry/pull/1298)
+-   Add Back Button to Facility Claims [#1307](https://github.com/open-apparel-registry/open-apparel-registry/pull/1307)
+-   Add models to persist embed config [#1304](https://github.com/open-apparel-registry/open-apparel-registry/pull/1304)
+-   Add API to get nonstandard fields for contributor [#1321](https://github.com/open-apparel-registry/open-apparel-registry/pull/1321)
+-   Add new admin reports [#1326](https://github.com/open-apparel-registry/open-apparel-registry/pull/1326)
+-   Connect embed section of settings page to API [#1329](https://github.com/open-apparel-registry/open-apparel-registry/pull/1329)
+-   Show custom facility fields when in embed mode [#1341](https://github.com/open-apparel-registry/open-apparel-registry/pull/1341)
+-   Add NonstandardFields model [#1340](https://github.com/open-apparel-registry/open-apparel-registry/pull/1340)
+-   Enable custom styles [#1348](https://github.com/open-apparel-registry/open-apparel-registry/pull/1348)
+-   Add contributor embed level field [#1349](https://github.com/open-apparel-registry/open-apparel-registry/pull/1349)
+-   Add full-width embedded map support [#1352](https://github.com/open-apparel-registry/open-apparel-registry/pull/1352)
+-   Embedded map settings changes [#1353](https://github.com/open-apparel-registry/open-apparel-registry/pull/1353)
+-   Disable PPE search in embed mode [#1364](https://github.com/open-apparel-registry/open-apparel-registry/pull/1364)
+-   Enable the default embed map custom fields by default [#1365](https://github.com/open-apparel-registry/open-apparel-registry/pull/1365)
+-   Allow IFrames [#1367](https://github.com/open-apparel-registry/open-apparel-registry/pull/1367)
+-   Prevent embedded map use without authorization [#1370](https://github.com/open-apparel-registry/open-apparel-registry/pull/1370)
+-   Show messages when the embed config is incomplete [#1376](https://github.com/open-apparel-registry/open-apparel-registry/pull/1376)
+-   Download and map changes for embed mode [#1378](https://github.com/open-apparel-registry/open-apparel-registry/pull/1378)
+-   Use contributor ID rather than user ID when building embed code [#1380](https://github.com/open-apparel-registry/open-apparel-registry/pull/1380)
+-   Disable claim a facility in embed mode [#1382](https://github.com/open-apparel-registry/open-apparel-registry/pull/1382)
 
 ### Changed
 
-- Remove Sample Data and Update Registration Text [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1291)
-- Update Dependencies [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1303)
-- Update facility details API [#1333](https://github.com/open-apparel-registry/open-apparel-registry/pull/1333)
-- Show footer in embed mode [#1339](https://github.com/open-apparel-registry/open-apparel-registry/pull/1339)
-- Remove "show other contributor info" embed option and hide other contributor information in embed mode [#1342](https://github.com/open-apparel-registry/open-apparel-registry/pull/1342)
-- Hide "filter by contributor type" control in embed mode [#1358](https://github.com/open-apparel-registry/open-apparel-registry/pull/1358)
+-   Remove Sample Data and Update Registration Text [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1291)
+-   Update Dependencies [#1291](https://github.com/open-apparel-registry/open-apparel-registry/pull/1303)
+-   Update facility details API [#1333](https://github.com/open-apparel-registry/open-apparel-registry/pull/1333)
+-   Show footer in embed mode [#1339](https://github.com/open-apparel-registry/open-apparel-registry/pull/1339)
+-   Remove "show other contributor info" embed option and hide other contributor information in embed mode [#1342](https://github.com/open-apparel-registry/open-apparel-registry/pull/1342)
+-   Hide "filter by contributor type" control in embed mode [#1358](https://github.com/open-apparel-registry/open-apparel-registry/pull/1358)
 
 ### Removed
 
-- Remove debug logging from has_active_block [#1296](https://github.com/open-apparel-registry/open-apparel-registry/pull/1296)
+-   Remove debug logging from has_active_block [#1296](https://github.com/open-apparel-registry/open-apparel-registry/pull/1296)
 
 ### Fixed
 
-- Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
-- Fix raw data formatting [#1343](https://github.com/open-apparel-registry/open-apparel-registry/pull/1343)
-- Update embed permission check and return a detail message when returing 403 from an embed update [#1350](https://github.com/open-apparel-registry/open-apparel-registry/pull/1350)
-- Hide translation element on embedded map [#1357](https://github.com/open-apparel-registry/open-apparel-registry/pull/1357)
-- Returned merged facilities in contributor searches [#1369](https://github.com/open-apparel-registry/open-apparel-registry/pull/1369)
+-   Adjust settings so fast refresh works in development [#1284](https://github.com/open-apparel-registry/open-apparel-registry/pull/1284)
+-   Fix raw data formatting [#1343](https://github.com/open-apparel-registry/open-apparel-registry/pull/1343)
+-   Update embed permission check and return a detail message when returing 403 from an embed update [#1350](https://github.com/open-apparel-registry/open-apparel-registry/pull/1350)
+-   Hide translation element on embedded map [#1357](https://github.com/open-apparel-registry/open-apparel-registry/pull/1357)
+-   Returned merged facilities in contributor searches [#1369](https://github.com/open-apparel-registry/open-apparel-registry/pull/1369)
 
 ### Security
 
-- Bump djangorestframework from 3.10.1 to 3.11.2 in /src/django [#1289](https://github.com/open-apparel-registry/open-apparel-registry/pull/1289)
-- Bump ssri from 6.0.1 to 6.0.2 in /src/app [#1324](https://github.com/open-apparel-registry/open-apparel-registry/pull/1324)
-- Bump dns-packet from 1.3.1 to 1.3.4 in /src/app [#1360](https://github.com/open-apparel-registry/open-apparel-registry/pull/1360)
-- Bump hosted-git-info from 2.8.8 to 2.8.9 in /src/app [#1332](https://github.com/open-apparel-registry/open-apparel-registry/pull/1332)
-- Bump lodash from 4.17.19 to 4.17.21 in /src/app [#1331](https://github.com/open-apparel-registry/open-apparel-registry/pull/1331)
+-   Bump djangorestframework from 3.10.1 to 3.11.2 in /src/django [#1289](https://github.com/open-apparel-registry/open-apparel-registry/pull/1289)
+-   Bump ssri from 6.0.1 to 6.0.2 in /src/app [#1324](https://github.com/open-apparel-registry/open-apparel-registry/pull/1324)
+-   Bump dns-packet from 1.3.1 to 1.3.4 in /src/app [#1360](https://github.com/open-apparel-registry/open-apparel-registry/pull/1360)
+-   Bump hosted-git-info from 2.8.8 to 2.8.9 in /src/app [#1332](https://github.com/open-apparel-registry/open-apparel-registry/pull/1332)
+-   Bump lodash from 4.17.19 to 4.17.21 in /src/app [#1331](https://github.com/open-apparel-registry/open-apparel-registry/pull/1331)
 
 ## [2.41.1] - 2021-04-19
 
 ### Fixed
 
-- Increase default gunicorn worker timeout [#1317](https://github.com/open-apparel-registry/open-apparel-registry/pull/1317)
+-   Increase default gunicorn worker timeout [#1317](https://github.com/open-apparel-registry/open-apparel-registry/pull/1317)
 
 ## [2.41.0] - 2021-03-12
 
 ### Added
 
-- Provide Constant Access to GDPR [#1279](https://github.com/open-apparel-registry/open-apparel-registry/pull/1279)
+-   Provide Constant Access to GDPR [#1279](https://github.com/open-apparel-registry/open-apparel-registry/pull/1279)
 
 ### Changed
 
-- Use Craco and Prettier [#1271](https://github.com/open-apparel-registry/open-apparel-registry/pull/1271)
+-   Use Craco and Prettier [#1271](https://github.com/open-apparel-registry/open-apparel-registry/pull/1271)
 
 ### Fixed
 
-- Look up contributor via token when checking API blocks [#1280](https://github.com/open-apparel-registry/open-apparel-registry/pull/1280)
+-   Look up contributor via token when checking API blocks [#1280](https://github.com/open-apparel-registry/open-apparel-registry/pull/1280)
 
 ### Security
 
-- Bump react-dev-utils from 11.0.3 to 11.0.4 in /src/app [#1281](https://github.com/open-apparel-registry/open-apparel-registry/pull/1281)
+-   Bump react-dev-utils from 11.0.3 to 11.0.4 in /src/app [#1281](https://github.com/open-apparel-registry/open-apparel-registry/pull/1281)
 
 ## [2.40.0] - 2021-03-10
 
 ### Added
 
-- Add a management command to make CSVs from a CSV download [#1214](https://github.com/open-apparel-registry/open-apparel-registry/pull/1214)
-- Add API for reporting a facility as closed or reopened [#1231](https://github.com/open-apparel-registry/open-apparel-registry/pull/1231)
-- Confirm or reject status reports [#1235](https://github.com/open-apparel-registry/open-apparel-registry/pull/1235)
-- Report Facility Status from Facility Details [#1239](https://github.com/open-apparel-registry/open-apparel-registry/pull/1239)
-- Add Report Waffle Switch [#1246](https://github.com/open-apparel-registry/open-apparel-registry/pull/1246)
-- Add Closure to CSV Download [#1249](https://github.com/open-apparel-registry/open-apparel-registry/pull/1249)
-- Manage Embed Parameter [#1257](https://github.com/open-apparel-registry/open-apparel-registry/pull/1257)
-- Send Notification of Facility Report Response [#1250](https://github.com/open-apparel-registry/open-apparel-registry/pull/1250)
-- Render Appropriately in Embed Mode [#1260](https://github.com/open-apparel-registry/open-apparel-registry/pull/1260)
-- Filter Facilities by List [#1264](https://github.com/open-apparel-registry/open-apparel-registry/pull/1264)
-- Assign facilities in Holland the NL country code [#1278](https://github.com/open-apparel-registry/open-apparel-registry/pull/1278)
+-   Add a management command to make CSVs from a CSV download [#1214](https://github.com/open-apparel-registry/open-apparel-registry/pull/1214)
+-   Add API for reporting a facility as closed or reopened [#1231](https://github.com/open-apparel-registry/open-apparel-registry/pull/1231)
+-   Confirm or reject status reports [#1235](https://github.com/open-apparel-registry/open-apparel-registry/pull/1235)
+-   Report Facility Status from Facility Details [#1239](https://github.com/open-apparel-registry/open-apparel-registry/pull/1239)
+-   Add Report Waffle Switch [#1246](https://github.com/open-apparel-registry/open-apparel-registry/pull/1246)
+-   Add Closure to CSV Download [#1249](https://github.com/open-apparel-registry/open-apparel-registry/pull/1249)
+-   Manage Embed Parameter [#1257](https://github.com/open-apparel-registry/open-apparel-registry/pull/1257)
+-   Send Notification of Facility Report Response [#1250](https://github.com/open-apparel-registry/open-apparel-registry/pull/1250)
+-   Render Appropriately in Embed Mode [#1260](https://github.com/open-apparel-registry/open-apparel-registry/pull/1260)
+-   Filter Facilities by List [#1264](https://github.com/open-apparel-registry/open-apparel-registry/pull/1264)
+-   Assign facilities in Holland the NL country code [#1278](https://github.com/open-apparel-registry/open-apparel-registry/pull/1278)
 
 ### Changed
 
-- Rename Taiwan
-  [#1234](https://github.com/open-apparel-registry/open-apparel-registry/pull/1234) [#1238](https://github.com/open-apparel-registry/open-apparel-registry/pull/1238)
-- Update ecsmanage [#1240](https://github.com/open-apparel-registry/open-apparel-registry/pull/1240)
+-   Rename Taiwan
+    [#1234](https://github.com/open-apparel-registry/open-apparel-registry/pull/1234) [#1238](https://github.com/open-apparel-registry/open-apparel-registry/pull/1238)
+-   Update ecsmanage [#1240](https://github.com/open-apparel-registry/open-apparel-registry/pull/1240)
 
 ### Fixed
 
-- Align Facility Matches [#1243](https://github.com/open-apparel-registry/open-apparel-registry/pull/1243)
-- Update Reject Button Text [#1244](https://github.com/open-apparel-registry/open-apparel-registry/pull/1244)
-- Fix vagrant provisioning failure by pinning pip python version [#1262](https://github.com/open-apparel-registry/open-apparel-registry/pull/1262)
-- Fix list filtering [#1272](https://github.com/open-apparel-registry/open-apparel-registry/pull/1272)
+-   Align Facility Matches [#1243](https://github.com/open-apparel-registry/open-apparel-registry/pull/1243)
+-   Update Reject Button Text [#1244](https://github.com/open-apparel-registry/open-apparel-registry/pull/1244)
+-   Fix vagrant provisioning failure by pinning pip python version [#1262](https://github.com/open-apparel-registry/open-apparel-registry/pull/1262)
+-   Fix list filtering [#1272](https://github.com/open-apparel-registry/open-apparel-registry/pull/1272)
 
 ### Security
 
-- Bump elliptic from 6.5.3 to 6.5.4 in /src/app [#1277](https://github.com/open-apparel-registry/open-apparel-registry/pull/1277)
+-   Bump elliptic from 6.5.3 to 6.5.4 in /src/app [#1277](https://github.com/open-apparel-registry/open-apparel-registry/pull/1277)
 
 ## [2.39.2] - 2021-02-38
 
 ### Added
 
-- Add verbose debug logging to API block checking [#1274](https://github.com/open-apparel-registry/open-apparel-registry/pull/1274)
+-   Add verbose debug logging to API block checking [#1274](https://github.com/open-apparel-registry/open-apparel-registry/pull/1274)
 
 ## [2.39.1] - 2021-02-02
 
 ### Added
 
-- Add a management command to make CSVs from a CSV download [#1214](https://github.com/open-apparel-registry/open-apparel-registry/pull/1214)
+-   Add a management command to make CSVs from a CSV download [#1214](https://github.com/open-apparel-registry/open-apparel-registry/pull/1214)
 
 ### Fixed
 
-- Only show cookie preferences for the logged in user [#1229](https://github.com/open-apparel-registry/open-apparel-registry/pull/1229)
+-   Only show cookie preferences for the logged in user [#1229](https://github.com/open-apparel-registry/open-apparel-registry/pull/1229)
 
 ## [2.39.0] - 2021-01-28
 
 ### Added
 
-- Add page to manage cookie preferences [#1213](https://github.com/open-apparel-registry/open-apparel-registry/pull/1213)
+-   Add page to manage cookie preferences [#1213](https://github.com/open-apparel-registry/open-apparel-registry/pull/1213)
 
 ## [2.38.3] - 2021-01-13
 
 ### Fixed
 
-- Change monthly to yearly in API notification emails [#1211](https://github.com/open-apparel-registry/open-apparel-registry/pull/1211)
+-   Change monthly to yearly in API notification emails [#1211](https://github.com/open-apparel-registry/open-apparel-registry/pull/1211)
 
 ## [2.38.2] - 2021-01-12
 
 ### Changed
 
-- Allow setting NOTIFICATION_EMAIL_TO from a deployment var [#1203](https://github.com/open-apparel-registry/open-apparel-registry/pull/1203)
-- Admin updates to allow filtering the source admin list by type and contributor and search users [#1207](https://github.com/open-apparel-registry/open-apparel-registry/pull/1207)
+-   Allow setting NOTIFICATION_EMAIL_TO from a deployment var [#1203](https://github.com/open-apparel-registry/open-apparel-registry/pull/1203)
+-   Admin updates to allow filtering the source admin list by type and contributor and search users [#1207](https://github.com/open-apparel-registry/open-apparel-registry/pull/1207)
 
 ### Fixed
 
-- Fix S3 permissions to allow CloudFront logging [#1208](https://github.com/open-apparel-registry/open-apparel-registry/pull/1208)
+-   Fix S3 permissions to allow CloudFront logging [#1208](https://github.com/open-apparel-registry/open-apparel-registry/pull/1208)
 
 ## [2.38.1] - 2021-01-06
 
 ### Changed
 
-- Remove ApiLimit monthly_limit and make yearly_limit non-null [#1198](https://github.com/open-apparel-registry/open-apparel-registry/pull/1198)
+-   Remove ApiLimit monthly_limit and make yearly_limit non-null [#1198](https://github.com/open-apparel-registry/open-apparel-registry/pull/1198)
 
 ## [2.38.0] - 2021-01-06
 
 ### Added
 
-- Scheduled check_api_limits invocation with Step Functions [#1193](https://github.com/open-apparel-registry/open-apparel-registry/pull/1193)
+-   Scheduled check_api_limits invocation with Step Functions [#1193](https://github.com/open-apparel-registry/open-apparel-registry/pull/1193)
 
 ### Changed
 
-- Add ApiBlock.yearly_limit to prepare for replacing monthly_limit [#1197](https://github.com/open-apparel-registry/open-apparel-registry/pull/1197)
+-   Add ApiBlock.yearly_limit to prepare for replacing monthly_limit [#1197](https://github.com/open-apparel-registry/open-apparel-registry/pull/1197)
 
 ### Security
 
-- Bump ini from 1.3.5 to 1.3.7 in /src/app [#1188](https://github.com/open-apparel-registry/open-apparel-registry/pull/1188)
-- Bump axios from 0.19.0 to 0.21.1 in /src/app [#1194](https://github.com/open-apparel-registry/open-apparel-registry/pull/1194)
+-   Bump ini from 1.3.5 to 1.3.7 in /src/app [#1188](https://github.com/open-apparel-registry/open-apparel-registry/pull/1188)
+-   Bump axios from 0.19.0 to 0.21.1 in /src/app [#1194](https://github.com/open-apparel-registry/open-apparel-registry/pull/1194)
 
 ## [2.37.1] - 2020-12-14
 
 ### Fixed
 
-- Remove leading and trailing whitespace from country when parsing [#1184](https://github.com/open-apparel-registry/open-apparel-registry/pull/1184)
-- Fix pending matches bug [#1189](https://github.com/open-apparel-registry/open-apparel-registry/pull/1189)
+-   Remove leading and trailing whitespace from country when parsing [#1184](https://github.com/open-apparel-registry/open-apparel-registry/pull/1184)
+-   Fix pending matches bug [#1189](https://github.com/open-apparel-registry/open-apparel-registry/pull/1189)
 
 ## [2.37.0] - 2020-11-24
 
 ### Added
 
-- Add ApiBlock Dashboard [#1170](https://github.com/open-apparel-registry/open-apparel-registry/pull/1170)
+-   Add ApiBlock Dashboard [#1170](https://github.com/open-apparel-registry/open-apparel-registry/pull/1170)
 
 ### Changed
 
-- Include confirm and reject urls in API response examples [#1180](https://github.com/open-apparel-registry/open-apparel-registry/pull/1180)
+-   Include confirm and reject urls in API response examples [#1180](https://github.com/open-apparel-registry/open-apparel-registry/pull/1180)
 
 ### Fixed
 
-- Update facility claims when merging [#1181](https://github.com/open-apparel-registry/open-apparel-registry/pull/1181)
+-   Update facility claims when merging [#1181](https://github.com/open-apparel-registry/open-apparel-registry/pull/1181)
 
 ## [2.36.0] - 2020-11-09
 
 ### Added
 
-- Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
-- Add an admin-only ApiBlock API [#1161](https://github.com/open-apparel-registry/open-apparel-registry/pull/1161)
-- Add RequestMeter middleware [#1166](https://github.com/open-apparel-registry/open-apparel-registry/pull/1166)
+-   Add a dissociate API [#1156](https://github.com/open-apparel-registry/open-apparel-registry/pull/1156)
+-   Add an admin-only ApiBlock API [#1161](https://github.com/open-apparel-registry/open-apparel-registry/pull/1161)
+-   Add RequestMeter middleware [#1166](https://github.com/open-apparel-registry/open-apparel-registry/pull/1166)
 
 ### Changed
 
-- Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)
-- Allow setting the contributor on a new ApiLimit [1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1159)
-- Reenable survey popup [#1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1167)
-- Update contribute page text [#1171](https://github.com/open-apparel-registry/open-apparel-registry/pull/1171)
+-   Update the development environment to use PostgreSQL 12.4 [1146](https://github.com/open-apparel-registry/open-apparel-registry/pull/1146)
+-   Allow setting the contributor on a new ApiLimit [1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1159)
+-   Reenable survey popup [#1159](https://github.com/open-apparel-registry/open-apparel-registry/pull/1167)
+-   Update contribute page text [#1171](https://github.com/open-apparel-registry/open-apparel-registry/pull/1171)
 
 ## [2.35.0] - 2020-10-21
 
 ### Added
 
-- Add ApiLimit and ApiBlock models [#1141](https://github.com/open-apparel-registry/open-apparel-registry/pull/1141)
+-   Add ApiLimit and ApiBlock models [#1141](https://github.com/open-apparel-registry/open-apparel-registry/pull/1141)
 
 ### Changed
 
-- Update `django-ecsmanage` to version 2.0.0 [1129](https://github.com/open-apparel-registry/open-apparel-registry/pull/1129)
-- Update reports to consider sources and source.create [#1142](https://github.com/open-apparel-registry/open-apparel-registry/pull/1142)
+-   Update `django-ecsmanage` to version 2.0.0 [1129](https://github.com/open-apparel-registry/open-apparel-registry/pull/1129)
+-   Update reports to consider sources and source.create [#1142](https://github.com/open-apparel-registry/open-apparel-registry/pull/1142)
 
 ## [2.34.0] - 2020-10-13
 
 ### Added
 
-- Make it possible to modify the RDS DB parameter group [#1125](https://github.com/open-apparel-registry/open-apparel-registry/pull/1125)
+-   Make it possible to modify the RDS DB parameter group [#1125](https://github.com/open-apparel-registry/open-apparel-registry/pull/1125)
 
 ### Fixed
 
-- Always return accept/reject links with potential matches [#1131](https://github.com/open-apparel-registry/open-apparel-registry/pull/1131)
+-   Always return accept/reject links with potential matches [#1131](https://github.com/open-apparel-registry/open-apparel-registry/pull/1131)
 
 ## [2.33.0] - 2020-10-07
 
@@ -841,222 +850,222 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 ### Fixed
 
-- Return distinct source names from the facility API [#1113](https://github.com/open-apparel-registry/open-apparel-registry/pull/1113)
-- Exclude contributors if all sources are create=False [#1114](https://github.com/open-apparel-registry/open-apparel-registry/pull/1114)
+-   Return distinct source names from the facility API [#1113](https://github.com/open-apparel-registry/open-apparel-registry/pull/1113)
+-   Exclude contributors if all sources are create=False [#1114](https://github.com/open-apparel-registry/open-apparel-registry/pull/1114)
 
 ## [2.31.1] - 2020-09-21
 
 ### Added
 
-- Simulate tile server throughput with k6 load test [#1103](https://github.com/open-apparel-registry/open-apparel-registry/pull/1103)
+-   Simulate tile server throughput with k6 load test [#1103](https://github.com/open-apparel-registry/open-apparel-registry/pull/1103)
 
 ### Fixed
 
-- Apply `ST_Transform()` when `hex_grid` table is created [#1109](https://github.com/open-apparel-registry/open-apparel-registry/pull/1109)
+-   Apply `ST_Transform()` when `hex_grid` table is created [#1109](https://github.com/open-apparel-registry/open-apparel-registry/pull/1109)
 
 ## [2.31.0] - 2020-09-09
 
 ### Added
 
-- Add trigram match on facility name fallback when matching via API [#1099](https://github.com/open-apparel-registry/open-apparel-registry/pull/1099)
+-   Add trigram match on facility name fallback when matching via API [#1099](https://github.com/open-apparel-registry/open-apparel-registry/pull/1099)
 
 ### Security
 
-- Bump http-proxy from 1.17.0 to 1.18.1 in /src/app [#1098](https://github.com/open-apparel-registry/open-apparel-registry/pull/1098)
+-   Bump http-proxy from 1.17.0 to 1.18.1 in /src/app [#1098](https://github.com/open-apparel-registry/open-apparel-registry/pull/1098)
 
 ## [2.30.0] - 2020-08-11
 
 ### Fixed
 
-- Rework GazetteerCache [#1076](https://github.com/open-apparel-registry/open-apparel-registry/pull/1076)
+-   Rework GazetteerCache [#1076](https://github.com/open-apparel-registry/open-apparel-registry/pull/1076)
 
 ## [2.29.0] - 2020-08-06
 
 ### Changed
 
-- Update PPE fields when deactivating sources and matches or confirming/rejecting matches [#1069](https://github.com/open-apparel-registry/open-apparel-registry/pull/1069)
+-   Update PPE fields when deactivating sources and matches or confirming/rejecting matches [#1069](https://github.com/open-apparel-registry/open-apparel-registry/pull/1069)
 
 ## [2.28.0] - 2020-07-30
 
 ### Changed
 
-- Added tooltips if table cells exceed certain lengths [#1054](https://github.com/open-apparel-registry/open-apparel-registry/pull/1054)
-- Add alternate country names [#1064](https://github.com/open-apparel-registry/open-apparel-registry/pull/1064)
-- Expand ppe_product_types and ppe_contact_phone [#1067](https://github.com/open-apparel-registry/open-apparel-registry/pull/1067)
+-   Added tooltips if table cells exceed certain lengths [#1054](https://github.com/open-apparel-registry/open-apparel-registry/pull/1054)
+-   Add alternate country names [#1064](https://github.com/open-apparel-registry/open-apparel-registry/pull/1064)
+-   Expand ppe_product_types and ppe_contact_phone [#1067](https://github.com/open-apparel-registry/open-apparel-registry/pull/1067)
 
 ### Fixed
 
-- Prevent crashing the parse job if ppe_product_types value too long [#1062](https://github.com/open-apparel-registry/open-apparel-registry/pull/1062)
+-   Prevent crashing the parse job if ppe_product_types value too long [#1062](https://github.com/open-apparel-registry/open-apparel-registry/pull/1062)
 
 ### Security
 
-- Bump lodash from 4.17.13 to 4.17.19 in /src/app [#1051](https://github.com/open-apparel-registry/open-apparel-registry/pull/1051)
-- Bump elliptic from 6.4.1 to 6.5.3 in /src/app [#1066](https://github.com/open-apparel-registry/open-apparel-registry/pull/1066)
+-   Bump lodash from 4.17.13 to 4.17.19 in /src/app [#1051](https://github.com/open-apparel-registry/open-apparel-registry/pull/1051)
+-   Bump elliptic from 6.4.1 to 6.5.3 in /src/app [#1066](https://github.com/open-apparel-registry/open-apparel-registry/pull/1066)
 
 ## [2.27.0] - 2020-07-29
 
 ### Added
 
-- Add PPE-related model fields and API support [#1037](https://github.com/open-apparel-registry/open-apparel-registry/pull/1037)
-- Show PPE fields on facility detail and include in CSV downloads [#1041](https://github.com/open-apparel-registry/open-apparel-registry/pull/1041)
-- Add PPE filter checkbox to the facility search page [#1044](https://github.com/open-apparel-registry/open-apparel-registry/pull/1044)
-- Include PPE product types in free text query [#1045](https://github.com/open-apparel-registry/open-apparel-registry/pull/1045)
-- Update PPE filter checkbox label / allow viewing RequestLog in the Django admin / log matching traceback [#1049](https://github.com/open-apparel-registry/open-apparel-registry/pull/1049)
-- Update PPE fields when matching, splitting, and merging [#1055](https://github.com/open-apparel-registry/open-apparel-registry/pull/1055)
+-   Add PPE-related model fields and API support [#1037](https://github.com/open-apparel-registry/open-apparel-registry/pull/1037)
+-   Show PPE fields on facility detail and include in CSV downloads [#1041](https://github.com/open-apparel-registry/open-apparel-registry/pull/1041)
+-   Add PPE filter checkbox to the facility search page [#1044](https://github.com/open-apparel-registry/open-apparel-registry/pull/1044)
+-   Include PPE product types in free text query [#1045](https://github.com/open-apparel-registry/open-apparel-registry/pull/1045)
+-   Update PPE filter checkbox label / allow viewing RequestLog in the Django admin / log matching traceback [#1049](https://github.com/open-apparel-registry/open-apparel-registry/pull/1049)
+-   Update PPE fields when matching, splitting, and merging [#1055](https://github.com/open-apparel-registry/open-apparel-registry/pull/1055)
 
 ### Changed
 
-- Use popovers for help text and match PPE checkbox style to contributor overlap [#1059](https://github.com/open-apparel-registry/open-apparel-registry/pull/1059)
+-   Use popovers for help text and match PPE checkbox style to contributor overlap [#1059](https://github.com/open-apparel-registry/open-apparel-registry/pull/1059)
 
 ## [2.26.1] - 2020-07-28
 
-- Log stack trace of exception raised during single item matching [95e27f2](https://github.com/open-apparel-registry/open-apparel-registry/commit/95e27f201618ad8cb6c652325eeeae6169cd4974)
+-   Log stack trace of exception raised during single item matching [95e27f2](https://github.com/open-apparel-registry/open-apparel-registry/commit/95e27f201618ad8cb6c652325eeeae6169cd4974)
 
 ## [2.26.0] - 2020-06-25
 
 ### Added
 
-- Mobile optimization for map ui [#1023](https://github.com/open-apparel-registry/open-apparel-registry/pull/1023)
-- Add country first appearance report [#1024](https://github.com/open-apparel-registry/open-apparel-registry/pull/1024)
+-   Mobile optimization for map ui [#1023](https://github.com/open-apparel-registry/open-apparel-registry/pull/1023)
+-   Add country first appearance report [#1024](https://github.com/open-apparel-registry/open-apparel-registry/pull/1024)
 
 ### Security
 
-- Bump websocket-extensions from 0.1.3 to 0.1.4 in /src/app [#1026](https://github.com/open-apparel-registry/open-apparel-registry/pull/1026)
+-   Bump websocket-extensions from 0.1.3 to 0.1.4 in /src/app [#1026](https://github.com/open-apparel-registry/open-apparel-registry/pull/1026)
 
 ## [2.25.0] - 2020-05-14
 
 ### Changed
 
-- If there are multiple high quality matches choose exact string match [#1016](https://github.com/open-apparel-registry/open-apparel-registry/pull/1016)
+-   If there are multiple high quality matches choose exact string match [#1016](https://github.com/open-apparel-registry/open-apparel-registry/pull/1016)
 
 ## [2.24.0] - 2020-04-02
 
 ### Added
 
-- Return contributor details from list API and include in CSV download [#1005](https://github.com/open-apparel-registry/open-apparel-registry/pull/1005)
+-   Return contributor details from list API and include in CSV download [#1005](https://github.com/open-apparel-registry/open-apparel-registry/pull/1005)
 
 ## [2.23.2] - 2020-03-23
 
 ### Fixed
 
-- Only count contributors with active public items for type count [#1002](https://github.com/open-apparel-registry/open-apparel-registry/pull/1002)
+-   Only count contributors with active public items for type count [#1002](https://github.com/open-apparel-registry/open-apparel-registry/pull/1002)
 
 ## [2.23.1] - 2020-03-20
 
 ### Fixed
 
-- Include contributors if they have any active facilities [#999](https://github.com/open-apparel-registry/open-apparel-registry/pull/999)
+-   Include contributors if they have any active facilities [#999](https://github.com/open-apparel-registry/open-apparel-registry/pull/999)
 
 ## [2.23.0] - 2020-03-18
 
 ### Added
 
-- Add a report that groups facility counts by country [#979](https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
-- Add confirmed matches to canonical facility list when matching [#964](https://github.com/open-apparel-registry/open-apparel-registry/pull/964)
-- Add polygonal search [#969](https://github.com/open-apparel-registry/open-apparel-registry/pull/969)
-- Add report that lists contributors with active lists
-  [#990](https://github.com/open-apparel-registry/open-apparel-registry/pull/990) [#991](https://github.com/open-apparel-registry/open-apparel-registry/pull/991)
+-   Add a report that groups facility counts by country [#979](https://github.com/open-apparel-registry/open-apparel-registry/pull/979)
+-   Add confirmed matches to canonical facility list when matching [#964](https://github.com/open-apparel-registry/open-apparel-registry/pull/964)
+-   Add polygonal search [#969](https://github.com/open-apparel-registry/open-apparel-registry/pull/969)
+-   Add report that lists contributors with active lists
+    [#990](https://github.com/open-apparel-registry/open-apparel-registry/pull/990) [#991](https://github.com/open-apparel-registry/open-apparel-registry/pull/991)
 
 ### Changed
 
-- Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)
-- Display number of contributors per type [#981](https://github.com/open-apparel-registry/open-apparel-registry/pull/981)
-- Open to search on page load; show results count in tab bar [#985](https://github.com/open-apparel-registry/open-apparel-registry/pull/985)
+-   Zoom to search [#966](https://github.com/open-apparel-registry/open-apparel-registry/pull/966)
+-   Display number of contributors per type [#981](https://github.com/open-apparel-registry/open-apparel-registry/pull/981)
+-   Open to search on page load; show results count in tab bar [#985](https://github.com/open-apparel-registry/open-apparel-registry/pull/985)
 
 ### Fixed
 
-- Ignore case for forgot-password email [#970](https://github.com/open-apparel-registry/open-apparel-registry/pull/970)
-- Update 'parent company' label to 'parent company / supplier group' [#971](https://github.com/open-apparel-registry/open-apparel-registry/pull/971)
-- Hide contributors with only errored facilities [#974](https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
-- Show automated GPS coordinates after update [#978](https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
-- Allow click through polygon after search
-- Fix contributor types when no contributors are found [#989](https://github.com/open-apparel-registry/open-apparel-registry/pull/989)
-- Prevent reload of facilities list on confirm [#993](https://github.com/open-apparel-registry/open-apparel-registry/pull/993)
+-   Ignore case for forgot-password email [#970](https://github.com/open-apparel-registry/open-apparel-registry/pull/970)
+-   Update 'parent company' label to 'parent company / supplier group' [#971](https://github.com/open-apparel-registry/open-apparel-registry/pull/971)
+-   Hide contributors with only errored facilities [#974](https://github.com/open-apparel-registry/open-apparel-registry/pull/974)
+-   Show automated GPS coordinates after update [#978](https://github.com/open-apparel-registry/open-apparel-registry/pull/978)
+-   Allow click through polygon after search
+-   Fix contributor types when no contributors are found [#989](https://github.com/open-apparel-registry/open-apparel-registry/pull/989)
+-   Prevent reload of facilities list on confirm [#993](https://github.com/open-apparel-registry/open-apparel-registry/pull/993)
 
 ### Security
 
-- Bump acorn from 5.7.3 to 5.7.4 in /src/app [#992](https://github.com/open-apparel-registry/open-apparel-registry/pull/992)
+-   Bump acorn from 5.7.3 to 5.7.4 in /src/app [#992](https://github.com/open-apparel-registry/open-apparel-registry/pull/992)
 
 ## [2.22.0] - 2020-02-20
 
 ### Changed
 
-- Use a nested query when filtering by contributor type [#954](https://github.com/open-apparel-registry/open-apparel-registry/pull/954)
+-   Use a nested query when filtering by contributor type [#954](https://github.com/open-apparel-registry/open-apparel-registry/pull/954)
 
 ## [2.21.1] - 2020-02-11
 
 ### Fixed
 
-- Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950) [#952](https://github.com/open-apparel-registry/open-apparel-registry/pull/952)
+-   Return the contributor admin ID when serializing other locations [#950](https://github.com/open-apparel-registry/open-apparel-registry/pull/950) [#952](https://github.com/open-apparel-registry/open-apparel-registry/pull/952)
 
 ## [2.21.0] - 2020-01-08
 
 ### Added
 
-- Allow groups memberships to be changed in the Django admin [#934](https://github.com/open-apparel-registry/open-apparel-registry/pull/934)
+-   Allow groups memberships to be changed in the Django admin [#934](https://github.com/open-apparel-registry/open-apparel-registry/pull/934)
 
 ### Fixed
 
-- Update reports to properly handle multiple years [#938](https://github.com/open-apparel-registry/open-apparel-registry/pull/938)
+-   Update reports to properly handle multiple years [#938](https://github.com/open-apparel-registry/open-apparel-registry/pull/938)
 
 ### Security
 
-- Bump handlebars from 4.1.2 to 4.5.3 [#932](https://github.com/open-apparel-registry/open-apparel-registry/pull/932)
+-   Bump handlebars from 4.1.2 to 4.5.3 [#932](https://github.com/open-apparel-registry/open-apparel-registry/pull/932)
 
 ## [2.20.0] - 2019-12-18
 
 ### Added
 
-- Add filter option to search for contributor overlap [#925](https://github.com/open-apparel-registry/open-apparel-registry/pull/925)
+-   Add filter option to search for contributor overlap [#925](https://github.com/open-apparel-registry/open-apparel-registry/pull/925)
 
 ### Fixed
 
-- Fix FacilityList to string and serilization with no Source [#931](https://github.com/open-apparel-registry/open-apparel-registry/pull/931)
+-   Fix FacilityList to string and serilization with no Source [#931](https://github.com/open-apparel-registry/open-apparel-registry/pull/931)
 
 ## [2.19.0] - 2019-11-20
 
 ### Changed
 
-- Move the facility match confirm/reject API to allow single-item match handling [#918](https://github.com/open-apparel-registry/open-apparel-registry/pull/918/)
+-   Move the facility match confirm/reject API to allow single-item match handling [#918](https://github.com/open-apparel-registry/open-apparel-registry/pull/918/)
 
 ### Fixed
 
-- Add a dissociate history event when list item is replaced [#919](https://github.com/open-apparel-registry/open-apparel-registry/pull/919)
+-   Add a dissociate history event when list item is replaced [#919](https://github.com/open-apparel-registry/open-apparel-registry/pull/919)
 
 ## [2.18.0] - 2019-11-12
 
 ### Changed
 
-- Train persistant Dedupe model on first app request [#905](https://github.com/open-apparel-registry/open-apparel-registry/pull/905/)
-- List inactive or private sources by contributor type [#907](https://github.com/open-apparel-registry/open-apparel-registry/pull/907)
-- Add can view full contributor detail flag/group [#910](https://github.com/open-apparel-registry/open-apparel-registry/pull/910)
-- Add downloadable XLSX contributor template [#912](https://github.com/open-apparel-registry/open-apparel-registry/pull/912)
+-   Train persistant Dedupe model on first app request [#905](https://github.com/open-apparel-registry/open-apparel-registry/pull/905/)
+-   List inactive or private sources by contributor type [#907](https://github.com/open-apparel-registry/open-apparel-registry/pull/907)
+-   Add can view full contributor detail flag/group [#910](https://github.com/open-apparel-registry/open-apparel-registry/pull/910)
+-   Add downloadable XLSX contributor template [#912](https://github.com/open-apparel-registry/open-apparel-registry/pull/912)
 
 ### Fixed
 
-- Handle EmptyResultSet error raised by tile requests [#911](https://github.com/open-apparel-registry/open-apparel-registry/pull/911)
+-   Handle EmptyResultSet error raised by tile requests [#911](https://github.com/open-apparel-registry/open-apparel-registry/pull/911)
 
 ## [2.17.0] - 2019-11-04
 
 ### Added
 
-- Add single facility submission endpoint [#896](https://github.com/open-apparel-registry/open-apparel-registry/pull/896)
+-   Add single facility submission endpoint [#896](https://github.com/open-apparel-registry/open-apparel-registry/pull/896)
 
 ### Changed
 
-- Replace facility history feature switch with feature flag [#881](https://github.com/open-apparel-registry/open-apparel-registry/pull/881)
-- Better accommodate outside contributors [#895](https://github.com/open-apparel-registry/open-apparel-registry/pull/895)
-- Allow superusers to change the Contributor of a Source [#901](https://github.com/open-apparel-registry/open-apparel-registry/pull/901)
+-   Replace facility history feature switch with feature flag [#881](https://github.com/open-apparel-registry/open-apparel-registry/pull/881)
+-   Better accommodate outside contributors [#895](https://github.com/open-apparel-registry/open-apparel-registry/pull/895)
+-   Allow superusers to change the Contributor of a Source [#901](https://github.com/open-apparel-registry/open-apparel-registry/pull/901)
 
 ### Deprecated
 
 ### Removed
 
-- Remove legacy API [#888](https://github.com/open-apparel-registry/open-apparel-registry/pull/888)
+-   Remove legacy API [#888](https://github.com/open-apparel-registry/open-apparel-registry/pull/888)
 
 ### Fixed
 
-- Handle cases when Source contributor or facility_list are None [#903](https://github.com/open-apparel-registry/open-apparel-registry/pull/903)
+-   Handle cases when Source contributor or facility_list are None [#903](https://github.com/open-apparel-registry/open-apparel-registry/pull/903)
 
 ### Security
 
@@ -1064,45 +1073,45 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 ### Changed
 
-- Implement Source model step 3 [#858](https://github.com/open-apparel-registry/open-apparel-registry/pull/858)
+-   Implement Source model step 3 [#858](https://github.com/open-apparel-registry/open-apparel-registry/pull/858)
 
 ### Fixed
 
-- Use a decimal value for opacity in App.css rather than percent [#891](https://github.com/open-apparel-registry/open-apparel-registry/pull/891)
-- Fix AWS Batch submission to use Source ID [#893](https://github.com/open-apparel-registry/open-apparel-registry/pull/893)
+-   Use a decimal value for opacity in App.css rather than percent [#891](https://github.com/open-apparel-registry/open-apparel-registry/pull/891)
+-   Fix AWS Batch submission to use Source ID [#893](https://github.com/open-apparel-registry/open-apparel-registry/pull/893)
 
 ## [2.15.0] - 2019-10-14
 
 ### Added
 
-- Implement Source model step 2 [#857](https://github.com/open-apparel-registry/open-apparel-registry/pull/857)
-- Add OAR survey dialog [#869](https://github.com/open-apparel-registry/open-apparel-registry/pull/869)
-- Add People's Republic of China as alternate country name [#876](https://github.com/open-apparel-registry/open-apparel-registry/pull/876)
+-   Implement Source model step 2 [#857](https://github.com/open-apparel-registry/open-apparel-registry/pull/857)
+-   Add OAR survey dialog [#869](https://github.com/open-apparel-registry/open-apparel-registry/pull/869)
+-   Add People's Republic of China as alternate country name [#876](https://github.com/open-apparel-registry/open-apparel-registry/pull/876)
 
 ## [2.14.0] - 2019-10-11
 
 ### Added
 
-- Add facility list items uploaded report [#865](https://github.com/open-apparel-registry/open-apparel-registry/pull/865)
-- Implement Source model [#856](https://github.com/open-apparel-registry/open-apparel-registry/pull/856)
+-   Add facility list items uploaded report [#865](https://github.com/open-apparel-registry/open-apparel-registry/pull/865)
+-   Implement Source model [#856](https://github.com/open-apparel-registry/open-apparel-registry/pull/856)
 
 ## [2.13.0] - 2019-10-07
 
 ### Added
 
-- Add facility history API endpoint [#830](https://github.com/open-apparel-registry/open-apparel-registry/pull/830)
+-   Add facility history API endpoint [#830](https://github.com/open-apparel-registry/open-apparel-registry/pull/830)
 
 ### Changed
 
-- Include match association records in facility history list [#851](https://github.com/open-apparel-registry/open-apparel-registry/pull/851)
-- Include facility claim data in facility history list [#852](https://github.com/open-apparel-registry/open-apparel-registry/pull/852)
-- Enable Waffle switches when running resetdb [#859](https://github.com/open-apparel-registry/open-apparel-registry/pull/859)
+-   Include match association records in facility history list [#851](https://github.com/open-apparel-registry/open-apparel-registry/pull/851)
+-   Include facility claim data in facility history list [#852](https://github.com/open-apparel-registry/open-apparel-registry/pull/852)
+-   Enable Waffle switches when running resetdb [#859](https://github.com/open-apparel-registry/open-apparel-registry/pull/859)
 
 ### Fixed
 
-- Check geocoded_point is not None when serializing other locations [#861](https://github.com/open-apparel-registry/open-apparel-registry/pull/861)
-- Remove duplicate entries from other locations data [#860](https://github.com/open-apparel-registry/open-apparel-registry/pull/860)
-- Fix facility history entry order [#862](https://github.com/open-apparel-registry/open-apparel-registry/pull/862)
+-   Check geocoded_point is not None when serializing other locations [#861](https://github.com/open-apparel-registry/open-apparel-registry/pull/861)
+-   Remove duplicate entries from other locations data [#860](https://github.com/open-apparel-registry/open-apparel-registry/pull/860)
+-   Fix facility history entry order [#862](https://github.com/open-apparel-registry/open-apparel-registry/pull/862)
 
 ### Security
 
@@ -1110,100 +1119,100 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 ### Added
 
-- Add update facility location dashboard page [#814](https://github.com/open-apparel-registry/open-apparel-registry/pull/814)
-- Display other locations on facility details page [#827](https://github.com/open-apparel-registry/open-apparel-registry/pull/827)
-- Add reports to count API requests and API token creation [#833](https://github.com/open-apparel-registry/open-apparel-registry/pull/833)
+-   Add update facility location dashboard page [#814](https://github.com/open-apparel-registry/open-apparel-registry/pull/814)
+-   Display other locations on facility details page [#827](https://github.com/open-apparel-registry/open-apparel-registry/pull/827)
+-   Add reports to count API requests and API token creation [#833](https://github.com/open-apparel-registry/open-apparel-registry/pull/833)
 
 ### Changed
 
-- Restyle grid layer legend & show conditionally based on zoom level [#826](https://github.com/open-apparel-registry/open-apparel-registry/pull/826)
-- Update guide tab text along with vector tile feature [#834](https://github.com/open-apparel-registry/open-apparel-registry/pull/834)
+-   Restyle grid layer legend & show conditionally based on zoom level [#826](https://github.com/open-apparel-registry/open-apparel-registry/pull/826)
+-   Update guide tab text along with vector tile feature [#834](https://github.com/open-apparel-registry/open-apparel-registry/pull/834)
 
 ### Fixed
 
-- Close Disambiguation Popup on Reset [#812](https://github.com/open-apparel-registry/open-apparel-registry/pull/812)
-- Close Disambiguation Popup on New Search [#825](https://github.com/open-apparel-registry/open-apparel-registry/pull/825)
-- Change "Accept" to "Confirm" in About/Processing [#815](https://github.com/open-apparel-registry/open-apparel-registry/pull/815)
-- Regularize vector tile map zoom behavior [#799](https://github.com/open-apparel-registry/open-apparel-registry/pull/799)
-- Fix a bug which caused the vector tile map to crash on login/logout [#837](https://github.com/open-apparel-registry/open-apparel-registry/pull/837)
-- Remove Visual Artifacts from the Vector Grid [#839](https://github.com/open-apparel-registry/open-apparel-registry/pull/839)
+-   Close Disambiguation Popup on Reset [#812](https://github.com/open-apparel-registry/open-apparel-registry/pull/812)
+-   Close Disambiguation Popup on New Search [#825](https://github.com/open-apparel-registry/open-apparel-registry/pull/825)
+-   Change "Accept" to "Confirm" in About/Processing [#815](https://github.com/open-apparel-registry/open-apparel-registry/pull/815)
+-   Regularize vector tile map zoom behavior [#799](https://github.com/open-apparel-registry/open-apparel-registry/pull/799)
+-   Fix a bug which caused the vector tile map to crash on login/logout [#837](https://github.com/open-apparel-registry/open-apparel-registry/pull/837)
+-   Remove Visual Artifacts from the Vector Grid [#839](https://github.com/open-apparel-registry/open-apparel-registry/pull/839)
 
 ## [2.11.0] - 2019-09-12
 
 ### Added
 
-- Adjust marker icon on selecting a new facility on the vector tiles layer [#749](https://github.com/open-apparel-registry/open-apparel-registry/pull/749)
-- Fetch next page of facilities while scrolling through sidebar list [#750](https://github.com/open-apparel-registry/open-apparel-registry/pull/750)
-- Enable signed-in users to download all facilities results as CSV [#752](https://github.com/open-apparel-registry/open-apparel-registry/pull/752)
-- Add disambiguation marker to work with vector tile layer [#760](https://github.com/open-apparel-registry/open-apparel-registry/pull/760)
-- Make facilities tab primary & load all facilities by default when vector tile feature is switched on [#771](https://github.com/open-apparel-registry/open-apparel-registry/pull/771)
-- Add facility grid layer [#755](https://github.com/open-apparel-registry/open-apparel-registry/pull/755)
-- Encode querystring params into tile cache key used by client to request vector tiles [#773](https://github.com/open-apparel-registry/open-apparel-registry/pull/773)
-- Cache vector tiles for a year [#776](https://github.com/open-apparel-registry/open-apparel-registry/pull/776)
+-   Adjust marker icon on selecting a new facility on the vector tiles layer [#749](https://github.com/open-apparel-registry/open-apparel-registry/pull/749)
+-   Fetch next page of facilities while scrolling through sidebar list [#750](https://github.com/open-apparel-registry/open-apparel-registry/pull/750)
+-   Enable signed-in users to download all facilities results as CSV [#752](https://github.com/open-apparel-registry/open-apparel-registry/pull/752)
+-   Add disambiguation marker to work with vector tile layer [#760](https://github.com/open-apparel-registry/open-apparel-registry/pull/760)
+-   Make facilities tab primary & load all facilities by default when vector tile feature is switched on [#771](https://github.com/open-apparel-registry/open-apparel-registry/pull/771)
+-   Add facility grid layer [#755](https://github.com/open-apparel-registry/open-apparel-registry/pull/755)
+-   Encode querystring params into tile cache key used by client to request vector tiles [#773](https://github.com/open-apparel-registry/open-apparel-registry/pull/773)
+-   Cache vector tiles for a year [#776](https://github.com/open-apparel-registry/open-apparel-registry/pull/776)
 
 ### Changed
 
-- Use PostgreSQL 10.9 in development [#751](https://github.com/open-apparel-registry/open-apparel-registry/pull/751)
-- Add open graph meta tags for social media sharing [#780](https://github.com/open-apparel-registry/open-apparel-registry/pull/780/files)
-- Restrict `/tile` Endpoint to Allowed Hosts Only [#791](https://github.com/open-apparel-registry/open-apparel-registry/pull/791)
-- Redesign facility grid layer [#797](https://github.com/open-apparel-registry/open-apparel-registry/pull/797)
-- Set minimum map zoom level to 2 [#802](https://github.com/open-apparel-registry/open-apparel-registry/pull/802)
+-   Use PostgreSQL 10.9 in development [#751](https://github.com/open-apparel-registry/open-apparel-registry/pull/751)
+-   Add open graph meta tags for social media sharing [#780](https://github.com/open-apparel-registry/open-apparel-registry/pull/780/files)
+-   Restrict `/tile` Endpoint to Allowed Hosts Only [#791](https://github.com/open-apparel-registry/open-apparel-registry/pull/791)
+-   Redesign facility grid layer [#797](https://github.com/open-apparel-registry/open-apparel-registry/pull/797)
+-   Set minimum map zoom level to 2 [#802](https://github.com/open-apparel-registry/open-apparel-registry/pull/802)
 
 ### Removed
 
-- Drop undocumented endpoint from Swagger docs [#803](https://github.com/open-apparel-registry/open-apparel-registry/pull/803)
+-   Drop undocumented endpoint from Swagger docs [#803](https://github.com/open-apparel-registry/open-apparel-registry/pull/803)
 
 ### Fixed
 
-- Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)
-- Fix a bug which prevented the vector tile marker layer from rendering [#782](https://github.com/open-apparel-registry/open-apparel-registry/pull/782)
-- Capture infinite-scroll emitted bug in an ErrorBoundary in order not to crash the map component [#777](https://github.com/open-apparel-registry/open-apparel-registry/pull/777)
-- Correct Facility Parent Company link [#772](https://github.com/open-apparel-registry/open-apparel-registry/pull/772)
-- Escape newline and double-quote characters when downloading CSVs [#809](https://github.com/open-apparel-registry/open-apparel-registry/pull/809)
+-   Fix a bug which prevented the facility claims dashboard page header from loading [#778](https://github.com/open-apparel-registry/open-apparel-registry/pull/778)
+-   Fix a bug which prevented the vector tile marker layer from rendering [#782](https://github.com/open-apparel-registry/open-apparel-registry/pull/782)
+-   Capture infinite-scroll emitted bug in an ErrorBoundary in order not to crash the map component [#777](https://github.com/open-apparel-registry/open-apparel-registry/pull/777)
+-   Correct Facility Parent Company link [#772](https://github.com/open-apparel-registry/open-apparel-registry/pull/772)
+-   Escape newline and double-quote characters when downloading CSVs [#809](https://github.com/open-apparel-registry/open-apparel-registry/pull/809)
 
 ### Security
 
-- Fix several npm security vulnerabilities via GitHub dependabot [#792](https://github.com/open-apparel-registry/open-apparel-registry/pull/792)
+-   Fix several npm security vulnerabilities via GitHub dependabot [#792](https://github.com/open-apparel-registry/open-apparel-registry/pull/792)
 
 ## [2.10.0] - 2019-08-22
 
 ### Added
 
-- Add vector tile ADR [#723](https://github.com/open-apparel-registry/open-apparel-registry/pull/723)
-- Add contributor and mailing list admin reports and the ability to download admin reports [#726](https://github.com/open-apparel-registry/open-apparel-registry/pull/726)
-- Create `/tile` endpoint to return all facilities as vector tiles, along with React components for displaying the vector tiles [#730](https://github.com/open-apparel-registry/open-apparel-registry/pull/730)
+-   Add vector tile ADR [#723](https://github.com/open-apparel-registry/open-apparel-registry/pull/723)
+-   Add contributor and mailing list admin reports and the ability to download admin reports [#726](https://github.com/open-apparel-registry/open-apparel-registry/pull/726)
+-   Create `/tile` endpoint to return all facilities as vector tiles, along with React components for displaying the vector tiles [#730](https://github.com/open-apparel-registry/open-apparel-registry/pull/730)
 
 ### Fixed
 
-- Restore django-waffle admin pages [#732](https://github.com/open-apparel-registry/open-apparel-registry/pull/732)
-- Prevent map crash by not using strict equality when comparing point coordinates [#737](https://github.com/open-apparel-registry/open-apparel-registry/pull/737)
-- Fix map marker anchor location [#745](https://github.com/open-apparel-registry/open-apparel-registry/pull/745)
+-   Restore django-waffle admin pages [#732](https://github.com/open-apparel-registry/open-apparel-registry/pull/732)
+-   Prevent map crash by not using strict equality when comparing point coordinates [#737](https://github.com/open-apparel-registry/open-apparel-registry/pull/737)
+-   Fix map marker anchor location [#745](https://github.com/open-apparel-registry/open-apparel-registry/pull/745)
 
 ## [2.9.0] - 2019-08-07
 
 ### Added
 
-- Add admin reports [#709](https://github.com/open-apparel-registry/open-apparel-registry/pull/709)
+-   Add admin reports [#709](https://github.com/open-apparel-registry/open-apparel-registry/pull/709)
 
 ### Changed
 
-- Require authentication for facility CSV downloads and log requests [#697](https://github.com/open-apparel-registry/open-apparel-registry/pull/697)
-- Wrap facility search results with react-infinite via react-infininte-any-height [#711](https://github.com/open-apparel-registry/open-apparel-registry/pull/711)
-- Replace Google Map component with a React Leaflet component using a Google basemap [#710](https://github.com/open-apparel-registry/open-apparel-registry/pull/710)
+-   Require authentication for facility CSV downloads and log requests [#697](https://github.com/open-apparel-registry/open-apparel-registry/pull/697)
+-   Wrap facility search results with react-infinite via react-infininte-any-height [#711](https://github.com/open-apparel-registry/open-apparel-registry/pull/711)
+-   Replace Google Map component with a React Leaflet component using a Google basemap [#710](https://github.com/open-apparel-registry/open-apparel-registry/pull/710)
 
 ### Fixed
 
-- Pan map on selecting a new facility only when the selected facility is off-screen [#719](https://github.com/open-apparel-registry/open-apparel-registry/pull/719)
+-   Pan map on selecting a new facility only when the selected facility is off-screen [#719](https://github.com/open-apparel-registry/open-apparel-registry/pull/719)
 
 ## [2.8.0] - 2019-07-24
 
 ### Added
 
-- Enable admins to promote matches to become the canonical facility [#695](https://github.com/open-apparel-registry/open-apparel-registry/pull/695)
+-   Enable admins to promote matches to become the canonical facility [#695](https://github.com/open-apparel-registry/open-apparel-registry/pull/695)
 
 ### Changed
 
-- Upgrade Django to 2.2, along with upgrading some related libraries [#676](https://github.com/open-apparel-registry/open-apparel-registry/pull/676)
+-   Upgrade Django to 2.2, along with upgrading some related libraries [#676](https://github.com/open-apparel-registry/open-apparel-registry/pull/676)
 
 ### Deprecated
 
@@ -1211,7 +1220,7 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 ### Fixed
 
-- Set Swagger API docs header [#694](https://github.com/open-apparel-registry/open-apparel-registry/pull/694)
+-   Set Swagger API docs header [#694](https://github.com/open-apparel-registry/open-apparel-registry/pull/694)
 
 ### Security
 
@@ -1219,78 +1228,78 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 ### Added
 
-- Enable administrators to split facility matches into new facilities [#633](https://github.com/open-apparel-registry/open-apparel-registry/pull/633)
-- Log requests made with token authentication [#646](https://github.com/open-apparel-registry/open-apparel-registry/pull/646)
-- `./scripts/resetdb` to expedite refreshing application data during development [#672](https://github.com/open-apparel-registry/open-apparel-registry/pull/672)
-- Enable searching by OAR ID from the facility search tab [#675](https://github.com/open-apparel-registry/open-apparel-registry/pull/675)
+-   Enable administrators to split facility matches into new facilities [#633](https://github.com/open-apparel-registry/open-apparel-registry/pull/633)
+-   Log requests made with token authentication [#646](https://github.com/open-apparel-registry/open-apparel-registry/pull/646)
+-   `./scripts/resetdb` to expedite refreshing application data during development [#672](https://github.com/open-apparel-registry/open-apparel-registry/pull/672)
+-   Enable searching by OAR ID from the facility search tab [#675](https://github.com/open-apparel-registry/open-apparel-registry/pull/675)
 
 ### Changed
 
-- Require a token for all API endpoints [#644](https://github.com/open-apparel-registry/open-apparel-registry/pull/644)
-- Validate claimed facility website field and show as hyperlink [#647](https://github.com/open-apparel-registry/open-apparel-registry/pull/647)
-- Update app text in claim a facility workflow [#642](https://github.com/open-apparel-registry/open-apparel-registry/pull/642)
-- Make "Dashboard" text on dashboard screens a clickable link [#667](https://github.com/open-apparel-registry/open-apparel-registry/pull/667)
-- Display RouteNotFound component for unmatched routes [#657](https://github.com/open-apparel-registry/open-apparel-registry/pull/657)
-- Add disclaimer text for claimed facility details [#670](https://github.com/open-apparel-registry/open-apparel-registry/pull/670)
-- Update claim a facility form and profile fields [#650](https://github.com/open-apparel-registry/open-apparel-registry/pull/650)
-- Add facility field changes to contributor notification emails [#649](https://github.com/open-apparel-registry/open-apparel-registry/pull/649)
-- Add affiliations and certifications fields to claimed facility profile [#671](https://github.com/open-apparel-registry/open-apparel-registry/pull/671)
-- Add product and production type to claimed facility profile [#680](https://github.com/open-apparel-registry/open-apparel-registry/pull/680)
-- Make facility description required on claim a facility form [#679](https://github.com/open-apparel-registry/open-apparel-registry/pull/679)
-- Adjust how product and production type options are set for claimed details profile form [#684](https://github.com/open-apparel-registry/open-apparel-registry/pull/684)
+-   Require a token for all API endpoints [#644](https://github.com/open-apparel-registry/open-apparel-registry/pull/644)
+-   Validate claimed facility website field and show as hyperlink [#647](https://github.com/open-apparel-registry/open-apparel-registry/pull/647)
+-   Update app text in claim a facility workflow [#642](https://github.com/open-apparel-registry/open-apparel-registry/pull/642)
+-   Make "Dashboard" text on dashboard screens a clickable link [#667](https://github.com/open-apparel-registry/open-apparel-registry/pull/667)
+-   Display RouteNotFound component for unmatched routes [#657](https://github.com/open-apparel-registry/open-apparel-registry/pull/657)
+-   Add disclaimer text for claimed facility details [#670](https://github.com/open-apparel-registry/open-apparel-registry/pull/670)
+-   Update claim a facility form and profile fields [#650](https://github.com/open-apparel-registry/open-apparel-registry/pull/650)
+-   Add facility field changes to contributor notification emails [#649](https://github.com/open-apparel-registry/open-apparel-registry/pull/649)
+-   Add affiliations and certifications fields to claimed facility profile [#671](https://github.com/open-apparel-registry/open-apparel-registry/pull/671)
+-   Add product and production type to claimed facility profile [#680](https://github.com/open-apparel-registry/open-apparel-registry/pull/680)
+-   Make facility description required on claim a facility form [#679](https://github.com/open-apparel-registry/open-apparel-registry/pull/679)
+-   Adjust how product and production type options are set for claimed details profile form [#684](https://github.com/open-apparel-registry/open-apparel-registry/pull/684)
 
 ### Fixed
 
-- Use a loop and `save` rather than `update` [#666](https://github.com/open-apparel-registry/open-apparel-registry/pull/666)
-- Allow non-signed-in users to see API docs [#690](https://github.com/open-apparel-registry/open-apparel-registry/pull/690)
+-   Use a loop and `save` rather than `update` [#666](https://github.com/open-apparel-registry/open-apparel-registry/pull/666)
+-   Allow non-signed-in users to see API docs [#690](https://github.com/open-apparel-registry/open-apparel-registry/pull/690)
 
 ## [2.6.0] - 2019-06-25
 
 ### Added
 
-- Enable submitting claim a facility form [#540](https://github.com/open-apparel-registry/open-apparel-registry/pull/540)
-- Allow contributors to be verified [#563](https://github.com/open-apparel-registry/open-apparel-registry/pull/563)
-- Add routing to enable users to view claimed facilities [#572](https://github.com/open-apparel-registry/open-apparel-registry/pull/572)
-- Add claim a facility dashboard [#559](https://github.com/open-apparel-registry/open-apparel-registry/pull/559)
-- Add profile page and update form for approved facility claims [#575](https://github.com/open-apparel-registry/open-apparel-registry/pull/575)
-- Show a list of facilities successfully claimed by the current contributor [#573](https://github.com/open-apparel-registry/open-apparel-registry/pull/573)
-- Add GitHub issue template for "draft" issues [#590](https://github.com/open-apparel-registry/open-apparel-registry/pull/590)
-- Allow superusers to view all lists [#584](https://github.com/open-apparel-registry/open-apparel-registry/pull/584)
-- AboutClaimedFacilities component & disclaimer text [#608](https://github.com/open-apparel-registry/open-apparel-registry/pull/608)
-- Add facility delete API [#616](https://github.com/open-apparel-registry/open-apparel-registry/pull/616)
-- Add UI to enable administrators to delete and merge facilities through the dashboard [#615](https://github.com/open-apparel-registry/open-apparel-registry/pull/615)
-- Enable contributors to remove individual facility list items from public display [#619](https://github.com/open-apparel-registry/open-apparel-registry/pull/619)
+-   Enable submitting claim a facility form [#540](https://github.com/open-apparel-registry/open-apparel-registry/pull/540)
+-   Allow contributors to be verified [#563](https://github.com/open-apparel-registry/open-apparel-registry/pull/563)
+-   Add routing to enable users to view claimed facilities [#572](https://github.com/open-apparel-registry/open-apparel-registry/pull/572)
+-   Add claim a facility dashboard [#559](https://github.com/open-apparel-registry/open-apparel-registry/pull/559)
+-   Add profile page and update form for approved facility claims [#575](https://github.com/open-apparel-registry/open-apparel-registry/pull/575)
+-   Show a list of facilities successfully claimed by the current contributor [#573](https://github.com/open-apparel-registry/open-apparel-registry/pull/573)
+-   Add GitHub issue template for "draft" issues [#590](https://github.com/open-apparel-registry/open-apparel-registry/pull/590)
+-   Allow superusers to view all lists [#584](https://github.com/open-apparel-registry/open-apparel-registry/pull/584)
+-   AboutClaimedFacilities component & disclaimer text [#608](https://github.com/open-apparel-registry/open-apparel-registry/pull/608)
+-   Add facility delete API [#616](https://github.com/open-apparel-registry/open-apparel-registry/pull/616)
+-   Add UI to enable administrators to delete and merge facilities through the dashboard [#615](https://github.com/open-apparel-registry/open-apparel-registry/pull/615)
+-   Enable contributors to remove individual facility list items from public display [#619](https://github.com/open-apparel-registry/open-apparel-registry/pull/619)
 
 ### Changed
 
-- Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)
-- Ensure at most one claim can be approved per facility [#585](https://github.com/open-apparel-registry/open-apparel-registry/pull/585)
-- Order facility claim notes from oldest to newest on dashboard [#596](https://github.com/open-apparel-registry/open-apparel-registry/pull/596)
-- Prevent users from submitting another claim for a facility when they have a first claim still pending [#601](https://github.com/open-apparel-registry/open-apparel-registry/pull/601)
-- Email contributors when facility claims are approved or claim profiles are updated [#611](https://github.com/open-apparel-registry/open-apparel-registry/pull/611)
-- Add `parent_company` field to facility claims [#626](https://github.com/open-apparel-registry/open-apparel-registry/pull/626)
+-   Adjust /claimed routing container [#574](https://github.com/open-apparel-registry/open-apparel-registry/pull/574)
+-   Ensure at most one claim can be approved per facility [#585](https://github.com/open-apparel-registry/open-apparel-registry/pull/585)
+-   Order facility claim notes from oldest to newest on dashboard [#596](https://github.com/open-apparel-registry/open-apparel-registry/pull/596)
+-   Prevent users from submitting another claim for a facility when they have a first claim still pending [#601](https://github.com/open-apparel-registry/open-apparel-registry/pull/601)
+-   Email contributors when facility claims are approved or claim profiles are updated [#611](https://github.com/open-apparel-registry/open-apparel-registry/pull/611)
+-   Add `parent_company` field to facility claims [#626](https://github.com/open-apparel-registry/open-apparel-registry/pull/626)
 
 ### Fixed
 
-- Miscellaneous bugfixes [#622](https://github.com/open-apparel-registry/open-apparel-registry/pull/622)
+-   Miscellaneous bugfixes [#622](https://github.com/open-apparel-registry/open-apparel-registry/pull/622)
 
 ## [2.5.0] - 2019-06-05
 
 ### Added
 
-- Add django-waffle and configure Django & React apps to enable feature flags [#531](https://github.com/open-apparel-registry/open-apparel-registry/pull/531)
-- Support uploading Excel files [#532](https://github.com/open-apparel-registry/open-apparel-registry/pull/532)
-- Fetch client country code based on IP [#541](https://github.com/open-apparel-registry/open-apparel-registry/pull/541)
-- Free text search filter for facility list items [#542](https://github.com/open-apparel-registry/open-apparel-registry/pull/542)
-- Add admin-authorized dashboard route: [#553](https://github.com/open-apparel-registry/open-apparel-registry/pull/553)
-- Enabled hot reloading during development in React app [#556](https://github.com/open-apparel-registry/open-apparel-registry/pull/556)
-- Create `/dashboard/lists` and `/dashboard/claims` routes [#557](https://github.com/open-apparel-registry/open-apparel-registry/pull/557)
+-   Add django-waffle and configure Django & React apps to enable feature flags [#531](https://github.com/open-apparel-registry/open-apparel-registry/pull/531)
+-   Support uploading Excel files [#532](https://github.com/open-apparel-registry/open-apparel-registry/pull/532)
+-   Fetch client country code based on IP [#541](https://github.com/open-apparel-registry/open-apparel-registry/pull/541)
+-   Free text search filter for facility list items [#542](https://github.com/open-apparel-registry/open-apparel-registry/pull/542)
+-   Add admin-authorized dashboard route: [#553](https://github.com/open-apparel-registry/open-apparel-registry/pull/553)
+-   Enabled hot reloading during development in React app [#556](https://github.com/open-apparel-registry/open-apparel-registry/pull/556)
+-   Create `/dashboard/lists` and `/dashboard/claims` routes [#557](https://github.com/open-apparel-registry/open-apparel-registry/pull/557)
 
 ### Changed
 
-- Show active facility list names and descriptions on profile page [#534](https://github.com/open-apparel-registry/open-apparel-registry/pull/534)
-- Conditionally make requests to Google services based on client country
-  detected by IP geolocation [#548](https://github.com/open-apparel-registry/open-apparel-registry/pull/548)
+-   Show active facility list names and descriptions on profile page [#534](https://github.com/open-apparel-registry/open-apparel-registry/pull/534)
+-   Conditionally make requests to Google services based on client country
+    detected by IP geolocation [#548](https://github.com/open-apparel-registry/open-apparel-registry/pull/548)
 
 ### Deprecated
 
@@ -1298,104 +1307,104 @@ Directly connect health check to GazetteerCache and remove the use of threading 
 
 ### Fixed
 
-- Fixed script name in release issue template [#529](https://github.com/open-apparel-registry/open-apparel-registry/pull/529)
+-   Fixed script name in release issue template [#529](https://github.com/open-apparel-registry/open-apparel-registry/pull/529)
 
 ### Security
 
-- Bumped Django REST framework to version not impacted by [WS-2019-0037](https://github.com/encode/django-rest-framework/commit/75a489150ae24c2f3c794104a8e98fa43e2c9ce9) [#536](https://github.com/open-apparel-registry/open-apparel-registry/pull/536)
-- Upgrade axios to 0.19.0 [#554](https://github.com/open-apparel-registry/open-apparel-registry/pull/554)
+-   Bumped Django REST framework to version not impacted by [WS-2019-0037](https://github.com/encode/django-rest-framework/commit/75a489150ae24c2f3c794104a8e98fa43e2c9ce9) [#536](https://github.com/open-apparel-registry/open-apparel-registry/pull/536)
+-   Upgrade axios to 0.19.0 [#554](https://github.com/open-apparel-registry/open-apparel-registry/pull/554)
 
 ## [2.4.0] - 2019-05-20
 
 ### Added
 
-- Add django-simple-history and create audit model for facilities [#521](https://github.com/open-apparel-registry/open-apparel-registry/pull/521)
-- Facility list items can be filtered by status [#507](https://github.com/open-apparel-registry/open-apparel-registry/pull/507)
-- Facility lists pages displays a count of item statuses [#511](https://github.com/open-apparel-registry/open-apparel-registry/pull/511)
-- Retry failed batch jobs up to 3 times and report job failures to Rollbar [#512](https://github.com/open-apparel-registry/open-apparel-registry/pull/512/)
+-   Add django-simple-history and create audit model for facilities [#521](https://github.com/open-apparel-registry/open-apparel-registry/pull/521)
+-   Facility list items can be filtered by status [#507](https://github.com/open-apparel-registry/open-apparel-registry/pull/507)
+-   Facility lists pages displays a count of item statuses [#511](https://github.com/open-apparel-registry/open-apparel-registry/pull/511)
+-   Retry failed batch jobs up to 3 times and report job failures to Rollbar [#512](https://github.com/open-apparel-registry/open-apparel-registry/pull/512/)
 
 ### Changed
 
-- Set maximum page size for Facilities list API endpoint to 500 facilities per request. [#509](https://github.com/open-apparel-registry/open-apparel-registry/pull/509)
-- Upgraded React to 16.8.6 [#511](https://github.com/open-apparel-registry/open-apparel-registry/pull/511)
-- Changed the name of country code MK to North Macedonia [#525](https://github.com/open-apparel-registry/open-apparel-registry/pull/525)
+-   Set maximum page size for Facilities list API endpoint to 500 facilities per request. [#509](https://github.com/open-apparel-registry/open-apparel-registry/pull/509)
+-   Upgraded React to 16.8.6 [#511](https://github.com/open-apparel-registry/open-apparel-registry/pull/511)
+-   Changed the name of country code MK to North Macedonia [#525](https://github.com/open-apparel-registry/open-apparel-registry/pull/525)
 
 ### Fixed
 
-- Made some fields read only in the Django admin to prevent slow page loads resulting in service interruptions. [#527](https://github.com/open-apparel-registry/open-apparel-registry/pull/527)
+-   Made some fields read only in the Django admin to prevent slow page loads resulting in service interruptions. [#527](https://github.com/open-apparel-registry/open-apparel-registry/pull/527)
 
 ## [2.3.0] - 2019-05-08
 
 ### Changed
 
-- Change facility list CSV download to request one page at a time [#496](https://github.com/open-apparel-registry/open-apparel-registry/pull/496)
-- Handle CSV files that include a byte order mark [#498](https://github.com/open-apparel-registry/open-apparel-registry/pull/498)
+-   Change facility list CSV download to request one page at a time [#496](https://github.com/open-apparel-registry/open-apparel-registry/pull/496)
+-   Handle CSV files that include a byte order mark [#498](https://github.com/open-apparel-registry/open-apparel-registry/pull/498)
 
 ## [2.2.0] - 2019-04-11
 
 ### Added
 
-- Password can be changed from the profile page [#469](https://github.com/open-apparel-registry/open-apparel-registry/pull/469)
+-   Password can be changed from the profile page [#469](https://github.com/open-apparel-registry/open-apparel-registry/pull/469)
 
 ### Changed
 
-- Update release checklist to keep default commit messages [#451](https://github.com/open-apparel-registry/open-apparel-registry/pull/451)
-- Add support for encrypted RDS for PostgreSQL storage [#461](https://github.com/open-apparel-registry/open-apparel-registry/pull/461)
-- Update the text on the home page "Guide" tab [#468](https://github.com/open-apparel-registry/open-apparel-registry/pull/468)
+-   Update release checklist to keep default commit messages [#451](https://github.com/open-apparel-registry/open-apparel-registry/pull/451)
+-   Add support for encrypted RDS for PostgreSQL storage [#461](https://github.com/open-apparel-registry/open-apparel-registry/pull/461)
+-   Update the text on the home page "Guide" tab [#468](https://github.com/open-apparel-registry/open-apparel-registry/pull/468)
 
 ### Fixed
 
-- Add a new error boundary to enable the FacilitiesMap component to crash without crashing the rest of the app [#446](https://github.com/open-apparel-registry/open-apparel-registry/pull/446)
-- Revise geocoding unit test to be more robust [#466](https://github.com/open-apparel-registry/open-apparel-registry/pull/466)
-- Remove duplicate values from the contributors API [#453](https://github.com/open-apparel-registry/open-apparel-registry/pull/453)
+-   Add a new error boundary to enable the FacilitiesMap component to crash without crashing the rest of the app [#446](https://github.com/open-apparel-registry/open-apparel-registry/pull/446)
+-   Revise geocoding unit test to be more robust [#466](https://github.com/open-apparel-registry/open-apparel-registry/pull/466)
+-   Remove duplicate values from the contributors API [#453](https://github.com/open-apparel-registry/open-apparel-registry/pull/453)
 
 ## [2.1.0] - 2019-04-01
 
 ### Added
 
-- Add `reprocess_geocode_failures` management command [#439](https://github.com/open-apparel-registry/open-apparel-registry/pull/439)
+-   Add `reprocess_geocode_failures` management command [#439](https://github.com/open-apparel-registry/open-apparel-registry/pull/439)
 
 ### Changed
 
-- Add protocol to contributor website if mising [#445](https://github.com/open-apparel-registry/open-apparel-registry/pull/445)
-- Rename "Account Name" and "Account Description" registration form fields to "Contributor Name" and "Account Description" [#444](https://github.com/open-apparel-registry/open-apparel-registry/pull/444)
-- Filter contributors with no active and public lists from contributors search dropdown [#430](https://github.com/open-apparel-registry/open-apparel-registry/pull/430)
-- Remove `"(beta)"` from page title [#418](https://github.com/open-apparel-registry/open-apparel-registry/pull/418)
+-   Add protocol to contributor website if mising [#445](https://github.com/open-apparel-registry/open-apparel-registry/pull/445)
+-   Rename "Account Name" and "Account Description" registration form fields to "Contributor Name" and "Account Description" [#444](https://github.com/open-apparel-registry/open-apparel-registry/pull/444)
+-   Filter contributors with no active and public lists from contributors search dropdown [#430](https://github.com/open-apparel-registry/open-apparel-registry/pull/430)
+-   Remove `"(beta)"` from page title [#418](https://github.com/open-apparel-registry/open-apparel-registry/pull/418)
 
 ### Fixed
 
-- Set ERROR_MATCHING status to non-geocoded list items for which all potential matches have been rejected [#437](https://github.com/open-apparel-registry/open-apparel-registry/pull/437)
-- Return 400/Bad Request error for /api/facilities request with invalid contributor parameter type. [#433](https://github.com/open-apparel-registry/open-apparel-registry/pull/433)
-- Avoid unhandled exception when matching a list with no geocoded items [#439](https://github.com/open-apparel-registry/open-apparel-registry/pull/439)
+-   Set ERROR_MATCHING status to non-geocoded list items for which all potential matches have been rejected [#437](https://github.com/open-apparel-registry/open-apparel-registry/pull/437)
+-   Return 400/Bad Request error for /api/facilities request with invalid contributor parameter type. [#433](https://github.com/open-apparel-registry/open-apparel-registry/pull/433)
+-   Avoid unhandled exception when matching a list with no geocoded items [#439](https://github.com/open-apparel-registry/open-apparel-registry/pull/439)
 
 ## [2.0.0] - 2019-03-27
 
 ### Added
 
-- Google Analytics which activates only upon user's explicit consent [#409](https://github.com/open-apparel-registry/open-apparel-registry/pull/409)
+-   Google Analytics which activates only upon user's explicit consent [#409](https://github.com/open-apparel-registry/open-apparel-registry/pull/409)
 
 ## [0.2.0] - 2019-03-27
 
 ### Added
 
-- Summary status for facility lists [#378](https://github.com/open-apparel-registry/open-apparel-registry/pull/378)
-- Environment variables for Google Analytics [#395](https://github.com/open-apparel-registry/open-apparel-registry/pull/395)
+-   Summary status for facility lists [#378](https://github.com/open-apparel-registry/open-apparel-registry/pull/378)
+-   Environment variables for Google Analytics [#395](https://github.com/open-apparel-registry/open-apparel-registry/pull/395)
 
 ### Changed
 
-- Do not show facilities from inactive lists when searching [#401](https://github.com/open-apparel-registry/open-apparel-registry/pull/401)
-- Redirect to facility list upon successful upload [#404](https://github.com/open-apparel-registry/open-apparel-registry/pull/404)
-- Better support for wide and narrow browser widths [#392](https://github.com/open-apparel-registry/open-apparel-registry/pull/392)
+-   Do not show facilities from inactive lists when searching [#401](https://github.com/open-apparel-registry/open-apparel-registry/pull/401)
+-   Redirect to facility list upon successful upload [#404](https://github.com/open-apparel-registry/open-apparel-registry/pull/404)
+-   Better support for wide and narrow browser widths [#392](https://github.com/open-apparel-registry/open-apparel-registry/pull/392)
 
 ### Fixed
 
-- Handle geocodes with unescaped `#` character [#402](https://github.com/open-apparel-registry/open-apparel-registry/pull/402)
+-   Handle geocodes with unescaped `#` character [#402](https://github.com/open-apparel-registry/open-apparel-registry/pull/402)
 
 ## [0.1.0] - 2019-03-26
 
 ### Added
 
-- Initial release.
+-   Initial release.
 
 [unreleased]: https://github.com/open-apparel-registry/open-apparel-registry/compare/79-OSHUB...HEAD
 [79-oshub]: https://github.com/open-apparel-registry/open-apparel-registry/releases/tag/79-OSHUB

--- a/src/django/api/csv_download.py
+++ b/src/django/api/csv_download.py
@@ -41,15 +41,7 @@ def get_download_claim_contribution(claim, user_can_see_detail):
     return contribution
 
 
-def format_download_extended_fields(fields):
-    extended_fields = [
-        '',
-        '',
-        '',
-        '',
-        '',
-        '',
-    ]
+def format_download_extended_fields(fields, extended_fields):
     for field in fields:
         field_name = field.get('field_name', None)
         value = field.get('value', None)
@@ -58,34 +50,39 @@ def format_download_extended_fields(fields):
         if field_name == ExtendedField.NUMBER_OF_WORKERS:
             min = value.get('min', 0)
             max = value.get('max', 0)
-            extended_fields[0] = str(max) if max == min \
+            result = str(max) if max == min \
                 else "{}-{}".format(min, max)
+            extended_fields[0].append(result)
         elif field_name == ExtendedField.PARENT_COMPANY:
             contributor_name = value.get('contributor_name', None)
             name = value.get('name', None)
-            extended_fields[1] = contributor_name \
+            result = contributor_name \
                 if contributor_name is not None else name
+            extended_fields[1].append(result)
         elif field_name == ExtendedField.FACILITY_TYPE:
             raw_values = value.get('raw_values', [])
-            extended_fields[2] = combine_raw_values(
-                raw_values, extended_fields[2])
+            result = combine_raw_values(raw_values, extended_fields[2])
+            extended_fields[2].extend(result)
 
             matched_values = value.get('matched_values', [])
-            extended_fields[3] = "|".join([m_value[2]
-                                          for m_value in matched_values
-                                          if m_value[2] is not None])
+            result = [m_value[2]
+                      for m_value in matched_values
+                      if m_value[2] is not None]
+            extended_fields[3].extend(result)
         elif field_name == ExtendedField.PROCESSING_TYPE:
             raw_values = value.get('raw_values', [])
-            extended_fields[2] = combine_raw_values(
-                raw_values, extended_fields[2])
+            result = combine_raw_values(raw_values, extended_fields[2])
+            extended_fields[2].extend(result)
 
             matched_values = value.get('matched_values', [])
-            extended_fields[4] = "|".join([m_value[3]
-                                          for m_value in matched_values
-                                          if m_value[3] is not None])
+            result = [m_value[3]
+                      for m_value in matched_values
+                      if m_value[3] is not None]
+            extended_fields[4].extend(result)
         elif field_name == ExtendedField.PRODUCT_TYPE:
             raw_values = value.get('raw_values', [])
-            extended_fields[5] = "|".join(value_to_set(raw_values))
+            result = value_to_set(raw_values)
+            extended_fields[5].extend(result)
 
     return extended_fields
 
@@ -100,5 +97,4 @@ def combine_raw_values(new_values, old_values):
     old_set = set()
     if len(old_values) != 0:
         old_set = value_to_set(old_values)
-    return "|".join(
-        value_to_set(new_values).union(old_set))
+    return value_to_set(new_values).union(old_set)

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -857,26 +857,25 @@ class FacilityDownloadSerializer(Serializer):
         if is_embed_mode:
             contributor_fields = self.get_contributor_fields()
 
-        def add_non_base_fields(row, list_item, match_is_active):
-            row.append('|'.join(list_item.sector))
+        sectors = []
+        contributions_arr = []
+        contributor_fields_array = []
+        extended_fields = [[], [], [], [], [], []]
+
+        def add_non_base_fields(list_item, match_is_active):
+            contribution = None
             if not is_embed_mode:
                 contribution = get_download_contribution(
                     list_item.source, match_is_active, user_can_see_detail)
-                row.append(contribution)
-            else:
-                contributor_field_values = assign_contributor_field_values(
-                    list_item, contributor_fields)
-                row.extend([f['value'] if f['value'] is not None else ''
-                            for f in contributor_field_values])
+                contributions_arr.append(contribution)
 
-            extended_fields = ExtendedField.objects.filter(
+            format_download_extended_fields(ExtendedField.objects.filter(
                 facility_list_item=list_item
-            ).values('value', 'field_name')
-            row.extend(format_download_extended_fields(extended_fields))
+            ).values('value', 'field_name'),
+                extended_fields)
 
-            return row
-
-        rows = []
+            if list_item.sector is not None:
+                sectors.extend(list_item.sector)
 
         base_row = [
             facility.id,
@@ -920,33 +919,37 @@ class FacilityDownloadSerializer(Serializer):
             and int(contributor_id) == claim.contributor.id)
 
         if (claim and not is_embed_mode) or claimed_by_embed_contributor:
-            sector = claim.sector if claim.sector is not None \
-                else base_list_item.sector
-            base_row.append('|'.join(sector))
-
+            contribution = None
             if not is_embed_mode:
                 contribution = get_download_claim_contribution(
                     claim, user_can_see_detail)
-                base_row.append(contribution)
+                contributions_arr.append(contribution)
             else:
                 contributor_field_values = assign_contributor_field_values(
                     base_list_item, contributor_fields)
-                base_row.extend([f['value'] if f['value'] is not None else ''
-                                 for f in contributor_field_values])
+                contributor_fields_array = [
+                    f['value'] if f['value'] is not None else ''
+                    for f in contributor_field_values]
 
-            extended_fields = ExtendedField.objects.filter(
-                facility_claim=claim).values('value', 'field_name')
-            base_row.extend(format_download_extended_fields(extended_fields))
+            format_download_extended_fields(
+                ExtendedField.objects.filter(
+                    facility_claim=claim).values('value', 'field_name'),
+                extended_fields)
+
+            sector = claim.sector if claim.sector is not None \
+                else base_list_item.sector
+            sectors.extend(sector)
         else:
             match_is_active = facility_matches.filter(
                 facility_list_item=base_list_item,
                 is_active=True).exists()
-            base_row = add_non_base_fields(
-                base_row, base_list_item, match_is_active)
-
-        base_row.append(facility.is_closed if facility.is_closed else 'False')
-
-        rows.append(base_row)
+            if is_embed_mode:
+                contributor_field_values = assign_contributor_field_values(
+                    base_list_item, contributor_fields)
+                contributor_fields_array = [
+                    f['value'] if f['value'] is not None else ''
+                    for f in contributor_field_values]
+            add_non_base_fields(base_list_item, match_is_active)
 
         if not is_embed_mode:
             for facility_match in facility_matches:
@@ -955,17 +958,19 @@ class FacilityDownloadSerializer(Serializer):
                 if claim is None and facility.created_from_id == list_item.id:
                     continue
 
-                row = [facility.id,
-                       format_download_date(list_item.source.created_at),
-                       '', '', '', '', '', '']
-                row = add_non_base_fields(row, list_item,
-                                          facility_match.is_active)
-                # Add a blank slot for closure status
-                row.append('')
+                add_non_base_fields(list_item, facility_match.is_active)
 
-                rows.append(row)
+        base_row.append('|'.join(set(sectors)))
+        if not is_embed_mode:
+            valid_contributors = [
+                c for c in contributions_arr if c]
+            base_row.append('|'.join(valid_contributors))
+        else:
+            base_row.extend(contributor_fields_array)
+        base_row.extend(['|'.join(set(efs)) for efs in extended_fields])
+        base_row.append(facility.is_closed if facility.is_closed else 'False')
 
-        return rows
+        return [base_row]
 
     def get_contributor_fields(self):
         request = self.context.get('request') \
@@ -1310,7 +1315,7 @@ class FacilityDetailsSerializer(FacilitySerializer):
         user_can_see_detail = can_user_see_detail(self)
         list_item = facility.created_from
         matches = facility.facilitymatch_set \
-                          .filter(facility_list_item=list_item)
+            .filter(facility_list_item=list_item)
         should_display_associations = \
             any([m.should_display_association for m in matches])
         display_detail = user_can_see_detail and should_display_associations \
@@ -1903,8 +1908,8 @@ class ExtendedFieldListSerializer(ModelSerializer):
         if list_item_id is not None:
             matches = FacilityMatch.objects.filter(
                 facility_list_item_id=list_item_id)
-            should_display_association = \
-                any([m.should_display_association for m in matches])
+            should_display_association = any(
+                [m.should_display_association for m in matches])
 
         return should_display_association and user_can_see_detail
 
@@ -1926,10 +1931,10 @@ class ExtendedFieldListSerializer(ModelSerializer):
         from_claim = Q(facility_list_item=None)
         from_active_list = Q(facility_list_item__source__is_active=True)
         vals = ExtendedField.objects.filter(facility=instance.facility) \
-                                    .filter(field_name=instance.field_name) \
-                                    .filter(value=instance.value) \
-                                    .filter(from_claim | from_active_list) \
-                                    .count()
+            .filter(field_name=instance.field_name) \
+            .filter(value=instance.value) \
+            .filter(from_claim | from_active_list) \
+            .count()
         return vals
 
     def get_is_from_claim(self, instance):

--- a/src/django/api/serializers.py
+++ b/src/django/api/serializers.py
@@ -125,6 +125,7 @@ def prefer_contributor_name(serializer):
 
 class PipeSeparatedField(ListField):
     """Accepts either a list or a pipe-delimited string as input"""
+
     def to_internal_value(self, data):
         if isinstance(data, str):
             data = data.split('|')
@@ -734,10 +735,10 @@ class FacilitySerializer(GeoFeatureModelSerializer):
             return fields
 
         list_item = FacilityListItem.objects.filter(
-                facility=facility,
-                source__contributor=contributor,
-                source__is_active=True,
-                facilitymatch__is_active=True).order_by('-created_at').first()
+            facility=facility,
+            source__contributor=contributor,
+            source__is_active=True,
+            facilitymatch__is_active=True).order_by('-created_at').first()
 
         return assign_contributor_field_values(list_item, fields)
 
@@ -769,11 +770,11 @@ class FacilitySerializer(GeoFeatureModelSerializer):
 
         for field_name, _ in ExtendedField.FIELD_CHOICES:
             serializer = ExtendedFieldListSerializer(
-                        fields.filter(field_name=field_name),
-                        many=True,
-                        context={'user_can_see_detail': user_can_see_detail,
-                                 'embed_mode_active': embed_mode_active}
-                    )
+                fields.filter(field_name=field_name),
+                many=True,
+                context={'user_can_see_detail': user_can_see_detail,
+                         'embed_mode_active': embed_mode_active}
+            )
 
             if field_name == ExtendedField.NAME and not embed_mode_active:
                 unsorted_data = serializer.data
@@ -998,12 +999,12 @@ def assign_contributor_field_values(list_item, fields):
 
     if list_item.source.source_type == 'SINGLE':
         contributor_fields = get_single_contributor_field_values(
-                                list_item, contributor_fields
-                            )
+            list_item, contributor_fields
+        )
     else:
         contributor_fields = get_list_contributor_field_values(
-                                list_item, contributor_fields
-                             )
+            list_item, contributor_fields
+        )
 
     return [
         {
@@ -1043,12 +1044,12 @@ def get_contributor_id(contributor, user_can_see_detail):
 
 def create_name_field(name, contributor, updated_at, user_can_see_detail):
     return {
-      'value': name,
-      'field_name': ExtendedField.NAME,
-      'contributor_id': get_contributor_id(contributor, user_can_see_detail),
-      'contributor_name':
-      get_contributor_name(contributor, user_can_see_detail),
-      'updated_at': updated_at,
+        'value': name,
+        'field_name': ExtendedField.NAME,
+        'contributor_id': get_contributor_id(contributor, user_can_see_detail),
+        'contributor_name':
+        get_contributor_name(contributor, user_can_see_detail),
+        'updated_at': updated_at,
     }
 
 
@@ -1074,13 +1075,13 @@ def get_facility_names(facility):
 def create_address_field(address, contributor, updated_at,
                          user_can_see_detail, is_from_claim=False):
     return {
-      'value': address,
-      'field_name': ExtendedField.ADDRESS,
-      'contributor_id': get_contributor_id(contributor, user_can_see_detail),
-      'contributor_name':
-      get_contributor_name(contributor, user_can_see_detail),
-      'updated_at': updated_at,
-      'is_from_claim': is_from_claim,
+        'value': address,
+        'field_name': ExtendedField.ADDRESS,
+        'contributor_id': get_contributor_id(contributor, user_can_see_detail),
+        'contributor_name':
+        get_contributor_name(contributor, user_can_see_detail),
+        'updated_at': updated_at,
+        'is_from_claim': is_from_claim,
     }
 
 
@@ -1298,10 +1299,10 @@ class FacilityDetailsSerializer(FacilitySerializer):
                     embed_config=config, visible=True).order_by('order')
 
         list_item = FacilityListItem.objects.filter(
-                facility=facility,
-                source__contributor=contributor,
-                source__is_active=True,
-                facilitymatch__is_active=True).order_by('-created_at').first()
+            facility=facility,
+            source__contributor=contributor,
+            source__is_active=True,
+            facilitymatch__is_active=True).order_by('-created_at').first()
 
         return assign_contributor_field_values(list_item, fields)
 
@@ -1868,14 +1869,14 @@ class EmbedConfigSerializer(ModelSerializer):
 
     def get_embed_fields(self, instance):
         embed_fields = EmbedField.objects.filter(
-                            embed_config=instance).order_by('order')
+            embed_config=instance).order_by('order')
         return EmbedFieldsSerializer(embed_fields, many=True).data
 
     def get_extended_fields(self, instance):
         try:
             extended_fields = ExtendedField.objects \
-                        .filter(contributor_id=instance.contributor.id) \
-                        .values_list('field_name', flat=True).distinct()
+                .filter(contributor_id=instance.contributor.id) \
+                .values_list('field_name', flat=True).distinct()
             return extended_fields
         except Contributor.DoesNotExist:
             return []

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -783,7 +783,7 @@ geocoding_data = {'results': [{'address_components': [
     {'long_name': 'United States', 'short_name': 'US',
      'types': ['country', 'political']},
     {'long_name': '19123', 'short_name': '19123', 'types': ['postal_code']}
-    ],
+],
     'formatted_address': '990 Spring Garden St, Philadelphia, PA 19123, USA',
     'geometry': {'bounds': {
         'northeast': {'lat': 39.9614743, 'lng': -75.15379639999999},
@@ -798,139 +798,141 @@ geocoding_data = {'results': [{'address_components': [
     'status': 'OK'}
 
 geocoding_data_no_country = {
-   "results": [
-      {
-         "address_components": [
-            {
-               "long_name": "4WHM+QCX",
-               "short_name": "4WHM+QCX",
-               "types": ["plus_code"]
+    "results": [
+        {
+            "address_components": [
+                {
+                    "long_name": "4WHM+QCX",
+                    "short_name": "4WHM+QCX",
+                    "types": ["plus_code"]
+                },
+                {
+                    "long_name": "Famagusta",
+                    "short_name": "Famagusta",
+                    "types": ["locality", "political"]
+                },
+                {
+                    "long_name": "99450",
+                    "short_name": "99450",
+                    "types": ["postal_code"]
+                }
+            ],
+            "formatted_address": "4WHM+QCX, Famagusta 99450",
+            "geometry": {
+                "location": {"lat": 35.1294866, "lng": 33.9336133},
+                "location_type": "GEOMETRIC_CENTER",
+                "viewport": {
+                    "northeast": {
+                        "lat": 35.1308355802915,
+                        "lng": 33.9349622802915
+                    },
+                    "southwest": {
+                        "lat": 35.1281376197085,
+                        "lng": 33.9322643197085
+                    }
+                }
             },
-            {
-               "long_name": "Famagusta",
-               "short_name": "Famagusta",
-               "types": ["locality", "political"]
-            },
-            {
-               "long_name": "99450",
-               "short_name": "99450",
-               "types": ["postal_code"]
-            }
-         ],
-         "formatted_address": "4WHM+QCX, Famagusta 99450",
-         "geometry": {
-            "location": {"lat": 35.1294866, "lng": 33.9336133},
-            "location_type": "GEOMETRIC_CENTER",
-            "viewport": {
-               "northeast": {
-                  "lat": 35.1308355802915,
-                  "lng": 33.9349622802915
-               },
-               "southwest": {
-                  "lat": 35.1281376197085,
-                  "lng": 33.9322643197085
-               }
-            }
-         },
-         "partial_match": True,
-         "place_id": "ChIJDzTqezLI3xQRW5kjGEGLRzA",
-         "types": ["establishment", "point_of_interest"]
-      }
-   ],
-   "status": "OK"
+            "partial_match": True,
+            "place_id": "ChIJDzTqezLI3xQRW5kjGEGLRzA",
+            "types": ["establishment", "point_of_interest"]
+        }
+    ],
+    "status": "OK"
 }
 
 geocoding_data_second_country = {
-   "results": [
-      {
-         "address_components": [
-            {
-               "long_name": "Noor Bagh",
-               "short_name": "Noor Bagh",
-               "types": ["political", "sublocality", "sublocality_level_1"]
+    "results": [
+        {
+            "address_components": [
+                {
+                    "long_name": "Noor Bagh",
+                    "short_name": "Noor Bagh",
+                    "types": ["political",
+                              "sublocality",
+                              "sublocality_level_1"]
+                },
+                {
+                    "long_name": "Srinagar",
+                    "short_name": "Srinagar",
+                    "types": ["locality", "political"]
+                },
+                {
+                    "long_name": "190009",
+                    "short_name": "190009",
+                    "types": ["postal_code"]
+                }
+            ],
+            "formatted_address": "Noor Bagh, Srinagar 190009",
+            "geometry": {
+                "bounds": {
+                    "northeast": {"lat": 34.07490560000001, "lng": 74.8043599},
+                    "southwest": {"lat": 34.0734423, "lng": 74.8023449}
+                },
+                "location": {"lat": 34.0742387, "lng": 74.8035549},
+                "location_type": "APPROXIMATE",
+                "viewport": {
+                    "northeast": {
+                        "lat": 34.07552293029151,
+                        "lng": 74.8047013802915
+                    },
+                    "southwest": {
+                        "lat": 34.07282496970851,
+                        "lng": 74.80200341970848
+                    }
+                }
             },
-            {
-               "long_name": "Srinagar",
-               "short_name": "Srinagar",
-               "types": ["locality", "political"]
+            "partial_match": True,
+            "place_id": "ChIJmQlkN-2P4TgR6u3glWeOMTE",
+            "types": ["political", "sublocality", "sublocality_level_1"]
+        },
+        {
+            "address_components": [
+                {
+                    "long_name": "Kaliakair",
+                    "short_name": "Kaliakair",
+                    "types": ["locality", "political"]
+                },
+                {
+                    "long_name": "Gazipur District",
+                    "short_name": "Gazipur District",
+                    "types": ["administrative_area_level_2", "political"]
+                },
+                {
+                    "long_name": "Dhaka Division",
+                    "short_name": "Dhaka Division",
+                    "types": ["administrative_area_level_1", "political"]
+                },
+                {
+                    "long_name": "Bangladesh",
+                    "short_name": "BD",
+                    "types": ["country", "political"]
+                }
+            ],
+            "formatted_address": "Kaliakair, Bangladesh",
+            "geometry": {
+                "bounds": {
+                    "northeast": {"lat": 24.0840819, "lng": 90.2365494},
+                    "southwest": {"lat": 24.0535966, "lng": 90.2030754}
+                },
+                "location": {"lat": 24.0694528, "lng": 90.2221213},
+                "location_type": "APPROXIMATE",
+                "viewport": {
+                    "northeast": {
+                        "lat": 24.0840819,
+                        "lng": 90.2365494
+                    },
+                    "southwest": {
+                        "lat": 24.0535966,
+                        "lng": 90.2030754
+                    }
+                }
             },
-            {
-               "long_name": "190009",
-               "short_name": "190009",
-               "types": ["postal_code"]
-            }
-         ],
-         "formatted_address": "Noor Bagh, Srinagar 190009",
-         "geometry": {
-            "bounds": {
-               "northeast": {"lat": 34.07490560000001, "lng": 74.8043599},
-               "southwest": {"lat": 34.0734423, "lng": 74.8023449}
-            },
-            "location": {"lat": 34.0742387, "lng": 74.8035549},
-            "location_type": "APPROXIMATE",
-            "viewport": {
-               "northeast": {
-                  "lat": 34.07552293029151,
-                  "lng": 74.8047013802915
-               },
-               "southwest": {
-                  "lat": 34.07282496970851,
-                  "lng": 74.80200341970848
-               }
-            }
-         },
-         "partial_match": True,
-         "place_id": "ChIJmQlkN-2P4TgR6u3glWeOMTE",
-         "types": ["political", "sublocality", "sublocality_level_1"]
-      },
-      {
-         "address_components": [
-            {
-               "long_name": "Kaliakair",
-               "short_name": "Kaliakair",
-               "types": ["locality", "political"]
-            },
-            {
-               "long_name": "Gazipur District",
-               "short_name": "Gazipur District",
-               "types": ["administrative_area_level_2", "political"]
-            },
-            {
-               "long_name": "Dhaka Division",
-               "short_name": "Dhaka Division",
-               "types": ["administrative_area_level_1", "political"]
-            },
-            {
-               "long_name": "Bangladesh",
-               "short_name": "BD",
-               "types": ["country", "political"]
-            }
-         ],
-         "formatted_address": "Kaliakair, Bangladesh",
-         "geometry": {
-            "bounds": {
-               "northeast": {"lat": 24.0840819, "lng": 90.2365494},
-               "southwest": {"lat": 24.0535966, "lng": 90.2030754}
-            },
-            "location": {"lat": 24.0694528, "lng": 90.2221213},
-            "location_type": "APPROXIMATE",
-            "viewport": {
-               "northeast": {
-                  "lat": 24.0840819,
-                  "lng": 90.2365494
-               },
-               "southwest": {
-                  "lat": 24.0535966,
-                  "lng": 90.2030754
-               }
-            }
-         },
-         "partial_match":  True,
-         "place_id": "ChIJTfs3ierjVTcRysKYnbOKmZM",
-         "types": ["locality", "political"]
-      }
-   ],
-   "status": "OK"
+            "partial_match":  True,
+            "place_id": "ChIJTfs3ierjVTcRysKYnbOKmZM",
+            "types": ["locality", "political"]
+        }
+    ],
+    "status": "OK"
 }
 
 
@@ -1095,97 +1097,101 @@ class FacilityAndProcessingTypeTest(TestCase):
 
 
 listitem_geocode_data = {
-   "results": [
-      {
-         "address_components": [
-            {
-               "long_name": "Linjiacunzhen",
-               "short_name": "Linjiacunzhen",
-               "types": ["political", "sublocality", "sublocality_level_2"]
+    "results": [
+        {
+            "address_components": [
+                {
+                    "long_name": "Linjiacunzhen",
+                    "short_name": "Linjiacunzhen",
+                    "types": ["political",
+                              "sublocality",
+                              "sublocality_level_2"]
+                },
+                {
+                    "long_name": "Zhucheng",
+                    "short_name": "Zhucheng",
+                    "types": ["political",
+                              "sublocality",
+                              "sublocality_level_1"]
+                },
+                {
+                    "long_name": "Weifang",
+                    "short_name": "Weifang",
+                    "types": ["locality", "political"]
+                },
+                {
+                    "long_name": "Shandong",
+                    "short_name": "Shandong",
+                    "types": ["administrative_area_level_1", "political"]
+                },
+                {
+                    "long_name": "China",
+                    "short_name": "CN",
+                    "types": ["country", "political"]
+                },
+                {
+                    "long_name": "262232",
+                    "short_name": "262232",
+                    "types": ["postal_code"]
+                }
+            ],
+            "formatted_address": "Linjiacunzhen, Zhucheng, " +
+            "Weifang, Shandong, China, 262232",
+            "geometry": {
+                "location": {"lat": 35.994813, "lng": 119.65418},
+                "location_type": "APPROXIMATE",
+                "viewport": {
+                    "northeast": {"lat": 36.0038401, "lng": 119.6701874},
+                    "southwest": {"lat": 35.9857849, "lng": 119.6381726}
+                }
             },
-            {
-               "long_name": "Zhucheng",
-               "short_name": "Zhucheng",
-               "types": ["political", "sublocality", "sublocality_level_1"]
+            "partial_match": True,
+            "place_id": "ChIJV5SPiTEkvjUR7ErhmnSRTR8",
+            "types": ["political", "sublocality", "sublocality_level_2"]
+        },
+        {
+            "address_components": [
+                {
+                    "long_name": "396210",
+                    "short_name": "396210",
+                    "types": ["postal_code"]
+                },
+                {
+                    "long_name": "Daman",
+                    "short_name": "Daman",
+                    "types": ["administrative_area_level_2", "political"]
+                },
+                {
+                    "long_name": "Dadra and Nagar Haveli and Daman and Diu",
+                    "short_name": "DH",
+                    "types": ["administrative_area_level_1", "political"]
+                },
+                {
+                    "long_name": "India",
+                    "short_name": "IN",
+                    "types": ["country", "political"]
+                }
+            ],
+            "formatted_address":  "Dadra and Nagar Haveli and Daman and " +
+            "Diu 396210, India",
+            "geometry": {
+                "bounds": {
+                    "northeast": {"lat": 20.4696847, "lng": 72.8751228},
+                    "southwest": {"lat": 20.4051972, "lng": 72.82805549999999}
+                },
+                "location": {"lat": 20.4346424, "lng": 72.8456399},
+                "location_type": "APPROXIMATE",
+                "viewport": {
+                    "northeast": {"lat": 20.4696847, "lng": 72.8751228},
+                    "southwest": {"lat": 20.4051972, "lng": 72.82805549999999}
+                }
             },
-            {
-               "long_name": "Weifang",
-               "short_name": "Weifang",
-               "types": ["locality", "political"]
-            },
-            {
-               "long_name": "Shandong",
-               "short_name": "Shandong",
-               "types": ["administrative_area_level_1", "political"]
-            },
-            {
-               "long_name": "China",
-               "short_name": "CN",
-               "types": ["country", "political"]
-            },
-            {
-               "long_name": "262232",
-               "short_name": "262232",
-               "types": ["postal_code"]
-            }
-         ],
-         "formatted_address": "Linjiacunzhen, Zhucheng, " +
-                              "Weifang, Shandong, China, 262232",
-         "geometry": {
-            "location": {"lat": 35.994813, "lng": 119.65418},
-            "location_type": "APPROXIMATE",
-            "viewport": {
-               "northeast": {"lat": 36.0038401, "lng": 119.6701874},
-               "southwest": {"lat": 35.9857849, "lng": 119.6381726}
-            }
-         },
-         "partial_match": True,
-         "place_id": "ChIJV5SPiTEkvjUR7ErhmnSRTR8",
-         "types": ["political", "sublocality", "sublocality_level_2"]
-      },
-      {
-         "address_components": [
-            {
-               "long_name": "396210",
-               "short_name": "396210",
-               "types": ["postal_code"]
-            },
-            {
-               "long_name": "Daman",
-               "short_name": "Daman",
-               "types": ["administrative_area_level_2", "political"]
-            },
-            {
-               "long_name": "Dadra and Nagar Haveli and Daman and Diu",
-               "short_name": "DH",
-               "types": ["administrative_area_level_1", "political"]
-            },
-            {
-               "long_name": "India",
-               "short_name": "IN",
-               "types": ["country", "political"]
-            }
-         ],
-         "formatted_address":  "Dadra and Nagar Haveli and Daman and " +
-                               "Diu 396210, India",
-         "geometry": {
-            "bounds": {
-               "northeast": {"lat": 20.4696847, "lng": 72.8751228},
-               "southwest": {"lat": 20.4051972, "lng": 72.82805549999999}
-            },
-            "location": {"lat": 20.4346424, "lng": 72.8456399},
-            "location_type": "APPROXIMATE",
-            "viewport": {
-               "northeast": {"lat": 20.4696847, "lng": 72.8751228},
-               "southwest": {"lat": 20.4051972, "lng": 72.82805549999999}
-            }
-         },
-         "partial_match": True,
-         "place_id": "ChIJ8d4EeIra4DsR3xkUSZh_-ng",
-         "types": ["postal_code"]
-      }
-   ],
-   "status": "OK"
+            "partial_match": True,
+            "place_id": "ChIJ8d4EeIra4DsR3xkUSZh_-ng",
+            "types": ["postal_code"]
+        }
+    ],
+    "status": "OK"
 }
 
 
@@ -2122,7 +2128,7 @@ class DedupeMatchingTests(TestCase):
         facility_list = self.create_list([
             (facility.country_code, junk_chars(facility.name.upper()),
              junk_chars(facility.address.upper()))],
-                                         status=FacilityListItem.PARSED)
+            status=FacilityListItem.PARSED)
         result = match_facility_list_items(facility_list)
         self.assertTrue(result['results']['no_geocoded_items'])
 
@@ -7413,8 +7419,8 @@ class FacilitySearchContributorTest(FacilityAPITestCaseBase):
         contributors = self.fetch_facility_contributors(self.facility)
         self.assertEqual(1, len(contributors))
         self.assertEqual(
-                'An Auditor / Certification Scheme / Service Provider',
-                contributors[0].get('name'))
+            'An Auditor / Certification Scheme / Service Provider',
+            contributors[0].get('name'))
 
         self.contributor.contrib_type = 'Brand / Retailer'
         self.contributor.save()
@@ -8220,7 +8226,7 @@ class ApiLimitTest(TestCase):
                          contributor=self.contrib_one).count(), 0)
 
         warning = ContributorNotifications.objects.get(
-                  contributor=self.contrib_one)
+            contributor=self.contrib_one)
         self.assertIsNone(warning.api_limit_warning_sent_on)
 
     def test_limit_warning_sent_once(self):
@@ -8236,11 +8242,11 @@ class ApiLimitTest(TestCase):
                          contributor=self.contrib_two).count(), 0)
 
         warning = ContributorNotifications.objects.get(
-                  contributor=self.contrib_one)
+            contributor=self.contrib_one)
         self.assertIsNotNone(warning.api_limit_warning_sent_on)
 
         warning_two = ContributorNotifications.objects.get(
-                      contributor=self.contrib_two)
+            contributor=self.contrib_two)
         self.assertEqual(warning_two.api_limit_warning_sent_on,
                          self.notification_time)
 
@@ -8261,11 +8267,11 @@ class ApiLimitTest(TestCase):
                          contributor=self.contrib_two).count(), 1)
 
         notice = ContributorNotifications.objects.get(
-                 contributor=self.contrib_one)
+            contributor=self.contrib_one)
         self.assertIsNotNone(notice.api_limit_exceeded_sent_on)
 
         notice_two = ContributorNotifications.objects.get(
-                     contributor=self.contrib_two)
+            contributor=self.contrib_two)
         self.assertEqual(notice_two.api_limit_exceeded_sent_on,
                          self.notification_time)
 
@@ -10138,7 +10144,7 @@ class IndexFacilitiesTest(FacilityAPITestCaseBase):
 
     @patch('api.geocoding.requests.get')
     def test_posting_to_new_facility_should_create_index_with_sector(
-      self, mock_get):
+            self, mock_get):
         mock_get.return_value = Mock(ok=True, status_code=200)
         mock_get.return_value.json.return_value = geocoding_data
         self.join_group_and_login()
@@ -10159,7 +10165,7 @@ class IndexFacilitiesTest(FacilityAPITestCaseBase):
 
     @patch('api.geocoding.requests.get')
     def test_posting_to_existing_facility_should_update_sector(
-      self, mock_get):
+            self, mock_get):
         mock_get.return_value = Mock(ok=True, status_code=200)
         mock_get.return_value.json.return_value = geocoding_data
         self.join_group_and_login()
@@ -10357,20 +10363,22 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         self.contrib_api_list_item.facility = self.contrib_facility_two
         self.contrib_api_list_item.save()
 
-        self.default_headers = ['os_id', 'contribution_date', 'name',
-                                'address', 'country_code', 'country_name',
-                                'lat', 'lng', 'sector', 'contributor (list)',
-                                'number_of_workers', 'parent_company',
-                                'processing_type_facility_type_raw',
-                                'facility_type', 'processing_type',
-                                'product_type', 'is_closed']
-
-        self.contrib_facility_base_row = [self.contrib_facility.id,
-                                          self.date, 'Towel Factory 42',
-                                          '42 Dolphin St', 'US',
-                                          'United States', 0.0, 0.0, 'Apparel',
-                                          'test contributor 1 (First List)',
-                                          '', '', '', '', '', '', 'False']
+        self.default_headers = [
+            'os_id', 'contribution_date', 'name',
+            'address', 'country_code', 'country_name',
+            'lat', 'lng', 'sector', 'contributor (list)',
+            'number_of_workers', 'parent_company',
+            'processing_type_facility_type_raw',
+            'facility_type', 'processing_type',
+            'product_type', 'is_closed']
+        self.contrib_facility_base_row = [
+            self.contrib_facility.id,
+            self.date, 'Towel Factory 42',
+            '42 Dolphin St', 'US',
+            'United States', 0.0, 0.0,
+            'Apparel',
+            'test contributor 1 (First List)',
+            '', '', '', '', '', '', 'False']
 
         self.user_two = User.objects.create(email='test2@example.com')
         self.contributor_two = Contributor \
@@ -10483,9 +10491,9 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
                 field_name='facility_type',
                 value={'raw_values': ['biological recycling'],
                        'matched_values': [
-                        ['PROCESSING_TYPE', 'EXACT',
-                         'Raw Material Processing or Production',
-                         'Biological Recycling']]},
+                    ['PROCESSING_TYPE', 'EXACT',
+                     'Raw Material Processing or Production',
+                     'Biological Recycling']]},
                 contributor=self.contributor,
                 facility=self.facility,
                 facility_claim_id=claim_id,
@@ -10498,9 +10506,9 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
                 field_name='processing_type',
                 value={'raw_values': ['biological recycling'],
                        'matched_values': [
-                        ['PROCESSING_TYPE', 'EXACT',
-                         'Raw Material Processing or Production',
-                         'Biological Recycling']]},
+                    ['PROCESSING_TYPE', 'EXACT',
+                     'Raw Material Processing or Production',
+                     'Biological Recycling']]},
                 contributor=self.contributor,
                 facility=self.facility,
                 facility_claim_id=claim_id,
@@ -10592,7 +10600,8 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         base_row = self.get_rows(response)[0]
         expected_base_row = [self.facility.id, self.date, 'Name',
                              'Address', 'US', 'United States', 0.0, 0.0,
-                             'Apparel', 'test contributor 1 (First List)', '',
+                             'Apparel',
+                             'test contributor 1 (First List)', '',
                              '', '', '', '', '', 'False']
         self.assertEqual(len(base_row), len(expected_base_row))
         self.assertEqual(base_row, expected_base_row)
@@ -10638,31 +10647,31 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         params = 'q={}'.format(self.facility.id)
         response = self.get_facility_download(params)
         base_row = self.get_rows(response)[0]
-        expected_base_row = [self.facility.id, self.date, 'Name',
-                             'Address', 'US', 'United States', 0.0, 0.0,
-                             'Apparel', 'test contributor 1 (First List)',
-                             '100-5000', 'Contributor', 'biological recycling',
-                             'Raw Material Processing or Production',
-                             'Biological Recycling', 'Shirts', 'False']
-        self.assertEqual(len(base_row), len(expected_base_row))
-        self.assertEqual(base_row, expected_base_row)
+        row = [self.facility.id, self.date, 'Name',
+               'Address', 'US', 'United States', 0.0, 0.0,
+               'Apparel', 'test contributor 1 (First List)',
+               '100-5000', 'Contributor',
+               'biological recycling',
+               'Raw Material Processing or Production',
+               'Biological Recycling',
+               'Shirts', 'False']
+        self.assertEqual(len(base_row), len(row))
+        self.assertEqual(base_row, row)
 
     def test_claim_base_row(self):
         self.create_claim()
         params = 'q={}'.format(self.facility.id)
         response = self.get_facility_download(params)
         rows = self.get_rows(response)
-        claim_row = [self.facility.id, self.date, 'Claim Name',
-                     'Address', 'US', 'United States', 0.0, 0.0, 'Apparel',
-                     'test contributor 1 (Claimed)', '20',
-                     'Contributor', 'biological recycling',
-                     'Raw Material Processing or Production',
-                     'Biological Recycling', 'Shirts', 'False']
-        list_item_row = [self.facility.id, self.date, '', '', '', '', '', '',
-                         'Apparel', 'test contributor 1 (First List)', '', '',
-                         '', '', '', '', '']
-        self.assertEquals(rows[0], claim_row)
-        self.assertEquals(rows[1], list_item_row)
+        row = [
+            self.facility.id, self.date, 'Claim Name',
+            'Address', 'US', 'United States', 0.0, 0.0,
+            'Apparel',
+            'test contributor 1 (Claimed)|test contributor 1 (First List)',
+            '20', 'Contributor', 'biological recycling',
+            'Raw Material Processing or Production',
+            'Biological Recycling', 'Shirts', 'False']
+        self.assertEquals(rows[0], row)
 
     def test_handles_additional_list_items(self):
         self.create_additional_list_item()
@@ -10675,16 +10684,16 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
 
         rows = self.get_rows(response)
 
-        expected_base_row = self.contrib_facility_base_row
-        self.assertEqual(expected_base_row, rows[0])
-
-        expected_additional_row = [self.contrib_facility.id, self.date, '',
-                                   '', '', '', '', '', 'Apparel',
-                                   'test contributor 1 (API)', '0-100',
-                                   'Contributor A', 'biological recycling',
-                                   'Raw Material Processing or Production',
-                                   'Biological Recycling', 'a', '']
-        self.assertEqual(expected_additional_row, rows[1])
+        row = [
+            self.contrib_facility.id, self.date, 'Towel Factory 42',
+            '42 Dolphin St', 'US', 'United States', 0.0, 0.0,
+            'Apparel',
+            'test contributor 1 (First List)|test contributor 1 (API)',
+            '0-100', 'Contributor A', 'biological recycling',
+            'Raw Material Processing or Production',
+            'Biological Recycling', 'a', 'False']
+        print(rows[0])
+        self.assertEqual(row, rows[0])
 
     def test_embed_excludes_alt_contributors(self):
         list_item = self.create_additional_list_item()
@@ -10712,13 +10721,16 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         params = 'q={}'.format(self.contrib_facility.id)
         response = self.get_facility_download(params)
         rows = self.get_rows(response)
-        self.assertEquals(len(rows), 2)
 
-        expected_base_row = self.contrib_facility_base_row
-        self.assertEquals(rows[0], expected_base_row)
-
-        contributor = rows[1][self.contributor_column_index]
-        self.assertEquals(contributor, 'An Other (API)')
+        row = [
+            self.contrib_facility.id, self.date, 'Towel Factory 42',
+            '42 Dolphin St', 'US', 'United States', 0.0, 0.0,
+            'Apparel',
+            'test contributor 1 (First List)|An Other (API)',
+            '0-100', 'Contributor A', 'biological recycling',
+            'Raw Material Processing or Production',
+            'Biological Recycling', 'a', 'False']
+        self.assertEquals(rows[0], row)
 
     def test_private_source_is_anonymized(self):
         list_item = self.create_additional_list_item()
@@ -10728,13 +10740,15 @@ class FacilityDownloadTest(FacilityAPITestCaseBase):
         params = 'q={}'.format(self.contrib_facility.id)
         response = self.get_facility_download(params)
         rows = self.get_rows(response)
-        self.assertEquals(len(rows), 2)
 
-        expected_base_row = self.contrib_facility_base_row
-        self.assertEquals(rows[0], expected_base_row)
-
-        contributor = rows[1][self.contributor_column_index]
-        self.assertEquals(contributor, 'An Other (API)')
+        row = [self.contrib_facility.id, self.date, 'Towel Factory 42',
+               '42 Dolphin St', 'US', 'United States', 0.0, 0.0,
+               'Apparel',
+               'test contributor 1 (First List)|An Other (API)',
+               '0-100', 'Contributor A', 'biological recycling',
+               'Raw Material Processing or Production',
+               'Biological Recycling', 'a', 'False']
+        self.assertEquals(rows[0], row)
 
     def test_inactive_match_is_anonymized(self):
         self.match.is_active = False

--- a/src/django/api/views.py
+++ b/src/django/api/views.py
@@ -212,16 +212,16 @@ def add_user_to_mailing_list(email, name, contrib_type):
             return None
 
         headers = {
-          'Authorization': "Bearer {}".format(settings.HUBSPOT_API_KEY),
-          'Content-Type': 'application/json'
+            'Authorization': "Bearer {}".format(settings.HUBSPOT_API_KEY),
+            'Content-Type': 'application/json'
         }
 
         # Add new contact
         new_contact = json.dumps({
-          "properties": {
-            "company": name,
-            "email": email,
-          }
+            "properties": {
+                "company": name,
+                "email": email,
+            }
         })
         r = requests.post(HUBSPOT_CONTACT_URL, headers=headers,
                           data=new_contact)
@@ -957,7 +957,7 @@ facilities_list_parameters = [
             'The sectors that this facility belongs to. '
             'Values must match those returned from the '
             '`GET /api/sectors` endpoint'
-            )
+        )
     )
 ]
 facilities_create_parameters = [
@@ -1397,7 +1397,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
               "geocoded_address": null,
               "status": "ERROR_MATCHING"
             }
-        """ # noqa
+        """  # noqa
         # Adding the @permission_classes decorator was not working so we
         # explicitly invoke our custom permission class.
         if not IsRegisteredAndConfirmed().has_permission(request, self):
@@ -1413,17 +1413,17 @@ class FacilitiesViewSet(mixins.ListModelMixin,
         if clean_name is None:
             clean_name = ''
             raise ValidationError({
-              "clean_name": [
-                "This field may not be blank."
-              ]
+                "clean_name": [
+                    "This field may not be blank."
+                ]
             })
         clean_address = clean(body_serializer.validated_data.get('address'))
         if clean_address is None:
             clean_address = ''
             raise ValidationError({
-              "clean_address": [
-                "This field may not be blank."
-              ]
+                "clean_address": [
+                    "This field may not be blank."
+                ]
             })
 
         params_serializer = FacilityCreateQueryParamsSerializer(
@@ -1727,7 +1727,7 @@ class FacilitiesViewSet(mixins.ListModelMixin,
             else:
                 result['status'] = FacilityListItem.NEW_FACILITY
 
-        if should_create and result['status'] != FacilityListItem.ERROR_MATCHING: # noqa
+        if should_create and result['status'] != FacilityListItem.ERROR_MATCHING:  # noqa
             return Response(result, status=status.HTTP_201_CREATED)
         else:
             return Response(result, status=status.HTTP_200_OK)
@@ -1789,10 +1789,10 @@ class FacilitiesViewSet(mixins.ListModelMixin,
                     other_matches.filter(
                         status__in=(FacilityMatch.AUTOMATIC,
                                     FacilityMatch.CONFIRMED)
-                        ).exclude(
-                            facility_list_item__geocoded_point__isnull=True
-                        ).exclude(**{
-                            "facility_list_item__source__contributor":
+                    ).exclude(
+                        facility_list_item__geocoded_point__isnull=True
+                    ).exclude(**{
+                        "facility_list_item__source__contributor":
                             created_by_contributor}),
                     key=lambda m: m.confidence)
             except ValueError:
@@ -2877,10 +2877,10 @@ class AdminFacilityListView(ListAPIView):
         if status == FacilityList.MATCHED:
             sources = Source.objects \
                 .filter(facilitylistitem__status__in=[
-                            FacilityListItem.MATCHED,
-                            FacilityListItem.POTENTIAL_MATCH,
-                            FacilityListItem.ERROR_MATCHING
-                        ])
+                    FacilityListItem.MATCHED,
+                    FacilityListItem.POTENTIAL_MATCH,
+                    FacilityListItem.ERROR_MATCHING
+                ])
             facility_lists = facility_lists.filter(source__in=sources)
         elif status == FacilityList.REPLACED:
             facility_lists = facility_lists.filter(replaced_by__isnull=False)
@@ -3195,20 +3195,20 @@ class FacilityListViewSet(viewsets.ModelViewSet):
 
         special_case_q_statements = {
             FacilityListItem.NEW_FACILITY: Q(
-                        Q(status__in=('MATCHED', 'CONFIRMED_MATCH')) &
-                        Q(facility__created_from_id=F('id')) &
-                        ~Q(facilitymatch__is_active=False)),
+                Q(status__in=('MATCHED', 'CONFIRMED_MATCH')) &
+                Q(facility__created_from_id=F('id')) &
+                ~Q(facilitymatch__is_active=False)),
             FacilityListItem.MATCHED: Q(
-                        Q(status='MATCHED') &
-                        ~Q(facility__created_from_id=F('id')) &
-                        ~Q(facilitymatch__is_active=False)),
+                Q(status='MATCHED') &
+                ~Q(facility__created_from_id=F('id')) &
+                ~Q(facilitymatch__is_active=False)),
             FacilityListItem.CONFIRMED_MATCH: Q(
-                        Q(status='CONFIRMED_MATCH') &
-                        ~Q(facility__created_from_id=F('id')) &
-                        ~Q(facilitymatch__is_active=False)),
+                Q(status='CONFIRMED_MATCH') &
+                ~Q(facility__created_from_id=F('id')) &
+                ~Q(facilitymatch__is_active=False)),
             FacilityListItem.REMOVED: Q(
-                        Q(facilitymatch__is_active=False) |
-                        Q(status=FacilityListItem.ITEM_REMOVED)),
+                Q(facilitymatch__is_active=False) |
+                Q(status=FacilityListItem.ITEM_REMOVED)),
         }
 
         def make_q_from_status(status):
@@ -4170,9 +4170,10 @@ class IsListAndAdminOrNotList(IsAdminUser):
     """
     Custom permission to only allow access to lists for admins
     """
+
     def has_permission(self, request, view):
         is_admin = super(IsListAndAdminOrNotList, self) \
-                    .has_permission(request, view)
+            .has_permission(request, view)
         return view.action != 'list' or is_admin
 
 
@@ -4205,8 +4206,8 @@ class FacilityActivityReportViewSet(viewsets.GenericViewSet):
             raise NotFound()
 
         facility_activity_report = update_facility_activity_report_status(
-                                    facility_activity_report, request,
-                                    'CONFIRMED')
+            facility_activity_report, request,
+            'CONFIRMED')
 
         facility = facility_activity_report.facility
         if facility_activity_report.closure_state == 'CLOSED':
@@ -4216,7 +4217,7 @@ class FacilityActivityReportViewSet(viewsets.GenericViewSet):
         facility.save()
 
         response_data = FacilityActivityReportSerializer(
-                        facility_activity_report).data
+            facility_activity_report).data
 
         return Response(response_data)
 
@@ -4241,11 +4242,11 @@ class FacilityActivityReportViewSet(viewsets.GenericViewSet):
             raise NotFound()
 
         facility_activity_report = update_facility_activity_report_status(
-                                    facility_activity_report, request,
-                                    'REJECTED')
+            facility_activity_report, request,
+            'REJECTED')
 
         response_data = FacilityActivityReportSerializer(
-                        facility_activity_report).data
+            facility_activity_report).data
 
         return Response(response_data)
 


### PR DESCRIPTION
## Overview

Restores the previous download structure of one facility per row.

Connects #2392 

## Demo

New download format
[facilities - new.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/11534473/facilities.-.new.csv)

Embedded download format
[facilities - embed.csv](https://github.com/open-apparel-registry/open-apparel-registry/files/11534499/facilities.-.embed.csv)

## Testing Instructions

On `develop`:
* Run `./scripts/server`
* Download facilities, ensuring you have facilities with extended fields, claim data, and contributor fields, as well as some private and inactive items. 
* Download facilities in an embedded map (preferably one with contributor fields)

On this branch:
* Run `./scripts/server`
* Download facilities, ensuring you have facilities with extended fields, claim data, and contributor fields, as well as some private and inactive items. 
* Download facilities in an embedded map (preferably one with contributor fields)

* Compare the downloads. The data content should be the same, but the rows should be combined into one row per facility. 

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
- [ ] CHANGELOG.md updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] This PR is targeted at the correct branch (`develop` vs. `ogr/develop`)
- [ ] If this PR applies to both OAR and OGR a companion PR has been created
